### PR TITLE
Fix: specify `@default undefined` for undefined prop values

### DIFF
--- a/integration/carbon/COMPONENT_INDEX.md
+++ b/integration/carbon/COMPONENT_INDEX.md
@@ -167,12 +167,12 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value      | Description                                      |
-| :-------- | :--------------- | :------- | :-------------------------------- | ------------------ | ------------------------------------------------ |
-| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code> | Specify alignment of accordion item chevron icon |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | --                 | Specify the size of the accordion                |
-| disabled  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code> | Set to `true` to disable the accordion           |
-| skeleton  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code> | Set to `true` to display the skeleton state      |
+| Prop name | Kind             | Reactive | Type                              | Default value          | Description                                      |
+| :-------- | :--------------- | :------- | :-------------------------------- | ---------------------- | ------------------------------------------------ |
+| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| disabled  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
+| skeleton  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
 
 ### Slots
 
@@ -222,12 +222,12 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value      | Description                                      |
-| :-------- | :--------------- | :------- | :-------------------------------- | ------------------ | ------------------------------------------------ |
-| count     | <code>let</code> | No       | <code>number</code>               | <code>4</code>     | Specify the number of accordion items to render  |
-| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code> | Specify alignment of accordion item chevron icon |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | --                 | Specify the size of the accordion                |
-| open      | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>  | Set to `false` to close the first accordion item |
+| Prop name | Kind             | Reactive | Type                              | Default value          | Description                                      |
+| :-------- | :--------------- | :------- | :-------------------------------- | ---------------------- | ------------------------------------------------ |
+| count     | <code>let</code> | No       | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
+| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| open      | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
 
 ### Slots
 
@@ -288,10 +288,10 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value      | Description                                                      |
-| :------------ | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------------------------- |
-| href          | <code>let</code> | No       | <code>string</code>  | --                 | Set the `href` to use an anchor link                             |
-| isCurrentPage | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the breadcrumb item represents the current page |
+| Prop name     | Kind             | Reactive | Type                 | Default value          | Description                                                      |
+| :------------ | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------------------------- |
+| href          | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
+| isCurrentPage | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
 
 ### Slots
 
