### PR TITLE
feat(ts): add `sveltekit:reload` attribute to anchor links

### DIFF
--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -78,9 +78,19 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
           "\n",
           `
           /**
+           * SvelteKit attribute to trigger a full page
+           * reload after the link is clicked.
+           * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+           * @default false
+           */
+           "sveltekit:reload"?: boolean;
+          `,
+          "\n",
+          `
+          /**
            * SvelteKit attribute to prevent scrolling
            * after the link is clicked.
-           * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+           * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
            * @default false
            */
            "sveltekit:noscroll"?: boolean;

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -11,9 +11,17 @@ export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagName
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;


### PR DESCRIPTION
[`sveltekit:reload`](https://kit.svelte.dev/docs/a-options#sveltekit-reload) was recently added to SvelteKit.

This adds an optional `sveltekit:reload` prop and fixes a typo in the `sveltekit:noscroll` prop.