### PR TITLE
fix(ts): do not wrap `@event` detail in `CustomEvent` if type contains `CustomEvent`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   build:
     strategy:

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -101,10 +101,14 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
 }
 
 function genEventDef(def: Pick<ComponentDocApi, "events">) {
+  const createDispatchedEvent = (detail: string = ANY_TYPE) => {
+    if (/CustomEvent/.test(detail)) return detail;
+    return `CustomEvent<${detail}>`;
+  };
   return def.events
     .map((event) => {
       return `${clampKey(event.name)}: ${
-        event.type === "dispatched" ? `CustomEvent<${event.detail || ANY_TYPE}>` : `WindowEventMap["${event.name}"]`
+        event.type === "dispatched" ? createDispatchedEvent(event.detail) : `WindowEventMap["${event.name}"]`
       };`;
     })
     .join("\n");

--- a/tests/snapshots/mixed-events/input.svelte
+++ b/tests/snapshots/mixed-events/input.svelte
@@ -1,0 +1,19 @@
+<script>
+  /**
+   * @event {FocusEvent | number} custom-focus
+   * @event {FocusEvent | CustomEvent<FocusEvent>} blur
+   */
+  import { createEventDispatcher } from "svelte";
+
+  const dispatcher = createEventDispatcher();
+</script>
+
+<button
+  on:focus={(e) => {
+    dispatcher("custom-focus", e | 0);
+  }}
+  on:blur
+  on:blur={(e) => {
+    dispatcher("blur", e);
+  }}
+/>

--- a/tests/snapshots/mixed-events/output.d.ts
+++ b/tests/snapshots/mixed-events/output.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+export default class Input extends SvelteComponentTyped<
+  InputProps,
+  { ["custom-focus"]: CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
+  {}
+> {}

--- a/tests/snapshots/mixed-events/output.json
+++ b/tests/snapshots/mixed-events/output.json
@@ -1,0 +1,17 @@
+{
+  "props": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "custom-focus",
+      "detail": "FocusEvent | number"
+    },
+    {
+      "type": "dispatched",
+      "name": "blur",
+      "detail": "FocusEvent | CustomEvent<FocusEvent>"
+    }
+  ],
+  "typedefs": []
+}


### PR DESCRIPTION
Currently, generated TS definitions for `@event` always wrap the type in a `CustomEvent`.

This prevents the consumer from specifying a mixed type in the case of a forwarded/dispatched event.

```svelte
<script>
  /**
   * @event {FocusEvent | CustomEvent<FocusEvent>} blur
   */
  import { createEventDispatcher } from "svelte";

  const dispatcher = createEventDispatcher();
</script>

<button
  on:blur
  on:blur={(e) => {
    dispatcher("blur", e);
  }}
/>

```

The current output is:

```ts
CustomEvent<FocusEvent | CustomEvent<FocusEvent>>
```

The expected output should be:

```ts
FocusEvent | CustomEvent<FocusEvent>
```