### PR TITLE
fix: handle `export {}`

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -425,6 +425,11 @@ export default class ComponentParser {
         }
 
         if (node.type === "ExportNamedDeclaration") {
+          // Handle export {}
+          if (node.declaration == null && node.specifiers.length === 0) {
+            return;
+          }
+
           // Handle renamed exports
           let prop_name: string;
           if (node.declaration == null && node.specifiers[0]?.type === "ExportSpecifier") {


### PR DESCRIPTION
**Code**

```svelte
<script>
  export {}
</script>
```

**AST**

```json5
// ...
{
  type: "ExportNamedDeclaration";
  start: 10;
  end: 19;
  loc: {
    // ...
  }
  declaration: null;
  specifiers: [];
  source: null;
}
// ...
```

**Parse error**

```
TypeError: null is not an object (evaluating 'f.declaration.declarations')
```

---

### Why need handle `export {}`?

Typescript compiled

```ts
export type A = string
```

to

```js
export {};
```