@@ -340,14 +340,14 @@ None.
 | hasIconOnly      | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` for the icon-only variant                                                                                                                                                       |
 | kind             | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button                                                                                                                                                                    |
 | size             | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code>                                                                                      | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
-| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                              | --                     | Specify the icon from `carbon-icons-svelte` to render                                                                                                                                         |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                                                                                                       | --                     | Specify the ARIA label for the button icon                                                                                                                                                    |
+| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                              | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render                                                                                                                                         |
+| iconDescription  | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon                                                                                                                                                    |
 | tooltipAlignment | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon<br />`hasIconOnly` must be set to `true`                                                                                                |
 | tooltipPosition  | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon                                                                                                                                          |
 | as               | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Button let:props&gt;&lt;div {...props}&gt;...&lt;/div&gt;&lt;/Button&gt;) |
 | skeleton         | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                   |
 | disabled         | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                           |
-| href             | <code>let</code> | No       | <code>string</code>                                                                                                                       | --                     | Set the `href` to use an anchor link                                                                                                                                                          |
+| href             | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link                                                                                                                                                          |
 | tabindex         | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                          |
 | type             | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                           |
 
@@ -390,7 +390,7 @@ None.
 
 | Prop name | Kind             | Reactive | Type                                                 | Default value          | Description                          |
 | :-------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | ------------------------------------ |
-| href      | <code>let</code> | No       | <code>string</code>                                  | --                     | Set the `href` to use an anchor link |
+| href      | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link |
 | size      | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton  |
 | small     | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | --                                   |
 
@@ -422,7 +422,7 @@ None.
 | labelText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                            |
 | hideLabel     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text     |
 | name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Set a name for the input element                  |
-| title         | <code>let</code> | No       | <code>string</code>                       | --                                               | Specify the title attribute for the label element |
+| title         | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the title attribute for the label element |
 | id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input label                     |
 
 ### Slots
@@ -463,11 +463,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| clicked   | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code> | Set to `true` to click the tile           |
-| light     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
-| href      | <code>let</code> | No       | <code>string</code>  | --                 | Set the `href`                            |
+| Prop name | Kind             | Reactive | Type                 | Default value          | Description                               |
+| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ----------------------------------------- |
+| clicked   | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
+| light     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
+| href      | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
 
 ### Slots
 
@@ -495,14 +495,14 @@ None.
 | showMoreLess          | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the show more/less button                                                                          |
 | expanded              | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to expand a multi-line code snippet (type="multi")                                                           |
 | type                  | <code>let</code> | No       | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                            | Set the type of code snippet                                                                                               |
-| code                  | <code>let</code> | No       | <code>string</code>                                  | --                                               | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;) |
+| code                  | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;) |
 | hideCopyButton        | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to hide the copy button                                                                                      |
 | disabled              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                    |
 | wrapText              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                       |
 | light                 | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                                                                                  |
 | skeleton              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to display the skeleton state                                                                                |
-| copyButtonDescription | <code>let</code> | No       | <code>string</code>                                  | --                                               | Specify the ARIA label for the copy button icon                                                                            |
-| copyLabel             | <code>let</code> | No       | <code>string</code>                                  | --                                               | Specify the ARIA label of the copy button                                                                                  |
+| copyButtonDescription | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label for the copy button icon                                                                            |
+| copyLabel             | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label of the copy button                                                                                  |
 | feedback              | <code>let</code> | No       | <code>string</code>                                  | <code>"Copied!"</code>                           | Specify the feedback text displayed when clicking the snippet                                                              |
 | feedbackTimeout       | <code>let</code> | No       | <code>number</code>                                  | <code>2000</code>                                | Set the timeout duration (ms) to display feedback text                                                                     |
 | showLessText          | <code>let</code> | No       | <code>string</code>                                  | <code>"Show less"</code>                         | Specify the show less text<br />`type` must be "multi"                                                                     |
@@ -563,19 +563,19 @@ export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                                                                               | Default value      | Description                                                                                                                                                                                           |
-| :------------ | :--------------- | :------- | :------------------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
-| noGutter      | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                                    |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                               |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                              |
-| padding       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code> | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
-| aspectRatio   | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | --                 | Specify the aspect ratio of the column                                                                                                                                                                |
-| sm            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | --                 | Set the small breakpoint                                                                                                                                                                              |
-| md            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | --                 | Set the medium breakpoint                                                                                                                                                                             |
-| lg            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | --                 | Set the large breakpoint                                                                                                                                                                              |
-| xlg           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | --                 | Set the extra large breakpoint                                                                                                                                                                        |
-| max           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | --                 | Set the maximum breakpoint                                                                                                                                                                            |
+| Prop name     | Kind             | Reactive | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
+| :------------ | :--------------- | :------- | :------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
+| noGutter      | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
+| noGutterLeft  | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
+| noGutterRight | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
+| padding       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
+| aspectRatio   | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
+| sm            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
+| md            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
+| lg            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
+| xlg           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
+| max           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
 
 ### Slots
 
@@ -609,7 +609,7 @@ export interface ComboBoxItem {
 | selectedIndex    | <code>let</code> | Yes      | <code>number</code>                                         | <code>-1</code>                                       | Set the selected item by value index                                     |
 | items            | <code>let</code> | No       | <code>ComboBoxItem[]</code>                                 | <code>[]</code>                                       | Set the combobox items                                                   |
 | itemToString     | <code>let</code> | No       | <code>(item: ComboBoxItem) => string</code>                 | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a combobox item                                  |
-| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                               | --                                                    | Set the size of the combobox                                             |
+| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                               | <code>undefined</code>                                | Set the size of the combobox                                             |
 | disabled         | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to disable the combobox                                    |
 | titleText        | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the title text of the combobox                                   |
 | placeholder      | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the placeholder text                                             |
@@ -618,9 +618,9 @@ export interface ComboBoxItem {
 | invalid          | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to indicate an invalid state                               |
 | light            | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to enable the light variant                                |
 | shouldFilterItem | <code>let</code> | No       | <code>(item: ComboBoxItem, value: string) => boolean</code> | <code>() => true</code>                               | Determine if an item should be filtered given the current combobox value |
-| translateWithId  | <code>let</code> | No       | <code>(id: any) => string</code>                            | --                                                    | Override the default translation ids                                     |
+| translateWithId  | <code>let</code> | No       | <code>(id: any) => string</code>                            | <code>undefined</code>                                | Override the default translation ids                                     |
 | id               | <code>let</code> | No       | <code>string</code>                                         | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component                                     |
-| name             | <code>let</code> | No       | <code>string</code>                                         | --                                                    | Specify a name attribute for the input                                   |
+| name             | <code>let</code> | No       | <code>string</code>                                         | <code>undefined</code>                                | Specify a name attribute for the input                                   |
 
 ### Slots
 
@@ -645,7 +645,7 @@ None.
 | :------------------------- | :--------------- | :------- | :---------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
 | ref                        | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
 | open                       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
-| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | --                                        | Set the size of the composed modal                                    |
+| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
 | danger                     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
 | preventCloseOnClickOutside | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
 | containerClass             | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
@@ -692,11 +692,11 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                          | Default value      | Description                               |
-| :------------ | :--------------- | :------- | :---------------------------- | ------------------ | ----------------------------------------- |
-| selectedIndex | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>     | Set the selected index of the switch item |
-| light         | <code>let</code> | No       | <code>boolean</code>          | <code>false</code> | Set to `true` to enable the light variant |
-| size          | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | --                 | Specify the size of the content switcher  |
+| Prop name     | Kind             | Reactive | Type                          | Default value          | Description                               |
+| :------------ | :--------------- | :------- | :---------------------------- | ---------------------- | ----------------------------------------- |
+| selectedIndex | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
+| light         | <code>let</code> | No       | <code>boolean</code>          | <code>false</code>     | Set to `true` to enable the light variant |
+| size          | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
 
 ### Slots
 
@@ -798,23 +798,23 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                | Default value      | Description                                                                                                         |
-| :------------- | :--------------- | :------- | :-------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| selectedRowIds | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>    | Specify the row ids to be selected                                                                                  |
-| selectable     | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code> | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
-| expandedRowIds | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>    | Specify the row ids to be expanded                                                                                  |
-| expandable     | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code> | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
-| rows           | <code>let</code> | Yes      | <code>DataTableRow[]</code>                         | <code>[]</code>    | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
-| headers        | <code>let</code> | No       | <code>DataTableHeader[]</code>                      | <code>[]</code>    | Specify the data table headers                                                                                      |
-| size           | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | --                 | Set the size of the data table                                                                                      |
-| title          | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>    | Specify the title of the data table                                                                                 |
-| description    | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>    | Specify the description of the data table                                                                           |
-| zebra          | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to use zebra styles                                                                                   |
-| sortable       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` for the sortable variant                                                                              |
-| batchExpansion | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to enable batch expansion                                                                             |
-| radio          | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` for the radio selection variant                                                                       |
-| batchSelection | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to enable batch selection                                                                             |
-| stickyHeader   | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to enable a sticky header                                                                             |
+| Prop name      | Kind             | Reactive | Type                                                | Default value          | Description                                                                                                         |
+| :------------- | :--------------- | :------- | :-------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| selectedRowIds | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
+| selectable     | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
+| expandedRowIds | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
+| expandable     | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
+| rows           | <code>let</code> | Yes      | <code>DataTableRow[]</code>                         | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
+| headers        | <code>let</code> | No       | <code>DataTableHeader[]</code>                      | <code>[]</code>        | Specify the data table headers                                                                                      |
+| size           | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
+| title          | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
+| description    | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the description of the data table                                                                           |
+| zebra          | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
+| sortable       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
+| batchExpansion | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
+| radio          | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
+| batchSelection | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
+| stickyHeader   | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
 
 ### Slots
 
@@ -842,15 +842,15 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                                    | Default value      | Description                                                                                  |
-| :---------- | :--------------- | :------- | :------------------------------------------------------ | ------------------ | -------------------------------------------------------------------------------------------- |
-| columns     | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>     | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
-| rows        | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>     | Specify the number of rows                                                                   |
-| size        | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | --                 | Set the size of the data table                                                               |
-| zebra       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code> | Set to `true` to apply zebra styles to the datatable rows                                    |
-| showHeader  | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>  | Set to `false` to hide the header                                                            |
-| headers     | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>    | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
-| showToolbar | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>  | Set to `false` to hide the toolbar                                                           |
+| Prop name   | Kind             | Reactive | Type                                                    | Default value          | Description                                                                                  |
+| :---------- | :--------------- | :------- | :------------------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
+| columns     | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
+| rows        | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
+| size        | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
+| zebra       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
+| showHeader  | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
+| headers     | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
+| showToolbar | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
 
 ### Slots
 
@@ -873,7 +873,7 @@ None.
 | :------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
 | value          | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value           |
 | datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type                  |
-| appendTo       | <code>let</code> | No       | <code>HTMLElement</code>                             | --                                               | Specify the element to append the calendar to |
+| appendTo       | <code>let</code> | No       | <code>HTMLElement</code>                             | <code>undefined</code>                           | Specify the element to append the calendar to |
 | dateFormat     | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                       |
 | maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                      |
 | minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                      |
@@ -905,7 +905,7 @@ None.
 | Prop name       | Kind             | Reactive | Type                                      | Default value                                    | Description                                        |
 | :-------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
 | ref             | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element       |
-| size            | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | --                                               | Set the size of the input                          |
+| size            | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                          |
 | type            | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the input type                             |
 | placeholder     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input placeholder text                 |
 | pattern         | <code>let</code> | No       | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>      | Specify the Regular Expression for the input value |
@@ -916,7 +916,7 @@ None.
 | hideLabel       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text      |
 | invalid         | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state         |
 | invalidText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                     |
-| name            | <code>let</code> | No       | <code>string</code>                       | --                                               | Set a name for the input element                   |
+| name            | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Set a name for the input element                   |
 
 ### Slots
 
@@ -978,7 +978,7 @@ export interface DropdownItem {
 | items           | <code>let</code> | No       | <code>DropdownItem[]</code>                 | <code>[]</code>                                       | Set the dropdown items                        |
 | itemToString    | <code>let</code> | No       | <code>(item: DropdownItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item       |
 | type            | <code>let</code> | No       | <code>"default" &#124; "inline"</code>      | <code>"default"</code>                                | Specify the type of dropdown                  |
-| size            | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>   | --                                                    | Specify the size of the dropdown field        |
+| size            | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>   | <code>undefined</code>                                | Specify the size of the dropdown field        |
 | light           | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to enable the light variant     |
 | disabled        | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to disable the dropdown         |
 | titleText       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the title text                        |
@@ -987,10 +987,10 @@ export interface DropdownItem {
 | warn            | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to indicate an warning state    |
 | warnText        | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the warning state text                |
 | helperText      | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the helper text                       |
-| label           | <code>let</code> | No       | <code>string</code>                         | --                                                    | Specify the list box label                    |
-| translateWithId | <code>let</code> | No       | <code>(id: any) => string</code>            | --                                                    | Override the default translation ids          |
+| label           | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                                | Specify the list box label                    |
+| translateWithId | <code>let</code> | No       | <code>(id: any) => string</code>            | <code>undefined</code>                                | Override the default translation ids          |
 | id              | <code>let</code> | No       | <code>string</code>                         | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component          |
-| name            | <code>let</code> | No       | <code>string</code>                         | --                                                    | Specify a name attribute for the list box     |
+| name            | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                                | Specify a name attribute for the list box     |
 
 ### Slots
 
@@ -1362,16 +1362,16 @@ None.
 
 ### Props
 
-| Prop name               | Kind             | Reactive | Type                                       | Default value      | Description                                                                                                                      |
-| :---------------------- | :--------------- | :------- | :----------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| ref                     | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>  | Obtain a reference to the HTML anchor element                                                                                    |
-| isSideNavOpen           | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code> | Set to `true` to open the side nav                                                                                               |
-| expandedByDefault       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>  | Set to `false` to hide the side nav by default                                                                                   |
-| uiShellAriaLabel        | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the ARIA label for the header                                                                                            |
-| href                    | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the `href` attribute                                                                                                     |
-| company                 | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the company name                                                                                                         |
-| platformName            | <code>let</code> | No       | <code>string</code>                        | <code>""</code>    | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;) |
-| persistentHamburgerMenu | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code> | Set to `true` to persist the hamburger menu                                                                                      |
+| Prop name               | Kind             | Reactive | Type                                       | Default value          | Description                                                                                                                      |
+| :---------------------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| ref                     | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                    |
+| isSideNavOpen           | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to open the side nav                                                                                               |
+| expandedByDefault       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                   |
+| uiShellAriaLabel        | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the ARIA label for the header                                                                                            |
+| href                    | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                                                                                                     |
+| company                 | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the company name                                                                                                         |
+| platformName            | <code>let</code> | No       | <code>string</code>                        | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;) |
+| persistentHamburgerMenu | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                      |
 
 ### Slots
 
@@ -1405,8 +1405,8 @@ export interface HeaderActionSlideTransition {
 | :--------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
 | ref        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
 | isOpen     | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>             | Set to `true` to open the panel                                                                               |
-| icon       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                             | Specify the icon from `carbon-icons-svelte` to render                                                         |
-| text       | <code>let</code> | No       | <code>string</code>                                          | --                             | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
+| icon       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>         | Specify the icon from `carbon-icons-svelte` to render                                                         |
+| text       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
 | transition | <code>let</code> | No       | <code>false &#124; HeaderActionSlideTransition</code>        | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`)<br />Set to `false` to disable the transition       |
 
 ### Slots
