### PR TITLE
feat: export `sveld` for programmatic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ yarn add -D sveld
 npm i -D sveld
 ```
 
-### Set-up with Rollup
+### Rollup
 
 Import and add `sveld` as a plugin to your `rollup.config.js`.
 
@@ -194,9 +194,35 @@ Append `--json` or `--markdown` flags to generate documentation in JSON/Markdown
 npx sveld --json --markdown
 ```
 
+### Node.js
+
+You can also use sveld programmatically in Node.js.
+
+Note: sveld will still determine the entry point using the `svelte` field in your `package.json`.
+
+```js
+const { sveld } = require("sveld");
+const pkg = require("./package.json");
+
+sveld({
+  glob: true,
+  markdown: true,
+  markdownOptions: {
+    onAppend: (type, document, components) => {
+      if (type === "h1")
+        document.append("quote", `${components.size} components exported from ${pkg.name}@${pkg.version}.`);
+    },
+  },
+  json: true,
+  jsonOptions: {
+    outFile: "docs/src/COMPONENT_API.json",
+  },
+});
+```
+
 ### Publishing to NPM
 
-Specify the entry point for the TypeScript definitions in your `package.json`.
+TypeScript definitions are outputted to the `types` folder by default. Don't forget to include the folder in your `package.json` when publishing the package to NPM.
 
 ```diff
 {

--- a/README.md
+++ b/README.md
@@ -196,15 +196,16 @@ npx sveld --json --markdown
 
 ### Node.js
 
-You can also use sveld programmatically in Node.js.
+You can also use `sveld` programmatically in Node.js.
 
-Note: sveld will still determine the entry point using the `svelte` field in your `package.json`.
+If no `input` is specified, `sveld` will infer the entry point based on the `package.json#svelte` field.
 
 ```js
 const { sveld } = require("sveld");
 const pkg = require("./package.json");
 
 sveld({
+  input: "./src/index.js",
   glob: true,
   markdown: true,
   markdownOptions: {

--- a/src/get-svelte-entry.ts
+++ b/src/get-svelte-entry.ts
@@ -4,10 +4,21 @@ import * as path from "path";
 export type SvelteEntryPoint = string;
 
 /**
- * Get the file path entrypoint for uncompiled Svelte source code
+ * Get the file path entry point for uncompiled Svelte source code
  * Expects a "svelte" field in the consumer's `package.json`
  */
-export function getSvelteEntry(): SvelteEntryPoint | null {
+export function getSvelteEntry(entryPoint?: SvelteEntryPoint): SvelteEntryPoint | null {
+  if (entryPoint) {
+    const entry_path = path.join(process.cwd(), entryPoint);
+
+    if (fs.existsSync(entry_path)) {
+      return entry_path;
+    } else {
+      process.stdout.write(`Invalid entry point: ${entry_path}.\n`);
+      return null;
+    }
+  }
+
   const pkg_path = path.join(process.cwd(), "package.json");
 
   if (fs.existsSync(pkg_path)) {
@@ -15,8 +26,8 @@ export function getSvelteEntry(): SvelteEntryPoint | null {
 
     if (pkg.svelte !== undefined) return pkg.svelte;
 
-    process.stdout.write("Could not determine an entrypoint.\n");
-    process.stdout.write('Specify an entrypoint to your Svelte code in the "svelte" field of your package.json.\n');
+    process.stdout.write("Could not determine an entry point.\n");
+    process.stdout.write('Specify an entry point to your Svelte code in the "svelte" field of your package.json.\n');
     return null;
   } else {
     process.stdout.write("Could not locate a package.json file.\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./rollup-plugin";
 export { default as ComponentParser } from "./ComponentParser";
 export { cli } from "./cli";
+export { sveld } from "./sveld";

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,0 +1,9 @@
+import { getSvelteEntry } from "./get-svelte-entry";
+import { PluginSveldOptions, generateBundle, writeOutput } from "./rollup-plugin";
+
+export async function sveld(opts?: PluginSveldOptions) {
+  const input = getSvelteEntry();
+  if (input === null) return;
+  const result = await generateBundle(input, opts?.glob === true);
+  writeOutput(result, opts || {}, input);
+}

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,8 +1,17 @@
 import { getSvelteEntry } from "./get-svelte-entry";
 import { PluginSveldOptions, generateBundle, writeOutput } from "./rollup-plugin";
 
-export async function sveld(opts?: PluginSveldOptions) {
-  const input = getSvelteEntry();
+interface SveldOptions extends PluginSveldOptions {
+  /**
+   * Specify the input to the uncompiled Svelte source.
+   * If no value is provided, `sveld` will attempt to infer
+   * the entry point from the `package.json#svelte` field.
+   */
+  input?: string;
+}
+
+export async function sveld(opts?: SveldOptions) {
+  const input = getSvelteEntry(opts?.input);
   if (input === null) return;
   const result = await generateBundle(input, opts?.glob === true);
   writeOutput(result, opts || {}, input);


### PR DESCRIPTION
Closes #65 

Future work:

- allow the `input` to be passed as an option (currently, it will still use `package.json#svelte`

```js
const { sveld } = require("sveld");
const pkg = require("./package.json");

sveld({
  glob: true,
  markdown: true,
  markdownOptions: {
    onAppend: (type, document, components) => {
      if (type === "h1")
        document.append("quote", `${components.size} components exported from ${pkg.name}@${pkg.version}.`);
    },
  },
  json: true,
  jsonOptions: {
    outFile: "docs/src/COMPONENT_API.json",
  },
});
```