### PR TITLE
feat(slot): support `@slot` tag descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,11 +354,19 @@ export let authors = [];
 
 Use the `@slot` tag for typing component slots. Note that `@slot` is a non-standard JSDoc tag.
 
+Descriptions are optional for named slots. Currently, the default slot cannot have a description.
+
 Signature:
 
 ```js
 /**
- * @slot {Type} [slot name]
+ * @slot {Type} slot-name [slot description]
+ */
+
+Omit the `slot-name` to type the default slot.
+
+/**
+ * @slot {Type}
  */
 ```
 
@@ -368,7 +376,8 @@ Example:
 <script>
   /**
    * @slot {{ prop: number; doubled: number; }}
-   * @slot {{ props: { class?: string; } }} description
+   * @slot {{}} title
+   * @slot {{ prop: number }} body - Customize the paragraph text.
    */
 
   export let prop = 0;
@@ -376,10 +385,11 @@ Example:
 
 <h1>
   <slot {prop} doubled={prop * 2} />
+  <slot name="title" />
 </h1>
 
 <p>
-  <slot name="description" props={{ class: $$props.class }} />
+  <slot name="body" {prop} />
 </p>
 ```
 

--- a/integration/carbon/COMPONENT_API.json
+++ b/integration/carbon/COMPONENT_API.json
@@ -2060,7 +2060,8 @@
         {
           "name": "expanded-row",
           "default": false,
-          "slot_props": "{ row: DataTableRow; }"
+          "slot_props": "{ row: DataTableRow; }",
+          "description": "The expanded row"
         }
       ],
       "events": [

--- a/integration/carbon/src/DataTable/DataTable.svelte
+++ b/integration/carbon/src/DataTable/DataTable.svelte
@@ -8,7 +8,7 @@
    * @typedef {{ id: any; [key: string]: DataTableValue; }} DataTableRow
    * @typedef {string} DataTableRowId
    * @typedef {{ key: DataTableKey; value: DataTableValue; }} DataTableCell
-   * @slot {{ row: DataTableRow; }} expanded-row
+   * @slot {{ row: DataTableRow; }} expanded-row - The expanded row
    * @slot {{ header: DataTableNonEmptyHeader; }} cell-header
    * @slot {{ row: DataTableRow; cell: DataTableCell; }} cell
    * @event {{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell; }} click

--- a/integration/carbon/test/Accordion.svelte
+++ b/integration/carbon/test/Accordion.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion, AccordionItem, Checkbox } from "../types";
+  import { Accordion, AccordionItem, Checkbox, DataTable } from "../types";
   import Button from "../types/Button/Button.svelte";
 </script>
 
@@ -10,3 +10,9 @@
 <Button>Text</Button>
 
 <Checkbox on:check />
+
+<DataTable>
+  <span slot="expanded-row" let:row>
+    {row.id}
+  </span>
+</DataTable>

--- a/integration/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/integration/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -156,6 +156,7 @@ export default class DataTable extends SvelteComponentTyped<
     default: {};
     cell: { row: DataTableRow; cell: DataTableCell };
     ["cell-header"]: { header: DataTableNonEmptyHeader };
+    /** The expanded row */
     ["expanded-row"]: { row: DataTableRow };
   }
 > {}

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -43,6 +43,7 @@ interface ComponentSlot {
   default: boolean;
   fallback?: string;
   slot_props?: string;
+  description?: string;
 }
 
 interface SlotPropValue {
@@ -202,15 +203,18 @@ export default class ComponentParser {
     slot_name,
     slot_props,
     slot_fallback,
+    slot_description,
   }: {
     slot_name?: string;
     slot_props?: string;
     slot_fallback?: string;
+    slot_description?: string;
   }) {
     const default_slot = slot_name === undefined || slot_name === "";
     const name: ComponentSlotName = default_slot ? DEFAULT_SLOT_NAME : slot_name!;
     const fallback = ComponentParser.assignValue(slot_fallback);
     const props = ComponentParser.assignValue(slot_props);
+    const description = slot_description?.split("-").pop()?.trim();
 
     if (this.slots.has(name)) {
       const existing_slot = this.slots.get(name)!;
@@ -219,6 +223,7 @@ export default class ComponentParser {
         ...existing_slot,
         fallback,
         slot_props: existing_slot.slot_props === undefined ? props : existing_slot.slot_props,
+        description: existing_slot.description || description,
       });
     } else {
       this.slots.set(name, {
@@ -226,6 +231,7 @@ export default class ComponentParser {
         default: default_slot,
         fallback,
         slot_props,
+        description,
       });
     }
   }
@@ -284,6 +290,7 @@ export default class ComponentParser {
             this.addSlot({
               slot_name: name,
               slot_props: type,
+              slot_description: !!description ? description : undefined,
             });
             break;
           case "event":

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -198,7 +198,15 @@ export default class ComponentParser {
     return type;
   }
 
-  private addSlot(slot_name?: string, slot_props?: string, slot_fallback?: string) {
+  private addSlot({
+    slot_name,
+    slot_props,
+    slot_fallback,
+  }: {
+    slot_name?: string;
+    slot_props?: string;
+    slot_fallback?: string;
+  }) {
     const default_slot = slot_name === undefined || slot_name === "";
     const name: ComponentSlotName = default_slot ? DEFAULT_SLOT_NAME : slot_name!;
     const fallback = ComponentParser.assignValue(slot_fallback);
@@ -273,7 +281,10 @@ export default class ComponentParser {
             };
             break;
           case "slot":
-            this.addSlot(name, type);
+            this.addSlot({
+              slot_name: name,
+              slot_props: type,
+            });
             break;
           case "event":
             this.addDispatchedEvent({
@@ -610,7 +621,11 @@ export default class ComponentParser {
             .join("")
             .trim();
 
-          this.addSlot(slot_name, JSON.stringify(slot_props, null, 2), fallback);
+          this.addSlot({
+            slot_name,
+            slot_props: JSON.stringify(slot_props, null, 2),
+            slot_fallback: fallback,
+          });
         }
 
         if (node.type === "EventHandler" && node.expression == null) {

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -104,7 +104,8 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
   return def.slots
     .map(({ name, slot_props, ...rest }) => {
       const key = rest.default ? "default" : clampKey(name!);
-      return `${clampKey(key)}: ${formatTsProps(slot_props)};`;
+      const description = rest.description ? "/** " + rest.description + " */\n" : "";
+      return `${description}${clampKey(key)}: ${formatTsProps(slot_props)};`;
     })
     .join("\n");
 }

--- a/tests/snapshots/typed-slots/input.svelte
+++ b/tests/snapshots/typed-slots/input.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @slot {{ prop: number; doubled: number; }}
-   * @slot {{ props: { class?: string; } }} description
+   * @slot {{ props: { class?: string; } }} description - description
    */
 
   export let prop = 0;

--- a/tests/snapshots/typed-slots/output.d.ts
+++ b/tests/snapshots/typed-slots/output.d.ts
@@ -11,5 +11,9 @@ export interface InputProps {
 export default class Input extends SvelteComponentTyped<
   InputProps,
   {},
-  { default: { prop: number; doubled: number }; description: { props: { class?: string } } }
+  {
+    default: { prop: number; doubled: number };
+    /** description */
+    description: { props: { class?: string } };
+  }
 > {}

--- a/tests/snapshots/typed-slots/output.json
+++ b/tests/snapshots/typed-slots/output.json
@@ -22,7 +22,8 @@
     {
       "name": "description",
       "default": false,
-      "slot_props": "{ props: { class?: string; } }"
+      "slot_props": "{ props: { class?: string; } }",
+      "description": "description"
     }
   ],
   "events": [],


### PR DESCRIPTION
Similar to #99, this adds the ability to add a description for `@slot` tags.

One limitation is that the default slot cannot have a description because its name must be omitted (a slot can be named "default").

Signature:

```js
/**
 * @slot {Type} slot-name [slot description]
 */
```