### PR TITLE
fix: generate correct types for cut/copy/paste events

### DIFF
--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -150,6 +150,14 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
     .join("\n");
 }
 
+const mapEvent = (name: string) => {
+  if (["cut", "copy", "paste"].includes(name)) {
+    return "DocumentAndElementEventHandlersEventMap";
+  }
+
+  return "WindowEventMap";
+};
+
 function genEventDef(def: Pick<ComponentDocApi, "events">) {
   const createDispatchedEvent = (detail: string = ANY_TYPE) => {
     if (/CustomEvent/.test(detail)) return detail;
@@ -158,7 +166,7 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
   return def.events
     .map((event) => {
       return `${clampKey(event.name)}: ${
-        event.type === "dispatched" ? createDispatchedEvent(event.detail) : `WindowEventMap["${event.name}"]`
+        event.type === "dispatched" ? createDispatchedEvent(event.detail) : `${mapEvent(event.name)}["${event.name}"]`
       };`;
     })
     .join("\n");

--- a/tests/snapshots/input-events/input.svelte
+++ b/tests/snapshots/input-events/input.svelte
@@ -1,0 +1,1 @@
+<input on:input on:change on:paste />

--- a/tests/snapshots/input-events/output.d.ts
+++ b/tests/snapshots/input-events/output.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="svelte" />
+import type { SvelteComponentTyped } from "svelte";
+
+export interface InputProps {}
+
+export default class Input extends SvelteComponentTyped<
+  InputProps,
+  {
+    input: WindowEventMap["input"];
+    change: WindowEventMap["change"];
+    paste: DocumentAndElementEventHandlersEventMap["paste"];
+  },
+  {}
+> {}

--- a/tests/snapshots/input-events/output.json
+++ b/tests/snapshots/input-events/output.json
@@ -1,0 +1,23 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "forwarded",
+      "name": "input",
+      "element": "input"
+    },
+    {
+      "type": "forwarded",
+      "name": "change",
+      "element": "input"
+    },
+    {
+      "type": "forwarded",
+      "name": "paste",
+      "element": "input"
+    }
+  ],
+  "typedefs": []
+}


### PR DESCRIPTION
Forwarded cut/copy/paste events should use `DocumentAndElementEventHandlersEventMap` instead of `WindowEventMap` for the correct types.