### PR TITLE
Docs: Customize  output directory of sveld

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export default {
 
 When building the library with Rollup, TypeScript definitions will be written to the `types` folder by default.
 
-If we want to customize the output folder of typescript definitions , we can customize the `typesOptions.outDir` of `sveld` as below. 
+Use the `typesOptions.outDir` option to customize the output folder. 
 
 For example, specify the following for the output to be emitted to the `dist` folder:
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,19 @@ export default {
 };
 ```
 
-When building the library with Rollup, TypeScript definitions will be written to the `types` folder.
+When building the library with Rollup, TypeScript definitions will be written to the `types` folder by default.
+
+If we want to customize the output folder of typescript definitions , we can customize the `typesOptions.outDir` of `sveld` as below. 
+
+For example, if we want the output to be in `dist` folder (instead of the default `types` folder), we can enter the following
+
+```diff
+sveld({
++  typesOptions: {
++    outDir: 'dist'
++  }
+})
+```
 
 The [integration](integration) folder contains example set-ups:
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ When building the library with Rollup, TypeScript definitions will be written to
 
 If we want to customize the output folder of typescript definitions , we can customize the `typesOptions.outDir` of `sveld` as below. 
 
-For example, if we want the output to be in `dist` folder (instead of the default `types` folder), we can enter the following
+For example, specify the following for the output to be emitted to the `dist` folder:
 
 ```diff
 sveld({


### PR DESCRIPTION
Add documentation changes to customize the output directory of type definitions generated by sveld