### PR TITLE
feat(ts): add `sveltekit:prefetch`, `sveltekit:noscroll` attributes to `$$restProps` that extend `a` elements

### DIFF
--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -4567,7 +4567,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "p" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "p" }
+      "rest_props": { "type": "Element", "name": "a | p" }
     },
     {
       "moduleName": "ListBox",

--- a/integration/carbon/src/Link/Link.svelte
+++ b/integration/carbon/src/Link/Link.svelte
@@ -1,4 +1,6 @@
 <script>
+  /** @restProps {a | p} */
+
   /**
    * Specify the size of the link
    * @type {"sm" | "lg"}

--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -99,6 +99,11 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -99,10 +99,21 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -19,6 +19,11 @@ export interface ButtonSkeletonProps
    * @default false
    */
   small?: boolean;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ButtonSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -19,10 +19,21 @@ export interface ButtonSkeletonProps
    * @default false
    */
   small?: boolean;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -39,10 +39,21 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -2,7 +2,8 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]>,
+    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
   /**
    * Specify the size of the link
    * @default undefined
@@ -38,6 +39,11 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -20,6 +20,11 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ClickableTile extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -20,10 +20,21 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -51,6 +51,11 @@ export interface HeaderProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Header extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -51,10 +51,21 @@ export interface HeaderProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -26,6 +26,11 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderActionLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -26,10 +26,21 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -20,6 +20,11 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavItem extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -20,10 +20,21 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -32,6 +32,11 @@ export interface HeaderNavMenuProps
    * @default "Expand/Collapse"
    */
   iconDescription?: string;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavMenu extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -32,10 +32,21 @@ export interface HeaderNavMenuProps
    * @default "Expand/Collapse"
    */
   iconDescription?: string;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -14,10 +14,21 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -14,6 +14,11 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderPanelLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -32,10 +32,21 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -32,6 +32,11 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -26,6 +26,11 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavMenuItem extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -26,10 +26,21 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -14,6 +14,11 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SkipToContent extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -14,10 +14,21 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
-  /** @default false */
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -3,10 +3,20 @@ import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /** @default false */
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -2,7 +2,13 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export-typed/types/Link.svelte.d.ts
+++ b/integration/multi-export-typed/types/Link.svelte.d.ts
@@ -3,10 +3,20 @@ import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /** @default false */
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/multi-export-typed/types/Link.svelte.d.ts
+++ b/integration/multi-export-typed/types/Link.svelte.d.ts
@@ -2,7 +2,13 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export/types/Link.svelte.d.ts
+++ b/integration/multi-export/types/Link.svelte.d.ts
@@ -3,10 +3,20 @@ import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /** @default false */
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/integration/multi-export/types/Link.svelte.d.ts
+++ b/integration/multi-export/types/Link.svelte.d.ts
@@ -2,7 +2,13 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -31,7 +31,7 @@ function addCommentLine(value: any, returnValue?: any) {
 }
 
 function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleName" | "extends">) {
-  const props = def.props
+  const initial_props = def.props
     .filter((prop) => !prop.isFunctionDeclaration && prop.kind !== "const")
     .map((prop) => {
       let defaultValue = prop.value;
@@ -57,8 +57,23 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
       return `
       ${prop_comments.length > 0 ? `/**\n${prop_comments}*/` : EMPTY_STR}
       ${prop.name}?: ${prop_value};`;
-    })
-    .join("\n");
+    });
+
+  if (def.rest_props?.type === "Element") {
+    const elements = def.rest_props?.name.split("|").map((element) => element.replace(/\s+/g, ""));
+
+    if (elements.includes("a")) {
+      initial_props.push(
+        [
+          '/** @default false */\n"sveltekit:prefetch"?: boolean;',
+          "\n",
+          '/** @default false */\n"sveltekit:noscroll"?: boolean;',
+        ].join("\n")
+      );
+    }
+  }
+
+  const props = initial_props.join("\n");
 
   const props_name = `${def.moduleName}Props`;
 

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -65,9 +65,26 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
     if (elements.includes("a")) {
       initial_props.push(
         [
-          '/** @default false */\n"sveltekit:prefetch"?: boolean;',
           "\n",
-          '/** @default false */\n"sveltekit:noscroll"?: boolean;',
+          `
+          /**
+           * SvelteKit attribute to enable data prefetching
+           * if a link is hovered over or touched on mobile.
+           * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+           * @default false
+           */
+           "sveltekit:prefetch"?: boolean;
+          `,
+          "\n",
+          `
+          /**
+           * SvelteKit attribute to prevent scrolling
+           * after the link is clicked.
+           * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+           * @default false
+           */
+           "sveltekit:noscroll"?: boolean;
+          `,
         ].join("\n")
       );
     }

--- a/tests/snapshots/anchor-props/input.svelte
+++ b/tests/snapshots/anchor-props/input.svelte
@@ -1,0 +1,1 @@
+<a href="/" {...$$restProps}><slot /></a>

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="svelte" />
+import type { SvelteComponentTyped } from "svelte";
+
+export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+
+export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -2,10 +2,20 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /** @default false */
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:prefetch"?: boolean;
 
-  /** @default false */
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
   "sveltekit:noscroll"?: boolean;
 }
 

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -1,6 +1,12 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  /** @default false */
+  "sveltekit:prefetch"?: boolean;
+
+  /** @default false */
+  "sveltekit:noscroll"?: boolean;
+}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

--- a/tests/snapshots/anchor-props/output.json
+++ b/tests/snapshots/anchor-props/output.json
@@ -1,0 +1,17 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{}"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "rest_props": {
+    "type": "Element",
+    "name": "a"
+  }
+}


### PR DESCRIPTION
SvelteKit has [framework-specific attributes](https://kit.svelte.dev/docs/a-options#sveltekit-prefetch) for anchor links: `sveltekit:noscroll` and `sveltekit:prefetch`.

This PR includes those optional attributes to any component that passes `$$restProps` to an anchor element.

```tsx
/// <reference types="svelte" />
import type { SvelteComponentTyped } from "svelte";

export interface LinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
  /**
   * SvelteKit attribute to enable data prefetching
   * if a link is hovered over or touched on mobile.
   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
   * @default false
   */
  "sveltekit:prefetch"?: boolean;

  /**
   * SvelteKit attribute to prevent scrolling
   * after the link is clicked.
   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
   * @default false
   */
  "sveltekit:noscroll"?: boolean;
}

export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

```