### PR TITLE
fix(types): allow `data-*` attributes for `$$restProps` forwarded to HTML elements

### DIFF
--- a/integration/carbon/types/Accordion/AccordionItem.svelte.d.ts
+++ b/integration/carbon/types/Accordion/AccordionItem.svelte.d.ts
@@ -27,6 +27,8 @@ export interface AccordionItemProps
    * @default "Expand/Collapse"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 /** `AccordionItem` is slottable */

--- a/integration/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -26,6 +26,8 @@ export interface AccordionSkeletonProps
    * @default true
    */
   open?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class AccordionSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/integration/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -8,6 +8,8 @@ export interface AspectRatioProps
    * @default "2x1"
    */
   ratio?: "2x1" | "16x9" | "4x3" | "1x1" | "3x4" | "9x16" | "1x2";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class AspectRatio extends SvelteComponentTyped<

--- a/integration/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/integration/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -14,6 +14,8 @@ export interface BreadcrumbItemProps
    * @default false
    */
   isCurrentPage?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class BreadcrumbItem extends SvelteComponentTyped<

--- a/integration/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface BreadcrumbSkeletonProps
    * @default 3
    */
   count?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class BreadcrumbSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -100,6 +100,8 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/carbon/types/Button/ButtonSet.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSet.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ButtonSetProps
    * @default false
    */
   stacked?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ButtonSet extends SvelteComponentTyped<

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -21,6 +21,8 @@ export interface ButtonSkeletonProps
    * @default false
    */
   small?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ButtonSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface CheckboxSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class CheckboxSkeleton extends SvelteComponentTyped<
   CheckboxSkeletonProps,

--- a/integration/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/integration/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface CodeSnippetSkeletonProps
    * @default "single"
    */
   type?: "single" | "multi";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class CodeSnippetSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/integration/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -121,6 +121,8 @@ export interface ComboBoxProps
    * @default null
    */
   listRef?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ComboBox extends SvelteComponentTyped<

--- a/integration/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -44,6 +44,8 @@ export interface ComposedModalProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ComposedModal extends SvelteComponentTyped<

--- a/integration/carbon/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalBody.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ModalBodyProps
    * @default false
    */
   hasScrollingContent?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ModalBody extends SvelteComponentTyped<

--- a/integration/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -38,6 +38,8 @@ export interface ModalFooterProps
    * @default false
    */
   danger?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ModalFooter extends SvelteComponentTyped<

--- a/integration/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -44,6 +44,8 @@ export interface ModalHeaderProps
    * @default "Close"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ModalHeader extends SvelteComponentTyped<

--- a/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -20,6 +20,8 @@ export interface ContentSwitcherProps
    * @default undefined
    */
   size?: "sm" | "xl";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ContentSwitcher extends SvelteComponentTyped<

--- a/integration/carbon/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/integration/carbon/types/ContentSwitcher/Switch.svelte.d.ts
@@ -33,6 +33,8 @@ export interface SwitchProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Switch extends SvelteComponentTyped<

--- a/integration/carbon/types/Copy/Copy.svelte.d.ts
+++ b/integration/carbon/types/Copy/Copy.svelte.d.ts
@@ -20,6 +20,8 @@ export interface CopyProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Copy extends SvelteComponentTyped<

--- a/integration/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/integration/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -48,6 +48,8 @@ export interface DataTableSkeletonProps
    * @default true
    */
   showToolbar?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DataTableSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/DataTable/Table.svelte.d.ts
+++ b/integration/carbon/types/DataTable/Table.svelte.d.ts
@@ -38,6 +38,8 @@ export interface TableProps
    * @default false
    */
   stickyHeader?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Table extends SvelteComponentTyped<

--- a/integration/carbon/types/DataTable/TableBody.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableBody.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableBody extends SvelteComponentTyped<
   TableBodyProps,

--- a/integration/carbon/types/DataTable/TableCell.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableCell.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableCellProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableCell extends SvelteComponentTyped<
   TableCellProps,

