### PR TITLE
fix(component-parser): parse slot spread type

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "run-p test:*",
     "test:unit": "tsnd node_modules/tape/bin/tape tests/*.test.ts",
     "test:integration": "node tests/integration",
-    "format": "prettier --write '{src,tests}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.{ts,svelte}'",
     "prepack": "run-s build test"
   },
   "peerDependencies": {
@@ -36,6 +36,7 @@
     "@types/prettier": "^2.3.2",
     "@types/tape": "^4.13.2",
     "npm-run-all": "^4.1.5",
+    "prettier-plugin-svelte": "^2.4.0",
     "tape": "^5.3.1",
     "ts-node-dev": "^1.1.1"
   },

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -385,6 +385,8 @@ export default class ComponentParser {
                 replace: false,
               };
 
+              if (value === undefined) return {};
+
               if (value[0]) {
                 const { type, expression, raw, start, end } = value[0];
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -278,7 +278,7 @@ export default class ComponentParser {
     let dispatcher_name: undefined | string = undefined;
     let callees: { name: string; arguments: any }[] = [];
 
-    walk((this.compiled.ast as unknown) as Node, {
+    walk(this.compiled.ast as unknown as Node, {
       enter: (node, parent, prop) => {
         if (node.type === "CallExpression") {
           if (node.callee.name === "createEventDispatcher") {
@@ -301,9 +301,12 @@ export default class ComponentParser {
         }
 
         if (node.type === "ExportNamedDeclaration" && node.declaration != null) {
-          const { type: declaration_type, id, init, body } = node.declaration.declarations
-            ? node.declaration.declarations[0]
-            : node.declaration;
+          const {
+            type: declaration_type,
+            id,
+            init,
+            body,
+          } = node.declaration.declarations ? node.declaration.declarations[0] : node.declaration;
 
           const prop_name = id.name;
 

--- a/tests/snapshots/dispatched-events-dynamic/input.svelte
+++ b/tests/snapshots/dispatched-events-dynamic/input.svelte
@@ -13,4 +13,5 @@
   on:keydown={(e) => {
     dispatcher(e.key);
     dispatcher(KEY, { key: e.key });
-  }} />
+  }}
+/>

--- a/tests/snapshots/dispatched-events-typed/input.svelte
+++ b/tests/snapshots/dispatched-events-typed/input.svelte
@@ -15,7 +15,8 @@
 <button type="button" />
 <h1
   on:mouseover={() => {
-    dispatcher('hover', { h1: true });
-  }}>
+    dispatcher("hover", { h1: true });
+  }}
+>
   <slot />
 </h1>

--- a/tests/snapshots/dispatched-events/input.svelte
+++ b/tests/snapshots/dispatched-events/input.svelte
@@ -13,7 +13,8 @@
 <button type="button" />
 <h1
   on:mouseover={() => {
-    dispatcher('hover', { h1: true });
-  }}>
+    dispatcher("hover", { h1: true });
+  }}
+>
   <slot />
 </h1>

--- a/tests/snapshots/function-declaration/input.svelte
+++ b/tests/snapshots/function-declaration/input.svelte
@@ -7,7 +7,7 @@
     return a + b;
   }
 
-  /** 
+  /**
    * Multiplies two numbers
    * @type {(a: number, b: number) => number}
    */

--- a/tests/snapshots/infer-basic/input.svelte
+++ b/tests/snapshots/infer-basic/input.svelte
@@ -19,6 +19,7 @@
   class:id
   on:click={() => {
     propBool = !propBool;
-  }}>
+  }}
+>
   <slot>{name}</slot>
 </div>

--- a/tests/snapshots/infer-with-types/input.svelte
+++ b/tests/snapshots/infer-with-types/input.svelte
@@ -22,6 +22,7 @@
   class:id
   on:click={() => {
     propBool = !propBool;
-  }}>
+  }}
+>
   <slot>{name}</slot>
 </div>

