### PR TITLE
fix(ts): svg `$$restProps` should extend the correct attributes

### DIFF
--- a/integration/carbon/types/Icon/Icon.svelte.d.ts
+++ b/integration/carbon/types/Icon/Icon.svelte.d.ts
@@ -4,7 +4,7 @@ import type { IconSkeletonProps } from "./IconSkeleton.svelte";
 
 export interface IconProps
   extends IconSkeletonProps,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]> {
+    svelte.JSX.SVGAttributes<SVGSVGElement> {
   /**
    * Specify the icon from `carbon-icons-svelte` to render
    * @default undefined

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -99,7 +99,15 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
   if (def.rest_props?.type === "Element") {
     const extend_tag_map = def.rest_props.name
       .split("|")
-      .map((name) => `svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["${name.trim()}"]>`)
+      .map((name) => {
+        const element = name.trim();
+
+        if (element === "svg") {
+          return "svelte.JSX.SVGAttributes<SVGSVGElement>";
+        }
+
+        return `svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["${element}"]>`;
+      })
       .join(",");
 
     prop_def = `

--- a/tests/snapshots/svg-props/input.svelte
+++ b/tests/snapshots/svg-props/input.svelte
@@ -1,0 +1,1 @@
+<svg {...$$restProps} />

--- a/tests/snapshots/svg-props/output.d.ts
+++ b/tests/snapshots/svg-props/output.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="svelte" />
+import type { SvelteComponentTyped } from "svelte";
+
+export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]> {}
+
+export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}

--- a/tests/snapshots/svg-props/output.d.ts
+++ b/tests/snapshots/svg-props/output.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]> {}
+export interface InputProps extends svelte.JSX.SVGAttributes<SVGSVGElement> {}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}

--- a/tests/snapshots/svg-props/output.json
+++ b/tests/snapshots/svg-props/output.json
@@ -1,0 +1,11 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "rest_props": {
+    "type": "Element",
+    "name": "svg"
+  }
+}


### PR DESCRIPTION
Currently, `$$restProps` passed to `svg` will generate `Props extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]>`.

This is incorrect, as no "svg" element exists in the `HTMLElementTagNameMap` interface of `lib.dom.d.ts`.

The correct interface to extend is `svelte.JSX.SVGAttributes<SVGSVGElement>`.