@@ -1427,12 +1427,12 @@ export interface HeaderActionSlideTransition {
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                                                         | Default value      | Description                                           |
-| :----------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------ | ----------------------------------------------------- |
-| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>  | Obtain a reference to the HTML anchor element         |
-| linkIsActive | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code> | Set to `true` to use the active state                 |
-| href         | <code>let</code> | No       | <code>string</code>                                          | --                 | Specify the `href` attribute                          |
-| icon         | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                 | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name    | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :----------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
+| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
+| linkIsActive | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active state                 |
+| href         | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
+| icon         | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -1466,11 +1466,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                         | Default value      | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------ | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>  | Obtain a reference to the HTML button element |
-| isActive  | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code> | Set to `true` to use the active variant       |
-| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                 | Specify the icon to render                    |
+| Prop name | Kind             | Reactive | Type                                                         | Default value          | Description                                   |
+| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element |
+| isActive  | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active variant       |
+| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -1488,9 +1488,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value | Description                        |
-| :-------- | :--------------- | :------- | :------------------ | ------------- | ---------------------------------- |
-| ariaLabel | <code>let</code> | No       | <code>string</code> | --            | Specify the ARIA label for the nav |
+| Prop name | Kind             | Reactive | Type                | Default value          | Description                        |
+| :-------- | :--------------- | :------- | :------------------ | ---------------------- | ---------------------------------- |
+| ariaLabel | <code>let</code> | No       | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav |
 
 ### Slots
 
@@ -1506,11 +1506,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value     | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
-| href      | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
-| text      | <code>let</code> | No       | <code>string</code>                        | --                | Specify the text                              |
+| Prop name | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :-------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
 
 ### Slots
 
@@ -1538,7 +1538,7 @@ None.
 | ref             | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>              | Obtain a reference to the HTML anchor element |
 | expanded        | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>             | Set to `true` to toggle the expanded state    |
 | href            | <code>let</code> | No       | <code>string</code>                        | <code>"/"</code>               | Specify the `href` attribute                  |
-| text            | <code>let</code> | No       | <code>string</code>                        | --                             | Specify the text                              |
+| text            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>         | Specify the text                              |
 | iconDescription | <code>let</code> | No       | <code>string</code>                        | <code>"Expand/Collapse"</code> | Specify the ARIA label for the chevron icon   |
 
 ### Slots
@@ -1580,10 +1580,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value     | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
-| href      | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
+| Prop name | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :-------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
 
 ### Slots
 
@@ -1675,10 +1675,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                         | Default value      | Description                                           |
-| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------ | ----------------------------------------------------- |
-| render    | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                 | Specify the icon from `carbon-icons-svelte` to render |
-| skeleton  | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code> | Set to `true` to display the skeleton state           |
+| Prop name | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
+| render    | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| skeleton  | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to display the skeleton state           |
 
 ### Slots
 
@@ -1718,12 +1718,12 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                     | Default value         | Description                                                       |
-| :-------------- | :--------------- | :------- | :----------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------- |
-| status          | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code> | Set the loading status                                            |
-| description     | <code>let</code> | No       | <code>string</code>                                                      | --                    | Set the loading description                                       |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                      | --                    | Specify the ARIA label for the loading icon                       |
-| successDelay    | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>     | Specify the timeout delay (ms) after `status` is set to "success" |
+| Prop name       | Kind             | Reactive | Type                                                                     | Default value          | Description                                                       |
+| :-------------- | :--------------- | :------- | :----------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------- |
+| status          | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
+| description     | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
+| iconDescription | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
+| successDelay    | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
 
 ### Slots
 
@@ -1775,14 +1775,14 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                   | Default value      | Description                                      |
-| :-------- | :--------------- | :------- | :--------------------------------------------------------------------- | ------------------ | ------------------------------------------------ |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>  | Obtain a reference to the top-level HTML element |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | --                 | Specify the size of the link                     |
-| href      | <code>let</code> | No       | <code>string</code>                                                    | --                 | Specify the href value                           |
-| inline    | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code> | Set to `true` to use the inline variant          |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code> | Set to `true` to disable the checkbox            |
-| visited   | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code> | Set to `true` to allow visited styles            |
+| Prop name | Kind             | Reactive | Type                                                                   | Default value          | Description                                      |
+| :-------- | :--------------- | :------- | :--------------------------------------------------------------------- | ---------------------- | ------------------------------------------------ |
+| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element |
+| size      | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                     |
+| href      | <code>let</code> | No       | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                           |
+| inline    | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant          |
+| disabled  | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox            |
+| visited   | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles            |
 
 ### Slots
 
@@ -1805,7 +1805,7 @@ None.
 
 | Prop name   | Kind             | Reactive | Type                                   | Default value          | Description                                |
 | :---------- | :--------------- | :------- | :------------------------------------- | ---------------------- | ------------------------------------------ |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | --                     | Set the size of the list box               |
+| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
 | type        | <code>let</code> | No       | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
 | open        | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
 | light       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
@@ -1948,7 +1948,7 @@ export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 | Prop name       | Kind               | Reactive | Type                                                                     | Default value                                                            | Description                                      |
 | :-------------- | :----------------- | :------- | :----------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------ |
 | ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
-| selectionCount  | <code>let</code>   | No       | <code>any</code>                                                         | --                                                                       | Specify the number of selected items             |
+| selectionCount  | <code>let</code>   | No       | <code>any</code>                                                         | <code>undefined</code>                                                   | Specify the number of selected items             |
 | disabled        | <code>let</code>   | No       | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
 | translationIds  | <code>const</code> | No       | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
 | translateWithId | <code>let</code>   | No       | <code>(id: ListBoxSelectionTranslationId) => string</code>               | <code>(id) => defaultTranslations[id]</code>                             | Override the default translation ids             |
@@ -2012,13 +2012,13 @@ None.
 | :------------------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
 | ref                        | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                                | Obtain a reference to the top-level HTML element                           |
 | open                       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to open the modal                                            |
-| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | --                                               | Set the size of the modal                                                  |
+| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                           | Set the size of the modal                                                  |
 | danger                     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use the danger variant                                    |
 | alert                      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable alert mode                                         |
 | passiveModal               | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use the passive variant                                   |
-| modalHeading               | <code>let</code> | No       | <code>string</code>                       | --                                               | Specify the modal heading                                                  |
-| modalLabel                 | <code>let</code> | No       | <code>string</code>                       | --                                               | Specify the modal label                                                    |
-| modalAriaLabel             | <code>let</code> | No       | <code>string</code>                       | --                                               | Specify the ARIA label for the modal                                       |
+| modalHeading               | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the modal heading                                                  |
+| modalLabel                 | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the modal label                                                    |
+| modalAriaLabel             | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the ARIA label for the modal                                       |
 | iconDescription            | <code>let</code> | No       | <code>string</code>                       | <code>"Close the modal"</code>                   | Specify the ARIA label for the close icon                                  |
 | hasForm                    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` if the modal contains form elements                          |
 | hasScrollingContent        | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` if the modal contains scrolling content                      |
@@ -2075,14 +2075,14 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                 | Default value      | Description                                 |
-| :-------------------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------------- |
-| primaryButtonText     | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the primary button text             |
-| primaryButtonDisabled | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the primary button |
-| primaryClass          | <code>let</code> | No       | <code>string</code>  | --                 | Specify a class for the primary button      |
-| secondaryButtonText   | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the secondary button text           |
-| secondaryClass        | <code>let</code> | No       | <code>string</code>  | --                 | Specify a class for the secondary button    |
-| danger                | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the danger variant     |
+| Prop name             | Kind             | Reactive | Type                 | Default value          | Description                                 |
+| :-------------------- | :--------------- | :------- | :------------------- | ---------------------- | ------------------------------------------- |
+| primaryButtonText     | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the primary button text             |
+| primaryButtonDisabled | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the primary button |
+| primaryClass          | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the primary button      |
+| secondaryButtonText   | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the secondary button text           |
+| secondaryClass        | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the secondary button    |
+| danger                | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the danger variant     |
 
 ### Slots
 
@@ -2144,7 +2144,7 @@ export interface MultiSelectItem {
 | selectedIds       | <code>let</code> | Yes      | <code>MultiSelectItemId[]</code>                                                               | <code>[]</code>                                                                     | Set the selected ids                                                                  |
 | items             | <code>let</code> | Yes      | <code>MultiSelectItem[]</code>                                                                 | <code>[]</code>                                                                     | Set the multiselect items                                                             |
 | itemToString      | <code>let</code> | No       | <code>(item: MultiSelectItem) => string</code>                                                 | <code>(item) => item.text &#124;&#124; item.id</code>                               | Override the display of a multiselect item                                            |
-| size              | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                      | --                                                                                  | Set the size of the combobox                                                          |
+| size              | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                      | <code>undefined</code>                                                              | Set the size of the combobox                                                          |
 | type              | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                         | <code>"default"</code>                                                              | Specify the type of multiselect                                                       |
 | selectionFeedback | <code>let</code> | No       | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                    | <code>"top-after-reopen"</code>                                                     | Specify the selection feedback after selecting items                                  |
 | disabled          | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to disable the dropdown                                                 |
@@ -2154,7 +2154,7 @@ export interface MultiSelectItem {
 | locale            | <code>let</code> | No       | <code>string</code>                                                                            | <code>"en"</code>                                                                   | Specify the locale                                                                    |
 | placeholder       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the placeholder text                                                          |
 | sortItem          | <code>let</code> | No       | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | <code>(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })</code>      | Override the sorting logic<br />The default sorting compare the item text value       |
-| translateWithId   | <code>let</code> | No       | <code>(id: any) => string</code>                                                               | --                                                                                  | Override the default translation ids                                                  |
+| translateWithId   | <code>let</code> | No       | <code>(id: any) => string</code>                                                               | <code>undefined</code>                                                              | Override the default translation ids                                                  |
 | titleText         | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the title text                                                                |
 | useTitleInItem    | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to pass the item to `itemToString` in the checkbox                      |
 | invalid           | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to indicate an invalid state                                            |
@@ -2164,7 +2164,7 @@ export interface MultiSelectItem {
 | helperText        | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the helper text                                                               |
 | label             | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the list box label                                                            |
 | id                | <code>let</code> | No       | <code>string</code>                                                                            | <code>"ccs-" + Math.random().toString(36)</code>                                    | Set an id for the list box component                                                  |
-| name              | <code>let</code> | No       | <code>string</code>                                                                            | --                                                                                  | Specify a name attribute for the select                                               |
+| name              | <code>let</code> | No       | <code>string</code>                                                                            | <code>undefined</code>                                                              | Specify a name attribute for the select                                               |
 
 ### Slots
 
@@ -2208,8 +2208,8 @@ None.
 | Prop name        | Kind             | Reactive | Type                                                         | Default value             | Description                                           |
 | :--------------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------------- | ----------------------------------------------------- |
 | notificationType | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                         | <code>"toast"</code>      | Set the type of notification                          |
-| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                        | Specify the icon from `carbon-icons-svelte` to render |
-| title            | <code>let</code> | No       | <code>string</code>                                          | --                        | Specify the title of the icon                         |
+| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>    | Specify the icon from `carbon-icons-svelte` to render |
+| title            | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>    | Specify the title of the icon                         |
 | iconDescription  | <code>let</code> | No       | <code>string</code>                                          | <code>"Close icon"</code> | Specify the ARIA label for the icon                   |
 
 ### Slots
@@ -2278,10 +2278,10 @@ export type NumberInputTranslationId = "increment" | "decrement";
 | :-------------- | :----------------- | :------- | :-------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
 | ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element   |
 | value           | <code>let</code>   | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                                  | Specify the input value                        |
-| size            | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | --                                                               | Set the size of the input                      |
+| size            | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                      |
 | step            | <code>let</code>   | No       | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                     |
-| max             | <code>let</code>   | No       | <code>number</code>                                             | --                                                               | Specify the maximum value                      |
-| min             | <code>let</code>   | No       | <code>number</code>                                             | --                                                               | Specify the minimum value                      |
+| max             | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                      |
+| min             | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                      |
 | light           | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant      |
 | readonly        | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only    |
 | mobile          | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the mobile variant     |
@@ -2298,7 +2298,7 @@ export type NumberInputTranslationId = "increment" | "decrement";
 | translateWithId | <code>let</code>   | No       | <code>(id: NumberInputTranslationId) => string</code>           | <code>(id) => defaultTranslations[id]</code>                     | Override the default translation ids           |
 | translationIds  | <code>const</code> | No       | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                        |
 | id              | <code>let</code>   | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code>                 | Set an id for the input element                |
-| name            | <code>let</code>   | No       | <code>string</code>                                             | --                                                               | Specify a name attribute for the input         |
+| name            | <code>let</code>   | No       | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input         |
 
 ### Slots
 
@@ -2392,13 +2392,13 @@ None.
 | menuRef          | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>                    | <code>null</code>                                | Obtain a reference to the overflow menu element                   |
 | buttonRef        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>                                | Obtain a reference to the trigger button element                  |
 | open             | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to open the menu                                    |
-| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                | --                                               | Specify the size of the overflow menu                             |
+| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                | <code>undefined</code>                           | Specify the size of the overflow menu                             |
 | direction        | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                           | <code>"bottom"</code>                            | Specify the direction of the overflow menu relative to the button |
 | light            | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to enable the light variant                         |
 | flipped          | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to flip the menu relative to the button             |
-| menuOptionsClass | <code>let</code> | No       | <code>string</code>                                          | --                                               | Specify the menu options class                                    |
-| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                                               | Specify the icon from `carbon-icons-svelte` to render             |
-| iconClass        | <code>let</code> | No       | <code>string</code>                                          | --                                               | Specify the icon class                                            |
+| menuOptionsClass | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                           | Specify the menu options class                                    |
+| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render             |
+| iconClass        | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                           | Specify the icon class                                            |
 | iconDescription  | <code>let</code> | No       | <code>string</code>                                          | <code>"Open and close list of options"</code>    | Specify the ARIA label for the icon                               |
 | id               | <code>let</code> | No       | <code>string</code>                                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                  |
 
@@ -2535,7 +2535,7 @@ None.
 | ref               | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                | Obtain a reference to the input HTML element          |
 | type              | <code>let</code> | Yes      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                          | Set to `"text"` to toggle the password visibility     |
 | value             | <code>let</code> | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                  | Specify the input value                               |
-| size              | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | --                                               | Set the size of the input                             |
+| size              | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                           | Set the size of the input                             |
 | placeholder       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the placeholder text                          |
 | hidePasswordLabel | <code>let</code> | No       | <code>string</code>                                             | <code>"Hide password"</code>                     | Specify the hide password label text                  |
 | showPasswordLabel | <code>let</code> | No       | <code>string</code>                                             | <code>"Show password"</code>                     | Specify the show password label text                  |
@@ -2549,7 +2549,7 @@ None.
 | invalid           | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an invalid state            |
 | invalidText       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the text for the invalid state                |
 | id                | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                       |
-| name              | <code>let</code> | No       | <code>string</code>                                             | --                                               | Specify a name attribute for the input                |
+| name              | <code>let</code> | No       | <code>string</code>                                             | <code>undefined</code>                           | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -2681,11 +2681,11 @@ None.
 
 | Prop name     | Kind             | Reactive | Type                                        | Default value             | Description                                  |
 | :------------ | :--------------- | :------- | :------------------------------------------ | ------------------------- | -------------------------------------------- |
-| selected      | <code>let</code> | Yes      | <code>string</code>                         | --                        | Set the selected radio button value          |
+| selected      | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
 | disabled      | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
 | labelPosition | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
 | orientation   | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
-| id            | <code>let</code> | No       | <code>string</code>                         | --                        | Set an id for the container div element      |
+| id            | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
 
 ### Slots
 
@@ -2846,13 +2846,13 @@ None.
 | Prop name   | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
 | :---------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
 | ref         | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
-| selected    | <code>let</code> | Yes      | <code>string</code>                        | --                                               | Specify the selected item value                 |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | --                                               | Set the size of the select input                |
+| selected    | <code>let</code> | Yes      | <code>string</code>                        | <code>undefined</code>                           | Specify the selected item value                 |
+| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                           | Set the size of the select input                |
 | inline      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to use the inline variant         |
 | light       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant       |
 | disabled    | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select element     |
 | id          | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
-| name        | <code>let</code> | No       | <code>string</code>                        | --                                               | Specify a name attribute for the select element |
+| name        | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
 | invalid     | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an invalid state      |
 | invalidText | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the invalid state text                  |
 | helperText  | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the helper text                         |
@@ -2968,11 +2968,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                                |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------------ |
-| isOpen    | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code> | Set to `true` to toggle the expanded state |
-| fixed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fixed variant     |
-| ariaLabel | <code>let</code> | No       | <code>string</code>  | --                 | Specify the ARIA label for the nav         |
+| Prop name | Kind             | Reactive | Type                 | Default value          | Description                                |
+| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ------------------------------------------ |
+| isOpen    | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state |
+| fixed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant     |
+| ariaLabel | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav         |
 
 ### Slots
 
@@ -3004,13 +3004,13 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                         | Default value      | Description                                           |
-| :--------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------ | ----------------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>  | Obtain a reference to the HTML anchor element         |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code> | Set to `true` to select the current link              |
-| href       | <code>let</code> | No       | <code>string</code>                                          | --                 | Specify the `href` attribute                          |
-| text       | <code>let</code> | No       | <code>string</code>                                          | --                 | Specify the text                                      |
-| icon       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                 | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name  | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :--------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
+| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
+| isSelected | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to select the current link              |
+| href       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
+| text       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
+| icon       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -3026,12 +3026,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                         | Default value      | Description                                           |
-| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------ | ----------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>  | Obtain a reference to the HTML button element         |
-| expanded  | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code> | Set to `true` to toggle the expanded state            |
-| text      | <code>let</code> | No       | <code>string</code>                                          | --                 | Specify the text                                      |
-| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | --                 | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
+| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element         |
+| expanded  | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to toggle the expanded state            |
+| text      | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
+| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -3049,12 +3049,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                       | Default value     | Description                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                       | --                | Set to `true` to select the item              |
-| href       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the item text                         |
+| Prop name  | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :--------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| isSelected | <code>let</code> | No       | <code>boolean</code>                       | <code>undefined</code> | Set to `true` to select the item              |
+| href       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
 
 ### Slots
 
@@ -3193,11 +3193,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                                    |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------- |
-| selected  | <code>let</code> | Yes      | <code>string</code>  | --                 | Specify the selected structured list row value |
-| border    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the bordered variant      |
-| selection | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the selection variant     |
+| Prop name | Kind             | Reactive | Type                 | Default value          | Description                                    |
+| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------- |
+| selected  | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
+| border    | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the bordered variant      |
+| selection | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
 
 ### Slots
 
@@ -3428,14 +3428,14 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                | Default value      | Description                             |
-| :--------------- | :--------------- | :------- | :-------------------------------------------------- | ------------------ | --------------------------------------- |
-| size             | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | --                 | Set the size of the table               |
-| zebra            | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to use zebra styles       |
-| useStaticWidth   | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to use static width       |
-| shouldShowBorder | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` for the bordered variant  |
-| sortable         | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` for the sortable variant  |
-| stickyHeader     | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code> | Set to `true` to enable a sticky header |
+| Prop name        | Kind             | Reactive | Type                                                | Default value          | Description                             |
+| :--------------- | :--------------- | :------- | :-------------------------------------------------- | ---------------------- | --------------------------------------- |
+| size             | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table               |
+| zebra            | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles       |
+| useStaticWidth   | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use static width       |
+| shouldShowBorder | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the bordered variant  |
+| sortable         | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant  |
+| stickyHeader     | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header |
 
 ### Slots
 
@@ -3624,12 +3624,12 @@ None.
 
 | Prop name | Kind             | Reactive | Type                                                                                                                                                                                    | Default value                                    | Description                                            |
 | :-------- | :--------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
-| type      | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast"</code> | --                                               | Specify the type of tag                                |
+| type      | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast"</code> | <code>undefined</code>                           | Specify the type of tag                                |
 | filter    | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to use filterable variant                |
 | disabled  | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to disable a filterable tag              |
 | skeleton  | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to display the skeleton state            |
 | title     | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"Clear filter"</code>                      | Set the title for the close button in a filterable tag |
-| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                                                                            | --                                               | Specify the icon from `carbon-icons-svelte` to render  |
+| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                                                                            | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render  |
 | id        | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the filterable tag                       |
 
 ### Slots
@@ -3686,7 +3686,7 @@ None.
 | invalid     | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an invalid state      |
 | invalidText | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the text for the invalid state          |
 | id          | <code>let</code> | No       | <code>string</code>                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the textarea element              |
-| name        | <code>let</code> | No       | <code>string</code>                          | --                                               | Specify a name attribute for the input          |
+| name        | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                           | Specify a name attribute for the input          |
 
 ### Slots
 
@@ -3734,14 +3734,14 @@ None.
 | :---------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
 | ref         | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element  |
 | value       | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>                                  | Specify the input value                       |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | --                                               | Set the size of the input                     |
+| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                     |
 | type        | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input type                        |
 | placeholder | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the placeholder text                  |
 | light       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant     |
 | disabled    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input            |
 | helperText  | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the helper text                       |
 | id          | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element               |
-| name        | <code>let</code> | No       | <code>string</code>                       | --                                               | Specify a name attribute for the input        |
+| name        | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify a name attribute for the input        |
 | labelText   | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                        |
 | hideLabel   | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text |
 | invalid     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state    |
@@ -3817,11 +3817,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------- |
-| selected  | <code>let</code> | Yes      | <code>string</code>  | --                 | Specify the selected tile value         |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the tile group |
-| legend    | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the legend text                 |
+| Prop name | Kind             | Reactive | Type                 | Default value          | Description                             |
+| :-------- | :--------------- | :------- | :------------------- | ---------------------- | --------------------------------------- |
+| selected  | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
+| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
+| legend    | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
 
 ### Slots
 
@@ -3843,7 +3843,7 @@ None.
 | :---------- | :--------------- | :------- | :---------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
 | ref         | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
 | value       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | --                                                  | Specify the size of the input                         |
+| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
 | type        | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
 | placeholder | <code>let</code> | No       | <code>string</code>                       | <code>"hh=mm"</code>                                | Specify the input placeholder text                    |
 | pattern     | <code>let</code> | No       | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
@@ -3855,7 +3855,7 @@ None.
 | invalid     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
 | invalidText | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
 | id          | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code>    | Set an id for the input element                       |
-| name        | <code>let</code> | No       | <code>string</code>                       | --                                                  | Specify a name attribute for the input                |
+| name        | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -3889,7 +3889,7 @@ None.
 | labelText       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
 | hideLabel       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>                                | --                                              |
 | id              | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
-| name            | <code>let</code> | No       | <code>string</code>                        | --                                               | Specify a name attribute for the select element |
+| name            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
 
 ### Slots
 
@@ -3951,7 +3951,7 @@ None.
 | labelB    | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
 | labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
 | id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name      | <code>let</code> | No       | <code>string</code>                | --                                               | Specify a name attribute for the checkbox input |
+| name      | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -4006,7 +4006,7 @@ None.
 | labelB    | <code>let</code> | No       | <code>string</code>  | <code>"On"</code>                                | Specify the label for the toggled state         |
 | labelText | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the label text                          |
 | id        | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name      | <code>let</code> | No       | <code>string</code>  | --                                               | Specify a name attribute for the checkbox input |
+| name      | <code>let</code> | No       | <code>string</code>  | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -4172,7 +4172,7 @@ None.
 | align           | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                                                                              |
 | direction       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the button                                                                            |
 | hideIcon        | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to hide the tooltip icon                                                                                             |
-| icon            | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>    | --                                               | Specify the icon from `carbon-icons-svelte` to render for the tooltip button<br />Icon size must be 16px (e.g., `Add16`, `Task16`) |
+| icon            | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>    | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render for the tooltip button<br />Icon size must be 16px (e.g., `Add16`, `Task16`) |
 | iconDescription | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the ARIA label for the tooltip button                                                                                      |
 | iconName        | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the icon name attribute                                                                                                    |
 | tabindex        | <code>let</code> | No       | <code>string</code>                                             | <code>"0"</code>                                 | Set the button tabindex                                                                                                            |

--- a/integration/carbon/types/Accordion/Accordion.svelte.d.ts
+++ b/integration/carbon/types/Accordion/Accordion.svelte.d.ts
@@ -11,6 +11,7 @@ export interface AccordionProps extends AccordionSkeletonProps {
 
   /**
    * Specify the size of the accordion
+   * @default undefined
    */
   size?: "sm" | "xl";
 

--- a/integration/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -17,6 +17,7 @@ export interface AccordionSkeletonProps
 
   /**
    * Specify the size of the accordion
+   * @default undefined
    */
   size?: "sm" | "xl";
 

--- a/integration/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/integration/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -5,6 +5,7 @@ export interface BreadcrumbItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
   /**
    * Set the `href` to use an anchor link
+   * @default undefined
    */
   href?: string;
 

--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -34,11 +34,13 @@ export interface ButtonProps
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 
   /**
    * Specify the ARIA label for the button icon
+   * @default undefined
    */
   iconDescription?: string;
 
@@ -76,6 +78,7 @@ export interface ButtonProps
 
   /**
    * Set the `href` to use an anchor link
+   * @default undefined
    */
   href?: string;
 

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -5,6 +5,7 @@ export interface ButtonSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
    * Set the `href` to use an anchor link
+   * @default undefined
    */
   href?: string;
 

--- a/integration/carbon/types/Checkbox/Checkbox.svelte.d.ts
+++ b/integration/carbon/types/Checkbox/Checkbox.svelte.d.ts
@@ -52,6 +52,7 @@ export interface CheckboxProps {
 
   /**
    * Specify the title attribute for the label element
+   * @default undefined
    */
   title?: string;
 

--- a/integration/carbon/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/integration/carbon/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -11,6 +11,7 @@ export interface CodeSnippetProps {
   /**
    * Set the code snippet text
    * Alternatively, use the default slot (e.g., <CodeSnippet>{`code`}</CodeSnippet>)
+   * @default undefined
    */
   code?: string;
 
@@ -54,11 +55,13 @@ export interface CodeSnippetProps {
 
   /**
    * Specify the ARIA label for the copy button icon
+   * @default undefined
    */
   copyButtonDescription?: string;
 
   /**
    * Specify the ARIA label of the copy button
+   * @default undefined
    */
   copyLabel?: string;
 

--- a/integration/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/integration/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -34,6 +34,7 @@ export interface ComboBoxProps
 
   /**
    * Set the size of the combobox
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -93,6 +94,7 @@ export interface ComboBoxProps
 
   /**
    * Override the default translation ids
+   * @default undefined
    */
   translateWithId?: (id: any) => string;
 
@@ -104,6 +106,7 @@ export interface ComboBoxProps
 
   /**
    * Specify a name attribute for the input
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -5,6 +5,7 @@ export interface ComposedModalProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Set the size of the composed modal
+   * @default undefined
    */
   size?: "xs" | "sm" | "lg";
 

--- a/integration/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -17,6 +17,7 @@ export interface ModalFooterProps
 
   /**
    * Specify a class for the primary button
+   * @default undefined
    */
   primaryClass?: string;
 
@@ -28,6 +29,7 @@ export interface ModalFooterProps
 
   /**
    * Specify a class for the secondary button
+   * @default undefined
    */
   secondaryClass?: string;
 

--- a/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -17,6 +17,7 @@ export interface ContentSwitcherProps
 
   /**
    * Specify the size of the content switcher
+   * @default undefined
    */
   size?: "sm" | "xl";
 }

--- a/integration/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/integration/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -51,6 +51,7 @@ export interface DataTableProps {
 
   /**
    * Set the size of the data table
+   * @default undefined
    */
   size?: "compact" | "short" | "tall";
 

--- a/integration/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/integration/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -20,6 +20,7 @@ export interface DataTableSkeletonProps
 
   /**
    * Set the size of the data table
+   * @default undefined
    */
   size?: "compact" | "short" | "tall";
 

--- a/integration/carbon/types/DataTable/Table.svelte.d.ts
+++ b/integration/carbon/types/DataTable/Table.svelte.d.ts
@@ -5,6 +5,7 @@ export interface TableProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {
   /**
    * Set the size of the table
+   * @default undefined
    */
   size?: "compact" | "short" | "tall";
 

--- a/integration/carbon/types/DatePicker/DatePicker.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePicker.svelte.d.ts
@@ -17,6 +17,7 @@ export interface DatePickerProps
 
   /**
    * Specify the element to append the calendar to
+   * @default undefined
    */
   appendTo?: HTMLElement;
 

--- a/integration/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -5,6 +5,7 @@ export interface DatePickerInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Set the size of the input
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -70,6 +71,7 @@ export interface DatePickerInputProps
 
   /**
    * Set a name for the input element
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -38,6 +38,7 @@ export interface DropdownProps
 
   /**
    * Specify the size of the dropdown field
+   * @default undefined
    */
   size?: "sm" | "lg" | "xl";
 
@@ -103,11 +104,13 @@ export interface DropdownProps
 
   /**
    * Specify the list box label
+   * @default undefined
    */
   label?: string;
 
   /**
    * Override the default translation ids
+   * @default undefined
    */
   translateWithId?: (id: any) => string;
 
@@ -119,6 +122,7 @@ export interface DropdownProps
 
   /**
    * Specify a name attribute for the list box
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/Grid/Column.svelte.d.ts
+++ b/integration/carbon/types/Grid/Column.svelte.d.ts
@@ -45,31 +45,37 @@ export interface ColumnProps
 
   /**
    * Specify the aspect ratio of the column
+   * @default undefined
    */
   aspectRatio?: "2x1" | "16x9" | "9x16" | "1x2" | "4x3" | "3x4" | "1x1";
 
   /**
    * Set the small breakpoint
+   * @default undefined
    */
   sm?: ColumnBreakpoint;
 
   /**
    * Set the medium breakpoint
+   * @default undefined
    */
   md?: ColumnBreakpoint;
 
   /**
    * Set the large breakpoint
+   * @default undefined
    */
   lg?: ColumnBreakpoint;
 
   /**
    * Set the extra large breakpoint
+   * @default undefined
    */
   xlg?: ColumnBreakpoint;
 
   /**
    * Set the maximum breakpoint
+   * @default undefined
    */
   max?: ColumnBreakpoint;
 }

--- a/integration/carbon/types/Icon/Icon.svelte.d.ts
+++ b/integration/carbon/types/Icon/Icon.svelte.d.ts
@@ -7,6 +7,7 @@ export interface IconProps
     svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]> {
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   render?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/integration/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -11,11 +11,13 @@ export interface InlineLoadingProps
 
   /**
    * Set the loading description
+   * @default undefined
    */
   description?: string;
 
   /**
    * Specify the ARIA label for the loading icon
+   * @default undefined
    */
   iconDescription?: string;
 

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -5,11 +5,13 @@ export interface LinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
   /**
    * Specify the size of the link
+   * @default undefined
    */
   size?: "sm" | "lg";
 
   /**
    * Specify the href value
+   * @default undefined
    */
   href?: string;
 

--- a/integration/carbon/types/ListBox/ListBox.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBox.svelte.d.ts
@@ -5,6 +5,7 @@ export interface ListBoxProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Set the size of the list box
+   * @default undefined
    */
   size?: "sm" | "xl";
 

--- a/integration/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -7,6 +7,7 @@ export interface ListBoxSelectionProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Specify the number of selected items
+   * @default undefined
    */
   selectionCount?: any;
 

--- a/integration/carbon/types/Modal/Modal.svelte.d.ts
+++ b/integration/carbon/types/Modal/Modal.svelte.d.ts
@@ -5,6 +5,7 @@ export interface ModalProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Set the size of the modal
+   * @default undefined
    */
   size?: "xs" | "sm" | "lg";
 
@@ -34,16 +35,19 @@ export interface ModalProps
 
   /**
    * Specify the modal heading
+   * @default undefined
    */
   modalHeading?: string;
 
   /**
    * Specify the modal label
+   * @default undefined
    */
   modalLabel?: string;
 
   /**
    * Specify the ARIA label for the modal
+   * @default undefined
    */
   modalAriaLabel?: string;
 

--- a/integration/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/integration/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -38,6 +38,7 @@ export interface MultiSelectProps
 
   /**
    * Set the size of the combobox
+   * @default undefined
    */
   size?: "sm" | "lg" | "xl";
 
@@ -107,6 +108,7 @@ export interface MultiSelectProps
 
   /**
    * Override the default translation ids
+   * @default undefined
    */
   translateWithId?: (id: any) => string;
 
@@ -166,6 +168,7 @@ export interface MultiSelectProps
 
   /**
    * Specify a name attribute for the select
+   * @default undefined
    */
   name?: string;
 }

--- a/integration/carbon/types/Notification/NotificationButton.svelte.d.ts
+++ b/integration/carbon/types/Notification/NotificationButton.svelte.d.ts
@@ -11,11 +11,13 @@ export interface NotificationButtonProps
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 
   /**
    * Specify the title of the icon
+   * @default undefined
    */
   title?: string;
 

--- a/integration/carbon/types/NumberInput/NumberInput.svelte.d.ts
+++ b/integration/carbon/types/NumberInput/NumberInput.svelte.d.ts
@@ -7,6 +7,7 @@ export interface NumberInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Set the size of the input
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -24,11 +25,13 @@ export interface NumberInputProps
 
   /**
    * Specify the maximum value
+   * @default undefined
    */
   max?: number;
 
   /**
    * Specify the minimum value
+   * @default undefined
    */
   min?: number;
 
@@ -124,6 +127,7 @@ export interface NumberInputProps
 
   /**
    * Specify a name attribute for the input
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/integration/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -5,6 +5,7 @@ export interface OverflowMenuProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
    * Specify the size of the overflow menu
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -34,16 +35,19 @@ export interface OverflowMenuProps
 
   /**
    * Specify the menu options class
+   * @default undefined
    */
   menuOptionsClass?: string;
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 
   /**
    * Specify the icon class
+   * @default undefined
    */
   iconClass?: string;
 

--- a/integration/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/integration/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -5,6 +5,7 @@ export interface RadioButtonGroupProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Set the selected radio button value
+   * @default undefined
    */
   selected?: string;
 
@@ -28,6 +29,7 @@ export interface RadioButtonGroupProps
 
   /**
    * Set an id for the container div element
+   * @default undefined
    */
   id?: string;
 }

--- a/integration/carbon/types/Select/Select.svelte.d.ts
+++ b/integration/carbon/types/Select/Select.svelte.d.ts
@@ -5,11 +5,13 @@ export interface SelectProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Specify the selected item value
+   * @default undefined
    */
   selected?: string;
 
   /**
    * Set the size of the select input
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -39,6 +41,7 @@ export interface SelectProps
 
   /**
    * Specify a name attribute for the select element
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/StructuredList/StructuredList.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredList.svelte.d.ts
@@ -5,6 +5,7 @@ export interface StructuredListProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Specify the selected structured list row value
+   * @default undefined
    */
   selected?: string;
 

--- a/integration/carbon/types/Tag/Tag.svelte.d.ts
+++ b/integration/carbon/types/Tag/Tag.svelte.d.ts
@@ -6,6 +6,7 @@ export interface TagProps
     svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
   /**
    * Specify the type of tag
+   * @default undefined
    */
   type?:
     | "red"
@@ -46,6 +47,7 @@ export interface TagProps
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/TextArea/TextArea.svelte.d.ts
+++ b/integration/carbon/types/TextArea/TextArea.svelte.d.ts
@@ -77,6 +77,7 @@ export interface TextAreaProps
 
   /**
    * Specify a name attribute for the input
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/TextInput/PasswordInput.svelte.d.ts
+++ b/integration/carbon/types/TextInput/PasswordInput.svelte.d.ts
@@ -5,6 +5,7 @@ export interface PasswordInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
   /**
    * Set the size of the input
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -100,6 +101,7 @@ export interface PasswordInputProps
 
   /**
    * Specify a name attribute for the input
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/TextInput/TextInput.svelte.d.ts
+++ b/integration/carbon/types/TextInput/TextInput.svelte.d.ts
@@ -5,6 +5,7 @@ export interface TextInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
   /**
    * Set the size of the input
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -52,6 +53,7 @@ export interface TextInputProps
 
   /**
    * Specify a name attribute for the input
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -17,6 +17,7 @@ export interface ClickableTileProps
 
   /**
    * Set the `href`
+   * @default undefined
    */
   href?: string;
 }

--- a/integration/carbon/types/Tile/TileGroup.svelte.d.ts
+++ b/integration/carbon/types/Tile/TileGroup.svelte.d.ts
@@ -5,6 +5,7 @@ export interface TileGroupProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {
   /**
    * Specify the selected tile value
+   * @default undefined
    */
   selected?: string;
 

--- a/integration/carbon/types/TimePicker/TimePicker.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePicker.svelte.d.ts
@@ -5,6 +5,7 @@ export interface TimePickerProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Specify the size of the input
+   * @default undefined
    */
   size?: "sm" | "xl";
 
@@ -82,6 +83,7 @@ export interface TimePickerProps
 
   /**
    * Specify a name attribute for the input
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -40,6 +40,7 @@ export interface TimePickerSelectProps
 
   /**
    * Specify a name attribute for the select element
+   * @default undefined
    */
   name?: string;
 

--- a/integration/carbon/types/Toggle/Toggle.svelte.d.ts
+++ b/integration/carbon/types/Toggle/Toggle.svelte.d.ts
@@ -47,6 +47,7 @@ export interface ToggleProps
 
   /**
    * Specify a name attribute for the checkbox input
+   * @default undefined
    */
   name?: string;
 }

--- a/integration/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
+++ b/integration/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
@@ -41,6 +41,7 @@ export interface ToggleSmallProps
 
   /**
    * Specify a name attribute for the checkbox input
+   * @default undefined
    */
   name?: string;
 }

--- a/integration/carbon/types/Tooltip/Tooltip.svelte.d.ts
+++ b/integration/carbon/types/Tooltip/Tooltip.svelte.d.ts
@@ -30,6 +30,7 @@ export interface TooltipProps
   /**
    * Specify the icon from `carbon-icons-svelte` to render for the tooltip button
    * Icon size must be 16px (e.g., `Add16`, `Task16`)
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -17,16 +17,19 @@ export interface HeaderProps
 
   /**
    * Specify the ARIA label for the header
+   * @default undefined
    */
   uiShellAriaLabel?: string;
 
   /**
    * Specify the `href` attribute
+   * @default undefined
    */
   href?: string;
 
   /**
    * Specify the company name
+   * @default undefined
    */
   company?: string;
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -17,12 +17,14 @@ export interface HeaderActionProps
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 
   /**
    * Specify the text
    * Alternatively, use the named slot "text" (e.g., <div slot="text">...</div>)
+   * @default undefined
    */
   text?: string;
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -11,11 +11,13 @@ export interface HeaderActionLinkProps
 
   /**
    * Specify the `href` attribute
+   * @default undefined
    */
   href?: string;
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
@@ -5,6 +5,7 @@ export interface HeaderNavProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
   /**
    * Specify the ARIA label for the nav
+   * @default undefined
    */
   ariaLabel?: string;
 }

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -5,11 +5,13 @@ export interface HeaderNavItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
    * Specify the `href` attribute
+   * @default undefined
    */
   href?: string;
 
   /**
    * Specify the text
+   * @default undefined
    */
   text?: string;
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -17,6 +17,7 @@ export interface HeaderNavMenuProps
 
   /**
    * Specify the text
+   * @default undefined
    */
   text?: string;
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -5,6 +5,7 @@ export interface HeaderPanelLinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
    * Specify the `href` attribute
+   * @default undefined
    */
   href?: string;
 

--- a/integration/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/integration/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -11,6 +11,7 @@ export interface HeaderGlobalActionProps
 
   /**
    * Specify the icon to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
@@ -11,6 +11,7 @@ export interface SideNavProps
 
   /**
    * Specify the ARIA label for the nav
+   * @default undefined
    */
   ariaLabel?: string;
 

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -11,16 +11,19 @@ export interface SideNavLinkProps
 
   /**
    * Specify the `href` attribute
+   * @default undefined
    */
   href?: string;
 
   /**
    * Specify the text
+   * @default undefined
    */
   text?: string;
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
@@ -11,11 +11,13 @@ export interface SideNavMenuProps
 
   /**
    * Specify the text
+   * @default undefined
    */
   text?: string;
 
   /**
    * Specify the icon from `carbon-icons-svelte` to render
+   * @default undefined
    */
   icon?: typeof import("carbon-icons-svelte").CarbonIcon;
 

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -5,16 +5,19 @@ export interface SideNavMenuItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
    * Set to `true` to select the item
+   * @default undefined
    */
   isSelected?: boolean;
 
   /**
    * Specify the `href` attribute
+   * @default undefined
    */
   href?: string;
 
   /**
    * Specify the item text
+   * @default undefined
    */
   text?: string;
 

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -18,7 +18,7 @@ function escapeHtml(text: string) {
 }
 
 function formatPropValue(value: any) {
-  if (value === undefined) return MD_TYPE_UNDEFINED;
+  if (value === undefined) return `<code>${value}</code>`;
   return `<code>${value.replace(/`/g, "\\`").replace(/\|/g, "&#124;")}</code>`;
 }
 

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -52,8 +52,6 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
         .filter(Boolean)
         .join("");
 
-      console.log(prop_comments);
-
       let prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
 
       return `

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -34,16 +34,25 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
   const props = def.props
     .filter((prop) => !prop.isFunctionDeclaration && prop.kind !== "const")
     .map((prop) => {
+      let defaultValue = prop.value;
+
+      if (typeof prop.value === "string") {
+        defaultValue = prop.value.replace(/\s+/g, " ");
+      }
+
+      if (prop.value === undefined) {
+        defaultValue = "undefined";
+      }
+
       const prop_comments = [
         addCommentLine(prop.description?.replace(/\n/g, "\n* ")),
         addCommentLine(prop.constant, "@constant"),
-        addCommentLine(
-          prop.value,
-          `@default ${typeof prop.value === "string" ? prop.value.replace(/\s+/g, " ") : prop.value}`
-        ),
+        `* @default ${defaultValue}\n`,
       ]
         .filter(Boolean)
         .join("");
+
+      console.log(prop_comments);
 
       let prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
 

--- a/tests/snapshots/bind-this-multiple/output.d.ts
+++ b/tests/snapshots/bind-this-multiple/output.d.ts
@@ -2,8 +2,14 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
+  /**
+   * @default undefined
+   */
   ref?: null | HTMLButtonElement | HTMLHeadingElement;
 
+  /**
+   * @default undefined
+   */
   ref2?: null | HTMLDivElement;
 
   /**

--- a/tests/snapshots/bind-this/output.d.ts
+++ b/tests/snapshots/bind-this/output.d.ts
@@ -2,6 +2,9 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
+  /**
+   * @default undefined
+   */
   ref?: null | HTMLButtonElement;
 }
 

--- a/tests/snapshots/infer-basic/output.d.ts
+++ b/tests/snapshots/infer-basic/output.d.ts
@@ -17,6 +17,9 @@ export interface InputProps {
    */
   propString?: string;
 
+  /**
+   * @default undefined
+   */
   name?: undefined;
 
   /**

--- a/tests/snapshots/infer-with-types/output.d.ts
+++ b/tests/snapshots/infer-with-types/output.d.ts
@@ -12,6 +12,9 @@ export interface InputProps {
    */
   propString?: string;
 
+  /**
+   * @default undefined
+   */
   name?: string;
 
   /**

--- a/tests/snapshots/typed-props/output.d.ts
+++ b/tests/snapshots/typed-props/output.d.ts
@@ -5,6 +5,7 @@ export interface InputProps {
   /**
    * prop1 description 1
    * prop1 description 2
+   * @default undefined
    */
   prop1?: string;
 

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -104,7 +104,7 @@ test("writeTsDefinition", (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n  \n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      /**\n* @default undefined\n*/\n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n  \n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
   );
   t.end();
 });


### PR DESCRIPTION
Currently, exported props that are `undefined` by default do not have a corresponding `@default` comment in the generated TypeScript definition.

**Input**

```svelte
<script>
  /** @type {boolean} */
  export let prop;
</script>
```

**Current output**

```ts
export interface InputProps {
  prop?: boolean;
}
```

**Expected output**

```diff
export interface InputProps {
+  /**
+   * @default undefined
+   */
  ref?: null | HTMLElement;
}
```

**Fixes**

- specify `@default undefined` for undefined prop values in TypeScript definitions
- use `<code>undefined</code>` instead of `--` for undefined default values in Markdown