--- a/tests/snapshots/rest-props-multiple/input.svelte
+++ b/tests/snapshots/rest-props-multiple/input.svelte
@@ -8,9 +8,7 @@
 
 {#if edit}
   <Button {...$$restProps} />
-{:else}
-  {#if heading}
-    <!-- svelte-ignore a11y-missing-content -->
-    <h1 {...$$restProps} />
-  {:else}<span {...$$restProps} />{/if}
-{/if}
+{:else if heading}
+  <!-- svelte-ignore a11y-missing-content -->
+  <h1 {...$$restProps} />
+{:else}<span {...$$restProps} />{/if}

--- a/tests/snapshots/slots-spread-typed/input.svelte
+++ b/tests/snapshots/slots-spread-typed/input.svelte
@@ -3,9 +3,9 @@
   /** @slot {{ a: number; }} text */
 
   const props = {
-    a: 4
-  }
+    a: 4,
+  };
 </script>
 
 <slot {...props}>Default text</slot>
-<slot name="text" {...props}></slot>
+<slot name="text" {...props} />

--- a/tests/snapshots/slots-spread-typed/input.svelte
+++ b/tests/snapshots/slots-spread-typed/input.svelte
@@ -1,0 +1,11 @@
+<script>
+  /** @slot {{ a: number; }} */
+  /** @slot {{ a: number; }} text */
+
+  const props = {
+    a: 4
+  }
+</script>
+
+<slot {...props}>Default text</slot>
+<slot name="text" {...props}></slot>

--- a/tests/snapshots/slots-spread-typed/output.d.ts
+++ b/tests/snapshots/slots-spread-typed/output.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+export default class Input extends SvelteComponentTyped<
+  InputProps,
+  {},
+  { default: { a: number }; text: { a: number } }
+> {}

--- a/tests/snapshots/slots-spread-typed/output.json
+++ b/tests/snapshots/slots-spread-typed/output.json
@@ -1,0 +1,18 @@
+{
+  "props": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "fallback": "Default text",
+      "slot_props": "{ a: number; }"
+    },
+    {
+      "name": "text",
+      "default": false,
+      "slot_props": "{ a: number; }"
+    }
+  ],
+  "events": [],
+  "typedefs": []
+}

--- a/tests/snapshots/slots-spread/input.svelte
+++ b/tests/snapshots/slots-spread/input.svelte
@@ -1,8 +1,8 @@
 <script>
   const props = {
-    a: 4
-  }
+    a: 4,
+  };
 </script>
 
 <slot {...props}>Default text</slot>
-<slot name="text" {...props}></slot>
+<slot name="text" {...props} />

--- a/tests/snapshots/slots-spread/input.svelte
+++ b/tests/snapshots/slots-spread/input.svelte
@@ -1,0 +1,8 @@
+<script>
+  const props = {
+    a: 4
+  }
+</script>
+
+<slot {...props}>Default text</slot>
+<slot name="text" {...props}></slot>

--- a/tests/snapshots/slots-spread/output.d.ts
+++ b/tests/snapshots/slots-spread/output.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {}; text: {} }> {}

--- a/tests/snapshots/slots-spread/output.json
+++ b/tests/snapshots/slots-spread/output.json
@@ -1,0 +1,18 @@
+{
+  "props": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "fallback": "Default text",
+      "slot_props": "{}"
+    },
+    {
+      "name": "text",
+      "default": false,
+      "slot_props": "{}"
+    }
+  ],
+  "events": [],
+  "typedefs": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,6 +875,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+prettier-plugin-svelte@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.4.0.tgz#482bb6003bf1d5bd7ff002261a42a32b87d42d00"
+  integrity sha512-JwJ9bOz4XHLQtiLnX4mTSSDUdhu12WH8sTwy/XTDCSyPlah6IcV7NWeYBZscPEcceu2YnW8Y9sJCP40Z2UH9GA==
+
 prettier@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"


### PR DESCRIPTION
#45 

**Fixes**

- tolerate slot spread syntax (`<slot {...props} />`) when parsing Svelte components

Note: this is a hot fix will not attempt to infer the type of the spread attributes. Add a JSDoc notation if spreading an object to a slot:

```svelte
<script>
  /** @slot {{ a: number; }} */

  const props = {
    a: 4,
  };
</script>

<slot {...props} />
```