### PR TITLE
fix: module exports should not be recognized as accessors

### DIFF
--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -49,6 +49,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         {
@@ -129,6 +130,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -198,6 +200,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ul" },
@@ -224,6 +227,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -256,6 +260,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         {
@@ -312,6 +317,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -355,6 +361,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -521,6 +528,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -569,6 +577,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -610,6 +619,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "a" },
@@ -745,6 +755,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "dispatched", "name": "check", "detail": "boolean" },
@@ -773,6 +784,7 @@
       "moduleName": "CheckboxSkeleton",
       "filePath": "src/Checkbox/CheckboxSkeleton.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -820,6 +832,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "a" },
@@ -1020,6 +1033,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -1070,6 +1084,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -1200,6 +1215,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -1438,6 +1454,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         {
@@ -1541,6 +1558,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -1571,6 +1589,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -1613,6 +1632,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "number" },
@@ -1662,6 +1682,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -1693,6 +1714,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Copy" },
@@ -1874,6 +1896,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -2057,6 +2080,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "table" },
@@ -2185,6 +2209,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -2342,6 +2367,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "input", "element": "input" },
@@ -2378,6 +2404,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -2609,6 +2636,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         {
@@ -2652,6 +2680,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -2788,6 +2817,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "above", "default": false, "slot_props": "{}" },
         { "name": "below", "default": false, "slot_props": "{}" }
@@ -2928,6 +2958,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "dispatched", "name": "add", "detail": "File[]" },
@@ -3072,6 +3103,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "label" },
@@ -3196,6 +3228,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "dispatched", "name": "add", "detail": "FileList" },
@@ -3291,6 +3324,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "dispatched", "name": "delete", "detail": "string" },
@@ -3305,6 +3339,7 @@
       "moduleName": "FileUploaderSkeleton",
       "filePath": "src/FileUploader/FileUploaderSkeleton.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -3353,6 +3388,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Close16" },
@@ -3365,6 +3401,7 @@
       "moduleName": "FluidForm",
       "filePath": "src/FluidForm/FluidForm.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "submit", "element": "Form" }],
       "typedefs": [],
@@ -3374,6 +3411,7 @@
       "moduleName": "Form",
       "filePath": "src/Form/Form.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "form" },
@@ -3434,6 +3472,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "fieldset" },
@@ -3448,6 +3487,7 @@
       "moduleName": "FormItem",
       "filePath": "src/FormItem/FormItem.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -3474,6 +3514,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
@@ -3577,6 +3618,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -3678,6 +3720,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -3750,6 +3793,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -3819,6 +3863,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [],
       "typedefs": [],
@@ -3840,6 +3885,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         {
@@ -3889,6 +3935,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -3916,6 +3963,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -3957,6 +4005,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "a" },
@@ -4030,6 +4079,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "a" },
@@ -4048,6 +4098,7 @@
       "moduleName": "HeaderPanelDivider",
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelDivider.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -4078,6 +4129,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
@@ -4087,6 +4139,7 @@
       "moduleName": "HeaderPanelLinks",
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelLinks.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -4151,6 +4204,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -4187,6 +4241,7 @@
       "moduleName": "HeaderUtilities",
       "filePath": "src/UIShell/GlobalHeader/HeaderUtilities.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -4217,6 +4272,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "IconSkeleton" },
@@ -4251,6 +4307,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -4308,6 +4365,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -4412,6 +4470,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         { "name": "actions", "default": false, "slot_props": "{}" }
@@ -4499,6 +4558,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "p" },
@@ -4612,6 +4672,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "div" },
@@ -4702,6 +4763,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -4747,6 +4809,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "scroll", "element": "div" }],
       "typedefs": [],
@@ -4790,6 +4853,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [{ "type": "forwarded", "name": "click", "element": "div" }],
       "typedefs": [
@@ -4828,6 +4892,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -4896,6 +4961,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [{ "type": "dispatched", "name": "clear" }],
       "typedefs": [
@@ -4911,6 +4977,7 @@
       "moduleName": "ListItem",
       "filePath": "src/ListItem/ListItem.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "li" },
@@ -4981,6 +5048,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [],
       "typedefs": [],
@@ -5196,6 +5264,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -5252,6 +5321,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -5326,6 +5396,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -5413,6 +5484,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
@@ -5706,6 +5778,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "clear", "element": "ListBoxSelection" },
@@ -5737,6 +5810,7 @@
       "moduleName": "NotificationActionButton",
       "filePath": "src/Notification/NotificationActionButton.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Button" },
