### PR TITLE
feat: Support Export all for component parsing in svelte entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 lib
 build
 dist

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -1,6 +1,7 @@
 import * as acorn from "acorn";
 import * as fs from "fs";
 import path from "path";
+import { normalizeSeparators } from "./path";
 
 interface NodeImportDeclaration extends acorn.Node {
   type: "ImportDeclaration";
@@ -62,7 +63,13 @@ export function parseExports(source: string, dir: string) {
       const export_file = fs.readFileSync(file_path, "utf-8");
       const exports = parseExports(export_file, path.dirname(file_path));
 
-      for (const [key, value] of Object.entries(exports)) exports_by_identifier[key] = value;
+      for (const [key, value] of Object.entries(exports)) {
+        const source = normalizeSeparators("./" + path.join(node.source.value, value.source));
+        exports_by_identifier[key] = {
+          ...value,
+          source
+        };
+      }
     } else if (node.type === "ExportNamedDeclaration") {
       node.specifiers.forEach((specifier) => {
         const exported_name = specifier.exported.name;

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -1,4 +1,6 @@
 import * as acorn from "acorn";
+import * as fs from "fs";
+import path from "path";
 
 interface NodeImportDeclaration extends acorn.Node {
   type: "ImportDeclaration";
@@ -16,11 +18,15 @@ interface NodeExportDefaultDeclaration extends acorn.Node {
   declaration: { name: string };
 }
 
-type BodyNode = NodeImportDeclaration | NodeExportNamedDeclaration | NodeExportDefaultDeclaration;
+interface NodeExportAllDeclaration extends acorn.Node, Pick<NodeImportDeclaration, "source"> {
+  type: "ExportAllDeclaration";
+}
+
+type BodyNode = NodeImportDeclaration | NodeExportNamedDeclaration | NodeExportDefaultDeclaration | NodeExportAllDeclaration;
 
 export type ParsedExports = Record<string, { source: string; default: boolean; mixed?: boolean }>;
 
-export function parseExports(source: string) {
+export function parseExports(source: string, dir: string) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
     sourceType: "module",
@@ -38,9 +44,26 @@ export function parseExports(source: string) {
       } else {
         exports_by_identifier[id] = { source: "", default: true };
       }
-    }
+    } else if (node.type === "ExportAllDeclaration") {
+      if (!node.source) return;
 
-    if (node.type === "ExportNamedDeclaration") {
+      let file_path = path.resolve(dir, node.source.value);
+
+      if (!fs.lstatSync(file_path).isFile()){
+        const files = fs.readdirSync(file_path);
+
+        for (const file of files)
+          if (file.includes("index")) {
+            file_path = path.join(file_path, file);
+            break;
+          }
+      }
+
+      const export_file = fs.readFileSync(file_path, "utf-8");
+      const exports = parseExports(export_file, path.dirname(file_path));
+
+      for (const [key, value] of Object.entries(exports)) exports_by_identifier[key] = value;
+    } else if (node.type === "ExportNamedDeclaration") {
       node.specifiers.forEach((specifier) => {
         const exported_name = specifier.exported.name;
         const id = exported_name || specifier.local.name;

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -59,7 +59,7 @@ interface GenerateBundleResult {
 export async function generateBundle(input: string, glob: boolean) {
   const dir = fs.lstatSync(input).isFile() ? path.dirname(input) : input;
   const entry = fs.readFileSync(input, "utf-8");
-  const exports = parseExports(entry);
+  const exports = parseExports(entry, dir);
 
   if (glob) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {


### PR DESCRIPTION
In current main, if your entrypoint looks something like:

```js
export { default as MyComponent } from './MyComponent.svelte';
export { default as AnotherComponent } from './AnotherComponent.svelte';

export * from './more-components';
export * from './other-components';
```

`more-components/index.js`
```js
export { default as UtilComponent } from './UtilComponent.svelte';
```

`other-components/index.js`
```js
export { default as AwesomeComponent } from './AwesomeComponent.svelte';

export * from './another-nested-components-dir';
```

`another-nested-components-dir/index.js`
```js
export { default as CoolComponent } from './CoolComponent.svelte';
```

Will only generate types for `MyComponent` and `AnotherComponent`, but with this PR it parses the export * statements and will generate typings for all components

Temporary NPM package: @ethan-jones-vizio/sveld 0.15.2-pr