### PR TITLE
fix(component-parser): preserve JSDoc tags in prop comments

### DIFF
--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -401,7 +401,7 @@
         {
           "name": "hasIconOnly",
           "kind": "let",
-          "description": "Set to `true` for the icon-only variant",
+          "description": "Set to `true` for the icon-only variant\n@deprecated inferred using the $$slots API",
           "type": "boolean",
           "value": "false",
           "isFunction": false,
@@ -611,6 +611,7 @@
         {
           "name": "small",
           "kind": "let",
+          "description": "@deprecated this prop will be removed in the next major release\nUse size=\"small\" instead",
           "type": "boolean",
           "value": "false",
           "isFunction": false,
@@ -3959,7 +3960,7 @@
         {
           "name": "ariaLabel",
           "kind": "let",
-          "description": "Specify the ARIA label for the nav",
+          "description": "Specify the ARIA label for the nav\n@deprecated use \"aria-label\" instead",
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -7743,6 +7744,7 @@
         {
           "name": "small",
           "kind": "let",
+          "description": "@deprecated this prop will be removed in the next major release\nUse size=\"sm\" instead",
           "type": "boolean",
           "value": "false",
           "isFunction": false,
@@ -7930,6 +7932,7 @@
         {
           "name": "small",
           "kind": "let",
+          "description": "@deprecated this prop will be removed in the next major release\nSet to `true` to use the small variant",
           "type": "boolean",
           "value": "false",
           "isFunction": false,
@@ -10567,6 +10570,7 @@
         {
           "name": "hideLabel",
           "kind": "let",
+          "description": "@deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.\nSet to `false` to show the label text",
           "type": "boolean",
           "value": "true",
           "isFunction": false,

--- a/integration/carbon/COMPONENT_INDEX.md
+++ b/integration/carbon/COMPONENT_INDEX.md
@@ -337,7 +337,7 @@ None.
 | Prop name        | Kind             | Reactive | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                   |
 | :--------------- | :--------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ref              | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                        |
-| hasIconOnly      | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` for the icon-only variant                                                                                                                                                       |
+| hasIconOnly      | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` for the icon-only variant<br />@deprecated inferred using the $$slots API                                                                                                       |
 | kind             | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button                                                                                                                                                                    |
 | size             | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code>                                                                                      | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
 | icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                              | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render                                                                                                                                         |
@@ -388,11 +388,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                 | Default value          | Description                          |
-| :-------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | ------------------------------------ |
-| href      | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link |
-| size      | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton  |
-| small     | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | --                                   |
+| Prop name | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                   |
+| :-------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
+| href      | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link                                                          |
+| size      | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton                                                           |
+| small     | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | @deprecated this prop will be removed in the next major release<br />Use size="small" instead |
 
 ### Slots
 
@@ -1488,9 +1488,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value          | Description                        |
-| :-------- | :--------------- | :------- | :------------------ | ---------------------- | ---------------------------------- |
-| ariaLabel | <code>let</code> | No       | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav |
+| Prop name | Kind             | Reactive | Type                | Default value          | Description                                                                  |
+| :-------- | :--------------- | :------- | :------------------ | ---------------------- | ---------------------------------------------------------------------------- |
+| ariaLabel | <code>let</code> | No       | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav<br />@deprecated use "aria-label" instead |
 
 ### Slots
 
@@ -2781,22 +2781,22 @@ None.
 
 ### Props
 
-| Prop name            | Kind             | Reactive | Type                                      | Default value                                    | Description                                             |
-| :------------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------- |
-| ref                  | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element            |
-| value                | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                  | Specify the value of the search input                   |
-| small                | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | --                                                      |
-| size                 | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>                                | Specify the size of the search input                    |
-| skeleton             | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state             |
-| light                | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant               |
-| disabled             | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the search input               |
-| type                 | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the `type` attribute of the search input        |
-| placeholder          | <code>let</code> | No       | <code>string</code>                       | <code>"Search..."</code>                         | Specify the `placeholder` attribute of the search input |
-| autocomplete         | <code>let</code> | No       | <code>"on" &#124; "off"</code>            | <code>"off"</code>                               | Specify the `autocomplete` attribute                    |
-| autofocus            | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to auto focus the search element          |
-| closeButtonLabelText | <code>let</code> | No       | <code>string</code>                       | <code>"Clear search input"</code>                | Specify the close button label text                     |
-| labelText            | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                                  |
-| id                   | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                         |
+| Prop name            | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                                |
+| :------------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| ref                  | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                                               |
+| value                | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                  | Specify the value of the search input                                                      |
+| small                | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | @deprecated this prop will be removed in the next major release<br />Use size="sm" instead |
+| size                 | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>                                | Specify the size of the search input                                                       |
+| skeleton             | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state                                                |
+| light                | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                                                  |
+| disabled             | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the search input                                                  |
+| type                 | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the `type` attribute of the search input                                           |
+| placeholder          | <code>let</code> | No       | <code>string</code>                       | <code>"Search..."</code>                         | Specify the `placeholder` attribute of the search input                                    |
+| autocomplete         | <code>let</code> | No       | <code>"on" &#124; "off"</code>            | <code>"off"</code>                               | Specify the `autocomplete` attribute                                                       |
+| autofocus            | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to auto focus the search element                                             |
+| closeButtonLabelText | <code>let</code> | No       | <code>string</code>                       | <code>"Clear search input"</code>                | Specify the close button label text                                                        |
+| labelText            | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                                                                     |
+| id                   | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                            |
 
 ### Slots
 
@@ -2821,10 +2821,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                      | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :---------------------------------------- | ------------------ | ------------------------------------ |
-| small     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | --                                   |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>  | Specify the size of the search input |
+| Prop name | Kind             | Reactive | Type                                      | Default value      | Description                                                                                                 |
+| :-------- | :--------------- | :------- | :---------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| small     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | @deprecated this prop will be removed in the next major release<br />Set to `true` to use the small variant |
+| size      | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>  | Specify the size of the search input                                                                        |
 
 ### Slots
 
@@ -3880,16 +3880,16 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
-| :-------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
-| value           | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                  | Specify the select value                        |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select             |
-| iconDescription | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>              | Specify the ARIA label for the chevron icon     |
-| labelText       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
-| hideLabel       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>                                | --                                              |
-| id              | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
-| name            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
+| Prop name       | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                                                                                   |
+| :-------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element                                                                                                                                                 |
+| value           | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                  | Specify the select value                                                                                                                                                                      |
+| disabled        | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select                                                                                                                                                           |
+| iconDescription | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>              | Specify the ARIA label for the chevron icon                                                                                                                                                   |
+| labelText       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                                                                                                                                                                        |
+| hideLabel       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>                                | @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.<br />Set to `false` to show the label text |
+| id              | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                                                                                                                                                              |
+| name            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element                                                                                                                                               |
 
 ### Slots
 

--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -28,6 +28,7 @@ export interface ButtonProps
 
   /**
    * Set to `true` for the icon-only variant
+   * @deprecated inferred using the $$slots API
    * @default false
    */
   hasIconOnly?: boolean;

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -16,6 +16,8 @@ export interface ButtonSkeletonProps
   size?: "default" | "field" | "small";
 
   /**
+   * @deprecated this prop will be removed in the next major release
+   * Use size="small" instead
    * @default false
    */
   small?: boolean;

--- a/integration/carbon/types/Search/Search.svelte.d.ts
+++ b/integration/carbon/types/Search/Search.svelte.d.ts
@@ -3,6 +3,8 @@ import type { SvelteComponentTyped } from "svelte";
 
 export interface SearchProps {
   /**
+   * @deprecated this prop will be removed in the next major release
+   * Use size="sm" instead
    * @default false
    */
   small?: boolean;

--- a/integration/carbon/types/Search/SearchSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Search/SearchSkeleton.svelte.d.ts
@@ -4,6 +4,8 @@ import type { SvelteComponentTyped } from "svelte";
 export interface SearchSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
+   * @deprecated this prop will be removed in the next major release
+   * Set to `true` to use the small variant
    * @default false
    */
   small?: boolean;

--- a/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -28,6 +28,8 @@ export interface TimePickerSelectProps
   labelText?: string;
 
   /**
+   * @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.
+   * Set to `false` to show the label text
    * @default true
    */
   hideLabel?: boolean;

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
@@ -5,6 +5,7 @@ export interface HeaderNavProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
   /**
    * Specify the ARIA label for the nav
+   * @deprecated use "aria-label" instead
    * @default undefined
    */
   ariaLabel?: string;

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -508,10 +508,13 @@ export default class ComponentParser {
 
             if (additional_tags.length > 0 && description === undefined) {
               description = "";
-              additional_tags.forEach((tag) => {
-                description += `${description ? "\n" : ""}@${tag.tag} ${tag.name}`;
-              });
             }
+
+            additional_tags.forEach((tag) => {
+              description += `${description ? "\n" : ""}@${tag.tag} ${tag.name}${
+                tag.description ? ` ${tag.description}` : ""
+              }`;
+            });
           }
 
           if (!description && this.typedefs.has(type)) {

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -453,7 +453,7 @@ export default class ComponentParser {
           let value = undefined;
           let type = undefined;
           let kind = node.declaration.kind;
-          let description = undefined;
+          let description: undefined | string = undefined;
           let isFunction = false;
           let isFunctionDeclaration = false;
 
@@ -497,9 +497,21 @@ export default class ComponentParser {
             const comment = commentParser.parse(ComponentParser.formatComment(last_comment.value), {
               spacing: "preserve",
             });
+
             const tag = comment[0]?.tags[comment[0]?.tags.length - 1];
             if (tag?.tag === "type") type = this.aliasType(tag.type);
             description = ComponentParser.assignValue(comment[0]?.description?.trim());
+
+            const additional_tags = comment[0]?.tags.filter(
+              (tag) => !["type", "extends", "restProps", "slot", "event", "typedef"].includes(tag.tag)
+            );
+
+            if (additional_tags.length > 0 && description === undefined) {
+              description = "";
+              additional_tags.forEach((tag) => {
+                description += `${description ? "\n" : ""}@${tag.tag} ${tag.name}`;
+              });
+            }
           }
 
           if (!description && this.typedefs.has(type)) {

--- a/tests/snapshots/prop-comments/input.svelte
+++ b/tests/snapshots/prop-comments/input.svelte
@@ -2,6 +2,7 @@
   /**
    * This is a comment.
    * @see https://github.com/
+   * @deprecated this prop will be removed in the next major release.
    * @type {boolean | string}
    */
   export let prop = true;

--- a/tests/snapshots/prop-comments/input.svelte
+++ b/tests/snapshots/prop-comments/input.svelte
@@ -1,0 +1,19 @@
+<script>
+  /**
+   * This is a comment.
+   * @see https://github.com/
+   * @type {boolean | string}
+   */
+  export let prop = true;
+
+  /** @see https://github.com/ */
+   export let prop1 = true;
+
+  /**
+   * This is a comment.
+   * @type {boolean | string}
+   */
+   export let prop2 = true;
+</script>
+
+<slot {prop} {prop1} {prop2} />

--- a/tests/snapshots/prop-comments/output.d.ts
+++ b/tests/snapshots/prop-comments/output.d.ts
@@ -4,6 +4,8 @@ import type { SvelteComponentTyped } from "svelte";
 export interface InputProps {
   /**
    * This is a comment.
+   * @see https://github.com/
+   * @deprecated this prop will be removed in the next major release.
    * @default true
    */
   prop?: boolean | string;

--- a/tests/snapshots/prop-comments/output.d.ts
+++ b/tests/snapshots/prop-comments/output.d.ts
@@ -1,0 +1,28 @@
+/// <reference types="svelte" />
+import type { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {
+  /**
+   * This is a comment.
+   * @default true
+   */
+  prop?: boolean | string;
+
+  /**
+   * @see https://github.com/
+   * @default true
+   */
+  prop1?: boolean;
+
+  /**
+   * This is a comment.
+   * @default true
+   */
+  prop2?: boolean | string;
+}
+
+export default class Input extends SvelteComponentTyped<
+  InputProps,
+  {},
+  { default: { prop: boolean | string; prop1: boolean; prop2: boolean | string } }
+> {}

--- a/tests/snapshots/prop-comments/output.json
+++ b/tests/snapshots/prop-comments/output.json
@@ -3,7 +3,7 @@
     {
       "name": "prop",
       "kind": "let",
-      "description": "This is a comment.",
+      "description": "This is a comment.\n@see https://github.com/\n@deprecated this prop will be removed in the next major release.",
       "type": "boolean | string",
       "value": "true",
       "isFunction": false,

--- a/tests/snapshots/prop-comments/output.json
+++ b/tests/snapshots/prop-comments/output.json
@@ -1,0 +1,47 @@
+{
+  "props": [
+    {
+      "name": "prop",
+      "kind": "let",
+      "description": "This is a comment.",
+      "type": "boolean | string",
+      "value": "true",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "prop1",
+      "kind": "let",
+      "description": "@see https://github.com/",
+      "type": "boolean",
+      "value": "true",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "prop2",
+      "kind": "let",
+      "description": "This is a comment.",
+      "type": "boolean | string",
+      "value": "true",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{ prop: boolean | string, prop1: boolean, prop2: boolean | string }"
+    }
+  ],
+  "events": [],
+  "typedefs": []
+}


### PR DESCRIPTION
Currently, valid JSDoc tags like `@see` in prop comments are not included in the emitted TypeScript definitions.

This fixes the logic to include such tags.

**Input**

```js
/**
  * This is a comment.
  * @see https://github.com/
  * @deprecated this prop will be removed in the next major release.
  * @type {boolean | string}
  */
export let prop = true;
```

**Output**

```ts
export interface InputProps {
  /**
   * This is a comment.
   * @see https://github.com/
   * @deprecated this prop will be removed in the next major release.
   * @default true
   */
  prop?: boolean | string;
}
```