@@ -5794,6 +5868,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "button" },
@@ -5842,6 +5917,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [],
       "typedefs": []
@@ -5895,6 +5971,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -6153,6 +6230,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "label",
@@ -6194,6 +6272,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -6231,6 +6310,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ol" },
@@ -6245,6 +6325,7 @@
       "moduleName": "OutboundLink",
       "filePath": "src/Link/OutboundLink.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Link" },
@@ -6389,6 +6470,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -6517,6 +6599,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -6713,6 +6796,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         {
@@ -6795,6 +6879,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         {
@@ -6820,6 +6905,7 @@
       "moduleName": "PaginationSkeleton",
       "filePath": "src/Pagination/PaginationSkeleton.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -7031,6 +7117,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -7095,6 +7182,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "number" },
@@ -7133,6 +7221,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ul" },
@@ -7236,6 +7325,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -7358,6 +7448,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [{ "type": "forwarded", "name": "change", "element": "input" }],
       "typedefs": [],
@@ -7421,6 +7512,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -7436,6 +7528,7 @@
       "moduleName": "RadioButtonSkeleton",
       "filePath": "src/RadioButton/RadioButtonSkeleton.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -7528,6 +7621,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "change", "element": "input" },
@@ -7622,6 +7716,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -7791,6 +7886,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "SearchSkeleton" },
@@ -7845,6 +7941,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8011,6 +8108,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "string" },
@@ -8068,6 +8166,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [],
       "typedefs": []
@@ -8099,6 +8198,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -8120,6 +8220,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8234,6 +8335,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
@@ -8282,6 +8384,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -8291,6 +8394,7 @@
       "moduleName": "SideNavItems",
       "filePath": "src/UIShell/SideNav/SideNavItems.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -8352,6 +8456,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
@@ -8404,6 +8509,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
@@ -8455,6 +8561,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
@@ -8464,6 +8571,7 @@
       "moduleName": "SkeletonPlaceholder",
       "filePath": "src/SkeletonPlaceholder/SkeletonPlaceholder.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8523,6 +8631,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8560,6 +8669,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -8764,6 +8874,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8791,6 +8902,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8838,6 +8950,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8853,6 +8966,7 @@
       "moduleName": "StructuredListBody",
       "filePath": "src/StructuredList/StructuredListBody.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8890,6 +9004,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8904,6 +9019,7 @@
       "moduleName": "StructuredListHead",
       "filePath": "src/StructuredList/StructuredListHead.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8985,6 +9101,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [],
       "typedefs": [],
@@ -9028,6 +9145,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
@@ -9066,6 +9184,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -9136,6 +9255,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -9225,6 +9345,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -9258,6 +9379,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -9333,6 +9455,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -9342,6 +9465,7 @@
       "moduleName": "TableBody",
       "filePath": "src/DataTable/TableBody.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -9351,6 +9475,7 @@
       "moduleName": "TableCell",
       "filePath": "src/DataTable/TableCell.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "td" },
@@ -9399,6 +9524,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -9408,6 +9534,7 @@
       "moduleName": "TableHead",
       "filePath": "src/DataTable/TableHead.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "thead" },
@@ -9456,6 +9583,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "mouseover", "element": "th" },
@@ -9470,6 +9598,7 @@
       "moduleName": "TableRow",
       "filePath": "src/DataTable/TableRow.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "tr" },
@@ -9529,6 +9658,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         { "name": "content", "default": false, "slot_props": "{}" }
@@ -9557,6 +9687,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -9647,6 +9778,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -9668,6 +9800,7 @@
       "moduleName": "TagSkeleton",
       "filePath": "src/Tag/TagSkeleton.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "span" },
@@ -9836,6 +9969,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -9866,6 +10000,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10077,6 +10212,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10108,6 +10244,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10134,6 +10271,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10181,6 +10319,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "dispatched", "name": "select" }],
       "typedefs": [],
