### PR TITLE
Feature: export json files into specified outDir folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 build
 dist
 node_modules
+pnpm*

--- a/README.md
+++ b/README.md
@@ -233,8 +233,24 @@ sveld({
   },
   json: true,
   jsonOptions: {
-    outFile: "docs/src/mycomponentname-api.json",
-    outDir: "docs/src/mycomponentname-api.json", // optional, if specified, all JSON files will be written in this folder
+    outFile: "docs/src/COMPONENT_API.json",
+  },
+});
+```
+
+#### `jsonOptions.outDir`
+
+If `json` is `true`, a `COMPONENT_API.json` file will be generated at the root of your project. This file contains documentation for all components.
+
+Use the `jsonOptions.outDir` option to specify the folder for individual JSON files to be emitted.
+
+```js
+sveld({
+  json: true,
+  jsonOptions: {
+    // an individual JSON file will be generated for each component API
+    // e.g. "docs/Button.api.json"
+    outDir: "docs",
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ sveld({
   },
   json: true,
   jsonOptions: {
-    outFile: "docs/src/COMPONENT_API.json",
+    outFile: "docs/src/mycomponentname-api.json",
+    outDir: "docs/src/mycomponentname-api.json", // optional, if specified, all JSON files will be written in this folder
   },
 });
 ```

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -30,7 +30,7 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
 
   output.map((c) => {
     const outFile = path.resolve(
-      path.join(dirname(options.outDir as string), `${c.moduleName.toLowerCase()}-api.json`)
+      path.join(options.outDir || "", `${c.moduleName.toLowerCase()}-api.json`));
     );
     const writer = new Writer({ parser: "json", printWidth: 80 });
     console.log(`created ${outFile}"\n`);

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -26,7 +26,7 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
   });
 
   output.map((c) => {
-    const outFile = path.resolve(path.join(options.outDir || "", `${c.moduleName.toLowerCase()}-api.json`));
+    const outFile = path.resolve(path.join(options.outDir || "", `${c.moduleName}.api.json`));
     const writer = new Writer({ parser: "json", printWidth: 80 });
     console.log(`created ${outFile}"\n`);
     return writer.write(outFile, JSON.stringify(c));
@@ -54,7 +54,6 @@ async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptio
 }
 
 export default async function writeJson(components: ComponentDocs, options: WriteJsonOptions) {
-  debugger;
   if (options.outDir) {
     await writeJsonComponents(components, options);
   } else {

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { dirname } from "path";
 import { normalizeSeparators } from "../path";
 import { ComponentDocApi, ComponentDocs } from "../rollup-plugin";
 import Writer from "./Writer";
@@ -7,14 +8,38 @@ export interface WriteJsonOptions {
   input: string;
   inputDir: string;
   outFile: string;
+  outDir?: string;
 }
 
 interface JsonOutput {
+  module?: string;
   total: number;
   components: ComponentDocApi[];
 }
 
-export default async function writeJson(components: ComponentDocs, options: WriteJsonOptions) {
+async function writeJsonComponents(components: ComponentDocs, options: WriteJsonOptions) {
+  debugger;
+  const output = Array.from(components, ([moduleName, component]) => ({
+    ...component,
+    filePath: normalizeSeparators(path.join(options.inputDir, path.normalize(component.filePath))),
+  })).sort((a, b) => {
+    if (a.moduleName < b.moduleName) return -1;
+    if (a.moduleName > b.moduleName) return 1;
+    return 0;
+  });
+
+  output.map((c) => {
+    const outFile = path.resolve(
+      path.join(dirname(options.outDir as string), `${c.moduleName.toLowerCase()}-api.json`)
+    );
+    const writer = new Writer({ parser: "json", printWidth: 80 });
+    console.log(`created ${outFile}"\n`);
+    return writer.write(outFile, JSON.stringify(c));
+  });
+}
+
+async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptions) {
+  debugger;
   const output: JsonOutput = {
     total: components.size,
     components: Array.from(components, ([moduleName, component]) => ({
@@ -32,4 +57,13 @@ export default async function writeJson(components: ComponentDocs, options: Writ
   await writer.write(output_path, JSON.stringify(output));
 
   console.log(`created "${options.outFile}".\n`);
+}
+
+export default async function writeJson(components: ComponentDocs, options: WriteJsonOptions) {
+  debugger;
+  if (options.outDir) {
+    await writeJsonComponents(components, options);
+  } else {
+    await writeJsonLocal(components, options);
+  }
 }

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -18,7 +18,6 @@ interface JsonOutput {
 }
 
 async function writeJsonComponents(components: ComponentDocs, options: WriteJsonOptions) {
-  debugger;
   const output = Array.from(components, ([moduleName, component]) => ({
     ...component,
     filePath: normalizeSeparators(path.join(options.inputDir, path.normalize(component.filePath))),

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,5 +1,4 @@
-import * as path from "path";
-import { dirname } from "path";
+import path from "path";
 import { normalizeSeparators } from "../path";
 import { ComponentDocApi, ComponentDocs } from "../rollup-plugin";
 import Writer from "./Writer";
@@ -12,7 +11,6 @@ export interface WriteJsonOptions {
 }
 
 interface JsonOutput {
-  module?: string;
   total: number;
   components: ComponentDocApi[];
 }
@@ -28,9 +26,7 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
   });
 
   output.map((c) => {
-    const outFile = path.resolve(
-      path.join(options.outDir || "", `${c.moduleName.toLowerCase()}-api.json`));
-    );
+    const outFile = path.resolve(path.join(options.outDir || "", `${c.moduleName.toLowerCase()}-api.json`));
     const writer = new Writer({ parser: "json", printWidth: 80 });
     console.log(`created ${outFile}"\n`);
     return writer.write(outFile, JSON.stringify(c));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "outDir": "lib",
     "skipLibCheck": true,
     "strict": true,
-    "esModuleInterop": true,
-    "sourceMap": true
+    "esModuleInterop": true
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "moduleResolution": "node",
     "outDir": "lib",
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true,
+    "sourceMap": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Currently JSON schemas representing Svelte components are stored into the component's folder with a predefined name.
This feature add the possibility to export those JSON files into a specified folder and to name each one by the name of the component they belong to.

To activate this feature, a new property has been added to the `WriteJsonOptions` interface: `outDir`.
By setting a proper value for `outDir`, all JSON schemas will be stored into this folder.