--- a/integration/carbon/types/DataTable/TableContainer.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableContainer.svelte.d.ts
@@ -20,6 +20,8 @@ export interface TableContainerProps
    * @default false
    */
   stickyHeader?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TableContainer extends SvelteComponentTyped<

--- a/integration/carbon/types/DataTable/TableHead.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableHead.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableHeadProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableHead extends SvelteComponentTyped<
   TableHeadProps,

--- a/integration/carbon/types/DataTable/TableHeader.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableHeader.svelte.d.ts
@@ -20,6 +20,8 @@ export interface TableHeaderProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TableHeader extends SvelteComponentTyped<

--- a/integration/carbon/types/DataTable/TableRow.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableRow.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableRowProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableRow extends SvelteComponentTyped<
   TableRowProps,

--- a/integration/carbon/types/DataTable/Toolbar.svelte.d.ts
+++ b/integration/carbon/types/DataTable/Toolbar.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ToolbarProps
    * @default "default"
    */
   size?: "sm" | "default";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Toolbar extends SvelteComponentTyped<

--- a/integration/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/integration/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ToolbarBatchActionsProps
    * @default (totalSelected) => `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`
    */
   formatTotalSelected?: (totalSelected: number) => string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<

--- a/integration/carbon/types/DatePicker/DatePicker.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePicker.svelte.d.ts
@@ -62,6 +62,8 @@ export interface DatePickerProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DatePicker extends SvelteComponentTyped<

--- a/integration/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -80,6 +80,8 @@ export interface DatePickerInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DatePickerInput extends SvelteComponentTyped<

--- a/integration/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface DatePickerSkeletonProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DatePickerSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -132,6 +132,8 @@ export interface DropdownProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Dropdown extends SvelteComponentTyped<

--- a/integration/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface DropdownSkeletonProps
    * @default false
    */
   inline?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DropdownSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/FileUploader/FileUploader.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploader.svelte.d.ts
@@ -62,6 +62,8 @@ export interface FileUploaderProps
    * @default ""
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploader extends SvelteComponentTyped<

--- a/integration/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -68,6 +68,8 @@ export interface FileUploaderButtonProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploaderButton extends SvelteComponentTyped<

--- a/integration/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -63,6 +63,8 @@ export interface FileUploaderDropContainerProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploaderDropContainer extends SvelteComponentTyped<

--- a/integration/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -44,6 +44,8 @@ export interface FileUploaderItemProps
    * @default ""
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploaderItem extends SvelteComponentTyped<

--- a/integration/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class FileUploaderSkeleton extends SvelteComponentTyped<
   FileUploaderSkeletonProps,

--- a/integration/carbon/types/Form/Form.svelte.d.ts
+++ b/integration/carbon/types/Form/Form.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FormProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Form extends SvelteComponentTyped<
   FormProps,

--- a/integration/carbon/types/FormGroup/FormGroup.svelte.d.ts
+++ b/integration/carbon/types/FormGroup/FormGroup.svelte.d.ts
@@ -26,6 +26,8 @@ export interface FormGroupProps
    * @default ""
    */
   legendText?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FormGroup extends SvelteComponentTyped<

--- a/integration/carbon/types/FormItem/FormItem.svelte.d.ts
+++ b/integration/carbon/types/FormItem/FormItem.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FormItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class FormItem extends SvelteComponentTyped<
   FormItemProps,

--- a/integration/carbon/types/FormLabel/FormLabel.svelte.d.ts
+++ b/integration/carbon/types/FormLabel/FormLabel.svelte.d.ts
@@ -8,6 +8,8 @@ export interface FormLabelProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FormLabel extends SvelteComponentTyped<

--- a/integration/carbon/types/Grid/Column.svelte.d.ts
+++ b/integration/carbon/types/Grid/Column.svelte.d.ts
@@ -78,6 +78,8 @@ export interface ColumnProps
    * @default undefined
    */
   max?: ColumnBreakpoint;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Column extends SvelteComponentTyped<

--- a/integration/carbon/types/Grid/Grid.svelte.d.ts
+++ b/integration/carbon/types/Grid/Grid.svelte.d.ts
@@ -51,6 +51,8 @@ export interface GridProps
    * @default false
    */
   padding?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Grid extends SvelteComponentTyped<