@@ -10354,6 +10493,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10459,6 +10599,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10573,6 +10714,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         {
@@ -10680,6 +10822,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         {
@@ -10737,6 +10880,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10828,6 +10972,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10869,6 +11014,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10895,6 +11041,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -10916,6 +11063,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -10925,6 +11073,7 @@
       "moduleName": "ToolbarContent",
       "filePath": "src/DataTable/ToolbarContent.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -10933,6 +11082,7 @@
       "moduleName": "ToolbarMenu",
       "filePath": "src/DataTable/ToolbarMenu.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
@@ -10946,6 +11096,7 @@
       "moduleName": "ToolbarMenuItem",
       "filePath": "src/DataTable/ToolbarMenuItem.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "OverflowMenuItem" },
@@ -11022,6 +11173,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [],
       "events": [
         { "type": "forwarded", "name": "change", "element": "Search" },
@@ -11190,6 +11342,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -11272,6 +11425,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -11351,6 +11505,7 @@
           "reactive": true
         }
       ],
+      "moduleExports": [],
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
@@ -11386,6 +11541,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ul" },

--- a/integration/glob/COMPONENT_API.json
+++ b/integration/glob/COMPONENT_API.json
@@ -26,7 +26,28 @@
           "reactive": false
         }
       ],
-      "moduleExports": [],
+      "moduleExports": [
+        {
+          "name": "tree",
+          "kind": "const",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "constant": true,
+          "reactive": false
+        },
+        {
+          "name": "computeTreeLeafDepth",
+          "kind": "function",
+          "type": "() => any",
+          "value": "() => {     let depth = 0;     if (node == null) return depth;     let parentNode = node.parentNode;     while (parentNode != null && parentNode.getAttribute(\"role\") !== \"tree\") {       parentNode = parentNode.parentNode;       if (parentNode.tagName === \"LI\") depth++;     }     return depth;   }",
+          "isFunction": true,
+          "isFunctionDeclaration": true,
+          "constant": false,
+          "reactive": false
+        }
+      ],
       "slots": [
         {
           "name": "__default__",

--- a/integration/glob/COMPONENT_API.json
+++ b/integration/glob/COMPONENT_API.json
@@ -26,6 +26,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",

--- a/integration/glob/COMPONENT_API.json
+++ b/integration/glob/COMPONENT_API.json
@@ -46,6 +46,17 @@
           "isFunctionDeclaration": true,
           "constant": false,
           "reactive": false
+        },
+        {
+          "name": "findParentTreeNode",
+          "kind": "function",
+          "description": "Finds the nearest parent tree node",
+          "type": "(node: HTMLElement) => null | HTMLElement",
+          "value": "() => {     if (node.classList.contains(\"bx--tree-parent-node\")) return node;     if (node.classList.contains(\"bx--tree\")) return null;     return findParentTreeNode(node.parentNode);   }",
+          "isFunction": true,
+          "isFunctionDeclaration": true,
+          "constant": false,
+          "reactive": false
         }
       ],
       "slots": [

--- a/integration/glob/src/button/Button.svelte
+++ b/integration/glob/src/button/Button.svelte
@@ -11,12 +11,12 @@
     }
     return depth;
   }
+  
   /**
    * Finds the nearest parent tree node
-   * @param {HTMLElement} node
-   * @returns {null | HTMLElement}
+   * @type {(node: HTMLElement) => null | HTMLElement}
    */
