### PR TITLE
Support `@component` comments

### DIFF
--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -77,7 +77,8 @@
       "extends": {
         "interface": "AccordionSkeletonProps",
         "import": "\"./AccordionSkeleton.svelte\""
-      }
+      },
+      "componentComment": "\n@example\n<Accordion>\n  <AccordionItem>...</AccordionItem>\n</Accordion>"
     },
     {
       "moduleName": "AccordionItem",
@@ -146,7 +147,8 @@
         { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": { "type": "Element", "name": "li" },
+      "componentComment": " `AccordionItem` is slottable"
     },
     {
       "moduleName": "AccordionSkeleton",

--- a/integration/carbon/src/Accordion/Accordion.svelte
+++ b/integration/carbon/src/Accordion/Accordion.svelte
@@ -30,6 +30,12 @@
   setContext("Accordion", { disableItems });
 </script>
 
+<!-- @component
+@example
+<Accordion>
+  <AccordionItem>...</AccordionItem>
+</Accordion>
+-->
 {#if skeleton}
   <AccordionSkeleton {...$$restProps} {align} {size} on:click on:mouseover on:mouseenter on:mouseleave />
 {:else}

--- a/integration/carbon/src/Accordion/AccordionItem.svelte
+++ b/integration/carbon/src/Accordion/AccordionItem.svelte
@@ -34,6 +34,7 @@
   });
 </script>
 
+<!-- @component `AccordionItem` is slottable -->
 <li
   class:bx--accordion__item={true}
   class:bx--accordion__item--active={open}

--- a/integration/carbon/types/Accordion/Accordion.svelte.d.ts
+++ b/integration/carbon/types/Accordion/Accordion.svelte.d.ts
@@ -27,6 +27,12 @@ export interface AccordionProps extends AccordionSkeletonProps {
   skeleton?: boolean;
 }
 
+/**
+ * @example
+ * <Accordion>
+ *   <AccordionItem>...</AccordionItem>
+ * </Accordion>
+ */
 export default class Accordion extends SvelteComponentTyped<
   AccordionProps,
   {

--- a/integration/carbon/types/Accordion/AccordionItem.svelte.d.ts
+++ b/integration/carbon/types/Accordion/AccordionItem.svelte.d.ts
@@ -29,6 +29,7 @@ export interface AccordionItemProps
   iconDescription?: string;
 }
 
+/** `AccordionItem` is slottable */
 export default class AccordionItem extends SvelteComponentTyped<
   AccordionItemProps,
   {

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -101,6 +101,7 @@ export interface ParsedComponent {
   typedefs: TypeDef[];
   rest_props: RestProps;
   extends?: Extends;
+  componentComment?: string;
 }
 
 export default class ComponentParser {
@@ -109,6 +110,7 @@ export default class ComponentParser {
   private compiled?: CompiledSvelteCode;
   private rest_props?: RestProps;
   private extends?: Extends;
+  private componentComment?: string;
   private readonly reactive_vars: Set<string> = new Set();
   private readonly props: Map<ComponentPropName, ComponentProp> = new Map();
   private readonly slots: Map<ComponentSlotName, ComponentSlot> = new Map();
@@ -256,6 +258,7 @@ export default class ComponentParser {
     this.compiled = undefined;
     this.rest_props = undefined;
     this.extends = undefined;
+    this.componentComment = undefined;
     this.reactive_vars.clear();
     this.props.clear();
     this.slots.clear();
@@ -375,6 +378,14 @@ export default class ComponentParser {
             constant: kind === "const",
             reactive: this.reactive_vars.has(prop_name),
           });
+        }
+
+        if (node.type === "Comment") {
+          let data: string = node?.data?.trim() ?? "";
+
+          if (/^@component/.test(data)) {
+            this.componentComment = data.replace(/^@component/, "");
+          }
         }
 
         if (node.type === "Slot") {
@@ -515,6 +526,7 @@ export default class ComponentParser {
       typedefs: ComponentParser.mapToArray(this.typedefs),
       rest_props: this.rest_props,
       extends: this.extends,
+      componentComment: this.componentComment,
     };
   }
 }

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -126,7 +126,7 @@ function genComponentComment(def: Pick<ComponentDocApi, "componentComment">) {
   if (!/\n/.test(def.componentComment)) return `/** ${def.componentComment.trim()} */`;
   return `/*${def.componentComment
     .split("\n")
-    .map((line) => `* ${line.trim()}`)
+    .map((line) => `* ${line}`)
     .join("\n")}\n*/`;
 }
 

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -121,8 +121,17 @@ function genImports(def: Pick<ComponentDocApi, "extends">) {
   return `import { ${def.extends.interface} } from ${def.extends.import};`;
 }
 
+function genComponentComment(def: Pick<ComponentDocApi, "componentComment">) {
+  if (!def.componentComment) return "";
+  if (!/\n/.test(def.componentComment)) return `/** ${def.componentComment.trim()} */`;
+  return `/*${def.componentComment
+    .split("\n")
+    .map((line) => `* ${line.trim()}`)
+    .join("\n")}\n*/`;
+}
+
 export function writeTsDefinition(component: ComponentDocApi) {
-  const { moduleName, typedefs, props, slots, events, rest_props, extends: _extends } = component;
+  const { moduleName, typedefs, props, slots, events, rest_props, extends: _extends, componentComment } = component;
   const { props_name, prop_def } = genPropDef({
     moduleName,
     props,
@@ -136,7 +145,7 @@ export function writeTsDefinition(component: ComponentDocApi) {
   ${genImports({ extends: _extends })}
   ${getTypeDefs({ typedefs })}
   ${prop_def}
-
+  ${genComponentComment({ componentComment })}
   export default class ${moduleName === "default" ? "" : moduleName} extends SvelteComponentTyped<
       ${props_name},
       {${genEventDef({ events })}},

--- a/tests/snapshots/component-comment-multi/input.svelte
+++ b/tests/snapshots/component-comment-multi/input.svelte
@@ -1,0 +1,4 @@
+<!-- @component
+ Component comment
+-->
+<div><slot /></div>

--- a/tests/snapshots/component-comment-multi/input.svelte
+++ b/tests/snapshots/component-comment-multi/input.svelte
@@ -1,4 +1,7 @@
 <!-- @component
- Component comment
+@example
+<div>
+  Component comment
+</div>
 -->
 <div><slot /></div>

--- a/tests/snapshots/component-comment-multi/output.d.ts
+++ b/tests/snapshots/component-comment-multi/output.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+/**
+ * Component comment
+ */
+export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

--- a/tests/snapshots/component-comment-multi/output.d.ts
+++ b/tests/snapshots/component-comment-multi/output.d.ts
@@ -4,6 +4,9 @@ import { SvelteComponentTyped } from "svelte";
 export interface InputProps {}
 
 /**
- * Component comment
+ * @example
+ * <div>
+ *   Component comment
+ * </div>
  */
 export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

--- a/tests/snapshots/component-comment-multi/output.json
+++ b/tests/snapshots/component-comment-multi/output.json
@@ -9,5 +9,5 @@
   ],
   "events": [],
   "typedefs": [],
-  "componentComment": "\n Component comment"
+  "componentComment": "\n@example\n<div>\n  Component comment\n</div>"
 }

--- a/tests/snapshots/component-comment-multi/output.json
+++ b/tests/snapshots/component-comment-multi/output.json
@@ -1,0 +1,13 @@
+{
+  "props": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{}"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "componentComment": "\n Component comment"
+}

--- a/tests/snapshots/component-comment-single/input.svelte
+++ b/tests/snapshots/component-comment-single/input.svelte
@@ -1,0 +1,2 @@
+<!-- @component Component comment -->
+<div><slot /></div>

--- a/tests/snapshots/component-comment-single/output.d.ts
+++ b/tests/snapshots/component-comment-single/output.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+/** Component comment */
+export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

--- a/tests/snapshots/component-comment-single/output.json
+++ b/tests/snapshots/component-comment-single/output.json
@@ -1,0 +1,13 @@
+{
+  "props": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{}"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "componentComment": " Component comment"
+}

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -104,7 +104,7 @@ test("writeTsDefinition", (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n\n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n  \n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
   );
   t.end();
 });
@@ -122,7 +122,7 @@ test('writeTsDefinition – "default" module name', (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface defaultProps  {\n      \n    }\n  \n\n  export default class  extends SvelteComponentTyped<\n      defaultProps,\n      {},\n      {}\n    > {\n      \n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface defaultProps  {\n      \n    }\n  \n  \n  export default class  extends SvelteComponentTyped<\n      defaultProps,\n      {},\n      {}\n    > {\n      \n    }'
   );
   t.end();
 });


### PR DESCRIPTION
#54 

This PR adds the ability to parse `<!-- @component -->` comments and add them to the generated TypeScript definition.

**Single-line comment**

Input:

```svelte
<!-- @component A button component -->
<button {...$$restProps} {type} class:primary on:click>
  <slot>Click me</slot>
</button>
```

Output:

```ts
// ...

/** A button component */
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
   { default: {} }
 > {}
```

**Multi-line comment**

Input:

```svelte
<!-- @component
@example
<Button>
  <slot />
</Button>
-->
<button {...$$restProps} {type} class:primary on:click>
  <slot>Click me</slot>
</button>
```

Output:

```ts
// ...

/**
 * @example
 * <Button>
 *   <slot />
 * </Button>
 */
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
   { default: {} }
 > {}
```