--- a/integration/carbon/types/Grid/Row.svelte.d.ts
+++ b/integration/carbon/types/Grid/Row.svelte.d.ts
@@ -45,6 +45,8 @@ export interface RowProps
    * @default false
    */
   padding?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Row extends SvelteComponentTyped<

--- a/integration/carbon/types/Icon/Icon.svelte.d.ts
+++ b/integration/carbon/types/Icon/Icon.svelte.d.ts
@@ -16,6 +16,8 @@ export interface IconProps
    * @default false
    */
   skeleton?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Icon extends SvelteComponentTyped<

--- a/integration/carbon/types/Icon/IconSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Icon/IconSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface IconSkeletonProps
    * @default 16
    */
   size?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class IconSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/integration/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -26,6 +26,8 @@ export interface InlineLoadingProps
    * @default 1500
    */
   successDelay?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class InlineLoading extends SvelteComponentTyped<

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -39,6 +39,8 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/integration/carbon/types/ListBox/ListBox.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBox.svelte.d.ts
@@ -56,6 +56,8 @@ export interface ListBoxProps
    * @default ""
    */
   warnText?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBox extends SvelteComponentTyped<

--- a/integration/carbon/types/ListBox/ListBoxField.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxField.svelte.d.ts
@@ -40,6 +40,8 @@ export interface ListBoxFieldProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxField extends SvelteComponentTyped<

--- a/integration/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ListBoxMenuProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxMenu extends SvelteComponentTyped<

--- a/integration/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -16,6 +16,8 @@ export interface ListBoxMenuIconProps
    * @default (id) => defaultTranslations[id]
    */
   translateWithId?: (id: ListBoxMenuIconTranslationId) => string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxMenuIcon extends SvelteComponentTyped<

--- a/integration/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ListBoxMenuItemProps
    * @default false
    */
   highlighted?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxMenuItem extends SvelteComponentTyped<

--- a/integration/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -28,6 +28,8 @@ export interface ListBoxSelectionProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxSelection extends SvelteComponentTyped<

--- a/integration/carbon/types/ListItem/ListItem.svelte.d.ts
+++ b/integration/carbon/types/ListItem/ListItem.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface ListItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class ListItem extends SvelteComponentTyped<
   ListItemProps,

--- a/integration/carbon/types/Loading/Loading.svelte.d.ts
+++ b/integration/carbon/types/Loading/Loading.svelte.d.ts
@@ -32,6 +32,8 @@ export interface LoadingProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Loading extends SvelteComponentTyped<

--- a/integration/carbon/types/Modal/Modal.svelte.d.ts
+++ b/integration/carbon/types/Modal/Modal.svelte.d.ts
@@ -116,6 +116,8 @@ export interface ModalProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Modal extends SvelteComponentTyped<

--- a/integration/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/integration/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -171,6 +171,8 @@ export interface MultiSelectProps
    * @default undefined
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class MultiSelect extends SvelteComponentTyped<

--- a/integration/carbon/types/Notification/InlineNotification.svelte.d.ts
+++ b/integration/carbon/types/Notification/InlineNotification.svelte.d.ts
@@ -56,6 +56,8 @@ export interface InlineNotificationProps
    * @default "Closes notification"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class InlineNotification extends SvelteComponentTyped<

--- a/integration/carbon/types/Notification/NotificationButton.svelte.d.ts
+++ b/integration/carbon/types/Notification/NotificationButton.svelte.d.ts
@@ -26,6 +26,8 @@ export interface NotificationButtonProps
    * @default "Close icon"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class NotificationButton extends SvelteComponentTyped<

--- a/integration/carbon/types/Notification/ToastNotification.svelte.d.ts
+++ b/integration/carbon/types/Notification/ToastNotification.svelte.d.ts
@@ -62,6 +62,8 @@ export interface ToastNotificationProps
    * @default false
    */
   hideCloseButton?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToastNotification extends SvelteComponentTyped<