-  function findParentTreeNode(node) {
+  export function findParentTreeNode(node) {
     if (node.classList.contains("bx--tree-parent-node")) return node;
     if (node.classList.contains("bx--tree")) return null;
     return findParentTreeNode(node.parentNode);

--- a/integration/glob/src/button/Button.svelte
+++ b/integration/glob/src/button/Button.svelte
@@ -1,6 +1,33 @@
+<script context="module">
+  export const tree = false;
+
+  export function computeTreeLeafDepth(node) {
+    let depth = 0;
+    if (node == null) return depth;
+    let parentNode = node.parentNode;
+    while (parentNode != null && parentNode.getAttribute("role") !== "tree") {
+      parentNode = parentNode.parentNode;
+      if (parentNode.tagName === "LI") depth++;
+    }
+    return depth;
+  }
+  /**
+   * Finds the nearest parent tree node
+   * @param {HTMLElement} node
+   * @returns {null | HTMLElement}
+   */
+  function findParentTreeNode(node) {
+    if (node.classList.contains("bx--tree-parent-node")) return node;
+    if (node.classList.contains("bx--tree")) return null;
+    return findParentTreeNode(node.parentNode);
+  }
+</script>
+
 <script>
   export let type = "button2";
   export let primary = false;
+
+  $: findParentTreeNode(null)
 </script>
 
 <button {...$$restProps} {type} class:primary on:click>

--- a/integration/glob/types/button/Button.svelte.d.ts
+++ b/integration/glob/types/button/Button.svelte.d.ts
@@ -5,6 +5,11 @@ export type tree = boolean;
 
 export type computeTreeLeafDepth = () => any;
 
+/**
+ * Finds the nearest parent tree node
+ */
+export type findParentTreeNode = (node: HTMLElement) => null | HTMLElement;
+
 export interface ButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**

--- a/integration/glob/types/button/Button.svelte.d.ts
+++ b/integration/glob/types/button/Button.svelte.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
+export type tree = false;
+
+export type computeTreeLeafDepth = () => any;
+
 export interface ButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**

--- a/integration/glob/types/button/Button.svelte.d.ts
+++ b/integration/glob/types/button/Button.svelte.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export type tree = false;
+export type tree = boolean;
 
 export type computeTreeLeafDepth = () => any;
 

--- a/integration/glob/types/index.d.ts
+++ b/integration/glob/types/index.d.ts
@@ -1,2 +1,6 @@
 export { default as Action } from "./action/";
-export { default as Button } from "./button/Button.svelte";
+export {
+  default as Button,
+  tree,
+  computeTreeLeafDepth,
+} from "./button/Button.svelte";

--- a/integration/glob/types/index.d.ts
+++ b/integration/glob/types/index.d.ts
@@ -3,4 +3,5 @@ export {
   default as Button,
   tree,
   computeTreeLeafDepth,
+  findParentTreeNode,
 } from "./button/Button.svelte";

--- a/integration/multi-export-typed/COMPONENT_API.json
+++ b/integration/multi-export-typed/COMPONENT_API.json
@@ -27,6 +27,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -43,6 +44,7 @@
       "moduleName": "Link",
       "filePath": "src/Link.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -80,6 +82,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -107,6 +110,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",

--- a/integration/multi-export/COMPONENT_API.json
+++ b/integration/multi-export/COMPONENT_API.json
@@ -36,6 +36,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -52,6 +53,7 @@
       "moduleName": "Header",
       "filePath": "src/nested/Header.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": []
@@ -60,6 +62,7 @@
       "moduleName": "Link",
       "filePath": "src/Link.svelte",
       "props": [],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",
@@ -97,6 +100,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",

--- a/integration/single-export/COMPONENT_API.json
+++ b/integration/single-export/COMPONENT_API.json
@@ -26,6 +26,7 @@
           "reactive": false
         }
       ],
