### PR TITLE
Support detecting renamed exports as props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add isAccessor field to API
 - update Markdown writer to generate a separate table for accessors
+- support props defined via renamed exports (ex: `export { className as class }`)
 
 ## [0.11.1](https://github.com/carbon-design-system/sveld/releases/tag/v0.11.1) - 2021-12-31
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -306,7 +306,7 @@ export default class ComponentParser {
         }
 
         if (node.type === "VariableDeclaration") {
-          this.vars.add(node);
+          this.vars.add(node as unknown as VariableDeclaration);
         }
 
         if (node.type === "ExportNamedDeclaration") {

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -305,21 +305,22 @@ export default class ComponentParser {
           }
         }
 
-        if (node.type === 'VariableDeclaration') {
+        if (node.type === "VariableDeclaration") {
           this.vars.add(node);
         }
 
         if (node.type === "ExportNamedDeclaration") {
           // Handle renamed exports
           let prop_name: string;
-          if (node.declaration == null && node.specifiers[0]?.type === 'ExportSpecifier') {
+          if (node.declaration == null && node.specifiers[0]?.type === "ExportSpecifier") {
             const specifier = node.specifiers[0];
-            const localName = specifier.local.name, exportedName = specifier.exported.name;
+            const localName = specifier.local.name,
+              exportedName = specifier.exported.name;
             let declaration: VariableDeclaration;
             // Search through all variable declarations for this variable
             //  Limitation: the variable must have been declared before the export
-            this.vars.forEach(varDecl => {
-              if (varDecl.declarations.some(decl => decl.id.type === 'Identifier' && decl.id.name === localName)) {
+            this.vars.forEach((varDecl) => {
+              if (varDecl.declarations.some((decl) => decl.id.type === "Identifier" && decl.id.name === localName)) {
                 declaration = varDecl;
               }
             });

--- a/tests/snapshots/renamed-props/input.svelte
+++ b/tests/snapshots/renamed-props/input.svelte
@@ -1,0 +1,10 @@
+<script>
+  let className = "test";
+  /**
+   * Just your average CSS class string.
+   * @type {string|null}
+   */
+  export { className as class };
+</script>
+
+{className}

--- a/tests/snapshots/renamed-props/output.d.ts
+++ b/tests/snapshots/renamed-props/output.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {
+  /**
+   * Just your average CSS class string.
+   * @default "test"
+   */
+  class?: string | null;
+}
+
+export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}

--- a/tests/snapshots/renamed-props/output.json
+++ b/tests/snapshots/renamed-props/output.json
@@ -1,0 +1,18 @@
+{
+  "props": [
+    {
+      "name": "class",
+      "kind": "let",
+      "description": "Just your average CSS class string.",
+      "type": "string|null",
+      "value": "\"test\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "slots": [],
+  "events": [],
+  "typedefs": []
+}


### PR DESCRIPTION
This PR adds support for renamed exports such as `export { className as class }` to be detected as props and added to the generated interface. This is done by storing a list of variable declarations encountered and then looking it up when a rename export is met.

Known limitations:
- The variable declaration must appear before the `export` statement in the source code.
- The leading comment of the `export` statement is parsed, while that of the declaration is ignored.

Resolves #50