### PR TITLE
feat(event): support description for `@event` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,13 +385,15 @@ Example:
 
 ### `@event`
 
-Use the `@event` tag for typing dispatched events. An event name must be specified.
+Use the `@event` tag to type dispatched events. An event name is required and a description optional.
+
+Use `null` as the value if no event detail is provided.
 
 Signature:
 
 ```js
 /**
- * @event {EventDetail} eventname
+ * @event {EventDetail} eventname [event description]
  */
 ```
 
@@ -400,6 +402,7 @@ Example:
 ```js
 /**
  * @event {{ key: string }} button:key
+ * @event {null} key – Fired when `key` changes.
  */
 
 export let key = "";
@@ -409,6 +412,20 @@ import { createEventDispatcher } from "svelte";
 const dispatch = createEventDispatcher();
 
 $: dispatch("button:key", { key });
+$: if (key) dispatch("key");
+```
+
+Output:
+
+```ts
+export default class Component extends SvelteComponentTyped<
+  ComponentProps,
+  {
+    "button:key": CustomEvent<{ key: string }>;
+    /** Fired when `key` changes. */ key: CustomEvent<null>;
+  },
+  {}
+> {}
 ```
 
 ### `@restProps`

--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -807,7 +807,18 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "dispatched", "name": "check", "detail": "boolean" },
+        {
+          "type": "dispatched",
+          "name": "check",
+          "detail": "boolean",
+          "description": "Fired when checking the input."
+        },
+        {
+          "type": "dispatched",
+          "name": "uncheck",
+          "detail": "boolean",
+          "description": "Fired when unchecking the input."
+        },
         { "type": "forwarded", "name": "click", "element": "CheckboxSkeleton" },
         {
           "type": "forwarded",
@@ -1746,7 +1757,12 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "number" },
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "number",
+          "description": "Fired when the `selectedIndex` is updated."
+        },
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },

--- a/integration/carbon/COMPONENT_INDEX.md
+++ b/integration/carbon/COMPONENT_INDEX.md
@@ -434,6 +434,7 @@ None.
 | Event name | Type       | Detail               |
 | :--------- | :--------- | :------------------- |
 | check      | dispatched | <code>boolean</code> |
+| uncheck    | dispatched | <code>boolean</code> |
 | click      | forwarded  | --                   |
 | mouseover  | forwarded  | --                   |
 | mouseenter | forwarded  | --                   |

--- a/integration/carbon/src/Checkbox/Checkbox.svelte
+++ b/integration/carbon/src/Checkbox/Checkbox.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @event {boolean} check
+   * @event {boolean} check Fired when checking the input.
+   * @event {boolean} uncheck Fired when unchecking the input.
    */
 
   /** Specify whether the checkbox is checked */

--- a/integration/carbon/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/integration/carbon/src/ContentSwitcher/ContentSwitcher.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {number} change
+   * @event {number} change - Fired when the `selectedIndex` is updated.
    */
 
   /** Set the selected index of the switch item */

--- a/integration/carbon/test/Accordion.svelte
+++ b/integration/carbon/test/Accordion.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion, AccordionItem } from "../types";
+  import { Accordion, AccordionItem, Checkbox } from "../types";
   import Button from "../types/Button/Button.svelte";
 </script>
 
@@ -8,3 +8,5 @@
 </Accordion>
 
 <Button>Text</Button>
+
+<Checkbox on:check />

--- a/integration/carbon/types/Checkbox/Checkbox.svelte.d.ts
+++ b/integration/carbon/types/Checkbox/Checkbox.svelte.d.ts
@@ -72,7 +72,9 @@ export interface CheckboxProps {
 export default class Checkbox extends SvelteComponentTyped<
   CheckboxProps,
   {
-    check: CustomEvent<boolean>;
+    /** Fired when checking the input. */ check: CustomEvent<boolean>;
+    /** Fired when unchecking the input. */
+    uncheck: CustomEvent<boolean>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];

--- a/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -25,6 +25,7 @@ export interface ContentSwitcherProps
 export default class ContentSwitcher extends SvelteComponentTyped<
   ContentSwitcherProps,
   {
+    /** Fired when the `selectedIndex` is updated. */
     change: CustomEvent<number>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -124,11 +124,15 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
   };
   return def.events
     .map((event) => {
-      return `${clampKey(event.name)}: ${
+      let description = "";
+      if (event.type === "dispatched" && event.description) {
+        description = "/** " + event.description + " */\n";
+      }
+      return `${description}${clampKey(event.name)}: ${
         event.type === "dispatched" ? createDispatchedEvent(event.detail) : `${mapEvent(event.name)}["${event.name}"]`
-      };`;
+      };\n`;
     })
-    .join("\n");
+    .join("");
 }
 
 function genAccessors(def: Pick<ComponentDocApi, "props">) {

--- a/tests/snapshots/dispatched-events-typed/input.svelte
+++ b/tests/snapshots/dispatched-events-typed/input.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {{ h1: boolean; }} hover
+   * @event {{ h1: boolean; }} hover - Fired on mouseover.
    */
 
   import { onDestroy, createEventDispatcher } from "svelte";

--- a/tests/snapshots/dispatched-events-typed/output.json
+++ b/tests/snapshots/dispatched-events-typed/output.json
@@ -12,7 +12,8 @@
     {
       "type": "dispatched",
       "name": "hover",
-      "detail": "{ h1: boolean; }"
+      "detail": "{ h1: boolean; }",
+      "description": "Fired on mouseover."
     },
     {
       "type": "dispatched",


### PR DESCRIPTION
Add the ability to add a description for `@event` tags.

Signature:

```js
/**
 * @event {EventDetail} eventname [event description]
 */
```