### PR TITLE
feat: support `@required` tag to denote required component props

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ export default class Button extends SvelteComponentTyped<
 - [API Reference](#api-reference)
   - [@type](#type)
   - [@typedef](#typedef)
+  - [@required](#required)
   - [@slot](#slot)
   - [@event](#event)
   - [@restProps](#restprops)
@@ -349,6 +350,36 @@ export let author = {};
 /** @type {Author[]} */
 export let authors = [];
 ```
+
+### `@required`
+
+By default, all props are typed as optional.
+
+Use the `@required` tag to denote a component prop as required.
+
+Example:
+
+```js
+/**
+ * This prop is required
+ * @required
+ */
+export let isRequired = true;
+```
+
+TypeScript output:
+
+```ts
+export interface ComponentProps {
+  /**
+   * This prop is required
+   * @default true
+   */
+  isRequired: boolean;
+}
+```
+
+Because `@required` is non-standard JSDoc tag, it is omitted from the prop comment in the TypeScript definitions.
 
 ### `@slot`
 

--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -2601,7 +2601,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
-          "isRequired": false,
+          "isRequired": true,
           "constant": false,
           "reactive": false
         },

--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -13,6 +13,7 @@
           "value": "\"end\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -23,6 +24,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -34,6 +36,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -45,6 +48,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -93,6 +97,7 @@
           "value": "\"title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -104,6 +109,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -115,6 +121,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -126,6 +133,7 @@
           "value": "\"Expand/Collapse\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -164,6 +172,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -175,6 +184,7 @@
           "value": "\"end\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -185,6 +195,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -196,6 +207,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -223,6 +235,7 @@
           "value": "\"2x1\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -245,6 +258,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -256,6 +270,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -302,6 +317,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -313,6 +329,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -346,6 +363,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -357,6 +375,7 @@
           "value": "3",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -384,6 +403,7 @@
           "value": "\"primary\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -395,6 +415,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -406,6 +427,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -416,6 +438,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -426,6 +449,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -437,6 +461,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -448,6 +473,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -459,6 +485,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -470,6 +497,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -481,6 +509,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -491,6 +520,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -502,6 +532,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -513,6 +544,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -524,6 +556,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -573,6 +606,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -594,6 +628,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -605,6 +640,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -616,6 +652,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -643,6 +680,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -654,6 +692,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -665,6 +704,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -676,6 +716,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -687,6 +728,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -698,6 +740,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -709,6 +752,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -720,6 +764,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -730,6 +775,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -741,6 +787,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -752,6 +799,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -808,6 +856,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -819,6 +868,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -829,6 +879,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -857,6 +908,7 @@
           "value": "\"single\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -867,6 +919,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -878,6 +931,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -889,6 +943,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -900,6 +955,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -911,6 +967,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -922,6 +979,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -933,6 +991,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -943,6 +1002,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -953,6 +1013,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -964,6 +1025,7 @@
           "value": "\"Copied!\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -975,6 +1037,7 @@
           "value": "2000",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -986,6 +1049,7 @@
           "value": "\"Show less\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -997,6 +1061,7 @@
           "value": "\"Show more\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1008,6 +1073,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1019,6 +1085,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1030,6 +1097,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1081,6 +1149,7 @@
           "value": "\"single\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1108,6 +1177,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1119,6 +1189,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1130,6 +1201,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1141,6 +1213,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1152,6 +1225,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1162,6 +1236,7 @@
           "type": "\"2x1\" | \"16x9\" | \"9x16\" | \"1x2\" | \"4x3\" | \"3x4\" | \"1x1\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1172,6 +1247,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1182,6 +1258,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1192,6 +1269,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1202,6 +1280,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1212,6 +1291,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1256,6 +1336,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1267,6 +1348,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1278,6 +1360,7 @@
           "value": "-1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1289,6 +1372,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1299,6 +1383,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1310,6 +1395,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1321,6 +1407,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1332,6 +1419,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1343,6 +1431,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1354,6 +1443,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1365,6 +1455,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1376,6 +1467,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1387,6 +1479,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1398,6 +1491,7 @@
           "value": "() => true",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1408,6 +1502,7 @@
           "type": "(id: any) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1419,6 +1514,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1429,6 +1525,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1440,6 +1537,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1451,6 +1549,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1489,6 +1588,7 @@
           "type": "\"xs\" | \"sm\" | \"lg\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1500,6 +1600,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1511,6 +1612,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1522,6 +1624,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1533,6 +1636,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1544,6 +1648,7 @@
           "value": "\"[data-modal-primary-focus]\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1555,6 +1660,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1586,6 +1692,7 @@
           "value": "\"main-content\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1608,6 +1715,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1619,6 +1727,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1629,6 +1738,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1657,6 +1767,7 @@
           "value": "\"Copied!\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1668,6 +1779,7 @@
           "value": "2000",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1679,6 +1791,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1711,6 +1824,7 @@
           "value": "\"Copy to clipboard\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1740,6 +1854,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1751,6 +1866,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1761,6 +1877,7 @@
           "type": "\"compact\" | \"short\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1772,6 +1889,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1783,6 +1901,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1794,6 +1913,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1805,6 +1925,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1816,6 +1937,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1827,6 +1949,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1838,6 +1961,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1849,6 +1973,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1860,6 +1985,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1871,6 +1997,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1882,6 +2009,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1893,6 +2021,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2012,6 +2141,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2023,6 +2153,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2033,6 +2164,7 @@
           "type": "\"compact\" | \"short\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2044,6 +2176,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2055,6 +2188,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2066,6 +2200,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2077,6 +2212,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2108,6 +2244,7 @@
           "value": "\"simple\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2119,6 +2256,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2129,6 +2267,7 @@
           "type": "HTMLElement",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2140,6 +2279,7 @@
           "value": "\"m/d/Y\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2151,6 +2291,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2162,6 +2303,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2173,6 +2315,7 @@
           "value": "\"en\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2184,6 +2327,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2195,6 +2339,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2206,6 +2351,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2233,6 +2379,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2244,6 +2391,7 @@
           "value": "\"text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2255,6 +2403,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2266,6 +2415,7 @@
           "value": "\"\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2277,6 +2427,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2288,6 +2439,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2299,6 +2451,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2310,6 +2463,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2321,6 +2475,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2332,6 +2487,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2343,6 +2499,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2353,6 +2510,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2364,6 +2522,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -2390,6 +2549,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2401,6 +2561,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2428,6 +2589,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2439,6 +2601,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2450,6 +2613,7 @@
           "value": "-1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2461,6 +2625,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2471,6 +2636,7 @@
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2482,6 +2648,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2493,6 +2660,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2504,6 +2672,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2515,6 +2684,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2526,6 +2696,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2537,6 +2708,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2548,6 +2720,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2559,6 +2732,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2570,6 +2744,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2581,6 +2756,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2591,6 +2767,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2601,6 +2778,7 @@
           "type": "(id: any) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2612,6 +2790,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2622,6 +2801,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2633,6 +2813,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -2677,6 +2858,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2704,6 +2886,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2715,6 +2898,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2726,6 +2910,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2737,6 +2922,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2748,6 +2934,7 @@
           "value": "\"Interact to expand Tile\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2759,6 +2946,7 @@
           "value": "\"Interact to collapse Tile\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2770,6 +2958,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2781,6 +2970,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2792,6 +2982,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2803,6 +2994,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2814,6 +3006,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -2845,6 +3038,7 @@
           "value": "\"uploading\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2856,6 +3050,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2867,6 +3062,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2878,6 +3074,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2889,6 +3086,7 @@
           "value": "() => {     files = [];   }",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -2900,6 +3098,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2911,6 +3110,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2922,6 +3122,7 @@
           "value": "\"primary\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2933,6 +3134,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2944,6 +3146,7 @@
           "value": "\"Provide icon description\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2955,6 +3158,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2990,6 +3194,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3001,6 +3206,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3012,6 +3218,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3023,6 +3230,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3034,6 +3242,7 @@
           "value": "\"primary\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3045,6 +3254,7 @@
           "value": "\"Add file\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3056,6 +3266,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3067,6 +3278,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3078,6 +3290,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3089,6 +3302,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3100,6 +3314,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3126,6 +3341,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3137,6 +3353,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3148,6 +3365,7 @@
           "value": "(files) => files",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3159,6 +3377,7 @@
           "value": "\"Add file\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3170,6 +3389,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3181,6 +3401,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3192,6 +3413,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3203,6 +3425,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3214,6 +3437,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3225,6 +3449,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3255,6 +3480,7 @@
           "value": "\"uploading\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3266,6 +3492,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3277,6 +3504,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3288,6 +3516,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3299,6 +3528,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3310,6 +3540,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3321,6 +3552,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3363,6 +3595,7 @@
           "value": "\"uploading\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3374,6 +3607,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3385,6 +3619,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3436,6 +3671,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3447,6 +3683,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3458,6 +3695,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3469,6 +3707,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3511,6 +3750,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3538,6 +3778,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3549,6 +3790,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3560,6 +3802,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3571,6 +3814,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3582,6 +3826,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3593,6 +3838,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3604,6 +3850,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3615,6 +3862,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3643,6 +3891,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3654,6 +3903,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3664,6 +3914,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3674,6 +3925,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3684,6 +3936,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3695,6 +3948,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3706,6 +3960,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3717,6 +3972,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3748,6 +4004,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3758,6 +4015,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3768,6 +4026,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3779,6 +4038,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3790,6 +4050,7 @@
           "value": "{ duration: 200 }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3829,6 +4090,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3839,6 +4101,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3849,6 +4112,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3860,6 +4124,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3882,6 +4147,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3915,6 +4181,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3925,6 +4192,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3936,6 +4204,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3964,6 +4233,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3985,6 +4255,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3995,6 +4266,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4006,6 +4278,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4037,6 +4310,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4048,6 +4322,7 @@
           "value": "\"/\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4058,6 +4333,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4069,6 +4345,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4080,6 +4357,7 @@
           "value": "\"Expand/Collapse\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4119,6 +4397,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4130,6 +4409,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4161,6 +4441,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4172,6 +4453,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4183,6 +4465,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4194,6 +4477,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4205,6 +4489,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4262,6 +4547,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4273,6 +4559,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4308,6 +4595,7 @@
           "value": "16",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4335,6 +4623,7 @@
           "value": "\"active\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4345,6 +4634,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4355,6 +4645,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4366,6 +4657,7 @@
           "value": "1500",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4394,6 +4686,7 @@
           "value": "\"error\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4405,6 +4698,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4416,6 +4710,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4427,6 +4722,7 @@
           "value": "\"alert\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4438,6 +4734,7 @@
           "value": "\"Title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4449,6 +4746,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4460,6 +4758,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4471,6 +4770,7 @@
           "value": "\"Closes notification\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4505,6 +4805,7 @@
           "type": "\"sm\" | \"lg\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4515,6 +4816,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4526,6 +4828,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4537,6 +4840,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4548,6 +4852,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4559,6 +4864,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4585,6 +4891,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4596,6 +4903,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4607,6 +4915,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4618,6 +4927,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4629,6 +4939,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4640,6 +4951,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4651,6 +4963,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4662,6 +4975,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4673,6 +4987,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4698,6 +5013,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4709,6 +5025,7 @@
           "value": "\"combobox\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4720,6 +5037,7 @@
           "value": "\"-1\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4731,6 +5049,7 @@
           "value": "{ close: \"close\", open: \"open\" }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -4742,6 +5061,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4753,6 +5073,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4764,6 +5085,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4799,6 +5121,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4810,6 +5133,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4832,6 +5156,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4843,6 +5168,7 @@
           "value": "{ close: \"close\", open: \"open\" }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -4854,6 +5180,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4882,6 +5209,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4893,6 +5221,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4918,6 +5247,7 @@
           "type": "any",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4929,6 +5259,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4940,6 +5271,7 @@
           "value": "{     clearAll: \"clearAll\",     clearSelection: \"clearSelection\",   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -4951,6 +5283,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4962,6 +5295,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -5005,6 +5339,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5016,6 +5351,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5027,6 +5363,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5038,6 +5375,7 @@
           "value": "\"Active loading indicator\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5049,6 +5387,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5070,6 +5409,7 @@
           "type": "\"xs\" | \"sm\" | \"lg\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5081,6 +5421,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5092,6 +5433,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5103,6 +5445,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5114,6 +5457,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5124,6 +5468,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5134,6 +5479,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5144,6 +5490,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5155,6 +5502,7 @@
           "value": "\"Close the modal\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5166,6 +5514,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5177,6 +5526,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5188,6 +5538,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5199,6 +5550,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5210,6 +5562,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5221,6 +5574,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5232,6 +5586,7 @@
           "value": "\"[data-modal-primary-focus]\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5243,6 +5598,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5254,6 +5610,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5265,6 +5622,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -5315,6 +5673,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5326,6 +5685,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5348,6 +5708,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5359,6 +5720,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5369,6 +5731,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5380,6 +5743,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5390,6 +5754,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5401,6 +5766,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5423,6 +5789,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5434,6 +5801,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5445,6 +5813,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5456,6 +5825,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5467,6 +5837,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5478,6 +5849,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5489,6 +5861,7 @@
           "value": "\"Close\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5511,6 +5884,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5522,6 +5896,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5533,6 +5908,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5544,6 +5920,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5554,6 +5931,7 @@
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5565,6 +5943,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5576,6 +5955,7 @@
           "value": "\"top-after-reopen\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5587,6 +5967,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5598,6 +5979,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5609,6 +5991,7 @@
           "value": "(item, value) => item.text.toLowerCase().includes(value.toLowerCase())",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5620,6 +6003,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5631,6 +6015,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5642,6 +6027,7 @@
           "value": "\"en\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5653,6 +6039,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5664,6 +6051,7 @@
           "value": "(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5674,6 +6062,7 @@
           "type": "(id: any) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5685,6 +6074,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5696,6 +6086,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5707,6 +6098,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5718,6 +6110,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5729,6 +6122,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5740,6 +6134,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5751,6 +6146,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5762,6 +6158,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5773,6 +6170,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5783,6 +6181,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5842,6 +6241,7 @@
           "value": "\"toast\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5852,6 +6252,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5862,6 +6263,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5873,6 +6275,7 @@
           "value": "\"Close icon\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5900,6 +6303,7 @@
           "value": "\"error\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5911,6 +6315,7 @@
           "value": "\"toast\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5922,6 +6327,7 @@
           "value": "\"Closes notification\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5943,6 +6349,7 @@
           "value": "\"toast\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5954,6 +6361,7 @@
           "value": "\"Title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5965,6 +6373,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5976,6 +6385,7 @@
           "value": "\"Caption\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5996,6 +6406,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6007,6 +6418,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6018,6 +6430,7 @@
           "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6028,6 +6441,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6038,6 +6452,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6049,6 +6464,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6060,6 +6476,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6071,6 +6488,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6082,6 +6500,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6093,6 +6512,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6104,6 +6524,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6115,6 +6536,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6126,6 +6548,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6137,6 +6560,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6148,6 +6572,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6159,6 +6584,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6170,6 +6596,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6181,6 +6608,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6192,6 +6620,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6203,6 +6632,7 @@
           "value": "{     increment: \"increment\",     decrement: \"decrement\",   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -6214,6 +6644,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6224,6 +6655,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6235,6 +6667,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -6277,6 +6710,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6304,6 +6738,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6315,6 +6750,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6357,6 +6793,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6368,6 +6805,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6379,6 +6817,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6390,6 +6829,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6401,6 +6841,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6411,6 +6852,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6421,6 +6863,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6431,6 +6874,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6442,6 +6886,7 @@
           "value": "\"Open and close list of options\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6453,6 +6898,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6464,6 +6910,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6475,6 +6922,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -6516,6 +6964,7 @@
           "value": "\"Provide text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6527,6 +6976,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6538,6 +6988,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6549,6 +7000,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6560,6 +7012,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6571,6 +7024,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6582,6 +7036,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6593,6 +7048,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6604,6 +7060,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -6636,6 +7093,7 @@
           "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6647,6 +7105,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6658,6 +7117,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6669,6 +7129,7 @@
           "value": "\"Next page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6680,6 +7141,7 @@
           "value": "\"Previous page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6691,6 +7153,7 @@
           "value": "\"Items per page:\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6702,6 +7165,7 @@
           "value": "(min, max) => `${min}–${max} items`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6713,6 +7177,7 @@
           "value": "(min, max, total) => `${min}–${max} of ${total} items`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6724,6 +7189,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6735,6 +7201,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6746,6 +7213,7 @@
           "value": "10",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6757,6 +7225,7 @@
           "value": "[10]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6768,6 +7237,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6779,6 +7249,7 @@
           "value": "(page) => `page ${page}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6790,6 +7261,7 @@
           "value": "(current, total) => `of ${total} page${total === 1 ? \"\" : \"s\"}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6801,6 +7273,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6829,6 +7302,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6840,6 +7314,7 @@
           "value": "10",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6851,6 +7326,7 @@
           "value": "10",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6862,6 +7338,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6873,6 +7350,7 @@
           "value": "\"Next page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6884,6 +7362,7 @@
           "value": "\"Previous page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6936,6 +7415,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6947,6 +7427,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6958,6 +7439,7 @@
           "value": "\"password\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6969,6 +7451,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6980,6 +7463,7 @@
           "value": "\"Hide password\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6991,6 +7475,7 @@
           "value": "\"Show password\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7002,6 +7487,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7013,6 +7499,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7024,6 +7511,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7035,6 +7523,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7046,6 +7535,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7057,6 +7547,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7068,6 +7559,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7079,6 +7571,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7090,6 +7583,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7101,6 +7595,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7111,6 +7606,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7122,6 +7618,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -7154,6 +7651,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7165,6 +7663,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7176,6 +7675,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7187,6 +7687,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7215,6 +7716,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7226,6 +7728,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7253,6 +7756,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7264,6 +7768,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7275,6 +7780,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7286,6 +7792,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7297,6 +7804,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7308,6 +7816,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7319,6 +7828,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7330,6 +7840,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7365,6 +7876,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7376,6 +7888,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7387,6 +7900,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7398,6 +7912,7 @@
           "value": "\"right\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7409,6 +7924,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7420,6 +7936,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7431,6 +7948,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7442,6 +7960,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7453,6 +7972,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -7474,6 +7994,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7485,6 +8006,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7496,6 +8018,7 @@
           "value": "\"right\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7507,6 +8030,7 @@
           "value": "\"horizontal\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7517,6 +8041,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7560,6 +8085,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7571,6 +8097,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7582,6 +8109,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7593,6 +8121,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7604,6 +8133,7 @@
           "value": "\"Tile checkmark\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7615,6 +8145,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7626,6 +8157,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7655,6 +8187,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7666,6 +8199,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7677,6 +8211,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7688,6 +8223,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7699,6 +8235,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7710,6 +8247,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7721,6 +8259,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7749,6 +8288,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7760,6 +8300,7 @@
           "value": "\"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7771,6 +8312,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7782,6 +8324,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7793,6 +8336,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7804,6 +8348,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7815,6 +8360,7 @@
           "value": "\"text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7826,6 +8372,7 @@
           "value": "\"Search...\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7837,6 +8384,7 @@
           "value": "\"off\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7848,6 +8396,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7859,6 +8408,7 @@
           "value": "\"Clear search input\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7870,6 +8420,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7881,6 +8432,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7892,6 +8444,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -7937,6 +8490,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7948,6 +8502,7 @@
           "value": "\"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7974,6 +8529,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7984,6 +8540,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7995,6 +8552,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8006,6 +8564,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8017,6 +8576,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8028,6 +8588,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8038,6 +8599,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8049,6 +8611,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8060,6 +8623,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8071,6 +8635,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8082,6 +8647,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8093,6 +8659,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8104,6 +8671,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8115,6 +8683,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8140,6 +8709,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8151,6 +8721,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8162,6 +8733,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8173,6 +8745,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8194,6 +8767,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8205,6 +8779,7 @@
           "value": "\"Provide label\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8227,6 +8802,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8254,6 +8830,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8265,6 +8842,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8276,6 +8854,7 @@
           "value": "\"title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8287,6 +8866,7 @@
           "value": "\"value\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8298,6 +8878,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8309,6 +8890,7 @@
           "value": "\"Tile checkmark\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8320,6 +8902,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8331,6 +8914,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8342,6 +8926,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8370,6 +8955,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8380,6 +8966,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8391,6 +8978,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8422,6 +9010,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8432,6 +9021,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8442,6 +9032,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8452,6 +9043,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8463,6 +9055,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8485,6 +9078,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8495,6 +9089,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8505,6 +9100,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8516,6 +9112,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8537,6 +9134,7 @@
           "type": "boolean",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8547,6 +9145,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8557,6 +9156,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8568,6 +9168,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8605,6 +9206,7 @@
           "value": "3",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8616,6 +9218,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8627,6 +9230,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8638,6 +9242,7 @@
           "value": "\"100%\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8665,6 +9270,7 @@
           "value": "\"#main-content\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8676,6 +9282,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8705,6 +9312,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8716,6 +9324,7 @@
           "value": "100",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8727,6 +9336,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8738,6 +9348,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8749,6 +9360,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8760,6 +9372,7 @@
           "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8771,6 +9384,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8782,6 +9396,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8793,6 +9408,7 @@
           "value": "\"number\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8804,6 +9420,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8815,6 +9432,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8826,6 +9444,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8837,6 +9456,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8848,6 +9468,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8859,6 +9480,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8870,6 +9492,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8881,6 +9504,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8909,6 +9533,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8935,6 +9560,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8946,6 +9572,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8957,6 +9584,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9000,6 +9628,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9011,6 +9640,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9053,6 +9683,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9064,6 +9695,7 @@
           "value": "\"title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9075,6 +9707,7 @@
           "value": "\"value\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9086,6 +9719,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9097,6 +9731,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9108,6 +9743,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9130,6 +9766,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9141,6 +9778,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9152,6 +9790,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9180,6 +9819,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9191,6 +9831,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9218,6 +9859,7 @@
           "value": "\"Provide text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9229,6 +9871,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9240,6 +9883,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9251,6 +9895,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9262,6 +9907,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9297,6 +9943,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9308,6 +9955,7 @@
           "value": "\"#\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9319,6 +9967,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9330,6 +9979,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9341,6 +9991,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9352,6 +10003,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9386,6 +10038,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9407,6 +10060,7 @@
           "type": "\"compact\" | \"short\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9418,6 +10072,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9429,6 +10084,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9440,6 +10096,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9451,6 +10108,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9462,6 +10120,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9509,6 +10168,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9520,6 +10180,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9531,6 +10192,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9568,6 +10230,7 @@
           "value": "\"col\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9579,6 +10242,7 @@
           "value": "() => \"\"",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9590,6 +10254,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9632,6 +10297,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9643,6 +10309,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9654,6 +10321,7 @@
           "value": "\"Show menu options\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9665,6 +10333,7 @@
           "value": "\"#\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9694,6 +10363,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9720,6 +10390,7 @@
           "type": "\"red\" | \"magenta\" | \"purple\" | \"blue\" | \"cyan\" | \"teal\" | \"green\" | \"gray\" | \"cool-gray\" | \"warm-gray\" | \"high-contrast\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9731,6 +10402,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9742,6 +10414,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9753,6 +10426,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9764,6 +10438,7 @@
           "value": "\"Clear filter\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9774,6 +10449,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9785,6 +10461,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9834,6 +10511,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9845,6 +10523,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9856,6 +10535,7 @@
           "value": "50",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9867,6 +10547,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9878,6 +10559,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9889,6 +10571,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9900,6 +10583,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9911,6 +10595,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9922,6 +10607,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9933,6 +10619,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9944,6 +10631,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9955,6 +10643,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9965,6 +10654,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9976,6 +10666,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10007,6 +10698,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10033,6 +10725,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10044,6 +10737,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10055,6 +10749,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10066,6 +10761,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10077,6 +10773,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10088,6 +10785,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10099,6 +10797,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10110,6 +10809,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10120,6 +10820,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10131,6 +10832,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10142,6 +10844,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10153,6 +10856,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10164,6 +10868,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10175,6 +10880,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10186,6 +10892,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10197,6 +10904,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10208,6 +10916,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10219,6 +10928,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10251,6 +10961,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10278,6 +10989,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10304,6 +11016,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10315,6 +11028,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10326,6 +11040,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10347,6 +11062,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10358,6 +11074,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10369,6 +11086,7 @@
           "value": "\"text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10380,6 +11098,7 @@
           "value": "\"hh=mm\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10391,6 +11110,7 @@
           "value": "\"(1[012]|[1-9]):[0-5][0-9](\\\\s)?\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10402,6 +11122,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10413,6 +11134,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10424,6 +11146,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10435,6 +11158,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10446,6 +11170,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10457,6 +11182,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10468,6 +11194,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10479,6 +11206,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10489,6 +11217,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10500,6 +11229,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10531,6 +11261,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10542,6 +11273,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10553,6 +11285,7 @@
           "value": "\"Open list of options\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10564,6 +11297,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10575,6 +11309,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10586,6 +11321,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10596,6 +11332,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10607,6 +11344,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10634,6 +11372,7 @@
           "value": "\"error\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10645,6 +11384,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10656,6 +11396,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10667,6 +11408,7 @@
           "value": "\"alert\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10678,6 +11420,7 @@
           "value": "\"Title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10689,6 +11432,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10700,6 +11444,7 @@
           "value": "\"Caption\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10711,6 +11456,7 @@
           "value": "\"Closes notification\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10722,6 +11468,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10754,6 +11501,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10765,6 +11513,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10776,6 +11525,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10787,6 +11537,7 @@
           "value": "\"Off\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10798,6 +11549,7 @@
           "value": "\"On\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10809,6 +11561,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10820,6 +11573,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10830,6 +11584,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10866,6 +11621,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10877,6 +11633,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10888,6 +11645,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10915,6 +11673,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10926,6 +11685,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10937,6 +11697,7 @@
           "value": "\"Off\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10948,6 +11709,7 @@
           "value": "\"On\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10959,6 +11721,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10970,6 +11733,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10980,6 +11744,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11011,6 +11776,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11022,6 +11788,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11049,6 +11816,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11071,6 +11839,7 @@
           "value": "(totalSelected) => `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11137,6 +11906,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11148,6 +11918,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11159,6 +11930,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11170,6 +11942,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11181,6 +11954,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -11208,6 +11982,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11219,6 +11994,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11230,6 +12006,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11241,6 +12018,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11251,6 +12029,7 @@
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11262,6 +12041,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11273,6 +12053,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11284,6 +12065,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11295,6 +12077,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11306,6 +12089,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11317,6 +12101,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11328,6 +12113,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11339,6 +12125,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11350,6 +12137,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -11389,6 +12177,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11400,6 +12189,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11411,6 +12201,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11422,6 +12213,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11433,6 +12225,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -11469,6 +12262,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11480,6 +12274,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11491,6 +12286,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11502,6 +12298,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11513,6 +12310,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -11549,6 +12347,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/integration/carbon/COMPONENT_INDEX.md
+++ b/integration/carbon/COMPONENT_INDEX.md
@@ -976,7 +976,7 @@ export interface DropdownItem {
 | open            | No       | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to open the dropdown            |
 | selectedIndex   | No       | <code>let</code> | Yes      | <code>number</code>                         | <code>-1</code>                                       | Specify the selected item index               |
 | items           | No       | <code>let</code> | No       | <code>DropdownItem[]</code>                 | <code>[]</code>                                       | Set the dropdown items                        |
-| itemToString    | No       | <code>let</code> | No       | <code>(item: DropdownItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item       |
+| itemToString    | Yes      | <code>let</code> | No       | <code>(item: DropdownItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item       |
 | type            | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>      | <code>"default"</code>                                | Specify the type of dropdown                  |
 | size            | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>   | <code>undefined</code>                                | Specify the size of the dropdown field        |
 | light           | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to enable the light variant     |

--- a/integration/carbon/COMPONENT_INDEX.md
+++ b/integration/carbon/COMPONENT_INDEX.md
@@ -167,12 +167,12 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value          | Description                                      |
-| :-------- | :--------------- | :------- | :-------------------------------- | ---------------------- | ------------------------------------------------ |
-| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
-| disabled  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
-| skeleton  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
+| Prop name | Required | Kind             | Reactive | Type                              | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | --------------------------------- | ---------------------- | ------------------------------------------------ |
+| align     | No       | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
+| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
 
 ### Slots
 
@@ -193,12 +193,12 @@
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value                  | Description                                                                                                                              |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| disabled        | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to disable the accordion item                                                                                              |
-| open            | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to open the first accordion item                                                                                           |
-| title           | <code>let</code> | No       | <code>string</code>  | <code>"title"</code>           | Specify the title of the accordion item heading<br />Alternatively, use the "title" slot (e.g., &lt;div slot="title"&gt;...&lt;/div&gt;) |
-| iconDescription | <code>let</code> | No       | <code>string</code>  | <code>"Expand/Collapse"</code> | Specify the ARIA label for the accordion item chevron icon                                                                               |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value                  | Description                                                                                                                              |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| disabled        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to disable the accordion item                                                                                              |
+| open            | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to open the first accordion item                                                                                           |
+| title           | No       | <code>let</code> | No       | <code>string</code>  | <code>"title"</code>           | Specify the title of the accordion item heading<br />Alternatively, use the "title" slot (e.g., &lt;div slot="title"&gt;...&lt;/div&gt;) |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>  | <code>"Expand/Collapse"</code> | Specify the ARIA label for the accordion item chevron icon                                                                               |
 
 ### Slots
 
@@ -222,12 +222,12 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value          | Description                                      |
-| :-------- | :--------------- | :------- | :-------------------------------- | ---------------------- | ------------------------------------------------ |
-| count     | <code>let</code> | No       | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
-| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
-| open      | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
+| Prop name | Required | Kind             | Reactive | Type                              | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | --------------------------------- | ---------------------- | ------------------------------------------------ |
+| count     | No       | <code>let</code> | No       | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
+| align     | No       | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| open      | No       | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
 
 ### Slots
 
@@ -246,9 +246,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                                               | Default value      | Description              |
-| :-------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ |
-| ratio     | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "9x16" &#124; "1x2"</code> | <code>"2x1"</code> | Specify the aspect ratio |
+| Prop name | Required | Kind             | Reactive | Type                                                                                               | Default value      | Description              |
+| :-------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ |
+| ratio     | No       | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "9x16" &#124; "1x2"</code> | <code>"2x1"</code> | Specify the aspect ratio |
 
 ### Slots
 
@@ -264,10 +264,10 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value      | Description                                         |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------------- |
-| noTrailingSlash | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
-| skeleton        | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to display skeleton state             |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value      | Description                                         |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------------- |
+| noTrailingSlash | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
+| skeleton        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to display skeleton state             |
 
 ### Slots
 
@@ -288,10 +288,10 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value          | Description                                                      |
-| :------------ | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------------------------- |
-| href          | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
-| isCurrentPage | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
+| Prop name     | Required | Kind             | Reactive | Type                 | Default value          | Description                                                      |
+| :------------ | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------------------------- |
+| href          | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
+| isCurrentPage | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
 
 ### Slots
 
@@ -312,10 +312,10 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value      | Description                                         |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------------- |
-| noTrailingSlash | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
-| count           | <code>let</code> | No       | <code>number</code>  | <code>3</code>     | Specify the number of breadcrumb items to render    |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value      | Description                                         |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------------- |
+| noTrailingSlash | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
+| count           | No       | <code>let</code> | No       | <code>number</code>  | <code>3</code>     | Specify the number of breadcrumb items to render    |
 
 ### Slots
 
@@ -334,22 +334,22 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                   |
-| :--------------- | :--------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref              | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                        |
-| hasIconOnly      | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` for the icon-only variant<br />@deprecated inferred using the $$slots API                                                                                                       |
-| kind             | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button                                                                                                                                                                    |
-| size             | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code>                                                                                      | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
-| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                              | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render                                                                                                                                         |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon                                                                                                                                                    |
-| tooltipAlignment | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon<br />`hasIconOnly` must be set to `true`                                                                                                |
-| tooltipPosition  | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon                                                                                                                                          |
-| as               | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Button let:props&gt;&lt;div {...props}&gt;...&lt;/div&gt;&lt;/Button&gt;) |
-| skeleton         | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                   |
-| disabled         | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                           |
-| href             | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link                                                                                                                                                          |
-| tabindex         | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                          |
-| type             | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                           |
+| Prop name        | Required | Kind             | Reactive | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                   |
+| :--------------- | :------- | :--------------- | :------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref              | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                        |
+| hasIconOnly      | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` for the icon-only variant<br />@deprecated inferred using the $$slots API                                                                                                       |
+| kind             | No       | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button                                                                                                                                                                    |
+| size             | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code>                                                                                      | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
+| icon             | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                              | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render                                                                                                                                         |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon                                                                                                                                                    |
+| tooltipAlignment | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon<br />`hasIconOnly` must be set to `true`                                                                                                |
+| tooltipPosition  | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon                                                                                                                                          |
+| as               | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Button let:props&gt;&lt;div {...props}&gt;...&lt;/div&gt;&lt;/Button&gt;) |
+| skeleton         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                   |
+| disabled         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                           |
+| href             | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link                                                                                                                                                          |
+| tabindex         | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                          |
+| type             | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                           |
 
 ### Slots
 
@@ -370,9 +370,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| stacked   | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to stack the buttons vertically |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| stacked   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to stack the buttons vertically |
 
 ### Slots
 
@@ -388,11 +388,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                   |
-| :-------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
-| href      | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link                                                          |
-| size      | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton                                                           |
-| small     | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | @deprecated this prop will be removed in the next major release<br />Use size="small" instead |
+| Prop name | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                   |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
+| href      | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link                                                          |
+| size      | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton                                                           |
+| small     | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | @deprecated this prop will be removed in the next major release<br />Use size="small" instead |
 
 ### Slots
 
@@ -411,19 +411,19 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                       |
-| :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
-| checked       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
-| indeterminate | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
-| skeleton      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state       |
-| readonly      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` for the checkbox to be read-only    |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the checkbox             |
-| labelText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                            |
-| hideLabel     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text     |
-| name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Set a name for the input element                  |
-| title         | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the title attribute for the label element |
-| id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input label                     |
+| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                       |
+| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
+| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
+| checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
+| indeterminate | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
+| skeleton      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state       |
+| readonly      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` for the checkbox to be read-only    |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the checkbox             |
+| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                            |
+| hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text     |
+| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Set a name for the input element                  |
+| title         | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the title attribute for the label element |
+| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input label                     |
 
 ### Slots
 
@@ -463,11 +463,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ----------------------------------------- |
-| clicked   | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
-| light     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
-| href      | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ----------------------------------------- |
+| clicked   | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
+| light     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
+| href      | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
 
 ### Slots
 
@@ -489,25 +489,25 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                                                |
-| :-------------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| ref                   | <code>let</code> | Yes      | <code>null &#124; HTMLPreElement</code>              | <code>null</code>                                | Obtain a reference to the pre HTML element                                                                                 |
-| showMoreLess          | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the show more/less button                                                                          |
-| expanded              | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to expand a multi-line code snippet (type="multi")                                                           |
-| type                  | <code>let</code> | No       | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                            | Set the type of code snippet                                                                                               |
-| code                  | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;) |
-| hideCopyButton        | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to hide the copy button                                                                                      |
-| disabled              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                    |
-| wrapText              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                       |
-| light                 | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                                                                                  |
-| skeleton              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to display the skeleton state                                                                                |
-| copyButtonDescription | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label for the copy button icon                                                                            |
-| copyLabel             | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label of the copy button                                                                                  |
-| feedback              | <code>let</code> | No       | <code>string</code>                                  | <code>"Copied!"</code>                           | Specify the feedback text displayed when clicking the snippet                                                              |
-| feedbackTimeout       | <code>let</code> | No       | <code>number</code>                                  | <code>2000</code>                                | Set the timeout duration (ms) to display feedback text                                                                     |
-| showLessText          | <code>let</code> | No       | <code>string</code>                                  | <code>"Show less"</code>                         | Specify the show less text<br />`type` must be "multi"                                                                     |
-| showMoreText          | <code>let</code> | No       | <code>string</code>                                  | <code>"Show more"</code>                         | Specify the show more text<br />`type` must be "multi"                                                                     |
-| id                    | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the code element                                                                                             |
+| Prop name             | Required | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                                                |
+| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| ref                   | No       | <code>let</code> | Yes      | <code>null &#124; HTMLPreElement</code>              | <code>null</code>                                | Obtain a reference to the pre HTML element                                                                                 |
+| showMoreLess          | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the show more/less button                                                                          |
+| expanded              | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to expand a multi-line code snippet (type="multi")                                                           |
+| type                  | No       | <code>let</code> | No       | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                            | Set the type of code snippet                                                                                               |
+| code                  | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;) |
+| hideCopyButton        | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to hide the copy button                                                                                      |
+| disabled              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                    |
+| wrapText              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                       |
+| light                 | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                                                                                  |
+| skeleton              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to display the skeleton state                                                                                |
+| copyButtonDescription | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label for the copy button icon                                                                            |
+| copyLabel             | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label of the copy button                                                                                  |
+| feedback              | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Copied!"</code>                           | Specify the feedback text displayed when clicking the snippet                                                              |
+| feedbackTimeout       | No       | <code>let</code> | No       | <code>number</code>                                  | <code>2000</code>                                | Set the timeout duration (ms) to display feedback text                                                                     |
+| showLessText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Show less"</code>                         | Specify the show less text<br />`type` must be "multi"                                                                     |
+| showMoreText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Show more"</code>                         | Specify the show more text<br />`type` must be "multi"                                                                     |
+| id                    | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the code element                                                                                             |
 
 ### Slots
 
@@ -529,9 +529,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                 | Default value         | Description                  |
-| :-------- | :--------------- | :------- | :----------------------------------- | --------------------- | ---------------------------- |
-| type      | <code>let</code> | No       | <code>"single" &#124; "multi"</code> | <code>"single"</code> | Set the type of code snippet |
+| Prop name | Required | Kind             | Reactive | Type                                 | Default value         | Description                  |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------ | --------------------- | ---------------------------- |
+| type      | No       | <code>let</code> | No       | <code>"single" &#124; "multi"</code> | <code>"single"</code> | Set the type of code snippet |
 
 ### Slots
 
@@ -563,19 +563,19 @@ export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
-| :------------ | :--------------- | :------- | :------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
-| noGutter      | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
-| padding       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
-| aspectRatio   | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
-| sm            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
-| md            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
-| lg            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
-| xlg           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
-| max           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
+| Prop name     | Required | Kind             | Reactive | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
+| :------------ | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
+| noGutter      | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
+| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
+| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
+| padding       | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
+| aspectRatio   | No       | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
+| sm            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
+| md            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
+| lg            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
+| xlg           | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
+| max           | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
 
 ### Slots
 
@@ -600,27 +600,27 @@ export interface ComboBoxItem {
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                        | Default value                                         | Description                                                              |
-| :--------------- | :--------------- | :------- | :---------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
-| listRef          | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                     | <code>null</code>                                     | Obtain a reference to the list HTML element                              |
-| ref              | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                   | <code>null</code>                                     | Obtain a reference to the input HTML element                             |
-| open             | <code>let</code> | Yes      | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to open the combobox menu dropdown                         |
-| value            | <code>let</code> | Yes      | <code>string</code>                                         | <code>""</code>                                       | Specify the selected combobox value                                      |
-| selectedIndex    | <code>let</code> | Yes      | <code>number</code>                                         | <code>-1</code>                                       | Set the selected item by value index                                     |
-| items            | <code>let</code> | No       | <code>ComboBoxItem[]</code>                                 | <code>[]</code>                                       | Set the combobox items                                                   |
-| itemToString     | <code>let</code> | No       | <code>(item: ComboBoxItem) => string</code>                 | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a combobox item                                  |
-| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                               | <code>undefined</code>                                | Set the size of the combobox                                             |
-| disabled         | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to disable the combobox                                    |
-| titleText        | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the title text of the combobox                                   |
-| placeholder      | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the placeholder text                                             |
-| helperText       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the helper text                                                  |
-| invalidText      | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the invalid state text                                           |
-| invalid          | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to indicate an invalid state                               |
-| light            | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to enable the light variant                                |
-| shouldFilterItem | <code>let</code> | No       | <code>(item: ComboBoxItem, value: string) => boolean</code> | <code>() => true</code>                               | Determine if an item should be filtered given the current combobox value |
-| translateWithId  | <code>let</code> | No       | <code>(id: any) => string</code>                            | <code>undefined</code>                                | Override the default translation ids                                     |
-| id               | <code>let</code> | No       | <code>string</code>                                         | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component                                     |
-| name             | <code>let</code> | No       | <code>string</code>                                         | <code>undefined</code>                                | Specify a name attribute for the input                                   |
+| Prop name        | Required | Kind             | Reactive | Type                                                        | Default value                                         | Description                                                              |
+| :--------------- | :------- | :--------------- | :------- | ----------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
+| listRef          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                     | <code>null</code>                                     | Obtain a reference to the list HTML element                              |
+| ref              | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                   | <code>null</code>                                     | Obtain a reference to the input HTML element                             |
+| open             | No       | <code>let</code> | Yes      | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to open the combobox menu dropdown                         |
+| value            | No       | <code>let</code> | Yes      | <code>string</code>                                         | <code>""</code>                                       | Specify the selected combobox value                                      |
+| selectedIndex    | No       | <code>let</code> | Yes      | <code>number</code>                                         | <code>-1</code>                                       | Set the selected item by value index                                     |
+| items            | No       | <code>let</code> | No       | <code>ComboBoxItem[]</code>                                 | <code>[]</code>                                       | Set the combobox items                                                   |
+| itemToString     | No       | <code>let</code> | No       | <code>(item: ComboBoxItem) => string</code>                 | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a combobox item                                  |
+| size             | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                               | <code>undefined</code>                                | Set the size of the combobox                                             |
+| disabled         | No       | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to disable the combobox                                    |
+| titleText        | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the title text of the combobox                                   |
+| placeholder      | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the placeholder text                                             |
+| helperText       | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the helper text                                                  |
+| invalidText      | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                       | Specify the invalid state text                                           |
+| invalid          | No       | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to indicate an invalid state                               |
+| light            | No       | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                    | Set to `true` to enable the light variant                                |
+| shouldFilterItem | No       | <code>let</code> | No       | <code>(item: ComboBoxItem, value: string) => boolean</code> | <code>() => true</code>                               | Determine if an item should be filtered given the current combobox value |
+| translateWithId  | No       | <code>let</code> | No       | <code>(id: any) => string</code>                            | <code>undefined</code>                                | Override the default translation ids                                     |
+| id               | No       | <code>let</code> | No       | <code>string</code>                                         | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component                                     |
+| name             | No       | <code>let</code> | No       | <code>string</code>                                         | <code>undefined</code>                                | Specify a name attribute for the input                                   |
 
 ### Slots
 
@@ -641,15 +641,15 @@ None.
 
 ### Props
 
-| Prop name                  | Kind             | Reactive | Type                                      | Default value                             | Description                                                           |
-| :------------------------- | :--------------- | :------- | :---------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
-| ref                        | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
-| open                       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
-| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
-| danger                     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
-| preventCloseOnClickOutside | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
-| containerClass             | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
-| selectorPrimaryFocus       | <code>let</code> | No       | <code>null &#124; string</code>           | <code>"[data-modal-primary-focus]"</code> | Specify a selector to be focused when opening the modal               |
+| Prop name                  | Required | Kind             | Reactive | Type                                      | Default value                             | Description                                                           |
+| :------------------------- | :------- | :--------------- | :------- | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| ref                        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
+| open                       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
+| size                       | No       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
+| danger                     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
+| preventCloseOnClickOutside | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
+| containerClass             | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
+| selectorPrimaryFocus       | No       | <code>let</code> | No       | <code>null &#124; string</code>           | <code>"[data-modal-primary-focus]"</code> | Specify a selector to be focused when opening the modal               |
 
 ### Slots
 
@@ -674,9 +674,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value               | Description                         |
-| :-------- | :--------------- | :------- | :------------------ | --------------------------- | ----------------------------------- |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"main-content"</code> | Specify the id for the main element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value               | Description                         |
+| :-------- | :------- | :--------------- | :------- | ------------------- | --------------------------- | ----------------------------------- |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"main-content"</code> | Specify the id for the main element |
 
 ### Slots
 
@@ -692,11 +692,11 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                          | Default value          | Description                               |
-| :------------ | :--------------- | :------- | :---------------------------- | ---------------------- | ----------------------------------------- |
-| selectedIndex | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
-| light         | <code>let</code> | No       | <code>boolean</code>          | <code>false</code>     | Set to `true` to enable the light variant |
-| size          | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
+| Prop name     | Required | Kind             | Reactive | Type                          | Default value          | Description                               |
+| :------------ | :------- | :--------------- | :------- | ----------------------------- | ---------------------- | ----------------------------------------- |
+| selectedIndex | No       | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
+| light         | No       | <code>let</code> | No       | <code>boolean</code>          | <code>false</code>     | Set to `true` to enable the light variant |
+| size          | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
 
 ### Slots
 
@@ -718,11 +718,11 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                       | Default value          | Description                                            |
-| :-------------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | ------------------------------------------------------ |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>      | Obtain a reference to the button HTML element          |
-| feedback        | <code>let</code> | No       | <code>string</code>                        | <code>"Copied!"</code> | Set the feedback text shown after clicking the button  |
-| feedbackTimeout | <code>let</code> | No       | <code>number</code>                        | <code>2000</code>      | Set the timeout duration (ms) to display feedback text |
+| Prop name       | Required | Kind             | Reactive | Type                                       | Default value          | Description                                            |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | ------------------------------------------------------ |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>      | Obtain a reference to the button HTML element          |
+| feedback        | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Copied!"</code> | Set the feedback text shown after clicking the button  |
+| feedbackTimeout | No       | <code>let</code> | No       | <code>number</code>                        | <code>2000</code>      | Set the timeout duration (ms) to display feedback text |
 
 ### Slots
 
@@ -741,9 +741,9 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                | Default value                    | Description                                      |
-| :-------------- | :--------------- | :------- | :------------------ | -------------------------------- | ------------------------------------------------ |
-| iconDescription | <code>let</code> | No       | <code>string</code> | <code>"Copy to clipboard"</code> | Set the title and ARIA label for the copy button |
+| Prop name       | Required | Kind             | Reactive | Type                | Default value                    | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | ------------------- | -------------------------------- | ------------------------------------------------ |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code> | <code>"Copy to clipboard"</code> | Set the title and ARIA label for the copy button |
 
 ### Slots
 
@@ -798,23 +798,23 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                | Default value          | Description                                                                                                         |
-| :------------- | :--------------- | :------- | :-------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| selectedRowIds | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
-| selectable     | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
-| expandedRowIds | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
-| expandable     | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
-| rows           | <code>let</code> | Yes      | <code>DataTableRow[]</code>                         | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
-| headers        | <code>let</code> | No       | <code>DataTableHeader[]</code>                      | <code>[]</code>        | Specify the data table headers                                                                                      |
-| size           | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
-| title          | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
-| description    | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the description of the data table                                                                           |
-| zebra          | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
-| sortable       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
-| batchExpansion | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
-| radio          | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
-| batchSelection | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
-| stickyHeader   | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
+| Prop name      | Required | Kind             | Reactive | Type                                                | Default value          | Description                                                                                                         |
+| :------------- | :------- | :--------------- | :------- | --------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| selectedRowIds | No       | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
+| selectable     | No       | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
+| expandedRowIds | No       | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
+| expandable     | No       | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
+| rows           | No       | <code>let</code> | Yes      | <code>DataTableRow[]</code>                         | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
+| headers        | No       | <code>let</code> | No       | <code>DataTableHeader[]</code>                      | <code>[]</code>        | Specify the data table headers                                                                                      |
+| size           | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
+| title          | No       | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
+| description    | No       | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the description of the data table                                                                           |
+| zebra          | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
+| sortable       | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
+| batchExpansion | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
+| radio          | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
+| batchSelection | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
+| stickyHeader   | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
 
 ### Slots
 
@@ -842,15 +842,15 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                                    | Default value          | Description                                                                                  |
-| :---------- | :--------------- | :------- | :------------------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
-| columns     | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
-| rows        | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
-| size        | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
-| zebra       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
-| showHeader  | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
-| headers     | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
-| showToolbar | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
+| Prop name   | Required | Kind             | Reactive | Type                                                    | Default value          | Description                                                                                  |
+| :---------- | :------- | :--------------- | :------- | ------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------- |
+| columns     | No       | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
+| rows        | No       | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
+| size        | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
+| zebra       | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
+| showHeader  | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
+| headers     | No       | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
+| showToolbar | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
 
 ### Slots
 
@@ -869,18 +869,18 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                 | Default value                                    | Description                                   |
-| :------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| value          | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value           |
-| datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type                  |
-| appendTo       | <code>let</code> | No       | <code>HTMLElement</code>                             | <code>undefined</code>                           | Specify the element to append the calendar to |
-| dateFormat     | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                       |
-| maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                      |
-| minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                      |
-| locale         | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                | Specify the locale                            |
-| short          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the short variant        |
-| light          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant     |
-| id             | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element         |
+| Prop name      | Required | Kind             | Reactive | Type                                                 | Default value                                    | Description                                   |
+| :------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| value          | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value           |
+| datePickerType | No       | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type                  |
+| appendTo       | No       | <code>let</code> | No       | <code>HTMLElement</code>                             | <code>undefined</code>                           | Specify the element to append the calendar to |
+| dateFormat     | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                       |
+| maxDate        | No       | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                      |
+| minDate        | No       | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                      |
+| locale         | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                | Specify the locale                            |
+| short          | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the short variant        |
+| light          | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant     |
+| id             | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element         |
 
 ### Slots
 
@@ -902,21 +902,21 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                      | Default value                                    | Description                                        |
-| :-------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element       |
-| size            | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                          |
-| type            | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the input type                             |
-| placeholder     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input placeholder text                 |
-| pattern         | <code>let</code> | No       | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>      | Specify the Regular Expression for the input value |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                 |
-| iconDescription | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the ARIA label for the calendar icon       |
-| id              | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                    |
-| labelText       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                             |
-| hideLabel       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text      |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state         |
-| invalidText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                     |
-| name            | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Set a name for the input element                   |
+| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                        |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element       |
+| size            | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                          |
+| type            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the input type                             |
+| placeholder     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input placeholder text                 |
+| pattern         | No       | <code>let</code> | No       | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>      | Specify the Regular Expression for the input value |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                 |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the ARIA label for the calendar icon       |
+| id              | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                    |
+| labelText       | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                             |
+| hideLabel       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text      |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state         |
+| invalidText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                     |
+| name            | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Set a name for the input element                   |
 
 ### Slots
 
@@ -934,10 +934,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value                                    | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ----------------------------------------- |
-| range     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the range variant    |
-| id        | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value                                    | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ----------------------------------------- |
+| range     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the range variant    |
+| id        | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
 
 ### Slots
 
@@ -969,28 +969,28 @@ export interface DropdownItem {
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                        | Default value                                         | Description                                   |
-| :-------------- | :--------------- | :------- | :------------------------------------------ | ----------------------------------------------------- | --------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>  | <code>null</code>                                     | Obtain a reference to the button HTML element |
-| inline          | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to use the inline variant       |
-| open            | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to open the dropdown            |
-| selectedIndex   | <code>let</code> | Yes      | <code>number</code>                         | <code>-1</code>                                       | Specify the selected item index               |
-| items           | <code>let</code> | No       | <code>DropdownItem[]</code>                 | <code>[]</code>                                       | Set the dropdown items                        |
-| itemToString    | <code>let</code> | No       | <code>(item: DropdownItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item       |
-| type            | <code>let</code> | No       | <code>"default" &#124; "inline"</code>      | <code>"default"</code>                                | Specify the type of dropdown                  |
-| size            | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>   | <code>undefined</code>                                | Specify the size of the dropdown field        |
-| light           | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to enable the light variant     |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to disable the dropdown         |
-| titleText       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the title text                        |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to indicate an invalid state    |
-| invalidText     | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the invalid state text                |
-| warn            | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to indicate an warning state    |
-| warnText        | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the warning state text                |
-| helperText      | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the helper text                       |
-| label           | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                                | Specify the list box label                    |
-| translateWithId | <code>let</code> | No       | <code>(id: any) => string</code>            | <code>undefined</code>                                | Override the default translation ids          |
-| id              | <code>let</code> | No       | <code>string</code>                         | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component          |
-| name            | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                                | Specify a name attribute for the list box     |
+| Prop name       | Required | Kind             | Reactive | Type                                        | Default value                                         | Description                                   |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------- | ----------------------------------------------------- | --------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>  | <code>null</code>                                     | Obtain a reference to the button HTML element |
+| inline          | No       | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to use the inline variant       |
+| open            | No       | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to open the dropdown            |
+| selectedIndex   | No       | <code>let</code> | Yes      | <code>number</code>                         | <code>-1</code>                                       | Specify the selected item index               |
+| items           | No       | <code>let</code> | No       | <code>DropdownItem[]</code>                 | <code>[]</code>                                       | Set the dropdown items                        |
+| itemToString    | No       | <code>let</code> | No       | <code>(item: DropdownItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item       |
+| type            | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>      | <code>"default"</code>                                | Specify the type of dropdown                  |
+| size            | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>   | <code>undefined</code>                                | Specify the size of the dropdown field        |
+| light           | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to enable the light variant     |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to disable the dropdown         |
+| titleText       | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the title text                        |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to indicate an invalid state    |
+| invalidText     | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the invalid state text                |
+| warn            | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                    | Set to `true` to indicate an warning state    |
+| warnText        | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the warning state text                |
+| helperText      | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                       | Specify the helper text                       |
+| label           | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                                | Specify the list box label                    |
+| translateWithId | No       | <code>let</code> | No       | <code>(id: any) => string</code>            | <code>undefined</code>                                | Override the default translation ids          |
+| id              | No       | <code>let</code> | No       | <code>string</code>                         | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component          |
+| name            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                                | Specify a name attribute for the list box     |
 
 ### Slots
 
@@ -1006,9 +1006,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------- |
-| inline    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the inline variant |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
+| inline    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the inline variant |
 
 ### Slots
 
@@ -1027,19 +1027,19 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                       | Default value                                    | Description                                           |
-| :-------------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
-| ref                   | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the top-level element           |
-| tilePadding           | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the padding of the tile (number of pixels)    |
-| tileMaxHeight         | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the max height of the tile (number of pixels) |
-| expanded              | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to expand the tile                      |
-| light                 | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant             |
-| tileCollapsedIconText | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to expand Tile"</code>           | Specify the icon text of the collapsed tile           |
-| tileExpandedIconText  | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to collapse Tile"</code>         | Specify the icon text of the expanded tile            |
-| tileExpandedLabel     | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the expanded tile           |
-| tileCollapsedLabel    | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the collapsed tile          |
-| tabindex              | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                  |
-| id                    | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level div element               |
+| Prop name             | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                           |
+| :-------------------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------- |
+| ref                   | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the top-level element           |
+| tilePadding           | No       | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the padding of the tile (number of pixels)    |
+| tileMaxHeight         | No       | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the max height of the tile (number of pixels) |
+| expanded              | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to expand the tile                      |
+| light                 | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant             |
+| tileCollapsedIconText | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to expand Tile"</code>           | Specify the icon text of the collapsed tile           |
+| tileExpandedIconText  | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to collapse Tile"</code>         | Specify the icon text of the expanded tile            |
+| tileExpandedLabel     | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the expanded tile           |
+| tileCollapsedLabel    | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the collapsed tile          |
+| tabindex              | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                  |
+| id                    | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level div element               |
 
 ### Slots
 
@@ -1062,19 +1062,19 @@ None.
 
 ### Props
 
-| Prop name        | Kind               | Reactive | Type                                                                                       | Default value                           | Description                                                           |
-| :--------------- | :----------------- | :------- | :----------------------------------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------- |
-| files            | <code>let</code>   | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                         | Obtain the uploaded file names                                        |
-| status           | <code>let</code>   | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code>                                   | <code>"uploading"</code>                | Specify the file uploader status                                      |
-| accept           | <code>let</code>   | No       | <code>string[]</code>                                                                      | <code>[]</code>                         | Specify the accepted file types                                       |
-| multiple         | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to allow multiple files                                 |
-| clearFiles       | <code>const</code> | No       | <code>() => void</code>                                                                    | <code>() => { files = []; }</code>      | Override the default behavior of clearing the array of uploaded files |
-| labelDescription | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label description                                         |
-| labelTitle       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label title                                               |
-| kind             | <code>let</code>   | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                  | Specify the kind of file uploader button                              |
-| buttonLabel      | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the button label                                              |
-| iconDescription  | <code>let</code>   | No       | <code>string</code>                                                                        | <code>"Provide icon description"</code> | Specify the ARIA label used for the status icons                      |
-| name             | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify a name attribute for the file button uploader input           |
+| Prop name        | Required | Kind               | Reactive | Type                                                                                       | Default value                           | Description                                                           |
+| :--------------- | :------- | :----------------- | :------- | ------------------------------------------------------------------------------------------ | --------------------------------------- | --------------------------------------------------------------------- |
+| files            | No       | <code>let</code>   | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                         | Obtain the uploaded file names                                        |
+| status           | No       | <code>let</code>   | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code>                                   | <code>"uploading"</code>                | Specify the file uploader status                                      |
+| accept           | No       | <code>let</code>   | No       | <code>string[]</code>                                                                      | <code>[]</code>                         | Specify the accepted file types                                       |
+| multiple         | No       | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to allow multiple files                                 |
+| clearFiles       | No       | <code>const</code> | No       | <code>() => void</code>                                                                    | <code>() => { files = []; }</code>      | Override the default behavior of clearing the array of uploaded files |
+| labelDescription | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label description                                         |
+| labelTitle       | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label title                                               |
+| kind             | No       | <code>let</code>   | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                  | Specify the kind of file uploader button                              |
+| buttonLabel      | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the button label                                              |
+| iconDescription  | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>"Provide icon description"</code> | Specify the ARIA label used for the status icons                      |
+| name             | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify a name attribute for the file button uploader input           |
 
 ### Slots
 
@@ -1097,19 +1097,19 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                                                                       | Default value                                    | Description                                  |
-| :------------------ | :--------------- | :------- | :----------------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
-| ref                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                  | <code>null</code>                                | Obtain a reference to the input HTML element |
-| labelText           | <code>let</code> | Yes      | <code>string</code>                                                                        | <code>"Add file"</code>                          | Specify the label text                       |
-| accept              | <code>let</code> | No       | <code>string[]</code>                                                                      | <code>[]</code>                                  | Specify the accepted file types              |
-| multiple            | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to allow multiple files        |
-| disabled            | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable the input           |
-| disableLabelChanges | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable label changes       |
-| kind                | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                           | Specify the kind of file uploader button     |
-| role                | <code>let</code> | No       | <code>string</code>                                                                        | <code>"button"</code>                            | Specify the label role                       |
-| tabindex            | <code>let</code> | No       | <code>string</code>                                                                        | <code>"0"</code>                                 | Specify `tabindex` attribute                 |
-| id                  | <code>let</code> | No       | <code>string</code>                                                                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
-| name                | <code>let</code> | No       | <code>string</code>                                                                        | <code>""</code>                                  | Specify a name attribute for the input       |
+| Prop name           | Required | Kind             | Reactive | Type                                                                                       | Default value                                    | Description                                  |
+| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ | -------------------------------------------- |
+| ref                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                  | <code>null</code>                                | Obtain a reference to the input HTML element |
+| labelText           | No       | <code>let</code> | Yes      | <code>string</code>                                                                        | <code>"Add file"</code>                          | Specify the label text                       |
+| accept              | No       | <code>let</code> | No       | <code>string[]</code>                                                                      | <code>[]</code>                                  | Specify the accepted file types              |
+| multiple            | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to allow multiple files        |
+| disabled            | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable the input           |
+| disableLabelChanges | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable label changes       |
+| kind                | No       | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                           | Specify the kind of file uploader button     |
+| role                | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"button"</code>                            | Specify the label role                       |
+| tabindex            | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"0"</code>                                 | Specify `tabindex` attribute                 |
+| id                  | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
+| name                | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>""</code>                                  | Specify a name attribute for the input       |
 
 ### Slots
 
@@ -1127,18 +1127,18 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                  |
-| :------------ | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>  | <code>null</code>                                | Obtain a reference to the input HTML element                                                                 |
-| accept        | <code>let</code> | No       | <code>string[]</code>                      | <code>[]</code>                                  | Specify the accepted file types                                                                              |
-| multiple      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to allow multiple files                                                                        |
-| validateFiles | <code>let</code> | No       | <code>(files: FileList) => FileList</code> | <code>(files) => files</code>                    | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
-| labelText     | <code>let</code> | No       | <code>string</code>                        | <code>"Add file"</code>                          | Specify the label text                                                                                       |
-| role          | <code>let</code> | No       | <code>string</code>                        | <code>"button"</code>                            | Specify the `role` attribute of the drop container                                                           |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the input                                                                           |
-| tabindex      | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify `tabindex` attribute                                                                                 |
-| id            | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                              |
-| name          | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify a name attribute for the input                                                                       |
+| Prop name     | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                  |
+| :------------ | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>  | <code>null</code>                                | Obtain a reference to the input HTML element                                                                 |
+| accept        | No       | <code>let</code> | No       | <code>string[]</code>                      | <code>[]</code>                                  | Specify the accepted file types                                                                              |
+| multiple      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to allow multiple files                                                                        |
+| validateFiles | No       | <code>let</code> | No       | <code>(files: FileList) => FileList</code> | <code>(files) => files</code>                    | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
+| labelText     | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Add file"</code>                          | Specify the label text                                                                                       |
+| role          | No       | <code>let</code> | No       | <code>string</code>                        | <code>"button"</code>                            | Specify the `role` attribute of the drop container                                                           |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the input                                                                           |
+| tabindex      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify `tabindex` attribute                                                                                 |
+| id            | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                              |
+| name          | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify a name attribute for the input                                                                       |
 
 ### Slots
 
@@ -1160,15 +1160,15 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                     | Default value                                    | Description                                      |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
-| status          | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code>                         | Specify the file uploader status                 |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the ARIA label used for the status icons |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                               | Set to `true` to indicate an invalid state       |
-| errorSubject    | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error subject text                   |
-| errorBody       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error body text                      |
-| id              | <code>let</code> | No       | <code>string</code>                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
-| name            | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the file uploader name                   |
+| Prop name       | Required | Kind             | Reactive | Type                                                     | Default value                                    | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
+| status          | No       | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code>                         | Specify the file uploader status                 |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the ARIA label used for the status icons |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                               | Set to `true` to indicate an invalid state       |
+| errorSubject    | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error subject text                   |
+| errorBody       | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error body text                      |
+| id              | No       | <code>let</code> | No       | <code>string</code>                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
+| name            | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the file uploader name                   |
 
 ### Slots
 
@@ -1206,11 +1206,11 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                     | Default value            | Description                                      |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
-| status          | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code> | Specify the file name status                     |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>          | Specify the ARIA label used for the status icons |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>       | Set to `true` to indicate an invalid state       |
+| Prop name       | Required | Kind             | Reactive | Type                                                     | Default value            | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
+| status          | No       | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code> | Specify the file name status                     |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>          | Specify the ARIA label used for the status icons |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>       | Set to `true` to indicate an invalid state       |
 
 ### Slots
 
@@ -1267,12 +1267,12 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                 | Default value      | Description                                |
-| :---------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------------ |
-| invalid     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state |
-| message     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a form requirement |
-| messageText | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the message text                   |
-| legendText  | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the legend text                    |
+| Prop name   | Required | Kind             | Reactive | Type                 | Default value      | Description                                |
+| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------------ |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state |
+| message     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a form requirement |
+| messageText | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the message text                   |
+| legendText  | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the legend text                    |
 
 ### Slots
 
@@ -1314,9 +1314,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                                    | Description                               |
-| :-------- | :--------------- | :------- | :------------------ | ------------------------------------------------ | ----------------------------------------- |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                                    | Description                               |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ------------------------------------------------ | ----------------------------------------- |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
 
 ### Slots
 
@@ -1337,16 +1337,16 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
-| :------------ | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Grid let:props&gt;&lt;header {...props}&gt;...&lt;/header&gt;&lt;/Grid&gt;) |
-| condensed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
-| narrow        | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
-| fullWidth     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fullWidth variant                                                                                                                                                      |
-| noGutter      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
-| padding       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
+| Prop name     | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
+| :------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Grid let:props&gt;&lt;header {...props}&gt;...&lt;/header&gt;&lt;/Grid&gt;) |
+| condensed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
+| narrow        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
+| fullWidth     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fullWidth variant                                                                                                                                                      |
+| noGutter      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
+| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
+| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
+| padding       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
 
 ### Slots
 
@@ -1362,16 +1362,16 @@ None.
 
 ### Props
 
-| Prop name               | Kind             | Reactive | Type                                       | Default value          | Description                                                                                                                      |
-| :---------------------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| ref                     | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                    |
-| isSideNavOpen           | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to open the side nav                                                                                               |
-| expandedByDefault       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                   |
-| uiShellAriaLabel        | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the ARIA label for the header                                                                                            |
-| href                    | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                                                                                                     |
-| company                 | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the company name                                                                                                         |
-| platformName            | <code>let</code> | No       | <code>string</code>                        | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;) |
-| persistentHamburgerMenu | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                      |
+| Prop name               | Required | Kind             | Reactive | Type                                       | Default value          | Description                                                                                                                      |
+| :---------------------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| ref                     | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                    |
+| isSideNavOpen           | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to open the side nav                                                                                               |
+| expandedByDefault       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                   |
+| uiShellAriaLabel        | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the ARIA label for the header                                                                                            |
+| href                    | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                                                                                                     |
+| company                 | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the company name                                                                                                         |
+| platformName            | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;) |
+| persistentHamburgerMenu | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                      |
 
 ### Slots
 
@@ -1401,13 +1401,13 @@ export interface HeaderActionSlideTransition {
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                         | Default value                  | Description                                                                                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
-| isOpen     | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>             | Set to `true` to open the panel                                                                               |
-| icon       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>         | Specify the icon from `carbon-icons-svelte` to render                                                         |
-| text       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
-| transition | <code>let</code> | No       | <code>false &#124; HeaderActionSlideTransition</code>        | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`)<br />Set to `false` to disable the transition       |
+| Prop name  | Required | Kind             | Reactive | Type                                                         | Default value                  | Description                                                                                                   |
+| :--------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
+| isOpen     | No       | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>             | Set to `true` to open the panel                                                                               |
+| icon       | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>         | Specify the icon from `carbon-icons-svelte` to render                                                         |
+| text       | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
+| transition | No       | <code>let</code> | No       | <code>false &#124; HeaderActionSlideTransition</code>        | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`)<br />Set to `false` to disable the transition       |
 
 ### Slots
 
@@ -1427,12 +1427,12 @@ export interface HeaderActionSlideTransition {
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :----------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
-| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
-| linkIsActive | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active state                 |
-| href         | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
-| icon         | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name    | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :----------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
+| linkIsActive | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active state                 |
+| href         | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
+| icon         | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -1446,9 +1446,9 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                 | Default value      | Description                       |
-| :------------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------- |
-| searchIsActive | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code> | Set to `true` to focus the search |
+| Prop name      | Required | Kind             | Reactive | Type                 | Default value      | Description                       |
+| :------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------- |
+| searchIsActive | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code> | Set to `true` to focus the search |
 
 ### Slots
 
@@ -1466,11 +1466,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                         | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element |
-| isActive  | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active variant       |
-| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon to render                    |
+| Prop name | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element |
+| isActive  | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active variant       |
+| icon      | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -1488,9 +1488,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value          | Description                                                                  |
-| :-------- | :--------------- | :------- | :------------------ | ---------------------- | ---------------------------------------------------------------------------- |
-| ariaLabel | <code>let</code> | No       | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav<br />@deprecated use "aria-label" instead |
+| Prop name | Required | Kind             | Reactive | Type                | Default value          | Description                                                                  |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| ariaLabel | No       | <code>let</code> | No       | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav<br />@deprecated use "aria-label" instead |
 
 ### Slots
 
@@ -1506,11 +1506,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| href      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
-| text      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
 
 ### Slots
 
@@ -1533,13 +1533,13 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                       | Default value                  | Description                                   |
-| :-------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------ | --------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>              | Obtain a reference to the HTML anchor element |
-| expanded        | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>             | Set to `true` to toggle the expanded state    |
-| href            | <code>let</code> | No       | <code>string</code>                        | <code>"/"</code>               | Specify the `href` attribute                  |
-| text            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>         | Specify the text                              |
-| iconDescription | <code>let</code> | No       | <code>string</code>                        | <code>"Expand/Collapse"</code> | Specify the ARIA label for the chevron icon   |
+| Prop name       | Required | Kind             | Reactive | Type                                       | Default value                  | Description                                   |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------ | --------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>              | Obtain a reference to the HTML anchor element |
+| expanded        | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>             | Set to `true` to toggle the expanded state    |
+| href            | No       | <code>let</code> | No       | <code>string</code>                        | <code>"/"</code>               | Specify the `href` attribute                  |
+| text            | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>         | Specify the text                              |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Expand/Collapse"</code> | Specify the ARIA label for the chevron icon   |
 
 ### Slots
 
@@ -1580,10 +1580,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| href      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
 
 ### Slots
 
@@ -1627,13 +1627,13 @@ export interface HeaderSearchResult {
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                      | Default value      | Description                                        |
-| :------------------ | :--------------- | :------- | :---------------------------------------- | ------------------ | -------------------------------------------------- |
-| selectedResultIndex | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
-| ref                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
-| active              | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
-| value               | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
-| results             | <code>let</code> | No       | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
+| Prop name           | Required | Kind             | Reactive | Type                                      | Default value      | Description                                        |
+| :------------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | -------------------------------------------------- |
+| selectedResultIndex | No       | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
+| ref                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
+| active              | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
+| value               | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
+| results             | No       | <code>let</code> | No       | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
 
 ### Slots
 
@@ -1675,10 +1675,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
-| render    | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
-| skeleton  | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to display the skeleton state           |
+| Prop name | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
+| render    | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to display the skeleton state           |
 
 ### Slots
 
@@ -1697,9 +1697,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value   | Description              |
-| :-------- | :--------------- | :------- | :------------------ | --------------- | ------------------------ |
-| size      | <code>let</code> | No       | <code>number</code> | <code>16</code> | Set the size of the icon |
+| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description              |
+| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ------------------------ |
+| size      | No       | <code>let</code> | No       | <code>number</code> | <code>16</code> | Set the size of the icon |
 
 ### Slots
 
@@ -1718,12 +1718,12 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                     | Default value          | Description                                                       |
-| :-------------- | :--------------- | :------- | :----------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------- |
-| status          | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
-| description     | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
-| successDelay    | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
+| Prop name       | Required | Kind             | Reactive | Type                                                                     | Default value          | Description                                                       |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------- |
+| status          | No       | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
+| description     | No       | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
+| successDelay    | No       | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
 
 ### Slots
 
@@ -1743,16 +1743,16 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| kind            | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
-| lowContrast     | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
-| timeout         | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
-| role            | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
-| title           | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
-| subtitle        | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
-| hideCloseButton | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
+| Prop name       | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| kind            | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
+| lowContrast     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
+| timeout         | No       | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
+| role            | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
+| title           | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
+| subtitle        | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
+| hideCloseButton | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
 
 ### Slots
 
@@ -1775,14 +1775,14 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                   | Default value          | Description                                      |
-| :-------- | :--------------- | :------- | :--------------------------------------------------------------------- | ---------------------- | ------------------------------------------------ |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                     |
-| href      | <code>let</code> | No       | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                           |
-| inline    | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant          |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox            |
-| visited   | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles            |
+| Prop name | Required | Kind             | Reactive | Type                                                                   | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------- | ---------------------- | ------------------------------------------------ |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                     |
+| href      | No       | <code>let</code> | No       | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                           |
+| inline    | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant          |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox            |
+| visited   | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles            |
 
 ### Slots
 
@@ -1803,17 +1803,17 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                   | Default value          | Description                                |
-| :---------- | :--------------- | :------- | :------------------------------------- | ---------------------- | ------------------------------------------ |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
-| type        | <code>let</code> | No       | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
-| open        | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
-| light       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to disable the list box      |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an invalid state |
-| invalidText | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the invalid state text             |
-| warn        | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an warning state |
-| warnText    | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the warning state text             |
+| Prop name   | Required | Kind             | Reactive | Type                                   | Default value          | Description                                |
+| :---------- | :------- | :--------------- | :------- | -------------------------------------- | ---------------------- | ------------------------------------------ |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
+| type        | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
+| open        | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to disable the list box      |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an invalid state |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the invalid state text             |
+| warn        | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an warning state |
+| warnText    | No       | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the warning state text             |
 
 ### Slots
 
@@ -1838,15 +1838,15 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                   | Default value                                    | Description                                      |
-| :-------------- | :----------------- | :------- | :----------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
-| ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                | <code>null</code>                                | Obtain a reference to the top-level HTML element |
-| disabled        | <code>let</code>   | No       | <code>boolean</code>                                   | <code>false</code>                               | Set to `true` to disable the list box field      |
-| role            | <code>let</code>   | No       | <code>string</code>                                    | <code>"combobox"</code>                          | Specify the role attribute                       |
-| tabindex        | <code>let</code>   | No       | <code>string</code>                                    | <code>"-1"</code>                                | Specify the tabindex                             |
-| translationIds  | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>          | <code>{ close: "close", open: "open" }</code>    | Default translation ids                          |
-| translateWithId | <code>let</code>   | No       | <code>(id: ListBoxFieldTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>     | Override the default translation ids             |
-| id              | <code>let</code>   | No       | <code>string</code>                                    | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
+| Prop name       | Required | Kind               | Reactive | Type                                                   | Default value                                    | Description                                      |
+| :-------------- | :------- | :----------------- | :------- | ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------ |
+| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                | <code>null</code>                                | Obtain a reference to the top-level HTML element |
+| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                   | <code>false</code>                               | Set to `true` to disable the list box field      |
+| role            | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"combobox"</code>                          | Specify the role attribute                       |
+| tabindex        | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"-1"</code>                                | Specify the tabindex                             |
+| translationIds  | No       | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>          | <code>{ close: "close", open: "open" }</code>    | Default translation ids                          |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxFieldTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>     | Override the default translation ids             |
+| id              | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
 
 ### Slots
 
@@ -1869,10 +1869,10 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                    | Default value                                    | Description                            |
-| :-------- | :--------------- | :------- | :-------------------------------------- | ------------------------------------------------ | -------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element |
-| id        | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element    |
+| Prop name | Required | Kind             | Reactive | Type                                    | Default value                                    | Description                            |
+| :-------- | :------- | :--------------- | :------- | --------------------------------------- | ------------------------------------------------ | -------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element |
+| id        | No       | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element    |
 
 ### Slots
 
@@ -1896,11 +1896,11 @@ export type ListBoxMenuIconTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                      | Default value                                 | Description                                  |
-| :-------------- | :----------------- | :------- | :-------------------------------------------------------- | --------------------------------------------- | -------------------------------------------- |
-| open            | <code>let</code>   | No       | <code>boolean</code>                                      | <code>false</code>                            | Set to `true` to open the list box menu icon |
-| translationIds  | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>             | <code>{ close: "close", open: "open" }</code> | Default translation ids                      |
-| translateWithId | <code>let</code>   | No       | <code>(id: ListBoxMenuIconTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>  | Override the default translation ids         |
+| Prop name       | Required | Kind               | Reactive | Type                                                      | Default value                                 | Description                                  |
+| :-------------- | :------- | :----------------- | :------- | --------------------------------------------------------- | --------------------------------------------- | -------------------------------------------- |
+| open            | No       | <code>let</code>   | No       | <code>boolean</code>                                      | <code>false</code>                            | Set to `true` to open the list box menu icon |
+| translationIds  | No       | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>             | <code>{ close: "close", open: "open" }</code> | Default translation ids                      |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxMenuIconTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>  | Override the default translation ids         |
 
 ### Slots
 
@@ -1916,10 +1916,10 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :---------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| active      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
-| highlighted | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
+| Prop name   | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
+| highlighted | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
 
 ### Slots
 
@@ -1945,13 +1945,13 @@ export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                                     | Default value                                                            | Description                                      |
-| :-------------- | :----------------- | :------- | :----------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------ |
-| ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
-| selectionCount  | <code>let</code>   | No       | <code>any</code>                                                         | <code>undefined</code>                                                   | Specify the number of selected items             |
-| disabled        | <code>let</code>   | No       | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
-| translationIds  | <code>const</code> | No       | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
-| translateWithId | <code>let</code>   | No       | <code>(id: ListBoxSelectionTranslationId) => string</code>               | <code>(id) => defaultTranslations[id]</code>                             | Override the default translation ids             |
+| Prop name       | Required | Kind               | Reactive | Type                                                                     | Default value                                                            | Description                                      |
+| :-------------- | :------- | :----------------- | :------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------ |
+| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
+| selectionCount  | No       | <code>let</code>   | No       | <code>any</code>                                                         | <code>undefined</code>                                                   | Specify the number of selected items             |
+| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
+| translationIds  | No       | <code>const</code> | No       | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxSelectionTranslationId) => string</code>               | <code>(id) => defaultTranslations[id]</code>                             | Override the default translation ids             |
 
 ### Slots
 
@@ -1988,13 +1988,13 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                 | Default value                                    | Description                                |
-| :---------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ------------------------------------------ |
-| small       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the small variant     |
-| active      | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the active state |
-| withOverlay | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the overlay      |
-| description | <code>let</code> | No       | <code>string</code>  | <code>"Active loading indicator"</code>          | Specify the label description              |
-| id          | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the label element            |
+| Prop name   | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                |
+| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ------------------------------------------ |
+| small       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the small variant     |
+| active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the active state |
+| withOverlay | No       | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the overlay      |
+| description | No       | <code>let</code> | No       | <code>string</code>  | <code>"Active loading indicator"</code>          | Specify the label description              |
+| id          | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the label element            |
 
 ### Slots
 
@@ -2008,27 +2008,27 @@ None.
 
 ### Props
 
-| Prop name                  | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                |
-| :------------------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
-| ref                        | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                                | Obtain a reference to the top-level HTML element                           |
-| open                       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to open the modal                                            |
-| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                           | Set the size of the modal                                                  |
-| danger                     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use the danger variant                                    |
-| alert                      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable alert mode                                         |
-| passiveModal               | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use the passive variant                                   |
-| modalHeading               | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the modal heading                                                  |
-| modalLabel                 | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the modal label                                                    |
-| modalAriaLabel             | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the ARIA label for the modal                                       |
-| iconDescription            | <code>let</code> | No       | <code>string</code>                       | <code>"Close the modal"</code>                   | Specify the ARIA label for the close icon                                  |
-| hasForm                    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` if the modal contains form elements                          |
-| hasScrollingContent        | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` if the modal contains scrolling content                      |
-| primaryButtonText          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the primary button text                                            |
-| primaryButtonDisabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the primary button                                |
-| shouldSubmitOnEnter        | <code>let</code> | No       | <code>boolean</code>                      | <code>true</code>                                | Set to `true` for the primary button to be triggered when pressing "Enter" |
-| secondaryButtonText        | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the secondary button text                                          |
-| selectorPrimaryFocus       | <code>let</code> | No       | <code>string</code>                       | <code>"[data-modal-primary-focus]"</code>        | Specify a selector to be focused when opening the modal                    |
-| preventCloseOnClickOutside | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to prevent the modal from closing when clicking outside      |
-| id                         | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                        |
+| Prop name                  | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                |
+| :------------------------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
+| ref                        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                                | Obtain a reference to the top-level HTML element                           |
+| open                       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to open the modal                                            |
+| size                       | No       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                           | Set the size of the modal                                                  |
+| danger                     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use the danger variant                                    |
+| alert                      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable alert mode                                         |
+| passiveModal               | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use the passive variant                                   |
+| modalHeading               | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the modal heading                                                  |
+| modalLabel                 | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the modal label                                                    |
+| modalAriaLabel             | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the ARIA label for the modal                                       |
+| iconDescription            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Close the modal"</code>                   | Specify the ARIA label for the close icon                                  |
+| hasForm                    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` if the modal contains form elements                          |
+| hasScrollingContent        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` if the modal contains scrolling content                      |
+| primaryButtonText          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the primary button text                                            |
+| primaryButtonDisabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the primary button                                |
+| shouldSubmitOnEnter        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>true</code>                                | Set to `true` for the primary button to be triggered when pressing "Enter" |
+| secondaryButtonText        | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the secondary button text                                          |
+| selectorPrimaryFocus       | No       | <code>let</code> | No       | <code>string</code>                       | <code>"[data-modal-primary-focus]"</code>        | Specify a selector to be focused when opening the modal                    |
+| preventCloseOnClickOutside | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to prevent the modal from closing when clicking outside      |
+| id                         | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                        |
 
 ### Slots
 
@@ -2056,10 +2056,10 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                 | Default value      | Description                                           |
-| :------------------ | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------------------- |
-| hasForm             | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains form elements     |
-| hasScrollingContent | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains scrolling content |
+| Prop name           | Required | Kind             | Reactive | Type                 | Default value      | Description                                           |
+| :------------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------- |
+| hasForm             | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains form elements     |
+| hasScrollingContent | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains scrolling content |
 
 ### Slots
 
@@ -2075,14 +2075,14 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                 | Default value          | Description                                 |
-| :-------------------- | :--------------- | :------- | :------------------- | ---------------------- | ------------------------------------------- |
-| primaryButtonText     | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the primary button text             |
-| primaryButtonDisabled | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the primary button |
-| primaryClass          | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the primary button      |
-| secondaryButtonText   | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the secondary button text           |
-| secondaryClass        | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the secondary button    |
-| danger                | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the danger variant     |
+| Prop name             | Required | Kind             | Reactive | Type                 | Default value          | Description                                 |
+| :-------------------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ------------------------------------------- |
+| primaryButtonText     | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the primary button text             |
+| primaryButtonDisabled | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the primary button |
+| primaryClass          | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the primary button      |
+| secondaryButtonText   | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the secondary button text           |
+| secondaryClass        | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the secondary button    |
+| danger                | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the danger variant     |
 
 ### Slots
 
@@ -2098,15 +2098,15 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                | Default value        | Description                               |
-| :-------------- | :--------------- | :------- | :------------------ | -------------------- | ----------------------------------------- |
-| title           | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal title                   |
-| label           | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal label                   |
-| labelClass      | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the label class                   |
-| titleClass      | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the title class                   |
-| closeClass      | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close class                   |
-| closeIconClass  | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close icon class              |
-| iconDescription | <code>let</code> | No       | <code>string</code> | <code>"Close"</code> | Specify the ARIA label for the close icon |
+| Prop name       | Required | Kind             | Reactive | Type                | Default value        | Description                               |
+| :-------------- | :------- | :--------------- | :------- | ------------------- | -------------------- | ----------------------------------------- |
+| title           | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal title                   |
+| label           | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal label                   |
+| labelClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the label class                   |
+| titleClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the title class                   |
+| closeClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close class                   |
+| closeIconClass  | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close icon class              |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code> | <code>"Close"</code> | Specify the ARIA label for the close icon |
 
 ### Slots
 
@@ -2137,34 +2137,34 @@ export interface MultiSelectItem {
 
 ### Props
 
-| Prop name         | Kind             | Reactive | Type                                                                                           | Default value                                                                       | Description                                                                           |
-| :---------------- | :--------------- | :------- | :--------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| open              | <code>let</code> | Yes      | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to open the dropdown                                                    |
-| value             | <code>let</code> | Yes      | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the multiselect value                                                         |
-| selectedIds       | <code>let</code> | Yes      | <code>MultiSelectItemId[]</code>                                                               | <code>[]</code>                                                                     | Set the selected ids                                                                  |
-| items             | <code>let</code> | Yes      | <code>MultiSelectItem[]</code>                                                                 | <code>[]</code>                                                                     | Set the multiselect items                                                             |
-| itemToString      | <code>let</code> | No       | <code>(item: MultiSelectItem) => string</code>                                                 | <code>(item) => item.text &#124;&#124; item.id</code>                               | Override the display of a multiselect item                                            |
-| size              | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                      | <code>undefined</code>                                                              | Set the size of the combobox                                                          |
-| type              | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                         | <code>"default"</code>                                                              | Specify the type of multiselect                                                       |
-| selectionFeedback | <code>let</code> | No       | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                    | <code>"top-after-reopen"</code>                                                     | Specify the selection feedback after selecting items                                  |
-| disabled          | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to disable the dropdown                                                 |
-| filterable        | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to filter items                                                         |
-| filterItem        | <code>let</code> | No       | <code>(item: MultiSelectItem, value: string) => string</code>                                  | <code>(item, value) => item.text.toLowerCase().includes(value.toLowerCase())</code> | Override the filtering logic<br />The default filtering is an exact string comparison |
-| light             | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to enable the light variant                                             |
-| locale            | <code>let</code> | No       | <code>string</code>                                                                            | <code>"en"</code>                                                                   | Specify the locale                                                                    |
-| placeholder       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the placeholder text                                                          |
-| sortItem          | <code>let</code> | No       | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | <code>(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })</code>      | Override the sorting logic<br />The default sorting compare the item text value       |
-| translateWithId   | <code>let</code> | No       | <code>(id: any) => string</code>                                                               | <code>undefined</code>                                                              | Override the default translation ids                                                  |
-| titleText         | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the title text                                                                |
-| useTitleInItem    | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to pass the item to `itemToString` in the checkbox                      |
-| invalid           | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to indicate an invalid state                                            |
-| invalidText       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the invalid state text                                                        |
-| warn              | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to indicate an warning state                                            |
-| warnText          | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the warning state text                                                        |
-| helperText        | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the helper text                                                               |
-| label             | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the list box label                                                            |
-| id                | <code>let</code> | No       | <code>string</code>                                                                            | <code>"ccs-" + Math.random().toString(36)</code>                                    | Set an id for the list box component                                                  |
-| name              | <code>let</code> | No       | <code>string</code>                                                                            | <code>undefined</code>                                                              | Specify a name attribute for the select                                               |
+| Prop name         | Required | Kind             | Reactive | Type                                                                                           | Default value                                                                       | Description                                                                           |
+| :---------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| open              | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to open the dropdown                                                    |
+| value             | No       | <code>let</code> | Yes      | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the multiselect value                                                         |
+| selectedIds       | No       | <code>let</code> | Yes      | <code>MultiSelectItemId[]</code>                                                               | <code>[]</code>                                                                     | Set the selected ids                                                                  |
+| items             | No       | <code>let</code> | Yes      | <code>MultiSelectItem[]</code>                                                                 | <code>[]</code>                                                                     | Set the multiselect items                                                             |
+| itemToString      | No       | <code>let</code> | No       | <code>(item: MultiSelectItem) => string</code>                                                 | <code>(item) => item.text &#124;&#124; item.id</code>                               | Override the display of a multiselect item                                            |
+| size              | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                      | <code>undefined</code>                                                              | Set the size of the combobox                                                          |
+| type              | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                         | <code>"default"</code>                                                              | Specify the type of multiselect                                                       |
+| selectionFeedback | No       | <code>let</code> | No       | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                    | <code>"top-after-reopen"</code>                                                     | Specify the selection feedback after selecting items                                  |
+| disabled          | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to disable the dropdown                                                 |
+| filterable        | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to filter items                                                         |
+| filterItem        | No       | <code>let</code> | No       | <code>(item: MultiSelectItem, value: string) => string</code>                                  | <code>(item, value) => item.text.toLowerCase().includes(value.toLowerCase())</code> | Override the filtering logic<br />The default filtering is an exact string comparison |
+| light             | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to enable the light variant                                             |
+| locale            | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>"en"</code>                                                                   | Specify the locale                                                                    |
+| placeholder       | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the placeholder text                                                          |
+| sortItem          | No       | <code>let</code> | No       | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | <code>(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })</code>      | Override the sorting logic<br />The default sorting compare the item text value       |
+| translateWithId   | No       | <code>let</code> | No       | <code>(id: any) => string</code>                                                               | <code>undefined</code>                                                              | Override the default translation ids                                                  |
+| titleText         | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the title text                                                                |
+| useTitleInItem    | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to pass the item to `itemToString` in the checkbox                      |
+| invalid           | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to indicate an invalid state                                            |
+| invalidText       | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the invalid state text                                                        |
+| warn              | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                                                  | Set to `true` to indicate an warning state                                            |
+| warnText          | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the warning state text                                                        |
+| helperText        | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the helper text                                                               |
+| label             | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                                                     | Specify the list box label                                                            |
+| id                | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>"ccs-" + Math.random().toString(36)</code>                                    | Set an id for the list box component                                                  |
+| name              | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>undefined</code>                                                              | Specify a name attribute for the select                                               |
 
 ### Slots
 
@@ -2205,12 +2205,12 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                         | Default value             | Description                                           |
-| :--------------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------------- | ----------------------------------------------------- |
-| notificationType | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                         | <code>"toast"</code>      | Set the type of notification                          |
-| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>    | Specify the icon from `carbon-icons-svelte` to render |
-| title            | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>    | Specify the title of the icon                         |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                          | <code>"Close icon"</code> | Specify the ARIA label for the icon                   |
+| Prop name        | Required | Kind             | Reactive | Type                                                         | Default value             | Description                                           |
+| :--------------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ------------------------- | ----------------------------------------------------- |
+| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                         | <code>"toast"</code>      | Set the type of notification                          |
+| icon             | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>    | Specify the icon from `carbon-icons-svelte` to render |
+| title            | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>    | Specify the title of the icon                         |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                          | <code>"Close icon"</code> | Specify the ARIA label for the icon                   |
 
 ### Slots
 
@@ -2229,11 +2229,11 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                           |
-| :--------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------- |
-| kind             | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification icon |
-| notificationType | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                                                                           | <code>"toast"</code>               | Set the type of notification          |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon   |
+| Prop name        | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                           |
+| :--------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------- |
+| kind             | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification icon |
+| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                                                                           | <code>"toast"</code>               | Set the type of notification          |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon   |
 
 ### Slots
 
@@ -2247,12 +2247,12 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                 | Default value          | Description                  |
-| :--------------- | :--------------- | :------- | :----------------------------------- | ---------------------- | ---------------------------- |
-| notificationType | <code>let</code> | No       | <code>"toast" &#124; "inline"</code> | <code>"toast"</code>   | Set the type of notification |
-| title            | <code>let</code> | No       | <code>string</code>                  | <code>"Title"</code>   | Specify the title text       |
-| subtitle         | <code>let</code> | No       | <code>string</code>                  | <code>""</code>        | Specify the subtitle text    |
-| caption          | <code>let</code> | No       | <code>string</code>                  | <code>"Caption"</code> | Specify the caption text     |
+| Prop name        | Required | Kind             | Reactive | Type                                 | Default value          | Description                  |
+| :--------------- | :------- | :--------------- | :------- | ------------------------------------ | ---------------------- | ---------------------------- |
+| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code> | <code>"toast"</code>   | Set the type of notification |
+| title            | No       | <code>let</code> | No       | <code>string</code>                  | <code>"Title"</code>   | Specify the title text       |
+| subtitle         | No       | <code>let</code> | No       | <code>string</code>                  | <code>""</code>        | Specify the subtitle text    |
+| caption          | No       | <code>let</code> | No       | <code>string</code>                  | <code>"Caption"</code> | Specify the caption text     |
 
 ### Slots
 
@@ -2274,31 +2274,31 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                            | Default value                                                    | Description                                    |
-| :-------------- | :----------------- | :------- | :-------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
-| ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element   |
-| value           | <code>let</code>   | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                                  | Specify the input value                        |
-| size            | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                      |
-| step            | <code>let</code>   | No       | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                     |
-| max             | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                      |
-| min             | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                      |
-| light           | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant      |
-| readonly        | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only    |
-| mobile          | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the mobile variant     |
-| allowEmpty      | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to allow for an empty value      |
-| disabled        | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to disable the input             |
-| iconDescription | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the ARIA label for the increment icons |
-| invalid         | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an invalid state     |
-| invalidText     | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the invalid state text                 |
-| warn            | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an warning state     |
-| warnText        | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the warning state text                 |
-| helperText      | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the helper text                        |
-| label           | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the label text                         |
-| hideLabel       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to visually hide the label text  |
-| translateWithId | <code>let</code>   | No       | <code>(id: NumberInputTranslationId) => string</code>           | <code>(id) => defaultTranslations[id]</code>                     | Override the default translation ids           |
-| translationIds  | <code>const</code> | No       | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                        |
-| id              | <code>let</code>   | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code>                 | Set an id for the input element                |
-| name            | <code>let</code>   | No       | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input         |
+| Prop name       | Required | Kind               | Reactive | Type                                                            | Default value                                                    | Description                                    |
+| :-------------- | :------- | :----------------- | :------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element   |
+| value           | No       | <code>let</code>   | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                                  | Specify the input value                        |
+| size            | No       | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                      |
+| step            | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                     |
+| max             | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                      |
+| min             | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                      |
+| light           | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant      |
+| readonly        | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only    |
+| mobile          | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the mobile variant     |
+| allowEmpty      | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to allow for an empty value      |
+| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to disable the input             |
+| iconDescription | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the ARIA label for the increment icons |
+| invalid         | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an invalid state     |
+| invalidText     | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the invalid state text                 |
+| warn            | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an warning state     |
+| warnText        | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the warning state text                 |
+| helperText      | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the helper text                        |
+| label           | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the label text                         |
+| hideLabel       | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to visually hide the label text  |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: NumberInputTranslationId) => string</code>           | <code>(id) => defaultTranslations[id]</code>                     | Override the default translation ids           |
+| translationIds  | No       | <code>const</code> | No       | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                        |
+| id              | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code>                 | Set an id for the input element                |
+| name            | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input         |
 
 ### Slots
 
@@ -2321,9 +2321,9 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -2342,10 +2342,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------- |
-| nested    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
-| native    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use native list styles |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
+| nested    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
+| native    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use native list styles |
 
 ### Slots
 
@@ -2387,20 +2387,20 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                         | Default value                                    | Description                                                       |
-| :--------------- | :--------------- | :------- | :----------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
-| menuRef          | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>                    | <code>null</code>                                | Obtain a reference to the overflow menu element                   |
-| buttonRef        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>                                | Obtain a reference to the trigger button element                  |
-| open             | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to open the menu                                    |
-| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                | <code>undefined</code>                           | Specify the size of the overflow menu                             |
-| direction        | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                           | <code>"bottom"</code>                            | Specify the direction of the overflow menu relative to the button |
-| light            | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to enable the light variant                         |
-| flipped          | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to flip the menu relative to the button             |
-| menuOptionsClass | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                           | Specify the menu options class                                    |
-| icon             | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render             |
-| iconClass        | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                           | Specify the icon class                                            |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                          | <code>"Open and close list of options"</code>    | Specify the ARIA label for the icon                               |
-| id               | <code>let</code> | No       | <code>string</code>                                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                  |
+| Prop name        | Required | Kind             | Reactive | Type                                                         | Default value                                    | Description                                                       |
+| :--------------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------- |
+| menuRef          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>                    | <code>null</code>                                | Obtain a reference to the overflow menu element                   |
+| buttonRef        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>                                | Obtain a reference to the trigger button element                  |
+| open             | No       | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to open the menu                                    |
+| size             | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                | <code>undefined</code>                           | Specify the size of the overflow menu                             |
+| direction        | No       | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                           | <code>"bottom"</code>                            | Specify the direction of the overflow menu relative to the button |
+| light            | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to enable the light variant                         |
+| flipped          | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                               | Set to `true` to flip the menu relative to the button             |
+| menuOptionsClass | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                           | Specify the menu options class                                    |
+| icon             | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render             |
+| iconClass        | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                           | Specify the icon class                                            |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                          | <code>"Open and close list of options"</code>    | Specify the ARIA label for the icon                               |
+| id               | No       | <code>let</code> | No       | <code>string</code>                                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                  |
 
 ### Slots
 
@@ -2424,17 +2424,17 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                                                                | Default value                                    | Description                                                                         |
-| :----------- | :--------------- | :------- | :------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the HTML element                                              |
-| primaryFocus | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` if the item should be focused when opening the menu                   |
-| text         | <code>let</code> | No       | <code>string</code>                                                 | <code>"Provide text"</code>                      | Specify the item text<br />Alternatively, use the default slot for a custom element |
-| href         | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>                                  | Specify the `href` attribute if the item is a link                                  |
-| disabled     | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to disable the item                                                   |
-| hasDivider   | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to include a divider                                                  |
-| danger       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to use the danger variant                                             |
-| requireTitle | <code>let</code> | No       | <code>boolean</code>                                                | <code>true</code>                                | Set to `false` to omit the button `title` attribute                                 |
-| id           | <code>let</code> | No       | <code>string</code>                                                 | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                 |
+| Prop name    | Required | Kind             | Reactive | Type                                                                | Default value                                    | Description                                                                         |
+| :----------- | :------- | :--------------- | :------- | ------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the HTML element                                              |
+| primaryFocus | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` if the item should be focused when opening the menu                   |
+| text         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>"Provide text"</code>                      | Specify the item text<br />Alternatively, use the default slot for a custom element |
+| href         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>                                  | Specify the `href` attribute if the item is a link                                  |
+| disabled     | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to disable the item                                                   |
+| hasDivider   | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to include a divider                                                  |
+| danger       | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to use the danger variant                                             |
+| requireTitle | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>true</code>                                | Set to `false` to omit the button `title` attribute                                 |
+| id           | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                 |
 
 ### Slots
 
@@ -2453,24 +2453,24 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                                             | Default value                                                                  | Description                                      |
-| :-------------------- | :--------------- | :------- | :--------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
-| pageSize              | <code>let</code> | Yes      | <code>number</code>                                              | <code>10</code>                                                                | Specify the number of items to display in a page |
-| page                  | <code>let</code> | Yes      | <code>number</code>                                              | <code>1</code>                                                                 | Specify the current page index                   |
-| totalItems            | <code>let</code> | No       | <code>number</code>                                              | <code>0</code>                                                                 | Specify the total number of items                |
-| disabled              | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the pagination          |
-| forwardText           | <code>let</code> | No       | <code>string</code>                                              | <code>"Next page"</code>                                                       | Specify the forward button text                  |
-| backwardText          | <code>let</code> | No       | <code>string</code>                                              | <code>"Previous page"</code>                                                   | Specify the backward button text                 |
-| itemsPerPageText      | <code>let</code> | No       | <code>string</code>                                              | <code>"Items per page:"</code>                                                 | Specify the items per page text                  |
-| itemText              | <code>let</code> | No       | <code>(min: number, max: number) => string</code>                | <code>(min, max) => \`${min}–${max} items\`</code>                             | Override the item text                           |
-| itemRangeText         | <code>let</code> | No       | <code>(min: number, max: number, total: number) => string</code> | <code>(min, max, total) => \`${min}–${max} of ${total} items\`</code>          | Override the item range text                     |
-| pageInputDisabled     | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page input          |
-| pageSizeInputDisabled | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page size input     |
-| pageSizes             | <code>let</code> | No       | <code>number[]</code>                                            | <code>[10]</code>                                                              | Specify the available page sizes                 |
-| pagesUnknown          | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` if the number of pages is unknown  |
-| pageText              | <code>let</code> | No       | <code>(page: number) => string</code>                            | <code>(page) => \`page ${page}\`</code>                                        | Override the page text                           |
-| pageRangeText         | <code>let</code> | No       | <code>(current: number, total: number) => string</code>          | <code>(current, total) => \`of ${total} page${total === 1 ? "" : "s"}\`</code> | Override the page range text                     |
-| id                    | <code>let</code> | No       | <code>string</code>                                              | <code>"ccs-" + Math.random().toString(36)</code>                               | Set an id for the top-level element              |
+| Prop name             | Required | Kind             | Reactive | Type                                                             | Default value                                                                  | Description                                      |
+| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| pageSize              | No       | <code>let</code> | Yes      | <code>number</code>                                              | <code>10</code>                                                                | Specify the number of items to display in a page |
+| page                  | No       | <code>let</code> | Yes      | <code>number</code>                                              | <code>1</code>                                                                 | Specify the current page index                   |
+| totalItems            | No       | <code>let</code> | No       | <code>number</code>                                              | <code>0</code>                                                                 | Specify the total number of items                |
+| disabled              | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the pagination          |
+| forwardText           | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Next page"</code>                                                       | Specify the forward button text                  |
+| backwardText          | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Previous page"</code>                                                   | Specify the backward button text                 |
+| itemsPerPageText      | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Items per page:"</code>                                                 | Specify the items per page text                  |
+| itemText              | No       | <code>let</code> | No       | <code>(min: number, max: number) => string</code>                | <code>(min, max) => \`${min}–${max} items\`</code>                             | Override the item text                           |
+| itemRangeText         | No       | <code>let</code> | No       | <code>(min: number, max: number, total: number) => string</code> | <code>(min, max, total) => \`${min}–${max} of ${total} items\`</code>          | Override the item range text                     |
+| pageInputDisabled     | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page input          |
+| pageSizeInputDisabled | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page size input     |
+| pageSizes             | No       | <code>let</code> | No       | <code>number[]</code>                                            | <code>[10]</code>                                                              | Specify the available page sizes                 |
+| pagesUnknown          | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` if the number of pages is unknown  |
+| pageText              | No       | <code>let</code> | No       | <code>(page: number) => string</code>                            | <code>(page) => \`page ${page}\`</code>                                        | Override the page text                           |
+| pageRangeText         | No       | <code>let</code> | No       | <code>(current: number, total: number) => string</code>          | <code>(current, total) => \`of ${total} page${total === 1 ? "" : "s"}\`</code> | Override the page range text                     |
+| id                    | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"ccs-" + Math.random().toString(36)</code>                               | Set an id for the top-level element              |
 
 ### Slots
 
@@ -2486,14 +2486,14 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                 | Default value                | Description                               |
-| :----------- | :--------------- | :------- | :------------------- | ---------------------------- | ----------------------------------------- |
-| page         | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
-| total        | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
-| shown        | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
-| loop         | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |
-| forwardText  | <code>let</code> | No       | <code>string</code>  | <code>"Next page"</code>     | Specify the forward button text           |
-| backwardText | <code>let</code> | No       | <code>string</code>  | <code>"Previous page"</code> | Specify the backward button text          |
+| Prop name    | Required | Kind             | Reactive | Type                 | Default value                | Description                               |
+| :----------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | ----------------------------------------- |
+| page         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
+| total        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
+| shown        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
+| loop         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |
+| forwardText  | No       | <code>let</code> | No       | <code>string</code>  | <code>"Next page"</code>     | Specify the forward button text           |
+| backwardText | No       | <code>let</code> | No       | <code>string</code>  | <code>"Previous page"</code> | Specify the backward button text          |
 
 ### Slots
 
@@ -2530,26 +2530,26 @@ None.
 
 ### Props
 
-| Prop name         | Kind             | Reactive | Type                                                            | Default value                                    | Description                                           |
-| :---------------- | :--------------- | :------- | :-------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
-| ref               | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                | Obtain a reference to the input HTML element          |
-| type              | <code>let</code> | Yes      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                          | Set to `"text"` to toggle the password visibility     |
-| value             | <code>let</code> | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                  | Specify the input value                               |
-| size              | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                           | Set the size of the input                             |
-| placeholder       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the placeholder text                          |
-| hidePasswordLabel | <code>let</code> | No       | <code>string</code>                                             | <code>"Hide password"</code>                     | Specify the hide password label text                  |
-| showPasswordLabel | <code>let</code> | No       | <code>string</code>                                             | <code>"Show password"</code>                     | Specify the show password label text                  |
-| tooltipAlignment  | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
-| tooltipPosition   | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the position of the tooltip relative to the icon  |
-| light             | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to enable the light variant             |
-| disabled          | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to disable the input                    |
-| helperText        | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the helper text                               |
-| labelText         | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the label text                                |
-| hideLabel         | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to visually hide the label text         |
-| invalid           | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an invalid state            |
-| invalidText       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the text for the invalid state                |
-| id                | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                       |
-| name              | <code>let</code> | No       | <code>string</code>                                             | <code>undefined</code>                           | Specify a name attribute for the input                |
+| Prop name         | Required | Kind             | Reactive | Type                                                            | Default value                                    | Description                                           |
+| :---------------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| ref               | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                | Obtain a reference to the input HTML element          |
+| type              | No       | <code>let</code> | Yes      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                          | Set to `"text"` to toggle the password visibility     |
+| value             | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                  | Specify the input value                               |
+| size              | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                           | Set the size of the input                             |
+| placeholder       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the placeholder text                          |
+| hidePasswordLabel | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"Hide password"</code>                     | Specify the hide password label text                  |
+| showPasswordLabel | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"Show password"</code>                     | Specify the show password label text                  |
+| tooltipAlignment  | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
+| tooltipPosition   | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the position of the tooltip relative to the icon  |
+| light             | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to enable the light variant             |
+| disabled          | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to disable the input                    |
+| helperText        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the helper text                               |
+| labelText         | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the label text                                |
+| hideLabel         | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to visually hide the label text         |
+| invalid           | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an invalid state            |
+| invalidText       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the text for the invalid state                |
+| id                | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                       |
+| name              | No       | <code>let</code> | No       | <code>string</code>                                             | <code>undefined</code>                           | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -2573,12 +2573,12 @@ None.
 
 ### Props
 
-| Prop name            | Kind             | Reactive | Type                 | Default value      | Description                                                                                    |
-| :------------------- | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| currentIndex         | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>     | Specify the current step index                                                                 |
-| vertical             | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant                                                      |
-| spaceEqually         | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to specify whether the progress steps should be split equally in size in the div |
-| preventChangeOnClick | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent `currentIndex` from updating                                          |
+| Prop name            | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                    |
+| :------------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| currentIndex         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>     | Specify the current step index                                                                 |
+| vertical             | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant                                                      |
+| spaceEqually         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to specify whether the progress steps should be split equally in size in the div |
+| preventChangeOnClick | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent `currentIndex` from updating                                          |
 
 ### Slots
 
@@ -2600,10 +2600,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| vertical  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant |
-| count     | <code>let</code> | No       | <code>number</code>  | <code>4</code>     | Specify the number of steps to render     |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| vertical  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant |
+| count     | No       | <code>let</code> | No       | <code>number</code>  | <code>4</code>     | Specify the number of steps to render     |
 
 ### Slots
 
@@ -2622,16 +2622,16 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                 | Default value                                    | Description                                |
-| :------------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ------------------------------------------ |
-| current        | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the current variant   |
-| complete       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` for the complete variant     |
-| disabled       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the progress step |
-| invalid        | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to indicate an invalid state |
-| description    | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step description               |
-| label          | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step label                     |
-| secondaryLabel | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step secondary label           |
-| id             | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element        |
+| Prop name      | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                |
+| :------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ------------------------------------------ |
+| current        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the current variant   |
+| complete       | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` for the complete variant     |
+| disabled       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the progress step |
+| invalid        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to indicate an invalid state |
+| description    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step description               |
+| label          | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step label                     |
+| secondaryLabel | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step secondary label           |
+| id             | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element        |
 
 ### Slots
 
@@ -2653,17 +2653,17 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                     |
-| :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element    |
-| checked       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the radio button         |
-| value         | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the value of the radio button           |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | et to `true` to disable the radio button        |
-| labelPosition | <code>let</code> | No       | <code>"right" &#124; "left"</code>        | <code>"right"</code>                             | Specify the label position                      |
-| labelText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                          |
-| hideLabel     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text   |
-| id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the checkbox input |
+| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                     |
+| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element    |
+| checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the radio button         |
+| value         | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the value of the radio button           |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | et to `true` to disable the radio button        |
+| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>        | <code>"right"</code>                             | Specify the label position                      |
+| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                          |
+| hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text   |
+| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
+| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -2679,13 +2679,13 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                        | Default value             | Description                                  |
-| :------------ | :--------------- | :------- | :------------------------------------------ | ------------------------- | -------------------------------------------- |
-| selected      | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
-| labelPosition | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
-| orientation   | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
-| id            | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
+| Prop name     | Required | Kind             | Reactive | Type                                        | Default value             | Description                                  |
+| :------------ | :------- | :--------------- | :------- | ------------------------------------------- | ------------------------- | -------------------------------------------- |
+| selected      | No       | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
+| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
+| orientation   | No       | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
+| id            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
 
 ### Slots
 
@@ -2726,15 +2726,15 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value                                    | Description                                              |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | -------------------------------------------------------- |
-| checked         | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to check the tile                          |
-| light           | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to enable the light variant                |
-| value           | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the value of the radio input                     |
-| tabindex        | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>                                 | Specify the tabindex                                     |
-| iconDescription | <code>let</code> | No       | <code>string</code>  | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the radio tile checkmark icon |
-| id              | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                          |
-| name            | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify a name attribute for the input                   |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                              |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| checked         | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to check the tile                          |
+| light           | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to enable the light variant                |
+| value           | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the value of the radio input                     |
+| tabindex        | No       | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>                                 | Specify the tabindex                                     |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>  | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the radio tile checkmark icon |
+| id              | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                          |
+| name            | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify a name attribute for the input                   |
 
 ### Slots
 
@@ -2757,15 +2757,15 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
-| :------------ | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Row let:props&gt;&lt;section {...props}&gt;...&lt;/section&gt;&lt;/Row&gt;) |
-| condensed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
-| narrow        | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
-| noGutter      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
-| padding       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
+| Prop name     | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
+| :------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Row let:props&gt;&lt;section {...props}&gt;...&lt;/section&gt;&lt;/Row&gt;) |
+| condensed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
+| narrow        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
+| noGutter      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
+| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
+| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
+| padding       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
 
 ### Slots
 
@@ -2781,22 +2781,22 @@ None.
 
 ### Props
 
-| Prop name            | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                                |
-| :------------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| ref                  | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                                               |
-| value                | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                  | Specify the value of the search input                                                      |
-| small                | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | @deprecated this prop will be removed in the next major release<br />Use size="sm" instead |
-| size                 | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>                                | Specify the size of the search input                                                       |
-| skeleton             | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state                                                |
-| light                | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                                                  |
-| disabled             | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the search input                                                  |
-| type                 | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the `type` attribute of the search input                                           |
-| placeholder          | <code>let</code> | No       | <code>string</code>                       | <code>"Search..."</code>                         | Specify the `placeholder` attribute of the search input                                    |
-| autocomplete         | <code>let</code> | No       | <code>"on" &#124; "off"</code>            | <code>"off"</code>                               | Specify the `autocomplete` attribute                                                       |
-| autofocus            | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to auto focus the search element                                             |
-| closeButtonLabelText | <code>let</code> | No       | <code>string</code>                       | <code>"Clear search input"</code>                | Specify the close button label text                                                        |
-| labelText            | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                                                                     |
-| id                   | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                            |
+| Prop name            | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                                |
+| :------------------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| ref                  | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                                               |
+| value                | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                  | Specify the value of the search input                                                      |
+| small                | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | @deprecated this prop will be removed in the next major release<br />Use size="sm" instead |
+| size                 | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>                                | Specify the size of the search input                                                       |
+| skeleton             | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state                                                |
+| light                | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                                                  |
+| disabled             | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the search input                                                  |
+| type                 | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the `type` attribute of the search input                                           |
+| placeholder          | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Search..."</code>                         | Specify the `placeholder` attribute of the search input                                    |
+| autocomplete         | No       | <code>let</code> | No       | <code>"on" &#124; "off"</code>            | <code>"off"</code>                               | Specify the `autocomplete` attribute                                                       |
+| autofocus            | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to auto focus the search element                                             |
+| closeButtonLabelText | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Clear search input"</code>                | Specify the close button label text                                                        |
+| labelText            | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                                                                     |
+| id                   | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                            |
 
 ### Slots
 
@@ -2821,10 +2821,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                      | Default value      | Description                                                                                                 |
-| :-------- | :--------------- | :------- | :---------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
-| small     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | @deprecated this prop will be removed in the next major release<br />Set to `true` to use the small variant |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>  | Specify the size of the search input                                                                        |
+| Prop name | Required | Kind             | Reactive | Type                                      | Default value      | Description                                                                                                 |
+| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| small     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | @deprecated this prop will be removed in the next major release<br />Set to `true` to use the small variant |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>  | Specify the size of the search input                                                                        |
 
 ### Slots
 
@@ -2843,22 +2843,22 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
-| :---------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
-| selected    | <code>let</code> | Yes      | <code>string</code>                        | <code>undefined</code>                           | Specify the selected item value                 |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                           | Set the size of the select input                |
-| inline      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to use the inline variant         |
-| light       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant       |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select element     |
-| id          | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
-| name        | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an invalid state      |
-| invalidText | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the invalid state text                  |
-| helperText  | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the helper text                         |
-| noLabel     | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to not render a label             |
-| labelText   | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to visually hide the label text   |
+| Prop name   | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
+| :---------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ----------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
+| selected    | No       | <code>let</code> | Yes      | <code>string</code>                        | <code>undefined</code>                           | Specify the selected item value                 |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                           | Set the size of the select input                |
+| inline      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to use the inline variant         |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant       |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select element     |
+| id          | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
+| name        | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an invalid state      |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the invalid state text                  |
+| helperText  | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the helper text                         |
+| noLabel     | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to not render a label             |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to visually hide the label text   |
 
 ### Slots
 
@@ -2877,12 +2877,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                         |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------- |
-| value     | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option value            |
-| text      | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option text             |
-| hidden    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the option    |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the option |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                         |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------- |
+| value     | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option value            |
+| text      | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option text             |
+| hidden    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the option    |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the option |
 
 ### Slots
 
@@ -2896,10 +2896,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value                | Description                                         |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------------- | --------------------------------------------------- |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to disable the optgroup element       |
-| label     | <code>let</code> | No       | <code>string</code>  | <code>"Provide label"</code> | Specify the label attribute of the optgroup element |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value                | Description                                         |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | --------------------------------------------------- |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to disable the optgroup element       |
+| label     | No       | <code>let</code> | No       | <code>string</code>  | <code>"Provide label"</code> | Specify the label attribute of the optgroup element |
 
 ### Slots
 
@@ -2915,9 +2915,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -2936,17 +2936,17 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                      | Default value                                    | Description                                                   |
-| :-------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                  |
-| selected        | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to select the tile                              |
-| light           | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                     |
-| title           | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the selectable tile                      |
-| value           | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the selectable tile                      |
-| tabindex        | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify the tabindex                                          |
-| iconDescription | <code>let</code> | No       | <code>string</code>                       | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the selectable tile checkmark icon |
-| id              | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                               |
-| name            | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                        |
+| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                                   |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                  |
+| selected        | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to select the tile                              |
+| light           | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                     |
+| title           | No       | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the selectable tile                      |
+| value           | No       | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the selectable tile                      |
+| tabindex        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify the tabindex                                          |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the selectable tile checkmark icon |
+| id              | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                               |
+| name            | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                        |
 
 ### Slots
 
@@ -2968,11 +2968,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                                |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ------------------------------------------ |
-| isOpen    | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state |
-| fixed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant     |
-| ariaLabel | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav         |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                                |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ------------------------------------------ |
+| isOpen    | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state |
+| fixed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant     |
+| ariaLabel | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav         |
 
 ### Slots
 
@@ -3004,13 +3004,13 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :--------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to select the current link              |
-| href       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
-| text       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
-| icon       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name  | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :--------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
+| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to select the current link              |
+| href       | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
+| text       | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
+| icon       | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -3026,12 +3026,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :-------- | :--------------- | :------- | :----------------------------------------------------------- | ---------------------- | ----------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element         |
-| expanded  | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to toggle the expanded state            |
-| text      | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
-| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element         |
+| expanded  | No       | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to toggle the expanded state            |
+| text      | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
+| icon      | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -3049,12 +3049,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                       | <code>undefined</code> | Set to `true` to select the item              |
-| href       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
+| Prop name  | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :--------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>undefined</code> | Set to `true` to select the item              |
+| href       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
 
 ### Slots
 
@@ -3089,12 +3089,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value       | Description                                     |
-| :-------- | :--------------- | :------- | :------------------- | ------------------- | ----------------------------------------------- |
-| lines     | <code>let</code> | No       | <code>number</code>  | <code>3</code>      | Specify the number of lines to render           |
-| heading   | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the heading size variant   |
-| paragraph | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the paragraph size variant |
-| width     | <code>let</code> | No       | <code>string</code>  | <code>"100%"</code> | Specify the width of the text (% or px)         |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value       | Description                                     |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------- | ----------------------------------------------- |
+| lines     | No       | <code>let</code> | No       | <code>number</code>  | <code>3</code>      | Specify the number of lines to render           |
+| heading   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the heading size variant   |
+| paragraph | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the paragraph size variant |
+| width     | No       | <code>let</code> | No       | <code>string</code>  | <code>"100%"</code> | Specify the width of the text (% or px)         |
 
 ### Slots
 
@@ -3113,10 +3113,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                | Description                  |
-| :-------- | :--------------- | :------- | :------------------ | ---------------------------- | ---------------------------- |
-| href      | <code>let</code> | No       | <code>string</code> | <code>"#main-content"</code> | Specify the `href` attribute |
-| tabindex  | <code>let</code> | No       | <code>string</code> | <code>"0"</code>             | Specify the tabindex         |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                | Description                  |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ---------------------------- | ---------------------------- |
+| href      | No       | <code>let</code> | No       | <code>string</code> | <code>"#main-content"</code> | Specify the `href` attribute |
+| tabindex  | No       | <code>let</code> | No       | <code>string</code> | <code>"0"</code>             | Specify the tabindex         |
 
 ### Slots
 
@@ -3134,25 +3134,25 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                    | Default value                                    | Description                                |
-| :------------- | :--------------- | :------- | :-------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
-| ref            | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element     |
-| value          | <code>let</code> | Yes      | <code>number</code>                     | <code>0</code>                                   | Specify the value of the slider            |
-| max            | <code>let</code> | No       | <code>number</code>                     | <code>100</code>                                 | Set the maximum slider value               |
-| maxLabel       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the max value        |
-| min            | <code>let</code> | No       | <code>number</code>                     | <code>0</code>                                   | Set the minimum slider value               |
-| minLabel       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the min value        |
-| step           | <code>let</code> | No       | <code>number</code>                     | <code>1</code>                                   | Set the step value                         |
-| stepMultiplier | <code>let</code> | No       | <code>number</code>                     | <code>4</code>                                   | Set the step multiplier value              |
-| required       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to require a value           |
-| inputType      | <code>let</code> | No       | <code>string</code>                     | <code>"number"</code>                            | Specify the input type                     |
-| disabled       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to disable the slider        |
-| light          | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to enable the light variant  |
-| hideTextInput  | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to hide the text input       |
-| id             | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the slider div element       |
-| invalid        | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to indicate an invalid state |
-| labelText      | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label text                     |
-| name           | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Set a name for the slider element          |
+| Prop name      | Required | Kind             | Reactive | Type                                    | Default value                                    | Description                                |
+| :------------- | :------- | :--------------- | :------- | --------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| ref            | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element     |
+| value          | No       | <code>let</code> | Yes      | <code>number</code>                     | <code>0</code>                                   | Specify the value of the slider            |
+| max            | No       | <code>let</code> | No       | <code>number</code>                     | <code>100</code>                                 | Set the maximum slider value               |
+| maxLabel       | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the max value        |
+| min            | No       | <code>let</code> | No       | <code>number</code>                     | <code>0</code>                                   | Set the minimum slider value               |
+| minLabel       | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the min value        |
+| step           | No       | <code>let</code> | No       | <code>number</code>                     | <code>1</code>                                   | Set the step value                         |
+| stepMultiplier | No       | <code>let</code> | No       | <code>number</code>                     | <code>4</code>                                   | Set the step multiplier value              |
+| required       | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to require a value           |
+| inputType      | No       | <code>let</code> | No       | <code>string</code>                     | <code>"number"</code>                            | Specify the input type                     |
+| disabled       | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to disable the slider        |
+| light          | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to enable the light variant  |
+| hideTextInput  | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to hide the text input       |
+| id             | No       | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the slider div element       |
+| invalid        | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to indicate an invalid state |
+| labelText      | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label text                     |
+| name           | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Set a name for the slider element          |
 
 ### Slots
 
@@ -3172,9 +3172,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -3193,11 +3193,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                                    |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------- |
-| selected  | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
-| border    | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the bordered variant      |
-| selection | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                                    |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
+| border    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the bordered variant      |
+| selection | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
 
 ### Slots
 
@@ -3240,10 +3240,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                       |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------- |
-| head      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header  |
-| noWrap    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent wrapping |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                       |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------- |
+| head      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header  |
+| noWrap    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent wrapping |
 
 ### Slots
 
@@ -3285,14 +3285,14 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                      | Default value                                    | Description                                  |
-| :-------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element |
-| checked   | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the input             |
-| title     | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the input               |
-| value     | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the input               |
-| id        | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
-| name      | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input       |
+| Prop name | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                  |
+| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element |
+| checked   | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the input             |
+| title     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the input               |
+| value     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the input               |
+| id        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
+| name      | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input       |
 
 ### Slots
 
@@ -3306,11 +3306,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| head      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header     |
-| label     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a label slot |
-| tabindex  | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>   | Specify the tabindex                 |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| head      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header     |
+| label     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a label slot |
+| tabindex  | No       | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>   | Specify the tabindex                 |
 
 ### Slots
 
@@ -3332,10 +3332,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| rows      | <code>let</code> | No       | <code>number</code>  | <code>5</code>     | Specify the number of rows                |
-| border    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the bordered variant |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| rows      | No       | <code>let</code> | No       | <code>number</code>  | <code>5</code>     | Specify the number of rows                |
+| border    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the bordered variant |
 
 ### Slots
 
@@ -3354,13 +3354,13 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                      |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the button HTML element                                                                    |
-| selected  | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` for the switch to be selected                                                                      |
-| text      | <code>let</code> | No       | <code>string</code>                        | <code>"Provide text"</code>                      | Specify the switch text<br />Alternatively, use the "text" slot (e.g., &lt;span slot="text"&gt;...&lt;/span&gt;) |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the switch                                                                              |
-| id        | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                                                                 |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                      |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the button HTML element                                                                    |
+| selected  | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` for the switch to be selected                                                                      |
+| text      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Provide text"</code>                      | Specify the switch text<br />Alternatively, use the "text" slot (e.g., &lt;span slot="text"&gt;...&lt;/span&gt;) |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the switch                                                                              |
+| id        | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                                                                 |
 
 ### Slots
 
@@ -3382,14 +3382,14 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                  |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>                                | Obtain a reference to the anchor HTML element                                                                                |
-| label     | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the tab label<br />Alternatively, use the default slot (e.g., &lt;Tab&gt;&lt;span&gt;Label&lt;/span&gt;&lt;/Tab&gt;) |
-| href      | <code>let</code> | No       | <code>string</code>                        | <code>"#"</code>                                 | Specify the href attribute                                                                                                   |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the tab                                                                                             |
-| tabindex  | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                                                                                         |
-| id        | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                                                          |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                  |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>                                | Obtain a reference to the anchor HTML element                                                                                |
+| label     | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the tab label<br />Alternatively, use the default slot (e.g., &lt;Tab&gt;&lt;span&gt;Label&lt;/span&gt;&lt;/Tab&gt;) |
+| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"#"</code>                                 | Specify the href attribute                                                                                                   |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the tab                                                                                             |
+| tabindex  | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                                                                                         |
+| id        | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                                                          |
 
 ### Slots
 
@@ -3410,9 +3410,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                                    | Description                         |
-| :-------- | :--------------- | :------- | :------------------ | ------------------------------------------------ | ----------------------------------- |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                                    | Description                         |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ------------------------------------------------ | ----------------------------------- |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element |
 
 ### Slots
 
@@ -3428,14 +3428,14 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                | Default value          | Description                             |
-| :--------------- | :--------------- | :------- | :-------------------------------------------------- | ---------------------- | --------------------------------------- |
-| size             | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table               |
-| zebra            | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles       |
-| useStaticWidth   | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use static width       |
-| shouldShowBorder | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the bordered variant  |
-| sortable         | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant  |
-| stickyHeader     | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header |
+| Prop name        | Required | Kind             | Reactive | Type                                                | Default value          | Description                             |
+| :--------------- | :------- | :--------------- | :------- | --------------------------------------------------- | ---------------------- | --------------------------------------- |
+| size             | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table               |
+| zebra            | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles       |
+| useStaticWidth   | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use static width       |
+| shouldShowBorder | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the bordered variant  |
+| sortable         | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant  |
+| stickyHeader     | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header |
 
 ### Slots
 
@@ -3488,11 +3488,11 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :----------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| title        | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the title of the data table       |
-| description  | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the description of the data table |
-| stickyHeader | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable a sticky header   |
+| Prop name    | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :----------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| title        | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the title of the data table       |
+| description  | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the description of the data table |
+| stickyHeader | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable a sticky header   |
 
 ### Slots
 
@@ -3529,11 +3529,11 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                      | Default value                                    | Description                          |
-| :-------------- | :--------------- | :------- | :------------------------ | ------------------------------------------------ | ------------------------------------ |
-| scope           | <code>let</code> | No       | <code>string</code>       | <code>"col"</code>                               | Specify the `scope` attribute        |
-| translateWithId | <code>let</code> | No       | <code>() => string</code> | <code>() => ""</code>                            | Override the default id translations |
-| id              | <code>let</code> | No       | <code>string</code>       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element  |
+| Prop name       | Required | Kind             | Reactive | Type                      | Default value                                    | Description                          |
+| :-------------- | :------- | :--------------- | :------- | ------------------------- | ------------------------------------------------ | ------------------------------------ |
+| scope           | No       | <code>let</code> | No       | <code>string</code>       | <code>"col"</code>                               | Specify the `scope` attribute        |
+| translateWithId | No       | <code>let</code> | No       | <code>() => string</code> | <code>() => ""</code>                            | Override the default id translations |
+| id              | No       | <code>let</code> | No       | <code>string</code>       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element  |
 
 ### Slots
 
@@ -3575,12 +3575,12 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                      | Default value                    | Description                                 |
-| :-------------- | :--------------- | :------- | :---------------------------------------- | -------------------------------- | ------------------------------------------- |
-| selected        | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>                   | Specify the selected tab index              |
-| type            | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code>           | Specify the type of tabs                    |
-| iconDescription | <code>let</code> | No       | <code>string</code>                       | <code>"Show menu options"</code> | Specify the ARIA label for the chevron icon |
-| triggerHref     | <code>let</code> | No       | <code>string</code>                       | <code>"#"</code>                 | Specify the tab trigger href attribute      |
+| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                    | Description                                 |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------- | ------------------------------------------- |
+| selected        | No       | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>                   | Specify the selected tab index              |
+| type            | No       | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code>           | Specify the type of tabs                    |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Show menu options"</code> | Specify the ARIA label for the chevron icon |
+| triggerHref     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"#"</code>                 | Specify the tab trigger href attribute      |
 
 ### Slots
 
@@ -3601,9 +3601,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value  | Description                          |
-| :-------- | :--------------- | :------- | :------------------ | -------------- | ------------------------------------ |
-| count     | <code>let</code> | No       | <code>number</code> | <code>4</code> | Specify the number of tabs to render |
+| Prop name | Required | Kind             | Reactive | Type                | Default value  | Description                          |
+| :-------- | :------- | :--------------- | :------- | ------------------- | -------------- | ------------------------------------ |
+| count     | No       | <code>let</code> | No       | <code>number</code> | <code>4</code> | Specify the number of tabs to render |
 
 ### Slots
 
@@ -3622,15 +3622,15 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                                                                                                                                    | Default value                                    | Description                                            |
-| :-------- | :--------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
-| type      | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast"</code> | <code>undefined</code>                           | Specify the type of tag                                |
-| filter    | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to use filterable variant                |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to disable a filterable tag              |
-| skeleton  | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to display the skeleton state            |
-| title     | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"Clear filter"</code>                      | Set the title for the close button in a filterable tag |
-| icon      | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                                                                            | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render  |
-| id        | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the filterable tag                       |
+| Prop name | Required | Kind             | Reactive | Type                                                                                                                                                                                    | Default value                                    | Description                                            |
+| :-------- | :------- | :--------------- | :------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| type      | No       | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast"</code> | <code>undefined</code>                           | Specify the type of tag                                |
+| filter    | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to use filterable variant                |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to disable a filterable tag              |
+| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                               | Set to `true` to display the skeleton state            |
+| title     | No       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"Clear filter"</code>                      | Set the title for the close button in a filterable tag |
+| icon      | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                                                                            | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render  |
+| id        | No       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the filterable tag                       |
 
 ### Slots
 
@@ -3671,22 +3671,22 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                         | Default value                                    | Description                                     |
-| :---------- | :--------------- | :------- | :------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                | Obtain a reference to the textarea HTML element |
-| value       | <code>let</code> | Yes      | <code>string</code>                          | <code>""</code>                                  | Specify the textarea value                      |
-| placeholder | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the placeholder text                    |
-| cols        | <code>let</code> | No       | <code>number</code>                          | <code>50</code>                                  | Specify the number of cols                      |
-| rows        | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                   | Specify the number of rows                      |
-| light       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to enable the light variant       |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to disable the input              |
-| helperText  | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the helper text                         |
-| labelText   | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the label text                          |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to visually hide the label text   |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an invalid state      |
-| invalidText | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the text for the invalid state          |
-| id          | <code>let</code> | No       | <code>string</code>                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the textarea element              |
-| name        | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                           | Specify a name attribute for the input          |
+| Prop name   | Required | Kind             | Reactive | Type                                         | Default value                                    | Description                                     |
+| :---------- | :------- | :--------------- | :------- | -------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                | Obtain a reference to the textarea HTML element |
+| value       | No       | <code>let</code> | Yes      | <code>string</code>                          | <code>""</code>                                  | Specify the textarea value                      |
+| placeholder | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the placeholder text                    |
+| cols        | No       | <code>let</code> | No       | <code>number</code>                          | <code>50</code>                                  | Specify the number of cols                      |
+| rows        | No       | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                   | Specify the number of rows                      |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to enable the light variant       |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to disable the input              |
+| helperText  | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the helper text                         |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the label text                          |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to visually hide the label text   |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an invalid state      |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the text for the invalid state          |
+| id          | No       | <code>let</code> | No       | <code>string</code>                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the textarea element              |
+| name        | No       | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                           | Specify a name attribute for the input          |
 
 ### Slots
 
@@ -3709,9 +3709,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
 
 ### Slots
 
@@ -3730,26 +3730,26 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                      | Default value                                    | Description                                   |
-| :---------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element  |
-| value       | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>                                  | Specify the input value                       |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                     |
-| type        | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input type                        |
-| placeholder | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the placeholder text                  |
-| light       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant     |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input            |
-| helperText  | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the helper text                       |
-| id          | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element               |
-| name        | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify a name attribute for the input        |
-| labelText   | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                        |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state    |
-| invalidText | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                |
-| warn        | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an warning state    |
-| warnText    | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the warning state text                |
-| required    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required   |
-| inline      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use inline version           |
+| Prop name   | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                   |
+| :---------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element  |
+| value       | No       | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>                                  | Specify the input value                       |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                     |
+| type        | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input type                        |
+| placeholder | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the placeholder text                  |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant     |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input            |
+| helperText  | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the helper text                       |
+| id          | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element               |
+| name        | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify a name attribute for the input        |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                        |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state    |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                |
+| warn        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an warning state    |
+| warnText    | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the warning state text                |
+| required    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required   |
+| inline      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to use inline version           |
 
 ### Slots
 
@@ -3773,9 +3773,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -3794,9 +3794,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| light     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| light     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
 
 ### Slots
 
@@ -3817,11 +3817,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | --------------------------------------- |
-| selected  | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
-| legend    | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                             |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | --------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
+| legend    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
 
 ### Slots
 
@@ -3839,23 +3839,23 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                      | Default value                                       | Description                                           |
-| :---------- | :--------------- | :------- | :---------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
-| value       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
-| type        | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
-| placeholder | <code>let</code> | No       | <code>string</code>                       | <code>"hh=mm"</code>                                | Specify the input placeholder text                    |
-| pattern     | <code>let</code> | No       | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
-| maxlength   | <code>let</code> | No       | <code>number</code>                       | <code>5</code>                                      | Specify the `maxlength` input attribute               |
-| light       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to enable the light variant             |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to disable the input                    |
-| labelText   | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the label text                                |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to visually hide the label text         |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
-| invalidText | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
-| id          | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code>    | Set an id for the input element                       |
-| name        | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
+| Prop name   | Required | Kind             | Reactive | Type                                      | Default value                                       | Description                                           |
+| :---------- | :------- | :--------------- | :------- | ----------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
+| value       | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
+| type        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
+| placeholder | No       | <code>let</code> | No       | <code>string</code>                       | <code>"hh=mm"</code>                                | Specify the input placeholder text                    |
+| pattern     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
+| maxlength   | No       | <code>let</code> | No       | <code>number</code>                       | <code>5</code>                                      | Specify the `maxlength` input attribute               |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to enable the light variant             |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to disable the input                    |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the label text                                |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to visually hide the label text         |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
+| id          | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code>    | Set an id for the input element                       |
+| name        | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -3880,16 +3880,16 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                                                                                   |
-| :-------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element                                                                                                                                                 |
-| value           | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                  | Specify the select value                                                                                                                                                                      |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select                                                                                                                                                           |
-| iconDescription | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>              | Specify the ARIA label for the chevron icon                                                                                                                                                   |
-| labelText       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                                                                                                                                                                        |
-| hideLabel       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>                                | @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.<br />Set to `false` to show the label text |
-| id              | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                                                                                                                                                              |
-| name            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element                                                                                                                                               |
+| Prop name       | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                                                                                   |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element                                                                                                                                                 |
+| value           | No       | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                  | Specify the select value                                                                                                                                                                      |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select                                                                                                                                                           |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>              | Specify the ARIA label for the chevron icon                                                                                                                                                   |
+| labelText       | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                                                                                                                                                                        |
+| hideLabel       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>                                | @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.<br />Set to `false` to show the label text |
+| id              | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                                                                                                                                                              |
+| name            | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element                                                                                                                                               |
 
 ### Slots
 
@@ -3910,17 +3910,17 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| kind            | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
-| lowContrast     | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
-| timeout         | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
-| role            | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
-| title           | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
-| subtitle        | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
-| caption         | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Caption"</code>             | Specify the caption text                                                |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
-| hideCloseButton | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
+| Prop name       | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| kind            | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
+| lowContrast     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
+| timeout         | No       | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
+| role            | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
+| title           | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
+| subtitle        | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
+| caption         | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Caption"</code>             | Specify the caption text                                                |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
+| hideCloseButton | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
 
 ### Slots
 
@@ -3942,16 +3942,16 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value                                    | Description                                     |
-| :-------- | :--------------- | :------- | :--------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| toggled   | <code>let</code> | Yes      | <code>boolean</code>               | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
-| size      | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size                         |
-| disabled  | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                               | Set to `true` to disable checkbox input         |
-| labelA    | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                               | Specify the label for the untoggled state       |
-| labelB    | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
-| labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
-| id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name      | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value                                    | Description                                     |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| toggled   | No       | <code>let</code> | Yes      | <code>boolean</code>               | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
+| size      | No       | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size                         |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                               | Set to `true` to disable checkbox input         |
+| labelA    | No       | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                               | Specify the label for the untoggled state       |
+| labelB    | No       | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
+| labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
+| id        | No       | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
+| name      | No       | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -3975,11 +3975,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value                                    | Description                     |
-| :-------- | :--------------- | :------- | :--------------------------------- | ------------------------------------------------ | ------------------------------- |
-| size      | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size         |
-| labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text          |
-| id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value                                    | Description                     |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ------------------------------------------------ | ------------------------------- |
+| size      | No       | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size         |
+| labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text          |
+| id        | No       | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
 
 ### Slots
 
@@ -3998,15 +3998,15 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value                                    | Description                                     |
-| :-------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| toggled   | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable checkbox input         |
-| labelA    | <code>let</code> | No       | <code>string</code>  | <code>"Off"</code>                               | Specify the label for the untoggled state       |
-| labelB    | <code>let</code> | No       | <code>string</code>  | <code>"On"</code>                                | Specify the label for the toggled state         |
-| labelText | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the label text                          |
-| id        | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name      | <code>let</code> | No       | <code>string</code>  | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                     |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| toggled   | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable checkbox input         |
+| labelA    | No       | <code>let</code> | No       | <code>string</code>  | <code>"Off"</code>                               | Specify the label for the untoggled state       |
+| labelB    | No       | <code>let</code> | No       | <code>string</code>  | <code>"On"</code>                                | Specify the label for the toggled state         |
+| labelText | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the label text                          |
+| id        | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
+| name      | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -4029,10 +4029,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                                    | Description                     |
-| :-------- | :--------------- | :------- | :------------------ | ------------------------------------------------ | ------------------------------- |
-| labelText | <code>let</code> | No       | <code>string</code> | <code>""</code>                                  | Specify the label text          |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                                    | Description                     |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ------------------------------------------------ | ------------------------------- |
+| labelText | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>                                  | Specify the label text          |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
 
 ### Slots
 
@@ -4051,9 +4051,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value          | Description              |
-| :-------- | :--------------- | :------- | :--------------------------------- | ---------------------- | ------------------------ |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | Specify the toolbar size |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value          | Description              |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ---------------------- | ------------------------ |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | Specify the toolbar size |
 
 ### Slots
 
@@ -4069,9 +4069,9 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                            |
-| :------------------ | :--------------- | :------- | :--------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| formatTotalSelected | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text |
+| Prop name           | Required | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                            |
+| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text |
 
 ### Slots
 
@@ -4138,13 +4138,13 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                      | Default value      | Description                                   |
-| :--------- | :--------------- | :------- | :---------------------------------------- | ------------------ | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element  |
-| expanded   | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to expand the search bar        |
-| value      | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>    | Specify the value of the search input         |
-| persistent | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | Set to `true` to keep the search bar expanded |
-| tabindex   | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>   | Specify the tabindex                          |
+| Prop name  | Required | Kind             | Reactive | Type                                      | Default value      | Description                                   |
+| :--------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | --------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element  |
+| expanded   | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to expand the search bar        |
+| value      | No       | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>    | Specify the value of the search input         |
+| persistent | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | Set to `true` to keep the search bar expanded |
+| tabindex   | No       | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>   | Specify the tabindex                          |
 
 ### Slots
 
@@ -4163,22 +4163,22 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                                                                                        |
-| :-------------- | :--------------- | :------- | :-------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| refIcon         | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the icon HTML element                                                                                        |
-| refTooltip      | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the tooltip HTML element                                                                                     |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the trigger text HTML element                                                                                |
-| open            | <code>let</code> | Yes      | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to open the tooltip                                                                                                  |
-| align           | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                                                                              |
-| direction       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the button                                                                            |
-| hideIcon        | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to hide the tooltip icon                                                                                             |
-| icon            | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>    | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render for the tooltip button<br />Icon size must be 16px (e.g., `Add16`, `Task16`) |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the ARIA label for the tooltip button                                                                                      |
-| iconName        | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the icon name attribute                                                                                                    |
-| tabindex        | <code>let</code> | No       | <code>string</code>                                             | <code>"0"</code>                                 | Set the button tabindex                                                                                                            |
-| tooltipId       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip                                                                                                          |
-| triggerId       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip button                                                                                                   |
-| triggerText     | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Set the tooltip button text                                                                                                        |
+| Prop name       | Required | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                                                                                        |
+| :-------------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| refIcon         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the icon HTML element                                                                                        |
+| refTooltip      | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the tooltip HTML element                                                                                     |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the trigger text HTML element                                                                                |
+| open            | No       | <code>let</code> | Yes      | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to open the tooltip                                                                                                  |
+| align           | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                                                                              |
+| direction       | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the button                                                                            |
+| hideIcon        | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to hide the tooltip icon                                                                                             |
+| icon            | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>    | <code>undefined</code>                           | Specify the icon from `carbon-icons-svelte` to render for the tooltip button<br />Icon size must be 16px (e.g., `Add16`, `Task16`) |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the ARIA label for the tooltip button                                                                                      |
+| iconName        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the icon name attribute                                                                                                    |
+| tabindex        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"0"</code>                                 | Set the button tabindex                                                                                                            |
+| tooltipId       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip                                                                                                          |
+| triggerId       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip button                                                                                                   |
+| triggerText     | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Set the tooltip button text                                                                                                        |
 
 ### Slots
 
@@ -4199,13 +4199,13 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                              | Default value                                    | Description                                           |
-| :---------- | :--------------- | :------- | :------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                | Obtain a reference to the button HTML element         |
-| tooltipText | <code>let</code> | No       | <code>string</code>                               | <code>""</code>                                  | Specify the tooltip text                              |
-| align       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
-| direction   | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon |
-| id          | <code>let</code> | No       | <code>string</code>                               | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip div element                 |
+| Prop name   | Required | Kind             | Reactive | Type                                              | Default value                                    | Description                                           |
+| :---------- | :------- | :--------------- | :------- | ------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                | Obtain a reference to the button HTML element         |
+| tooltipText | No       | <code>let</code> | No       | <code>string</code>                               | <code>""</code>                                  | Specify the tooltip text                              |
+| align       | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
+| direction   | No       | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon |
+| id          | No       | <code>let</code> | No       | <code>string</code>                               | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip div element                 |
 
 ### Slots
 
@@ -4228,13 +4228,13 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                       |
-| :---------- | :--------------- | :------- | :-------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                      | <code>null</code>                                | Obtain a reference to the button HTML element                     |
-| tooltipText | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the tooltip text.<br />Alternatively, use the "text" slot |
-| align       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon             |
-| direction   | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon             |
-| id          | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the span element                                    |
+| Prop name   | Required | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                       |
+| :---------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                      | <code>null</code>                                | Obtain a reference to the button HTML element                     |
+| tooltipText | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the tooltip text.<br />Alternatively, use the "text" slot |
+| align       | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon             |
+| direction   | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon             |
+| id          | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the span element                                    |
 
 ### Slots
 
@@ -4257,9 +4257,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------- |
-| nested    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
+| nested    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
 
 ### Slots
 

--- a/integration/carbon/src/Dropdown/Dropdown.svelte
+++ b/integration/carbon/src/Dropdown/Dropdown.svelte
@@ -14,6 +14,7 @@
 
   /**
    * Override the display of a dropdown item
+   * @required
    * @type {(item: DropdownItem) => string}
    */
   export let itemToString = (item) => item.text || item.id;

--- a/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -22,7 +22,7 @@ export interface DropdownProps
    * Override the display of a dropdown item
    * @default (item) => item.text || item.id
    */
-  itemToString?: (item: DropdownItem) => string;
+  itemToString: (item: DropdownItem) => string;
 
   /**
    * Specify the selected item index

--- a/integration/glob/COMPONENT_API.json
+++ b/integration/glob/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "value": "\"button2\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -22,6 +23,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -34,6 +36,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -44,6 +47,7 @@
           "value": "() => {     let depth = 0;     if (node == null) return depth;     let parentNode = node.parentNode;     while (parentNode != null && parentNode.getAttribute(\"role\") !== \"tree\") {       parentNode = parentNode.parentNode;       if (parentNode.tagName === \"LI\") depth++;     }     return depth;   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -55,6 +59,7 @@
           "value": "() => {     if (node.classList.contains(\"bx--tree-parent-node\")) return node;     if (node.classList.contains(\"bx--tree\")) return null;     return findParentTreeNode(node.parentNode);   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/integration/glob/COMPONENT_INDEX.md
+++ b/integration/glob/COMPONENT_INDEX.md
@@ -12,10 +12,10 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ----------- |
-| type      | <code>let</code> | No       | <code>string</code>  | <code>"button2"</code> | --          |
-| primary   | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | --          |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ----------- |
+| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button2"</code> | --          |
+| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | --          |
 
 ### Slots
 

--- a/integration/multi-export-typed/COMPONENT_API.json
+++ b/integration/multi-export-typed/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -23,6 +24,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -68,6 +70,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -78,6 +81,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -106,6 +110,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         }

--- a/integration/multi-export-typed/COMPONENT_INDEX.md
+++ b/integration/multi-export-typed/COMPONENT_INDEX.md
@@ -15,10 +15,10 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                 | Default value         | Description                              |
-| :-------- | :--------------- | :------- | :--------------------------------------------------- | --------------------- | ---------------------------------------- |
-| type      | <code>let</code> | No       | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
-| primary   | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
+| Prop name | Required | Kind             | Reactive | Type                                                 | Default value         | Description                              |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | --------------------- | ---------------------------------------- |
+| type      | No       | <code>let</code> | No       | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
+| primary   | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
 
 ### Slots
 
@@ -54,10 +54,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value   | Description |
-| :-------- | :--------------- | :------- | :------------------ | --------------- | ----------- |
-| quote     | <code>let</code> | No       | <code>string</code> | <code>""</code> | --          |
-| author    | <code>let</code> | No       | <code>string</code> | <code>""</code> | --          |
+| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description |
+| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------- |
+| quote     | No       | <code>let</code> | No       | <code>string</code> | <code>""</code> | --          |
+| author    | No       | <code>let</code> | No       | <code>string</code> | <code>""</code> | --          |
 
 ### Slots
 
@@ -73,9 +73,9 @@ None.
 
 ### Props
 
-| Prop name | Kind               | Reactive | Type                 | Default value     | Description |
-| :-------- | :----------------- | :------- | :------------------- | ----------------- | ----------- |
-| secondary | <code>const</code> | No       | <code>boolean</code> | <code>true</code> | --          |
+| Prop name | Required | Kind               | Reactive | Type                 | Default value     | Description |
+| :-------- | :------- | :----------------- | :------- | -------------------- | ----------------- | ----------- |
+| secondary | No       | <code>const</code> | No       | <code>boolean</code> | <code>true</code> | --          |
 
 ### Slots
 

--- a/integration/multi-export/COMPONENT_API.json
+++ b/integration/multi-export/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -22,6 +23,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -32,6 +34,7 @@
           "value": "() => {     console.log(0);   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -86,6 +89,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -96,6 +100,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/integration/multi-export/COMPONENT_INDEX.md
+++ b/integration/multi-export/COMPONENT_INDEX.md
@@ -15,11 +15,11 @@
 
 ### Props
 
-| Prop name | Kind                  | Reactive | Type                   | Default value                          | Description |
-| :-------- | :-------------------- | :------- | :--------------------- | -------------------------------------- | ----------- |
-| type      | <code>let</code>      | No       | <code>string</code>    | <code>"button"</code>                  | --          |
-| primary   | <code>let</code>      | No       | <code>boolean</code>   | <code>false</code>                     | --          |
-| print     | <code>function</code> | No       | <code>() => any</code> | <code>() => { console.log(0); }</code> | --          |
+| Prop name | Required | Kind                  | Reactive | Type                   | Default value                          | Description |
+| :-------- | :------- | :-------------------- | :------- | ---------------------- | -------------------------------------- | ----------- |
+| type      | No       | <code>let</code>      | No       | <code>string</code>    | <code>"button"</code>                  | --          |
+| primary   | No       | <code>let</code>      | No       | <code>boolean</code>   | <code>false</code>                     | --          |
+| print     | No       | <code>function</code> | No       | <code>() => any</code> | <code>() => { console.log(0); }</code> | --          |
 
 ### Slots
 
@@ -77,10 +77,10 @@ export type Author = string;
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value   | Description |
-| :-------- | :--------------- | :------- | :------------------ | --------------- | ----------- |
-| quote     | <code>let</code> | No       | <code>any</code>    | <code>""</code> | --          |
-| author    | <code>let</code> | No       | <code>Author</code> | <code>""</code> | --          |
+| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description |
+| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------- |
+| quote     | No       | <code>let</code> | No       | <code>any</code>    | <code>""</code> | --          |
+| author    | No       | <code>let</code> | No       | <code>Author</code> | <code>""</code> | --          |
 
 ### Slots
 

--- a/integration/multi-folders/COMPONENT_API.json
+++ b/integration/multi-folders/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -23,6 +24,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -86,6 +88,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -96,6 +99,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/integration/multi-folders/COMPONENT_INDEX.md
+++ b/integration/multi-folders/COMPONENT_INDEX.md
@@ -16,10 +16,10 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                 | Default value         | Description                              |
-| :-------- | :--------------- | :------- | :--------------------------------------------------- | --------------------- | ---------------------------------------- |
-| type      | <code>let</code> | No       | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
-| primary   | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
+| Prop name | Required | Kind             | Reactive | Type                                                 | Default value         | Description                              |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | --------------------- | ---------------------------------------- |
+| type      | No       | <code>let</code> | No       | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
+| primary   | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
 
 ### Slots
 
@@ -93,10 +93,10 @@ export type Author = string;
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value   | Description |
-| :-------- | :--------------- | :------- | :------------------ | --------------- | ----------- |
-| quote     | <code>let</code> | No       | <code>any</code>    | <code>""</code> | --          |
-| author    | <code>let</code> | No       | <code>Author</code> | <code>""</code> | --          |
+| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description |
+| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------- |
+| quote     | No       | <code>let</code> | No       | <code>any</code>    | <code>""</code> | --          |
+| author    | No       | <code>let</code> | No       | <code>Author</code> | <code>""</code> | --          |
 
 ### Slots
 

--- a/integration/single-export-default-only/COMPONENT_API.json
+++ b/integration/single-export-default-only/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -22,6 +23,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/integration/single-export-default-only/COMPONENT_INDEX.md
+++ b/integration/single-export-default-only/COMPONENT_INDEX.md
@@ -12,10 +12,10 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value         | Description |
-| :-------- | :--------------- | :------- | :------------------- | --------------------- | ----------- |
-| type      | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
-| primary   | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value         | Description |
+| :-------- | :------- | :--------------- | :------- | -------------------- | --------------------- | ----------- |
+| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
+| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
 
 ### Slots
 

--- a/integration/single-export/COMPONENT_API.json
+++ b/integration/single-export/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -22,6 +23,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/integration/single-export/COMPONENT_INDEX.md
+++ b/integration/single-export/COMPONENT_INDEX.md
@@ -12,10 +12,10 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value         | Description |
-| :-------- | :--------------- | :------- | :------------------- | --------------------- | ----------- |
-| type      | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
-| primary   | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value         | Description |
+| :-------- | :------- | :--------------- | :------- | -------------------- | --------------------- | ----------- |
+| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
+| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
 
 ### Slots
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -515,9 +515,11 @@ export default class ComponentParser {
 
             additional_tags.forEach((tag) => {
               isRequired = tag.tag === "required";
-              description += `${description ? "\n" : ""}@${tag.tag} ${tag.name}${
-                tag.description ? ` ${tag.description}` : ""
-              }`;
+              if (!isRequired) {
+                description += `${description ? "\n" : ""}@${tag.tag} ${tag.name}${
+                  tag.description ? ` ${tag.description}` : ""
+                }`;
+              }
             });
           }
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -30,6 +30,7 @@ interface ComponentProp {
   description?: string;
   isFunction: boolean;
   isFunctionDeclaration: boolean;
+  isRequired: boolean;
   reactive: boolean;
 }
 
@@ -385,6 +386,7 @@ export default class ComponentParser {
               value,
               isFunction,
               isFunctionDeclaration,
+              isRequired: false,
               constant: kind === "const",
               reactive: false,
             });
@@ -456,6 +458,7 @@ export default class ComponentParser {
           let description: undefined | string = undefined;
           let isFunction = false;
           let isFunctionDeclaration = false;
+          let isRequired = false;
 
           if (init != null) {
             if (
@@ -511,6 +514,7 @@ export default class ComponentParser {
             }
 
             additional_tags.forEach((tag) => {
+              isRequired = tag.tag === "required";
               description += `${description ? "\n" : ""}@${tag.tag} ${tag.name}${
                 tag.description ? ` ${tag.description}` : ""
               }`;
@@ -529,6 +533,7 @@ export default class ComponentParser {
             value,
             isFunction,
             isFunctionDeclaration,
+            isRequired,
             constant: kind === "const",
             reactive: this.reactive_vars.has(prop_name),
           });

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -3,7 +3,7 @@ import { ComponentDocs } from "../rollup-plugin";
 import WriterMarkdown, { AppendType } from "./WriterMarkdown";
 import { formatTsProps, getTypeDefs } from "./writer-ts-definitions";
 
-const PROP_TABLE_HEADER = `| Prop name | Kind | Reactive | Type | Default value | Description |\n| :- | :- | :- | :- |\n`;
+const PROP_TABLE_HEADER = `| Prop name | Required | Kind | Reactive | Type | Default value | Description |\n| :- | :- | :- | :- |\n`;
 const SLOT_TABLE_HEADER = `| Slot name | Default | Props | Fallback |\n| :- | :- | :- | :- |\n`;
 const EVENT_TABLE_HEADER = `| Event name | Type | Detail |\n| :- | :- | :- |\n`;
 const MD_TYPE_UNDEFINED = "--";
@@ -88,7 +88,7 @@ export default async function writeMarkdown(components: ComponentDocs, options: 
         .forEach((prop) => {
           document.append(
             "raw",
-            `| ${prop.name} | ${`<code>${prop.kind}</code>`} | ${prop.reactive ? "Yes" : "No"} | ${formatPropType(
+            `| ${prop.name} | ${prop.isRequired ? 'Yes' : 'No'} | ${`<code>${prop.kind}</code>`} | ${prop.reactive ? "Yes" : "No"} | ${formatPropType(
               prop.type
             )} | ${formatPropValue(prop.value)} | ${formatPropDescription(prop.description)} |\n`
           );

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -56,7 +56,7 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
 
       return `
       ${prop_comments.length > 0 ? `/**\n${prop_comments}*/` : EMPTY_STR}
-      ${prop.name}?: ${prop_value};`;
+      ${prop.name}${prop.isRequired ? "" : "?"}: ${prop_value};`;
     });
 
   if (def.rest_props?.type === "Element") {

--- a/tests/snapshots/bind-this-multiple/output.json
+++ b/tests/snapshots/bind-this-multiple/output.json
@@ -6,6 +6,7 @@
       "type": "null | HTMLButtonElement | HTMLHeadingElement",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": true
     },
@@ -15,6 +16,7 @@
       "type": "null | HTMLDivElement",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": true
     },
@@ -25,6 +27,7 @@
       "value": "false",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/bind-this/output.json
+++ b/tests/snapshots/bind-this/output.json
@@ -6,6 +6,7 @@
       "type": "null | HTMLButtonElement",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": true
     }

--- a/tests/snapshots/context-module/output.json
+++ b/tests/snapshots/context-module/output.json
@@ -7,6 +7,7 @@
       "value": "\"\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     }
@@ -19,6 +20,7 @@
       "value": "\"\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -29,6 +31,7 @@
       "value": "{ b: 4 }",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -40,6 +43,7 @@
       "value": "{ b: 4 }",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -51,6 +55,7 @@
       "value": "() => {     console.log(message);   }",
       "isFunction": true,
       "isFunctionDeclaration": true,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -61,6 +66,7 @@
       "value": "() => {}",
       "isFunction": true,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -71,6 +77,7 @@
       "value": "() => () => {}",
       "isFunction": true,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -81,6 +88,7 @@
       "value": "() => () => false",
       "isFunction": true,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     }

--- a/tests/snapshots/function-declaration/output.json
+++ b/tests/snapshots/function-declaration/output.json
@@ -7,6 +7,7 @@
       "value": "() => {}",
       "isFunction": true,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -17,6 +18,7 @@
       "value": "() => {}",
       "isFunction": true,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -27,6 +29,7 @@
       "value": "() => {     return a + b;   }",
       "isFunction": true,
       "isFunctionDeclaration": true,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -38,6 +41,7 @@
       "value": "() => {     return a * b;   }",
       "isFunction": true,
       "isFunctionDeclaration": true,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/infer-basic/output.json
+++ b/tests/snapshots/infer-basic/output.json
@@ -6,6 +6,7 @@
       "value": "null",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -16,6 +17,7 @@
       "value": "true",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": true
     },
@@ -26,6 +28,7 @@
       "value": "\"\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -34,6 +37,7 @@
       "kind": "let",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -44,6 +48,7 @@
       "value": "\"\" + Math.random().toString(36)",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -54,6 +59,7 @@
       "value": "{ [\"1\"]: true }",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -64,6 +70,7 @@
       "value": "() => {     localBool = !localBool;   }",
       "isFunction": true,
       "isFunctionDeclaration": true,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/infer-with-types/output.json
+++ b/tests/snapshots/infer-with-types/output.json
@@ -7,6 +7,7 @@
       "value": "true",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": true
     },
@@ -17,6 +18,7 @@
       "value": "\"\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -26,6 +28,7 @@
       "type": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -36,6 +39,7 @@
       "value": "\"\" + Math.random().toString(36)",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -46,6 +50,7 @@
       "value": "{ [\"1\"]: true }",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": true,
       "reactive": false
     },
@@ -56,6 +61,7 @@
       "value": "() => {     localBool = !localBool;   }",
       "isFunction": true,
       "isFunctionDeclaration": true,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/prop-comments/output.json
+++ b/tests/snapshots/prop-comments/output.json
@@ -8,6 +8,7 @@
       "value": "true",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -19,6 +20,7 @@
       "value": "true",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -30,6 +32,7 @@
       "value": "true",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/renamed-props/output.json
+++ b/tests/snapshots/renamed-props/output.json
@@ -8,6 +8,7 @@
       "value": "\"test\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/required/input.svelte
+++ b/tests/snapshots/required/input.svelte
@@ -1,0 +1,15 @@
+<script>
+  /**
+   * @required
+   */
+  export let prop = true;
+
+  /**
+   * This is a comment.
+   * @required
+   * @type {boolean | string}
+   */
+  export let prop1 = true;
+</script>
+
+<slot {prop} {prop1} />

--- a/tests/snapshots/required/output.d.ts
+++ b/tests/snapshots/required/output.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="svelte" />
+import type { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {
+  /**
+   * @required
+   * @default true
+   */
+  prop: boolean;
+
+  /**
+   * This is a comment.
+   * @required
+   * @default true
+   */
+  prop1: boolean | string;
+}
+
+export default class Input extends SvelteComponentTyped<
+  InputProps,
+  {},
+  { default: { prop: boolean; prop1: boolean | string } }
+> {}

--- a/tests/snapshots/required/output.d.ts
+++ b/tests/snapshots/required/output.d.ts
@@ -3,14 +3,12 @@ import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
   /**
-   * @required
    * @default true
    */
   prop: boolean;
 
   /**
    * This is a comment.
-   * @required
    * @default true
    */
   prop1: boolean | string;

--- a/tests/snapshots/required/output.json
+++ b/tests/snapshots/required/output.json
@@ -1,0 +1,38 @@
+{
+  "props": [
+    {
+      "name": "prop",
+      "kind": "let",
+      "description": "@required ",
+      "type": "boolean",
+      "value": "true",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "prop1",
+      "kind": "let",
+      "description": "This is a comment.\n@required ",
+      "type": "boolean | string",
+      "value": "true",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{ prop: boolean, prop1: boolean | string }"
+    }
+  ],
+  "events": [],
+  "typedefs": []
+}

--- a/tests/snapshots/required/output.json
+++ b/tests/snapshots/required/output.json
@@ -3,7 +3,7 @@
     {
       "name": "prop",
       "kind": "let",
-      "description": "@required ",
+      "description": "",
       "type": "boolean",
       "value": "true",
       "isFunction": false,
@@ -15,7 +15,7 @@
     {
       "name": "prop1",
       "kind": "let",
-      "description": "This is a comment.\n@required ",
+      "description": "This is a comment.",
       "type": "boolean | string",
       "value": "true",
       "isFunction": false,

--- a/tests/snapshots/rest-props-multiple/output.json
+++ b/tests/snapshots/rest-props-multiple/output.json
@@ -7,6 +7,7 @@
       "value": "false",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -17,6 +18,7 @@
       "value": "false",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/slots-named/output.json
+++ b/tests/snapshots/slots-named/output.json
@@ -7,6 +7,7 @@
       "value": "\"\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/typed-props/output.json
+++ b/tests/snapshots/typed-props/output.json
@@ -7,6 +7,7 @@
       "type": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -17,6 +18,7 @@
       "value": "null",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -27,6 +29,7 @@
       "value": "4",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -37,6 +40,7 @@
       "value": "\"red\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/typed-slots/output.json
+++ b/tests/snapshots/typed-slots/output.json
@@ -7,6 +7,7 @@
       "value": "0",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/typedef/output.json
+++ b/tests/snapshots/typedef/output.json
@@ -7,6 +7,7 @@
       "value": "\"id-\" + Math.random().toString(36)",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -17,6 +18,7 @@
       "value": "{ [\"1\"]: true }",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }

--- a/tests/snapshots/typedefs/output.json
+++ b/tests/snapshots/typedefs/output.json
@@ -7,6 +7,7 @@
       "value": "{ [\"1\"]: true }",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     },
@@ -17,6 +18,7 @@
       "value": "[]",
       "isFunction": false,
       "isFunctionDeclaration": false,
+      "isRequired": false,
       "constant": false,
       "reactive": false
     }


### PR DESCRIPTION
https://github.com/carbon-design-system/sveld/issues/22

There are use cases where a prop should be required by the consumer.

This PR supports required props through the non-standard `@required` tag:

**Input**

```svelte
<script>
  /**
   * @required
   */
  export let prop = true;

  /**
   * This is a comment.
   * @required
   * @type {boolean | string}
   */
  export let prop1 = true;
</script>

```

**Output**

```ts
/// <reference types="svelte" />
import type { SvelteComponentTyped } from "svelte";

export interface ComponentProps {
  /**
   * @default true
   */
  prop: boolean;

  /**
   * This is a comment.
   * @default true
   */
  prop1: boolean | string;
}

export default class Input extends SvelteComponentTyped<
  ComponentProps,
  {},
  { }
> {}

```