--- a/integration/carbon/types/NumberInput/NumberInput.svelte.d.ts
+++ b/integration/carbon/types/NumberInput/NumberInput.svelte.d.ts
@@ -136,6 +136,8 @@ export interface NumberInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class NumberInput extends SvelteComponentTyped<

--- a/integration/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/integration/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface NumberInputSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class NumberInputSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/OrderedList/OrderedList.svelte.d.ts
+++ b/integration/carbon/types/OrderedList/OrderedList.svelte.d.ts
@@ -14,6 +14,8 @@ export interface OrderedListProps
    * @default false
    */
   native?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class OrderedList extends SvelteComponentTyped<

--- a/integration/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/integration/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -74,6 +74,8 @@ export interface OverflowMenuProps
    * @default null
    */
   menuRef?: null | HTMLUListElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class OverflowMenu extends SvelteComponentTyped<

--- a/integration/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/integration/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -57,6 +57,8 @@ export interface OverflowMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class OverflowMenuItem extends SvelteComponentTyped<

--- a/integration/carbon/types/Pagination/Pagination.svelte.d.ts
+++ b/integration/carbon/types/Pagination/Pagination.svelte.d.ts
@@ -98,6 +98,8 @@ export interface PaginationProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Pagination extends SvelteComponentTyped<

--- a/integration/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface PaginationSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class PaginationSkeleton extends SvelteComponentTyped<
   PaginationSkeletonProps,

--- a/integration/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/integration/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -38,6 +38,8 @@ export interface PaginationNavProps
    * @default "Previous page"
    */
   backwardText?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class PaginationNav extends SvelteComponentTyped<

--- a/integration/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/integration/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -26,6 +26,8 @@ export interface ProgressIndicatorProps
    * @default false
    */
   preventChangeOnClick?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressIndicator extends SvelteComponentTyped<

--- a/integration/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/integration/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ProgressIndicatorSkeletonProps
    * @default 4
    */
   count?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressIndicatorSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/ProgressIndicator/ProgressStep.svelte.d.ts
+++ b/integration/carbon/types/ProgressIndicator/ProgressStep.svelte.d.ts
@@ -50,6 +50,8 @@ export interface ProgressStepProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressStep extends SvelteComponentTyped<

--- a/integration/carbon/types/RadioButton/RadioButton.svelte.d.ts
+++ b/integration/carbon/types/RadioButton/RadioButton.svelte.d.ts
@@ -56,6 +56,8 @@ export interface RadioButtonProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RadioButton extends SvelteComponentTyped<

--- a/integration/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface RadioButtonSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class RadioButtonSkeleton extends SvelteComponentTyped<
   RadioButtonSkeletonProps,

--- a/integration/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/integration/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -32,6 +32,8 @@ export interface RadioButtonGroupProps
    * @default undefined
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RadioButtonGroup extends SvelteComponentTyped<

--- a/integration/carbon/types/Search/SearchSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Search/SearchSkeleton.svelte.d.ts
@@ -15,6 +15,8 @@ export interface SearchSkeletonProps
    * @default "xl"
    */
   size?: "sm" | "lg" | "xl";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SearchSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Select/Select.svelte.d.ts
+++ b/integration/carbon/types/Select/Select.svelte.d.ts
@@ -86,6 +86,8 @@ export interface SelectProps
    * @default null
    */
   ref?: null | HTMLSelectElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Select extends SvelteComponentTyped<

--- a/integration/carbon/types/Select/SelectItemGroup.svelte.d.ts
+++ b/integration/carbon/types/Select/SelectItemGroup.svelte.d.ts
@@ -14,6 +14,8 @@ export interface SelectItemGroupProps
    * @default "Provide label"
    */
   label?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SelectItemGroup extends SvelteComponentTyped<

--- a/integration/carbon/types/Select/SelectSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Select/SelectSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface SelectSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SelectSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/integration/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface SkeletonPlaceholderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class SkeletonPlaceholder extends SvelteComponentTyped<
   SkeletonPlaceholderProps,

--- a/integration/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/integration/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -26,6 +26,8 @@ export interface SkeletonTextProps
    * @default "100%"
    */
   width?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SkeletonText extends SvelteComponentTyped<

