### PR TITLE
fix: accessing additional_tags while undefined

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -507,7 +507,7 @@ export default class ComponentParser {
 
             const additional_tags = comment[0]?.tags.filter(
               (tag) => !["type", "extends", "restProps", "slot", "event", "typedef"].includes(tag.tag)
-            );
+            ) ?? [];
 
             if (additional_tags.length > 0 && description === undefined) {
               description = "";


### PR DESCRIPTION
With my setup after #87, I was getting an error like this while trying to generate types:

```
> svelte-kit dev --port 3000 --host

(...)/node_modules/sveld/lib/ComponentParser.js:395
	if (additional_tags.length > 0 && description_1 === undefined) {
					    ^

TypeError: Cannot read properties of undefined (reading 'length')
	at Object.enter ((...)/node_modules/sveld/lib/ComponentParser.js:395:45)
	at SyncWalker.visit ((...)/node_modules/svelte/compiler.js:6115:17)
	at SyncWalker.visit ((...)/node_modules/svelte/compiler.js:6145:19)
	at SyncWalker.visit ((...)/node_modules/svelte/compiler.js:6152:12)
	at SyncWalker.visit ((...)/node_modules/svelte/compiler.js:6152:12)
	at walk ((...)/node_modules/svelte/compiler.js:6203:19)
	at ComponentParser.parseSvelteComponent ((...)/node_modules/sveld/lib/ComponentParser.js:304:29)
	at (...)/node_modules/sveld/lib/rollup-plugin.js:161:112
	at step ((...)/node_modules/sveld/lib/rollup-plugin.js:67:23)
	at Object.next ((...)/node_modules/sveld/lib/rollup-plugin.js:48:53)
```

This PR includes a simple fix to ensure that `additional_tags` has at least an empty array.