### PR TITLE
chore(writer)!: remove `sveltekit:*` attributes for anchor elements

### DIFF
--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -100,30 +100,6 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -21,30 +21,6 @@ export interface ButtonSkeletonProps
    * @default false
    */
   small?: boolean;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ButtonSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -39,30 +39,6 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -20,30 +20,6 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ClickableTile extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -51,30 +51,6 @@ export interface HeaderProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Header extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -26,30 +26,6 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderActionLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -20,30 +20,6 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavItem extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -32,30 +32,6 @@ export interface HeaderNavMenuProps
    * @default "Expand/Collapse"
    */
   iconDescription?: string;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavMenu extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -14,30 +14,6 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderPanelLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -32,30 +32,6 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -26,30 +26,6 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavMenuItem extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -14,30 +14,6 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SkipToContent extends SvelteComponentTyped<

--- a/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -2,31 +2,7 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
-}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export-typed/types/Link.svelte.d.ts
+++ b/integration/multi-export-typed/types/Link.svelte.d.ts
@@ -2,31 +2,7 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
-}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export/types/Link.svelte.d.ts
+++ b/integration/multi-export/types/Link.svelte.d.ts
@@ -2,31 +2,7 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
-}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-folders/types/Link.svelte.d.ts
+++ b/integration/multi-folders/types/Link.svelte.d.ts
@@ -2,31 +2,7 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
-}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -59,47 +59,6 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
       ${prop.name}${prop.isRequired ? "" : "?"}: ${prop_value};`;
     });
 
-  if (def.rest_props?.type === "Element") {
-    const elements = def.rest_props?.name.split("|").map((element) => element.replace(/\s+/g, ""));
-
-    if (elements.includes("a")) {
-      initial_props.push(
-        [
-          "\n",
-          `
-          /**
-           * SvelteKit attribute to enable data prefetching
-           * if a link is hovered over or touched on mobile.
-           * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-           * @default false
-           */
-           "sveltekit:prefetch"?: boolean;
-          `,
-          "\n",
-          `
-          /**
-           * SvelteKit attribute to trigger a full page
-           * reload after the link is clicked.
-           * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-           * @default false
-           */
-           "sveltekit:reload"?: boolean;
-          `,
-          "\n",
-          `
-          /**
-           * SvelteKit attribute to prevent scrolling
-           * after the link is clicked.
-           * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-           * @default false
-           */
-           "sveltekit:noscroll"?: boolean;
-          `,
-        ].join("\n")
-      );
-    }
-  }
-
   const props = initial_props.join("\n");
 
   const props_name = `${def.moduleName}Props`;

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -1,30 +1,6 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
-}
+export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}


### PR DESCRIPTION
Closes #95

As of SvelteKit version 1.0.0-next.454, `sveltekit:*` attributes have been replaced with native HTML data attributes.