--- a/integration/carbon/types/Slider/Slider.svelte.d.ts
+++ b/integration/carbon/types/Slider/Slider.svelte.d.ts
@@ -104,6 +104,8 @@ export interface SliderProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Slider extends SvelteComponentTyped<

--- a/integration/carbon/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Slider/SliderSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface SliderSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SliderSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/StructuredList/StructuredList.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredList.svelte.d.ts
@@ -20,6 +20,8 @@ export interface StructuredListProps
    * @default false
    */
   selection?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredList extends SvelteComponentTyped<

--- a/integration/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class StructuredListBody extends SvelteComponentTyped<
   StructuredListBodyProps,

--- a/integration/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -14,6 +14,8 @@ export interface StructuredListCellProps
    * @default false
    */
   noWrap?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListCell extends SvelteComponentTyped<

--- a/integration/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListHeadProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class StructuredListHead extends SvelteComponentTyped<
   StructuredListHeadProps,

--- a/integration/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -38,6 +38,8 @@ export interface StructuredListInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListInput extends SvelteComponentTyped<

--- a/integration/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -20,6 +20,8 @@ export interface StructuredListRowProps
    * @default "0"
    */
   tabindex?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListRow extends SvelteComponentTyped<

--- a/integration/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface StructuredListSkeletonProps
    * @default false
    */
   border?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Tabs/Tab.svelte.d.ts
+++ b/integration/carbon/types/Tabs/Tab.svelte.d.ts
@@ -39,6 +39,8 @@ export interface TabProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tab extends SvelteComponentTyped<

--- a/integration/carbon/types/Tabs/TabContent.svelte.d.ts
+++ b/integration/carbon/types/Tabs/TabContent.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TabContentProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TabContent extends SvelteComponentTyped<

--- a/integration/carbon/types/Tabs/Tabs.svelte.d.ts
+++ b/integration/carbon/types/Tabs/Tabs.svelte.d.ts
@@ -26,6 +26,8 @@ export interface TabsProps
    * @default "#"
    */
   triggerHref?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tabs extends SvelteComponentTyped<

--- a/integration/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TabsSkeletonProps
    * @default 4
    */
   count?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TabsSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Tag/Tag.svelte.d.ts
+++ b/integration/carbon/types/Tag/Tag.svelte.d.ts
@@ -56,6 +56,8 @@ export interface TagProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tag extends SvelteComponentTyped<

--- a/integration/carbon/types/Tag/TagSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Tag/TagSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TagSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TagSkeleton extends SvelteComponentTyped<
   TagSkeletonProps,

--- a/integration/carbon/types/TextArea/TextArea.svelte.d.ts
+++ b/integration/carbon/types/TextArea/TextArea.svelte.d.ts
@@ -86,6 +86,8 @@ export interface TextAreaProps
    * @default null
    */
   ref?: null | HTMLTextAreaElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextArea extends SvelteComponentTyped<

--- a/integration/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/integration/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TextAreaSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextAreaSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/TextInput/PasswordInput.svelte.d.ts
+++ b/integration/carbon/types/TextInput/PasswordInput.svelte.d.ts
@@ -110,6 +110,8 @@ export interface PasswordInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class PasswordInput extends SvelteComponentTyped<

--- a/integration/carbon/types/TextInput/TextInput.svelte.d.ts
+++ b/integration/carbon/types/TextInput/TextInput.svelte.d.ts
@@ -110,6 +110,8 @@ export interface TextInputProps
    * @default false
    */
   inline?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextInput extends SvelteComponentTyped<

--- a/integration/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/integration/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TextInputSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextInputSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -20,6 +20,8 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ClickableTile extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/ExpandableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ExpandableTile.svelte.d.ts
@@ -68,6 +68,8 @@ export interface ExpandableTileProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ExpandableTile extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/RadioTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/RadioTile.svelte.d.ts
@@ -44,6 +44,8 @@ export interface RadioTileProps
    * @default ""
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RadioTile extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/SelectableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/SelectableTile.svelte.d.ts
@@ -56,6 +56,8 @@ export interface SelectableTileProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SelectableTile extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/Tile.svelte.d.ts
+++ b/integration/carbon/types/Tile/Tile.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TileProps
    * @default false
    */
   light?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tile extends SvelteComponentTyped<