+      "moduleExports": [],
       "slots": [
         {
           "name": "__default__",

--- a/src/create-exports.ts
+++ b/src/create-exports.ts
@@ -1,16 +1,28 @@
 import { ParsedExports } from "./parse-exports";
+import { ComponentDocs } from "./rollup-plugin";
 
-export function createExports(parsed_exports: ParsedExports): string {
+export function createExports(parsed_exports: ParsedExports, components: ComponentDocs): string {
   const source = Object.entries(parsed_exports).map(([id, exportee]) => {
-    if (id === "default" || exportee.default) {
-      if (exportee.mixed) {
-        return `export { default as ${id} } from "${exportee.source}";\nexport { default } from "${exportee.source}";`;
-      }
-
-      return `export { default } from "${exportee.source}";`;
+    let module_exports: string[] = [];
+    if (components.has(id)) {
+      module_exports = components.get(id)!.moduleExports.map((moduleExport) => {
+        return moduleExport.name;
+      });
     }
 
-    return `export { default as ${id} } from "${exportee.source}";`;
+    let named_exports = "";
+
+    if (module_exports.length > 0) named_exports = module_exports.join(", ");
+
+    if (id === "default" || exportee.default) {
+      if (exportee.mixed) {
+        return `export { default as ${id}, ${named_exports} } from "${exportee.source}";\nexport { default } from "${exportee.source}";`;
+      }
+
+      return `export { default, ${named_exports} } from "${exportee.source}";`;
+    }
+
+    return `export { default as ${id}, ${named_exports} } from "${exportee.source}";`;
   });
 
   return source.join("\n");

--- a/src/create-exports.ts
+++ b/src/create-exports.ts
@@ -12,17 +12,17 @@ export function createExports(parsed_exports: ParsedExports, components: Compone
 
     let named_exports = "";
 
-    if (module_exports.length > 0) named_exports = module_exports.join(", ");
+    if (module_exports.length > 0) named_exports = ", " + module_exports.join(", ");
 
     if (id === "default" || exportee.default) {
       if (exportee.mixed) {
-        return `export { default as ${id}, ${named_exports} } from "${exportee.source}";\nexport { default } from "${exportee.source}";`;
+        return `export { default as ${id}${named_exports} } from "${exportee.source}";\nexport { default } from "${exportee.source}";`;
       }
 
-      return `export { default, ${named_exports} } from "${exportee.source}";`;
+      return `export { default${named_exports} } from "${exportee.source}";`;
     }
 
-    return `export { default as ${id}, ${named_exports} } from "${exportee.source}";`;
+    return `export { default as ${id}${named_exports} } from "${exportee.source}";`;
   });
 
   return source.join("\n");

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -201,7 +201,7 @@ export interface WriteTsDefinitionsOptions {
 export default async function writeTsDefinitions(components: ComponentDocs, options: WriteTsDefinitionsOptions) {
   const ts_base_path = path.join(process.cwd(), options.outDir, "index.d.ts");
   const writer = new Writer({ parser: "typescript", printWidth: 80 });
-  const indexDTs = options.preamble + createExports(options.exports);
+  const indexDTs = options.preamble + createExports(options.exports, components);
 
   for await (const [moduleName, component] of components) {
     const ts_filepath = convertSvelteExt(path.join(options.outDir, component.filePath));

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -141,8 +141,32 @@ function genComponentComment(def: Pick<ComponentDocApi, "componentComment">) {
     .join("\n")}\n*/`;
 }
 
+function genModuleExports(def: Pick<ComponentDocApi, "moduleExports">) {
+  return def.moduleExports
+    .map((prop) => {
+      const prop_comments = [addCommentLine(prop.description?.replace(/\n/g, "\n* "))].filter(Boolean).join("");
+
+      let prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
+
+      return `
+      ${prop_comments.length > 0 ? `/**\n${prop_comments}*/` : EMPTY_STR}
+      export type ${prop.name} = ${prop_value};`;
+    })
+    .join("\n");
+}
+
 export function writeTsDefinition(component: ComponentDocApi) {
-  const { moduleName, typedefs, props, slots, events, rest_props, extends: _extends, componentComment } = component;
+  const {
+    moduleName,
+    typedefs,
+    props,
+    moduleExports,
+    slots,
+    events,
+    rest_props,
+    extends: _extends,
+    componentComment,
+  } = component;
   const { props_name, prop_def } = genPropDef({
     moduleName,
     props,
@@ -154,6 +178,7 @@ export function writeTsDefinition(component: ComponentDocApi) {
   /// <reference types="svelte" />
   import { SvelteComponentTyped } from "svelte";
   ${genImports({ extends: _extends })}
+  ${genModuleExports({ moduleExports })}
   ${getTypeDefs({ typedefs })}
   ${prop_def}
   ${genComponentComment({ componentComment })}

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -146,11 +146,9 @@ function genModuleExports(def: Pick<ComponentDocApi, "moduleExports">) {
     .map((prop) => {
       const prop_comments = [addCommentLine(prop.description?.replace(/\n/g, "\n* "))].filter(Boolean).join("");
 
-      let prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
-
       return `
       ${prop_comments.length > 0 ? `/**\n${prop_comments}*/` : EMPTY_STR}
-      export type ${prop.name} = ${prop_value};`;
+      export type ${prop.name} = ${prop.type || ANY_TYPE};`;
     })
     .join("\n");
 }

--- a/tests/create-exports.test.ts
+++ b/tests/create-exports.test.ts
@@ -4,21 +4,21 @@ import { convertSvelteExt, createExports, removeSvelteExt } from "../src/create-
 test("createExports – single default export", (t) => {
   const source = { default: { source: "./Component.svelte", default: true } };
 
-  t.deepEqual(createExports(source), 'export { default } from "./Component.svelte";');
+  t.deepEqual(createExports(source, new Map()), 'export { default } from "./Component.svelte";');
   t.end();
 });
 
 test("createExports – single default export (declaration)", (t) => {
   const source = { Component: { source: "./Component.svelte", default: true } };
 
-  t.deepEqual(createExports(source), 'export { default } from "./Component.svelte";');
+  t.deepEqual(createExports(source, new Map()), 'export { default } from "./Component.svelte";');
   t.end();
 });
 
 test("createExports – single named export", (t) => {
   const source = { Component: { source: "./Component.svelte", default: false } };
 
-  t.deepEqual(createExports(source), 'export { default as Component } from "./Component.svelte";');
+  t.deepEqual(createExports(source, new Map()), 'export { default as Component } from "./Component.svelte";');
   t.end();
 });
 
@@ -29,7 +29,7 @@ test("createExports – multiple named exports", (t) => {
   };
 
   t.deepEqual(
-    createExports(source),
+    createExports(source, new Map()),
     'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";'
   );
   t.end();
@@ -43,7 +43,7 @@ test("createExports – multiple named exports with a default export", (t) => {
   };
 
   t.deepEqual(
-    createExports(source),
+    createExports(source, new Map()),
     'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";\nexport { default } from "./Component2.svelte";'
   );
   t.end();
@@ -57,7 +57,7 @@ test("createExports – multiple named exports with a default export (declaratio
   };
 
   t.deepEqual(
-    createExports(source),
+    createExports(source, new Map()),
     'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";\nexport { default } from "./Component3.svelte";'
   );
   t.end();
@@ -67,7 +67,7 @@ test("createExports – mixed exports", (t) => {
   const source = { Component: { source: "./Component.svelte", default: true, mixed: true } };
 
   t.deepEqual(
-    createExports(source),
+    createExports(source, new Map()),
     'export { default as Component } from "./Component.svelte";\nexport { default } from "./Component.svelte";'
   );
   t.end();

--- a/tests/snapshots/bind-this-multiple/output.json
+++ b/tests/snapshots/bind-this-multiple/output.json
@@ -29,6 +29,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/bind-this/output.json
+++ b/tests/snapshots/bind-this/output.json
@@ -10,6 +10,7 @@
       "reactive": true
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/component-comment-multi/output.json
+++ b/tests/snapshots/component-comment-multi/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/component-comment-single/output.json
+++ b/tests/snapshots/component-comment-single/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/context-module/input.svelte
+++ b/tests/snapshots/context-module/input.svelte
@@ -1,5 +1,15 @@
 <script context="module">
-  export const a = 4;
+  // should not be exported
+  const c = 0;
+  const d = () => {};
+
+  export const a = { b: 4 };
+
+  /**
+   * Description for e
+   * @type {{ [key: string]: any; }}
+   */
+  export const e = { b: 4 };
 
   /**
    * Log something
@@ -8,6 +18,8 @@
   export function log(message) {
     console.log(message);
   }
+
+  export const b = () => {};
 </script>
 
 <script>

--- a/tests/snapshots/context-module/input.svelte
+++ b/tests/snapshots/context-module/input.svelte
@@ -3,6 +3,8 @@
   const c = 0;
   const d = () => {};
 
+  export const bool = "";
+
   export const a = { b: 4 };
 
   /**

--- a/tests/snapshots/context-module/input.svelte
+++ b/tests/snapshots/context-module/input.svelte
@@ -1,0 +1,15 @@
+<script context="module">
+  export const a = 4;
+
+  /**
+   * Log something
+   * @type {(message: string) => void}
+   */
+  export function log(message) {
+    console.log(message);
+  }
+</script>
+
+<script>
+  export const a = "";
+</script>

--- a/tests/snapshots/context-module/output.d.ts
+++ b/tests/snapshots/context-module/output.d.ts
@@ -1,6 +1,20 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
+export type a = { b: 4 };
+
+/**
+ * Description for e
+ */
+export type e = { b: 4 };
+
+/**
+ * Log something
+ */
+export type log = (message: string) => void;
+
+export type b = () => {};
+
 export interface InputProps {}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {

--- a/tests/snapshots/context-module/output.d.ts
+++ b/tests/snapshots/context-module/output.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="svelte" />
+import { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
+  a: string;
+}

--- a/tests/snapshots/context-module/output.d.ts
+++ b/tests/snapshots/context-module/output.d.ts
@@ -1,12 +1,14 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
+export type bool = string;
+
 export type a = { b: 4 };
 
 /**
  * Description for e
  */
-export type e = { b: 4 };
+export type e = { [key: string]: any };
 
 /**
  * Log something

--- a/tests/snapshots/context-module/output.json
+++ b/tests/snapshots/context-module/output.json
@@ -11,6 +11,50 @@
       "reactive": false
     }
   ],
+  "moduleExports": [
+    {
+      "name": "a",
+      "kind": "const",
+      "type": "{ b: 4 }",
+      "value": "{ b: 4 }",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
+    },
+    {
+      "name": "e",
+      "kind": "const",
+      "description": "Description for e",
+      "type": "{ [key: string]: any; }",
+      "value": "{ b: 4 }",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
+    },
+    {
+      "name": "log",
+      "kind": "function",
+      "description": "Log something",
+      "type": "(message: string) => void",
+      "value": "() => {     console.log(message);   }",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "b",
+      "kind": "const",
+      "type": "() => {}",
+      "value": "() => {}",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
+    }
+  ],
   "slots": [],
   "events": [],
   "typedefs": []

--- a/tests/snapshots/context-module/output.json
+++ b/tests/snapshots/context-module/output.json
@@ -13,6 +13,16 @@
   ],
   "moduleExports": [
     {
+      "name": "bool",
+      "kind": "const",
+      "type": "string",
+      "value": "\"\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
+    },
+    {
       "name": "a",
       "kind": "const",
       "type": "{ b: 4 }",

--- a/tests/snapshots/context-module/output.json
+++ b/tests/snapshots/context-module/output.json
@@ -1,0 +1,17 @@
+{
+  "props": [
+    {
+      "name": "a",
+      "kind": "const",
+      "type": "string",
+      "value": "\"\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
+    }
+  ],
+  "slots": [],
+  "events": [],
+  "typedefs": []
+}

--- a/tests/snapshots/context-module/output.test.ts
+++ b/tests/snapshots/context-module/output.test.ts
@@ -1,0 +1,11 @@
+import { a, b, e, log } from "./output";
+
+const a: log = () => {};
+
+// @ts-expect-error
+a(4);
+
+a(4 + "");
+
+// @ts-expect-error
+const e_value: e = {};

--- a/tests/snapshots/dispatched-events-dynamic/output.json
+++ b/tests/snapshots/dispatched-events-dynamic/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [],
   "events": [
     {

--- a/tests/snapshots/dispatched-events-typed/output.json
+++ b/tests/snapshots/dispatched-events-typed/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/dispatched-events/output.json
+++ b/tests/snapshots/dispatched-events/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/forwarded-events/output.json
+++ b/tests/snapshots/forwarded-events/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/function-declaration/output.json
+++ b/tests/snapshots/function-declaration/output.json
@@ -42,6 +42,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [],
   "events": [],
   "typedefs": []

--- a/tests/snapshots/infer-basic/output.json
+++ b/tests/snapshots/infer-basic/output.json
@@ -68,6 +68,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/infer-with-types/output.json
+++ b/tests/snapshots/infer-with-types/output.json
@@ -60,6 +60,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/mixed-events/output.json
+++ b/tests/snapshots/mixed-events/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [],
   "events": [
     {

--- a/tests/snapshots/renamed-props/output.json
+++ b/tests/snapshots/renamed-props/output.json
@@ -12,6 +12,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [],
   "events": [],
   "typedefs": []

--- a/tests/snapshots/rest-props-multiple/output.json
+++ b/tests/snapshots/rest-props-multiple/output.json
@@ -21,6 +21,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [],
   "events": [],
   "typedefs": [],

--- a/tests/snapshots/rest-props/output.json
+++ b/tests/snapshots/rest-props/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [],
   "events": [],
   "typedefs": [],

--- a/tests/snapshots/slots-named/output.json
+++ b/tests/snapshots/slots-named/output.json
@@ -11,6 +11,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/slots-spread-typed/output.json
+++ b/tests/snapshots/slots-spread-typed/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/slots-spread/output.json
+++ b/tests/snapshots/slots-spread/output.json
@@ -1,5 +1,6 @@
 {
   "props": [],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/typed-props/output.json
+++ b/tests/snapshots/typed-props/output.json
@@ -41,6 +41,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [],
   "events": [],
   "typedefs": []

--- a/tests/snapshots/typed-slots/output.json
+++ b/tests/snapshots/typed-slots/output.json
@@ -11,6 +11,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/typedef/output.json
+++ b/tests/snapshots/typedef/output.json
@@ -21,6 +21,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/snapshots/typedefs/output.json
+++ b/tests/snapshots/typedefs/output.json
@@ -21,6 +21,7 @@
       "reactive": false
     }
   ],
+  "moduleExports": [],
   "slots": [
     {
       "name": "__default__",

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -83,6 +83,7 @@ test("writeTsDefinition", (t) => {
         reactive: false,
       },
     ],
+    moduleExports: [],
     slots: [
       {
         name: "__default__",
@@ -104,7 +105,7 @@ test("writeTsDefinition", (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      /**\n* @default undefined\n*/\n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n  \n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      /**\n* @default undefined\n*/\n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n  \n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    \n    propConst: { [key: string]: boolean; };\n    }'
   );
   t.end();
 });
@@ -114,6 +115,7 @@ test('writeTsDefinition – "default" module name', (t) => {
     moduleName: "default",
     filePath: "./src/ModuleName.svelte",
     props: [],
+    moduleExports: [],
     slots: [],
     events: [],
     typedefs: [],
@@ -122,7 +124,7 @@ test('writeTsDefinition – "default" module name', (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface defaultProps  {\n      \n    }\n  \n  \n  export default class  extends SvelteComponentTyped<\n      defaultProps,\n      {},\n      {}\n    > {\n      \n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n  \n    export interface defaultProps  {\n      \n    }\n  \n  \n  export default class  extends SvelteComponentTyped<\n      defaultProps,\n      {},\n      {}\n    > {\n      \n    }'
   );
   t.end();
 });


### PR DESCRIPTION
Fixes #56 

Currently, module exports are being falsely recognized as component accessors.

```svelte
<script context="module">
  /**
   * Log something (export)
   * @type {(message: string) => void}
   */
  export function log(message) {
    console.log(message);
  }
</script>

<script>
  /**
   * Log something (accessor)
   * @type {(message: string) => void}
   */
  export function log(message) {
    console.log(message);
  }
</script>

```

**Unexpected output**

```ts
/// <reference types="svelte" />
import { SvelteComponentTyped } from "svelte";

export interface InputProps {}

export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
  /**
   * Log something (export)
   */
  log: (message: string) => void;
}

```

**Expected output**

The expected behavior is that module exports should be treated as named exports.

```ts
/// <reference types="svelte" />
import { SvelteComponentTyped } from "svelte";

/**
 * Log something (export)
 */
export type log = (message: string) => void;

export interface InputProps {}

export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
  /**
   * Log something (accessor)
   */
  log: (message: string) => void;
}

```

The corresponding `index.d.ts` will also export any named exports:

```ts
export { default as Component, log } from "./Component.svelte";
```

### Approach

- still compile Svelte source to obtain `reactive_vars`
- parse Svelte source to obtain `instance`, `module`, and `html`
- walk `instance` and `module` separately