### PR TITLE
fix(writer): correctly generate context module functions

### DIFF
--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -109,9 +109,17 @@ export interface ButtonProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -29,9 +29,17 @@ export interface ButtonSkeletonProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -49,9 +49,17 @@ export interface LinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -30,9 +30,17 @@ export interface ClickableTileProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -61,9 +61,17 @@ export interface HeaderProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -36,9 +36,17 @@ export interface HeaderActionLinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -30,9 +30,17 @@ export interface HeaderNavItemProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -42,9 +42,17 @@ export interface HeaderNavMenuProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -24,9 +24,17 @@ export interface HeaderPanelLinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -42,9 +42,17 @@ export interface SideNavLinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -36,9 +36,17 @@ export interface SideNavMenuItemProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -24,9 +24,17 @@ export interface SkipToContentProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/glob/types/button/Button.svelte.d.ts
+++ b/integration/glob/types/button/Button.svelte.d.ts
@@ -3,12 +3,14 @@ import type { SvelteComponentTyped } from "svelte";
 
 export type tree = boolean;
 
-export type computeTreeLeafDepth = () => any;
+export declare function computeTreeLeafDepth(): any;
 
 /**
  * Finds the nearest parent tree node
  */
-export type findParentTreeNode = (node: HTMLElement) => null | HTMLElement;
+export declare function findParentTreeNode(
+  node: HTMLElement
+): null | HTMLElement;
 
 export interface ButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -12,9 +12,17 @@ export interface LinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/multi-export-typed/types/Link.svelte.d.ts
+++ b/integration/multi-export-typed/types/Link.svelte.d.ts
@@ -12,9 +12,17 @@ export interface LinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/integration/multi-export/types/Link.svelte.d.ts
+++ b/integration/multi-export/types/Link.svelte.d.ts
@@ -12,9 +12,17 @@ export interface LinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -196,9 +196,20 @@ function genModuleExports(def: Pick<ComponentDocApi, "moduleExports">) {
     .map((prop) => {
       const prop_comments = [addCommentLine(prop.description?.replace(/\n/g, "\n* "))].filter(Boolean).join("");
 
+      let type_def = `export type ${prop.name} = ${prop.type || ANY_TYPE};`;
+
+      const is_function = prop.type && /=>/.test(prop.type);
+
+      if (is_function) {
+        const [first, second, ...rest] = prop.type!.split("=>");
+        const rest_type = rest.map((item) => "=>" + item).join("");
+
+        type_def = `export declare function ${prop.name}${first}:${second}${rest_type};`;
+      }
+
       return `
       ${prop_comments.length > 0 ? `/**\n${prop_comments}*/` : EMPTY_STR}
-      export type ${prop.name} = ${prop.type || ANY_TYPE};`;
+      ${type_def}`;
     })
     .join("\n");
 }

--- a/tests/snapshots/context-module/input.svelte
+++ b/tests/snapshots/context-module/input.svelte
@@ -22,6 +22,11 @@
   }
 
   export const b = () => {};
+
+  export const b2 = () => () => {};
+
+  /** @type {() => () => false} */
+  export const b3 = () => () => false;
 </script>
 
 <script>

--- a/tests/snapshots/context-module/output.d.ts
+++ b/tests/snapshots/context-module/output.d.ts
@@ -13,9 +13,13 @@ export type e = { [key: string]: any };
 /**
  * Log something
  */
-export type log = (message: string) => void;
+export declare function log(message: string): void;
 
-export type b = () => {};
+export declare function b(): {};
+
+export declare function b2(): () => {};
+
+export declare function b3(): () => false;
 
 export interface InputProps {}
 

--- a/tests/snapshots/context-module/output.json
+++ b/tests/snapshots/context-module/output.json
@@ -63,6 +63,26 @@
       "isFunctionDeclaration": false,
       "constant": true,
       "reactive": false
+    },
+    {
+      "name": "b2",
+      "kind": "const",
+      "type": "() => () => {}",
+      "value": "() => () => {}",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
+    },
+    {
+      "name": "b3",
+      "kind": "const",
+      "type": "() => () => false",
+      "value": "() => () => false",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "constant": true,
+      "reactive": false
     }
   ],
   "slots": [],

--- a/tests/snapshots/context-module/types.ts
+++ b/tests/snapshots/context-module/types.ts
@@ -1,6 +1,14 @@
-import { a, e, log } from "./output";
+import { a, e, log, b2, b3 } from "./output";
 
-const a: log = () => {};
+log("");
+
+b2()();
+
+const function_b3: typeof b3 = () => () => false;
+
+const result = b3()();
+
+const a: typeof log = () => {};
 
 // @ts-expect-error
 a(4);


### PR DESCRIPTION
Currently, function exports from `script context="module"` are generated as types when they should be functions.

**Input**

```svelte
<script context="module">
  /** @type {(message: string) => void} */
  export function log(message) {
    console.log(message);
  }
</script>
```

**Output (before/after)**

```diff
- export type log = (message: string) => void;
+ export declare function log(message: string): void;
```

**Usage**

Now, the function can actually be invoked.

```ts
// invocation
log("message");

// typing
const logger: typeof log = (m) => console.log(m);
```