--- a/integration/carbon/types/Tile/TileGroup.svelte.d.ts
+++ b/integration/carbon/types/Tile/TileGroup.svelte.d.ts
@@ -20,6 +20,8 @@ export interface TileGroupProps
    * @default ""
    */
   legend?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TileGroup extends SvelteComponentTyped<

--- a/integration/carbon/types/TimePicker/TimePicker.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePicker.svelte.d.ts
@@ -92,6 +92,8 @@ export interface TimePickerProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TimePicker extends SvelteComponentTyped<

--- a/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -51,6 +51,8 @@ export interface TimePickerSelectProps
    * @default null
    */
   ref?: null | HTMLSelectElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TimePickerSelect extends SvelteComponentTyped<

--- a/integration/carbon/types/Toggle/Toggle.svelte.d.ts
+++ b/integration/carbon/types/Toggle/Toggle.svelte.d.ts
@@ -50,6 +50,8 @@ export interface ToggleProps
    * @default undefined
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Toggle extends SvelteComponentTyped<

--- a/integration/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -20,6 +20,8 @@ export interface ToggleSkeletonProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToggleSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
+++ b/integration/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
@@ -44,6 +44,8 @@ export interface ToggleSmallProps
    * @default undefined
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToggleSmall extends SvelteComponentTyped<

--- a/integration/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
+++ b/integration/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ToggleSmallSkeletonProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToggleSmallSkeleton extends SvelteComponentTyped<

--- a/integration/carbon/types/Tooltip/Tooltip.svelte.d.ts
+++ b/integration/carbon/types/Tooltip/Tooltip.svelte.d.ts
@@ -87,6 +87,8 @@ export interface TooltipProps
    * @default null
    */
   refIcon?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tooltip extends SvelteComponentTyped<

--- a/integration/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/integration/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -32,6 +32,8 @@ export interface TooltipDefinitionProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TooltipDefinition extends SvelteComponentTyped<

--- a/integration/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/integration/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -33,6 +33,8 @@ export interface TooltipIconProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TooltipIcon extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/Content.svelte.d.ts
+++ b/integration/carbon/types/UIShell/Content.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ContentProps
    * @default "main-content"
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Content extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -51,6 +51,8 @@ export interface HeaderProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Header extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -40,6 +40,8 @@ export interface HeaderActionProps
    * @default { duration: 200 }
    */
   transition?: false | HeaderActionSlideTransition;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderAction extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -26,6 +26,8 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderActionLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
@@ -9,6 +9,8 @@ export interface HeaderNavProps
    * @default undefined
    */
   ariaLabel?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderNav extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -20,6 +20,8 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderNavItem extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -32,6 +32,8 @@ export interface HeaderNavMenuProps
    * @default "Expand/Collapse"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderNavMenu extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -14,6 +14,8 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderPanelLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/integration/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -20,6 +20,8 @@ export interface HeaderGlobalActionProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderGlobalAction extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/integration/carbon/types/UIShell/HeaderSearch.svelte.d.ts
@@ -38,6 +38,8 @@ export interface HeaderSearchProps
    * @default 0
    */
   selectedResultIndex?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderSearch extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
@@ -20,6 +20,8 @@ export interface SideNavProps
    * @default false
    */
   isOpen?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNav extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -32,6 +32,8 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNavLink extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
@@ -26,6 +26,8 @@ export interface SideNavMenuProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNavMenu extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -26,6 +26,8 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNavMenuItem extends SvelteComponentTyped<

--- a/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -14,6 +14,8 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SkipToContent extends SvelteComponentTyped<

--- a/integration/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/integration/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -8,6 +8,8 @@ export interface UnorderedListProps
    * @default false
    */
   nested?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class UnorderedList extends SvelteComponentTyped<

