### PR TITLE
Omit `@constant`, `@default` notations for component accessors

### DIFF
--- a/integration/carbon/types/FileUploader/FileUploader.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploader.d.ts
@@ -80,8 +80,6 @@ export default class FileUploader extends SvelteComponentTyped<
 > {
   /**
    * Override the default behavior of clearing the array of uploaded files
-   * @constant
-   * @default () => { files = []; }
    */
   clearFiles: () => void;
 }

--- a/integration/carbon/types/ListBox/ListBoxField.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxField.d.ts
@@ -56,8 +56,6 @@ export default class ListBoxField extends SvelteComponentTyped<
 > {
   /**
    * Default translation ids
-   * @constant
-   * @default { close: "close", open: "open" }
    */
   translationIds: { close: "close"; open: "open" };
 }

--- a/integration/carbon/types/ListBox/ListBoxMenuIcon.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenuIcon.d.ts
@@ -25,8 +25,6 @@ export default class ListBoxMenuIcon extends SvelteComponentTyped<
 > {
   /**
    * Default translation ids
-   * @constant
-   * @default { close: "close", open: "open" }
    */
   translationIds: { close: "close"; open: "open" };
 }

--- a/integration/carbon/types/ListBox/ListBoxSelection.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxSelection.d.ts
@@ -36,8 +36,6 @@ export default class ListBoxSelection extends SvelteComponentTyped<
 > {
   /**
    * Default translation ids
-   * @constant
-   * @default { clearAll: "clearAll", clearSelection: "clearSelection", }
    */
   translationIds: { clearAll: "clearAll"; clearSelection: "clearSelection" };
 }

--- a/integration/carbon/types/NumberInput/NumberInput.d.ts
+++ b/integration/carbon/types/NumberInput/NumberInput.d.ts
@@ -148,8 +148,6 @@ export default class NumberInput extends SvelteComponentTyped<
 > {
   /**
    * Default translation ids
-   * @constant
-   * @default { increment: "increment", decrement: "decrement", }
    */
   translationIds: { increment: "increment"; decrement: "decrement" };
 }

--- a/integration/multi-export-typed-ts-only/types/secondary-button/secondary-button.d.ts
+++ b/integration/multi-export-typed-ts-only/types/secondary-button/secondary-button.d.ts
@@ -9,9 +9,5 @@ export default class SecondaryButton extends SvelteComponentTyped<
   { click: WindowEventMap["click"] },
   { default: {} }
 > {
-  /**
-   * @constant
-   * @default true
-   */
   secondary: boolean;
 }

--- a/integration/multi-export-typed/types/SecondaryButton.d.ts
+++ b/integration/multi-export-typed/types/SecondaryButton.d.ts
@@ -9,9 +9,5 @@ export default class SecondaryButton extends SvelteComponentTyped<
   { click: WindowEventMap["click"] },
   { default: {} }
 > {
-  /**
-   * @constant
-   * @default true
-   */
   secondary: boolean;
 }

--- a/integration/multi-export/types/Button.d.ts
+++ b/integration/multi-export/types/Button.d.ts
@@ -19,8 +19,5 @@ export default class Button extends SvelteComponentTyped<
   { click: WindowEventMap["click"] },
   { default: {} }
 > {
-  /**
-   * @default () => { console.log(0); }
-   */
   print: () => any;
 }

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -107,16 +107,7 @@ function genAccessors(def: Pick<ComponentDocApi, "props">) {
   return def.props
     .filter((prop) => prop.isFunctionDeclaration || prop.kind === "const")
     .map((prop) => {
-      const prop_comments = [
-        addCommentLine(prop.description?.replace(/\n/g, "\n* ")),
-        addCommentLine(prop.constant, "@constant"),
-        addCommentLine(
-          prop.value,
-          `@default ${typeof prop.value === "string" ? prop.value.replace(/\s+/g, " ") : prop.value}`
-        ),
-      ]
-        .filter(Boolean)
-        .join("");
+      const prop_comments = [addCommentLine(prop.description?.replace(/\n/g, "\n* "))].filter(Boolean).join("");
 
       return `
     ${prop_comments.length > 0 ? `/**\n${prop_comments}*/` : EMPTY_STR}

--- a/tests/snapshots/function-declaration/output.d.ts
+++ b/tests/snapshots/function-declaration/output.d.ts
@@ -9,20 +9,12 @@ export interface InputProps {
 }
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
-  /**
-   * @constant
-   * @default () => {}
-   */
   fnB: () => {};
 
-  /**
-   * @default () => { return a + b; }
-   */
   add: () => any;
 
   /**
    * Multiplies two numbers
-   * @default () => { return a * b; }
    */
   multiply: (a: number, b: number) => number;
 }

--- a/tests/snapshots/infer-basic/output.d.ts
+++ b/tests/snapshots/infer-basic/output.d.ts
@@ -26,14 +26,7 @@ export interface InputProps {
 }
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
-  /**
-   * @constant
-   * @default { ["1"]: true }
-   */
   propConst: { ["1"]: true };
 
-  /**
-   * @default () => { localBool = !localBool; }
-   */
   fn: () => any;
 }

--- a/tests/snapshots/infer-with-types/output.d.ts
+++ b/tests/snapshots/infer-with-types/output.d.ts
@@ -21,14 +21,7 @@ export interface InputProps {
 }
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
-  /**
-   * @constant
-   * @default { ["1"]: true }
-   */
   propConst: { [key: string]: boolean };
 
-  /**
-   * @default () => { localBool = !localBool; }
-   */
   fn: () => any;
 }

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -104,7 +104,7 @@ test("writeTsDefinition", (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n\n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    /**\n* @constant\n* @default { ["1"]: true }\n*/\n    propConst: { [key: string]: boolean; };\n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n\n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
   );
   t.end();
 });


### PR DESCRIPTION
#21

**Features**

- omit `@constant`, `@default` notations for component accessors