--- a/integration/glob/types/button/Button.svelte.d.ts
+++ b/integration/glob/types/button/Button.svelte.d.ts
@@ -23,6 +23,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/multi-export-typed-ts-only/types/button/button.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/button/button.svelte.d.ts
@@ -13,6 +13,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
@@ -12,6 +12,8 @@ export interface QuoteProps
    * @default ""
    */
   author?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Quote extends SvelteComponentTyped<

--- a/integration/multi-export-typed/types/Button.svelte.d.ts
+++ b/integration/multi-export-typed/types/Button.svelte.d.ts
@@ -13,6 +13,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/multi-export-typed/types/Link.svelte.d.ts
+++ b/integration/multi-export-typed/types/Link.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export-typed/types/Quote.svelte.d.ts
+++ b/integration/multi-export-typed/types/Quote.svelte.d.ts
@@ -12,6 +12,8 @@ export interface QuoteProps
    * @default ""
    */
   author?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Quote extends SvelteComponentTyped<

--- a/integration/multi-export/types/Button.svelte.d.ts
+++ b/integration/multi-export/types/Button.svelte.d.ts
@@ -12,6 +12,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/multi-export/types/Link.svelte.d.ts
+++ b/integration/multi-export/types/Link.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export/types/Quote.svelte.d.ts
+++ b/integration/multi-export/types/Quote.svelte.d.ts
@@ -14,6 +14,8 @@ export interface QuoteProps
    * @default ""
    */
   author?: Author;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Quote extends SvelteComponentTyped<

--- a/integration/multi-folders/types/Link.svelte.d.ts
+++ b/integration/multi-folders/types/Link.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-folders/types/Quote.svelte.d.ts
+++ b/integration/multi-folders/types/Quote.svelte.d.ts
@@ -14,6 +14,8 @@ export interface QuoteProps
    * @default ""
    */
   author?: Author;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Quote extends SvelteComponentTyped<

--- a/integration/multi-folders/types/components/Button.svelte.d.ts
+++ b/integration/multi-folders/types/components/Button.svelte.d.ts
@@ -13,6 +13,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/single-export-default-only/types/Button.svelte.d.ts
+++ b/integration/single-export-default-only/types/Button.svelte.d.ts
@@ -12,6 +12,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/integration/single-export/types/Button.svelte.d.ts
+++ b/integration/single-export/types/Button.svelte.d.ts
@@ -12,6 +12,8 @@ export interface ButtonProps
    * @default false
    */
   primary?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -79,11 +79,19 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
       })
       .join(",");
 
+    /**
+     * Components that extend HTML elements should allow for `data-*` attributes.
+     * @see https://github.com/sveltejs/language-tools/issues/1825
+     */
+    const dataAttributes = "[key: `data-${string}`]: any;";
+
     prop_def = `
     export interface ${props_name} extends ${
       def.extends !== undefined ? `${def.extends.interface}, ` : ""
     }${extend_tag_map} {
       ${props}
+      
+      ${dataAttributes}
     }
   `;
   } else {

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}

--- a/tests/snapshots/rest-props-multiple/output.d.ts
+++ b/tests/snapshots/rest-props-multiple/output.d.ts
@@ -13,6 +13,8 @@ export interface InputProps
    * @default false
    */
   heading?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}

--- a/tests/snapshots/rest-props/output.d.ts
+++ b/tests/snapshots/rest-props/output.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["h1"]> {}
+export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["h1"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}

--- a/tests/snapshots/svg-props/output.d.ts
+++ b/tests/snapshots/svg-props/output.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface InputProps extends svelte.JSX.SVGAttributes<SVGSVGElement> {}
+export interface InputProps extends svelte.JSX.SVGAttributes<SVGSVGElement> {
+  [key: `data-${string}`]: any;
+}
 
 export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}


### PR DESCRIPTION
`svelte-check` version 3 uses a [new transform](https://github.com/sveltejs/language-tools/issues/1352). This currently produces type errors for `data-*` attributes.

This PR adds a backwards-compatible fix by augmenting props forwarded to HTML elements to allow `data-*` attributes.

The fix was copied verbatim from this issue: https://github.com/sveltejs/language-tools/issues/1825