### PR TITLE
feat!: support Svelte 4 in generated TypeScript definitions

### DIFF
--- a/integration/carbon/types/Accordion/Accordion.svelte.d.ts
+++ b/integration/carbon/types/Accordion/Accordion.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { AccordionSkeletonProps } from "./AccordionSkeleton.svelte";
 

--- a/integration/carbon/types/Accordion/AccordionItem.svelte.d.ts
+++ b/integration/carbon/types/Accordion/AccordionItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface AccordionItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+type RestProps = SvelteHTMLElements["li"];
+
+export interface AccordionItemProps extends RestProps {
   /**
    * Specify the title of the accordion item heading
    * Alternatively, use the "title" slot (e.g., <div slot="title">...</div>)

--- a/integration/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface AccordionSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
+type RestProps = SvelteHTMLElements["ul"];
+
+export interface AccordionSkeletonProps extends RestProps {
   /**
    * Specify the number of accordion items to render
    * @default 4

--- a/integration/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/integration/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface AspectRatioProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface AspectRatioProps extends RestProps {
   /**
    * Specify the aspect ratio
    * @default "2x1"
@@ -14,6 +15,6 @@ export interface AspectRatioProps
 
 export default class AspectRatio extends SvelteComponentTyped<
   AspectRatioProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/Breadcrumb/Breadcrumb.svelte.d.ts
+++ b/integration/carbon/types/Breadcrumb/Breadcrumb.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { BreadcrumbSkeletonProps } from "./BreadcrumbSkeleton.svelte";
 

--- a/integration/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/integration/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface BreadcrumbItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+type RestProps = SvelteHTMLElements["li"];
+
+export interface BreadcrumbItemProps extends RestProps {
   /**
    * Set the `href` to use an anchor link
    * @default undefined

--- a/integration/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface BreadcrumbSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface BreadcrumbSkeletonProps extends RestProps {
   /**
    * Set to `true` to hide the breadcrumb trailing slash
    * @default false

--- a/integration/carbon/types/Button/Button.svelte.d.ts
+++ b/integration/carbon/types/Button/Button.svelte.d.ts
@@ -1,12 +1,13 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
 import type { ButtonSkeletonProps } from "./ButtonSkeleton.svelte";
 
-export interface ButtonProps
-  extends ButtonSkeletonProps,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]>,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]>,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["button"] &
+  SvelteHTMLElements["a"] &
+  SvelteHTMLElements["div"];
+
+export interface ButtonProps extends ButtonSkeletonProps, RestProps {
   /**
    * Specify the kind of button
    * @default "primary"

--- a/integration/carbon/types/Button/ButtonSet.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSet.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonSetProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ButtonSetProps extends RestProps {
   /**
    * Set to `true` to stack the buttons vertically
    * @default false
@@ -14,6 +15,6 @@ export interface ButtonSetProps
 
 export default class ButtonSet extends SvelteComponentTyped<
   ButtonSetProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface ButtonSkeletonProps extends RestProps {
   /**
    * Set the `href` to use an anchor link
    * @default undefined

--- a/integration/carbon/types/Checkbox/Checkbox.svelte.d.ts
+++ b/integration/carbon/types/Checkbox/Checkbox.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface CheckboxProps {

--- a/integration/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface CheckboxSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface CheckboxSkeletonProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/integration/carbon/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface CodeSnippetProps {

--- a/integration/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/integration/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface CodeSnippetSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface CodeSnippetSkeletonProps extends RestProps {
   /**
    * Set the type of code snippet
    * @default "single"

--- a/integration/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/integration/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -1,13 +1,14 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export interface ComboBoxItem {
   id: string;
   text: string;
 }
 
-export interface ComboBoxProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ComboBoxProps extends RestProps {
   /**
    * Set the combobox items
    * @default []

--- a/integration/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ComposedModalProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ComposedModalProps extends RestProps {
   /**
    * Set the size of the composed modal
    * @default undefined

--- a/integration/carbon/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalBody.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ModalBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ModalBodyProps extends RestProps {
   /**
    * Set to `true` if the modal contains form elements
    * @default false
@@ -20,6 +21,6 @@ export interface ModalBodyProps
 
 export default class ModalBody extends SvelteComponentTyped<
   ModalBodyProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ModalFooterProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ModalFooterProps extends RestProps {
   /**
    * Specify the primary button text
    * @default ""
@@ -44,6 +45,6 @@ export interface ModalFooterProps
 
 export default class ModalFooter extends SvelteComponentTyped<
   ModalFooterProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/integration/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ModalHeaderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ModalHeaderProps extends RestProps {
   /**
    * Specify the modal title
    * @default ""

--- a/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/integration/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ContentSwitcherProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ContentSwitcherProps extends RestProps {
   /**
    * Set the selected index of the switch item
    * @default 0

--- a/integration/carbon/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/integration/carbon/types/ContentSwitcher/Switch.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SwitchProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface SwitchProps extends RestProps {
   /**
    * Specify the switch text
    * Alternatively, use the "text" slot  (e.g., <span slot="text">...</span>)

--- a/integration/carbon/types/Copy/Copy.svelte.d.ts
+++ b/integration/carbon/types/Copy/Copy.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface CopyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface CopyProps extends RestProps {
   /**
    * Set the feedback text shown after clicking the button
    * @default "Copied!"

--- a/integration/carbon/types/CopyButton/CopyButton.svelte.d.ts
+++ b/integration/carbon/types/CopyButton/CopyButton.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { CopyProps } from "../Copy/Copy.svelte";
 

--- a/integration/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/integration/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export type DataTableKey = string;

--- a/integration/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/integration/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
 import type { DataTableHeader } from "../DataTable/DataTable.svelte";
 
-export interface DataTableSkeletonProps
-  extends DataTableHeader,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface DataTableSkeletonProps extends DataTableHeader, RestProps {
   /**
    * Specify the number of columns
    * Superseded by `headers` if `headers` is a non-empty array

--- a/integration/carbon/types/DataTable/Table.svelte.d.ts
+++ b/integration/carbon/types/DataTable/Table.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {
+type RestProps = SvelteHTMLElements["section"];
+
+export interface TableProps extends RestProps {
   /**
    * Set the size of the table
    * @default undefined
@@ -44,6 +45,6 @@ export interface TableProps
 
 export default class Table extends SvelteComponentTyped<
   TableProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/TableBody.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableBody.svelte.d.ts
@@ -1,13 +1,14 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {
+type RestProps = SvelteHTMLElements["tbody"];
+
+export interface TableBodyProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 
 export default class TableBody extends SvelteComponentTyped<
   TableBodyProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/TableCell.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableCell.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableCellProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {
+type RestProps = SvelteHTMLElements["td"];
+
+export interface TableCellProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/DataTable/TableContainer.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableContainer.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableContainerProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TableContainerProps extends RestProps {
   /**
    * Specify the title of the data table
    * @default ""
@@ -26,6 +27,6 @@ export interface TableContainerProps
 
 export default class TableContainer extends SvelteComponentTyped<
   TableContainerProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/TableHead.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableHead.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableHeadProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {
+type RestProps = SvelteHTMLElements["thead"];
+
+export interface TableHeadProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/DataTable/TableHeader.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableHeader.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableHeaderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["th"]> {
+type RestProps = SvelteHTMLElements["th"];
+
+export interface TableHeaderProps extends RestProps {
   /**
    * Specify the `scope` attribute
    * @default "col"

--- a/integration/carbon/types/DataTable/TableRow.svelte.d.ts
+++ b/integration/carbon/types/DataTable/TableRow.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TableRowProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {
+type RestProps = SvelteHTMLElements["tr"];
+
+export interface TableRowProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/DataTable/Toolbar.svelte.d.ts
+++ b/integration/carbon/types/DataTable/Toolbar.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToolbarProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {
+type RestProps = SvelteHTMLElements["section"];
+
+export interface ToolbarProps extends RestProps {
   /**
    * Specify the toolbar size
    * @default "default"
@@ -14,6 +15,6 @@ export interface ToolbarProps
 
 export default class Toolbar extends SvelteComponentTyped<
   ToolbarProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/integration/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToolbarBatchActionsProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ToolbarBatchActionsProps extends RestProps {
   /**
    * Override the total items selected text
    * @default (totalSelected) => `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`
@@ -14,6 +15,6 @@ export interface ToolbarBatchActionsProps
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<
   ToolbarBatchActionsProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/ToolbarContent.svelte.d.ts
+++ b/integration/carbon/types/DataTable/ToolbarContent.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface ToolbarContentProps {}
 
 export default class ToolbarContent extends SvelteComponentTyped<
   ToolbarContentProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/ToolbarMenu.svelte.d.ts
+++ b/integration/carbon/types/DataTable/ToolbarMenu.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { OverflowMenuProps } from "../OverflowMenu/OverflowMenu.svelte";
 
@@ -6,6 +5,6 @@ export interface ToolbarMenuProps extends OverflowMenuProps {}
 
 export default class ToolbarMenu extends SvelteComponentTyped<
   ToolbarMenuProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/DataTable/ToolbarMenuItem.svelte.d.ts
+++ b/integration/carbon/types/DataTable/ToolbarMenuItem.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { OverflowMenuItemProps } from "../OverflowMenu/OverflowMenuItem.svelte";
 

--- a/integration/carbon/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/integration/carbon/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface ToolbarSearchProps {

--- a/integration/carbon/types/DatePicker/DatePicker.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePicker.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface DatePickerProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface DatePickerProps extends RestProps {
   /**
    * Specify the date picker type
    * @default "simple"

--- a/integration/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface DatePickerInputProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface DatePickerInputProps extends RestProps {
   /**
    * Set the size of the input
    * @default undefined

--- a/integration/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/integration/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface DatePickerSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface DatePickerSkeletonProps extends RestProps {
   /**
    * Set to `true` to use the range variant
    * @default false

--- a/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/integration/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type DropdownItemId = string;
 
@@ -10,8 +10,9 @@ export interface DropdownItem {
   text: DropdownItemText;
 }
 
-export interface DropdownProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface DropdownProps extends RestProps {
   /**
    * Set the dropdown items
    * @default []

--- a/integration/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface DropdownSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface DropdownSkeletonProps extends RestProps {
   /**
    * Set to `true` to use the inline variant
    * @default false

--- a/integration/carbon/types/FileUploader/FileUploader.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploader.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FileUploaderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface FileUploaderProps extends RestProps {
   /**
    * Specify the file uploader status
    * @default "uploading"

--- a/integration/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FileUploaderButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
+type RestProps = SvelteHTMLElements["input"];
+
+export interface FileUploaderButtonProps extends RestProps {
   /**
    * Specify the accepted file types
    * @default []

--- a/integration/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FileUploaderDropContainerProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface FileUploaderDropContainerProps extends RestProps {
   /**
    * Specify the accepted file types
    * @default []

--- a/integration/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FileUploaderItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
+type RestProps = SvelteHTMLElements["span"];
+
+export interface FileUploaderItemProps extends RestProps {
   /**
    * Specify the file uploader status
    * @default "uploading"

--- a/integration/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FileUploaderSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface FileUploaderSkeletonProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/FileUploader/Filename.svelte.d.ts
+++ b/integration/carbon/types/FileUploader/Filename.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FilenameProps {

--- a/integration/carbon/types/FluidForm/FluidForm.svelte.d.ts
+++ b/integration/carbon/types/FluidForm/FluidForm.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FluidFormProps {}

--- a/integration/carbon/types/Form/Form.svelte.d.ts
+++ b/integration/carbon/types/Form/Form.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FormProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {
+type RestProps = SvelteHTMLElements["form"];
+
+export interface FormProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/FormGroup/FormGroup.svelte.d.ts
+++ b/integration/carbon/types/FormGroup/FormGroup.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FormGroupProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {
+type RestProps = SvelteHTMLElements["fieldset"];
+
+export interface FormGroupProps extends RestProps {
   /**
    * Set to `true` to indicate an invalid state
    * @default false

--- a/integration/carbon/types/FormItem/FormItem.svelte.d.ts
+++ b/integration/carbon/types/FormItem/FormItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FormItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface FormItemProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/FormLabel/FormLabel.svelte.d.ts
+++ b/integration/carbon/types/FormLabel/FormLabel.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface FormLabelProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
+type RestProps = SvelteHTMLElements["label"];
+
+export interface FormLabelProps extends RestProps {
   /**
    * Set an id to be used by the label element
    * @default "ccs-" + Math.random().toString(36)

--- a/integration/carbon/types/Grid/Column.svelte.d.ts
+++ b/integration/carbon/types/Grid/Column.svelte.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ColumnSize = boolean | number;
 
@@ -10,8 +10,9 @@ export interface ColumnSizeDescriptor {
 
 export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
-export interface ColumnProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ColumnProps extends RestProps {
   /**
    * Set to `true` to render a custom HTML element
    * Props are destructured as `props` in the default slot (e.g., <Column let:props><article {...props}>...</article></Column>)
@@ -84,6 +85,6 @@ export interface ColumnProps
 
 export default class Column extends SvelteComponentTyped<
   ColumnProps,
-  {},
+  Record<string, any>,
   { default: { props: { class: string; [key: string]: any } } }
 > {}

--- a/integration/carbon/types/Grid/Grid.svelte.d.ts
+++ b/integration/carbon/types/Grid/Grid.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface GridProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface GridProps extends RestProps {
   /**
    * Set to `true` to render a custom HTML element
    * Props are destructured as `props` in the default slot (e.g., <Grid let:props><header {...props}>...</header></Grid>)
@@ -57,6 +58,6 @@ export interface GridProps
 
 export default class Grid extends SvelteComponentTyped<
   GridProps,
-  {},
+  Record<string, any>,
   { default: { props: { class: string; [key: string]: any } } }
 > {}

--- a/integration/carbon/types/Grid/Row.svelte.d.ts
+++ b/integration/carbon/types/Grid/Row.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface RowProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface RowProps extends RestProps {
   /**
    * Set to `true` to render a custom HTML element
    * Props are destructured as `props` in the default slot (e.g., <Row let:props><section {...props}>...</section></Row>)
@@ -51,6 +52,6 @@ export interface RowProps
 
 export default class Row extends SvelteComponentTyped<
   RowProps,
-  {},
+  Record<string, any>,
   { default: { props: { class: string; [key: string]: any } } }
 > {}

--- a/integration/carbon/types/Icon/Icon.svelte.d.ts
+++ b/integration/carbon/types/Icon/Icon.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
 import type { IconSkeletonProps } from "./IconSkeleton.svelte";
 
-export interface IconProps
-  extends IconSkeletonProps,
-    svelte.JSX.SVGAttributes<SVGSVGElement> {
+type RestProps = SvelteHTMLElements["svg"];
+
+export interface IconProps extends IconSkeletonProps, RestProps {
   /**
    * Specify the icon from `carbon-icons-svelte` to render
    * @default undefined

--- a/integration/carbon/types/Icon/IconSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Icon/IconSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface IconSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface IconSkeletonProps extends RestProps {
   /**
    * Set the size of the icon
    * @default 16

--- a/integration/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/integration/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface InlineLoadingProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface InlineLoadingProps extends RestProps {
   /**
    * Set the loading status
    * @default "active"

--- a/integration/carbon/types/Link/Link.svelte.d.ts
+++ b/integration/carbon/types/Link/Link.svelte.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]>,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
+type RestProps = SvelteHTMLElements["a"] & SvelteHTMLElements["p"];
+
+export interface LinkProps extends RestProps {
   /**
    * Specify the size of the link
    * @default undefined

--- a/integration/carbon/types/Link/OutboundLink.svelte.d.ts
+++ b/integration/carbon/types/Link/OutboundLink.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { LinkProps } from "./Link.svelte";
 

--- a/integration/carbon/types/ListBox/ListBox.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBox.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ListBoxProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ListBoxProps extends RestProps {
   /**
    * Set the size of the list box
    * @default undefined

--- a/integration/carbon/types/ListBox/ListBoxField.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxField.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxFieldTranslationId = "close" | "open";
 
-export interface ListBoxFieldProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ListBoxFieldProps extends RestProps {
   /**
    * Set to `true` to disable the list box field
    * @default false

--- a/integration/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ListBoxMenuProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ListBoxMenuProps extends RestProps {
   /**
    * Set an id for the top-level element
    * @default "ccs-" + Math.random().toString(36)

--- a/integration/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxMenuIconTranslationId = "close" | "open";
 
-export interface ListBoxMenuIconProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ListBoxMenuIconProps extends RestProps {
   /**
    * Set to `true` to open the list box menu icon
    * @default false

--- a/integration/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ListBoxMenuItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ListBoxMenuItemProps extends RestProps {
   /**
    * Set to `true` to enable the active state
    * @default false

--- a/integration/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/integration/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
-export interface ListBoxSelectionProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ListBoxSelectionProps extends RestProps {
   /**
    * Specify the number of selected items
    * @default undefined

--- a/integration/carbon/types/ListItem/ListItem.svelte.d.ts
+++ b/integration/carbon/types/ListItem/ListItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ListItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+type RestProps = SvelteHTMLElements["li"];
+
+export interface ListItemProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/Loading/Loading.svelte.d.ts
+++ b/integration/carbon/types/Loading/Loading.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface LoadingProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface LoadingProps extends RestProps {
   /**
    * Set to `true` to use the small variant
    * @default false
@@ -38,6 +39,6 @@ export interface LoadingProps
 
 export default class Loading extends SvelteComponentTyped<
   LoadingProps,
-  {},
+  Record<string, any>,
   {}
 > {}

--- a/integration/carbon/types/Modal/Modal.svelte.d.ts
+++ b/integration/carbon/types/Modal/Modal.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ModalProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ModalProps extends RestProps {
   /**
    * Set the size of the modal
    * @default undefined

--- a/integration/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/integration/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type MultiSelectItemId = string;
 
@@ -10,8 +10,9 @@ export interface MultiSelectItem {
   text: MultiSelectItemText;
 }
 
-export interface MultiSelectProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface MultiSelectProps extends RestProps {
   /**
    * Set the multiselect items
    * @default []

--- a/integration/carbon/types/Notification/InlineNotification.svelte.d.ts
+++ b/integration/carbon/types/Notification/InlineNotification.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface InlineNotificationProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface InlineNotificationProps extends RestProps {
   /**
    * Specify the kind of notification
    * @default "error"

--- a/integration/carbon/types/Notification/NotificationActionButton.svelte.d.ts
+++ b/integration/carbon/types/Notification/NotificationActionButton.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface NotificationActionButtonProps {}

--- a/integration/carbon/types/Notification/NotificationButton.svelte.d.ts
+++ b/integration/carbon/types/Notification/NotificationButton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface NotificationButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface NotificationButtonProps extends RestProps {
   /**
    * Set the type of notification
    * @default "toast"

--- a/integration/carbon/types/Notification/NotificationIcon.svelte.d.ts
+++ b/integration/carbon/types/Notification/NotificationIcon.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface NotificationIconProps {
@@ -29,6 +28,6 @@ export interface NotificationIconProps {
 
 export default class NotificationIcon extends SvelteComponentTyped<
   NotificationIconProps,
-  {},
+  Record<string, any>,
   {}
 > {}

--- a/integration/carbon/types/Notification/NotificationTextDetails.svelte.d.ts
+++ b/integration/carbon/types/Notification/NotificationTextDetails.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface NotificationTextDetailsProps {
@@ -29,6 +28,6 @@ export interface NotificationTextDetailsProps {
 
 export default class NotificationTextDetails extends SvelteComponentTyped<
   NotificationTextDetailsProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/Notification/ToastNotification.svelte.d.ts
+++ b/integration/carbon/types/Notification/ToastNotification.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToastNotificationProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ToastNotificationProps extends RestProps {
   /**
    * Specify the kind of notification
    * @default "error"

--- a/integration/carbon/types/NumberInput/NumberInput.svelte.d.ts
+++ b/integration/carbon/types/NumberInput/NumberInput.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type NumberInputTranslationId = "increment" | "decrement";
 
-export interface NumberInputProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface NumberInputProps extends RestProps {
   /**
    * Set the size of the input
    * @default undefined

--- a/integration/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/integration/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface NumberInputSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface NumberInputSkeletonProps extends RestProps {
   /**
    * Set to `true` to hide the label text
    * @default false

--- a/integration/carbon/types/OrderedList/OrderedList.svelte.d.ts
+++ b/integration/carbon/types/OrderedList/OrderedList.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface OrderedListProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ol"]> {
+type RestProps = SvelteHTMLElements["ol"];
+
+export interface OrderedListProps extends RestProps {
   /**
    * Set to `true` to use the nested variant
    * @default false

--- a/integration/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/integration/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface OverflowMenuProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface OverflowMenuProps extends RestProps {
   /**
    * Specify the size of the overflow menu
    * @default undefined

--- a/integration/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/integration/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface OverflowMenuItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+type RestProps = SvelteHTMLElements["li"];
+
+export interface OverflowMenuItemProps extends RestProps {
   /**
    * Specify the item text
    * Alternatively, use the default slot for a custom element

--- a/integration/carbon/types/Pagination/Pagination.svelte.d.ts
+++ b/integration/carbon/types/Pagination/Pagination.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface PaginationProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface PaginationProps extends RestProps {
   /**
    * Specify the current page index
    * @default 1

--- a/integration/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface PaginationSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface PaginationSkeletonProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/integration/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface PaginationNavProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
+type RestProps = SvelteHTMLElements["nav"];
+
+export interface PaginationNavProps extends RestProps {
   /**
    * Specify the current page index
    * @default 0

--- a/integration/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/integration/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ProgressIndicatorProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
+type RestProps = SvelteHTMLElements["ul"];
+
+export interface ProgressIndicatorProps extends RestProps {
   /**
    * Specify the current step index
    * @default 0

--- a/integration/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/integration/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ProgressIndicatorSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
+type RestProps = SvelteHTMLElements["ul"];
+
+export interface ProgressIndicatorSkeletonProps extends RestProps {
   /**
    * Set to `true` to use the vertical variant
    * @default false

--- a/integration/carbon/types/ProgressIndicator/ProgressStep.svelte.d.ts
+++ b/integration/carbon/types/ProgressIndicator/ProgressStep.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ProgressStepProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+type RestProps = SvelteHTMLElements["li"];
+
+export interface ProgressStepProps extends RestProps {
   /**
    * Set to `true` for the complete variant
    * @default false

--- a/integration/carbon/types/RadioButton/RadioButton.svelte.d.ts
+++ b/integration/carbon/types/RadioButton/RadioButton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface RadioButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface RadioButtonProps extends RestProps {
   /**
    * Specify the value of the radio button
    * @default ""

--- a/integration/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/integration/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface RadioButtonSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface RadioButtonSkeletonProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/integration/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface RadioButtonGroupProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface RadioButtonGroupProps extends RestProps {
   /**
    * Set the selected radio button value
    * @default undefined

--- a/integration/carbon/types/Search/Search.svelte.d.ts
+++ b/integration/carbon/types/Search/Search.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface SearchProps {

--- a/integration/carbon/types/Search/SearchSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Search/SearchSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SearchSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SearchSkeletonProps extends RestProps {
   /**
    * @deprecated this prop will be removed in the next major release
    * Set to `true` to use the small variant

--- a/integration/carbon/types/Select/Select.svelte.d.ts
+++ b/integration/carbon/types/Select/Select.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SelectProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SelectProps extends RestProps {
   /**
    * Specify the selected item value
    * @default undefined

--- a/integration/carbon/types/Select/SelectItem.svelte.d.ts
+++ b/integration/carbon/types/Select/SelectItem.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface SelectItemProps {
@@ -29,6 +28,6 @@ export interface SelectItemProps {
 
 export default class SelectItem extends SvelteComponentTyped<
   SelectItemProps,
-  {},
+  Record<string, any>,
   {}
 > {}

--- a/integration/carbon/types/Select/SelectItemGroup.svelte.d.ts
+++ b/integration/carbon/types/Select/SelectItemGroup.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SelectItemGroupProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["optgroup"]> {
+type RestProps = SvelteHTMLElements["optgroup"];
+
+export interface SelectItemGroupProps extends RestProps {
   /**
    * Set to `true` to disable the optgroup element
    * @default false
@@ -20,6 +21,6 @@ export interface SelectItemGroupProps
 
 export default class SelectItemGroup extends SvelteComponentTyped<
   SelectItemGroupProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/Select/SelectSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Select/SelectSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SelectSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SelectSkeletonProps extends RestProps {
   /**
    * Set to `true` to hide the label text
    * @default false

--- a/integration/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/integration/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SkeletonPlaceholderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SkeletonPlaceholderProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/integration/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SkeletonTextProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SkeletonTextProps extends RestProps {
   /**
    * Specify the number of lines to render
    * @default 3

--- a/integration/carbon/types/Slider/Slider.svelte.d.ts
+++ b/integration/carbon/types/Slider/Slider.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SliderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SliderProps extends RestProps {
   /**
    * Specify the value of the slider
    * @default 0

--- a/integration/carbon/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Slider/SliderSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SliderSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface SliderSkeletonProps extends RestProps {
   /**
    * Set to `true` to hide the label text
    * @default false

--- a/integration/carbon/types/StructuredList/StructuredList.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredList.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface StructuredListProps extends RestProps {
   /**
    * Specify the selected structured list row value
    * @default undefined

--- a/integration/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface StructuredListBodyProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListCellProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface StructuredListCellProps extends RestProps {
   /**
    * Set to `true` to use as a header
    * @default false

--- a/integration/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListHeadProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface StructuredListHeadProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListInputProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
+type RestProps = SvelteHTMLElements["input"];
+
+export interface StructuredListInputProps extends RestProps {
   /**
    * Set to `true` to check the input
    * @default false
@@ -44,6 +45,6 @@ export interface StructuredListInputProps
 
 export default class StructuredListInput extends SvelteComponentTyped<
   StructuredListInputProps,
-  {},
+  Record<string, any>,
   {}
 > {}

--- a/integration/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListRowProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
+type RestProps = SvelteHTMLElements["label"];
+
+export interface StructuredListRowProps extends RestProps {
   /**
    * Set to `true` to use as a header
    * @default false

--- a/integration/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/integration/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface StructuredListSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface StructuredListSkeletonProps extends RestProps {
   /**
    * Specify the number of rows
    * @default 5

--- a/integration/carbon/types/Tabs/Tab.svelte.d.ts
+++ b/integration/carbon/types/Tabs/Tab.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TabProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+type RestProps = SvelteHTMLElements["li"];
+
+export interface TabProps extends RestProps {
   /**
    * Specify the tab label
    * Alternatively, use the default slot (e.g., <Tab><span>Label</span></Tab>)

--- a/integration/carbon/types/Tabs/TabContent.svelte.d.ts
+++ b/integration/carbon/types/Tabs/TabContent.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TabContentProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TabContentProps extends RestProps {
   /**
    * Set an id for the top-level element
    * @default "ccs-" + Math.random().toString(36)
@@ -14,6 +15,6 @@ export interface TabContentProps
 
 export default class TabContent extends SvelteComponentTyped<
   TabContentProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/Tabs/Tabs.svelte.d.ts
+++ b/integration/carbon/types/Tabs/Tabs.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TabsProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TabsProps extends RestProps {
   /**
    * Specify the selected tab index
    * @default 0

--- a/integration/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TabsSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TabsSkeletonProps extends RestProps {
   /**
    * Specify the number of tabs to render
    * @default 4

--- a/integration/carbon/types/Tag/Tag.svelte.d.ts
+++ b/integration/carbon/types/Tag/Tag.svelte.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TagProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]>,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
+type RestProps = SvelteHTMLElements["div"] & SvelteHTMLElements["span"];
+
+export interface TagProps extends RestProps {
   /**
    * Specify the type of tag
    * @default undefined

--- a/integration/carbon/types/Tag/TagSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Tag/TagSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TagSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
+type RestProps = SvelteHTMLElements["span"];
+
+export interface TagSkeletonProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/carbon/types/TextArea/TextArea.svelte.d.ts
+++ b/integration/carbon/types/TextArea/TextArea.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TextAreaProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["textarea"]> {
+type RestProps = SvelteHTMLElements["textarea"];
+
+export interface TextAreaProps extends RestProps {
   /**
    * Specify the textarea value
    * @default ""

--- a/integration/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/integration/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TextAreaSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TextAreaSkeletonProps extends RestProps {
   /**
    * Set to `true` to visually hide the label text
    * @default false

--- a/integration/carbon/types/TextInput/PasswordInput.svelte.d.ts
+++ b/integration/carbon/types/TextInput/PasswordInput.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface PasswordInputProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
+type RestProps = SvelteHTMLElements["input"];
+
+export interface PasswordInputProps extends RestProps {
   /**
    * Set the size of the input
    * @default undefined

--- a/integration/carbon/types/TextInput/TextInput.svelte.d.ts
+++ b/integration/carbon/types/TextInput/TextInput.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TextInputProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
+type RestProps = SvelteHTMLElements["input"];
+
+export interface TextInputProps extends RestProps {
   /**
    * Set the size of the input
    * @default undefined

--- a/integration/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/integration/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TextInputSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TextInputSkeletonProps extends RestProps {
   /**
    * Set to `true` to hide the label text
    * @default false

--- a/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ClickableTileProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface ClickableTileProps extends RestProps {
   /**
    * Set to `true` to click the tile
    * @default false

--- a/integration/carbon/types/Tile/ExpandableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/ExpandableTile.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ExpandableTileProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ExpandableTileProps extends RestProps {
   /**
    * Set to `true` to expand the tile
    * @default false

--- a/integration/carbon/types/Tile/RadioTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/RadioTile.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface RadioTileProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
+type RestProps = SvelteHTMLElements["label"];
+
+export interface RadioTileProps extends RestProps {
   /**
    * Set to `true` to check the tile
    * @default false

--- a/integration/carbon/types/Tile/SelectableTile.svelte.d.ts
+++ b/integration/carbon/types/Tile/SelectableTile.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SelectableTileProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
+type RestProps = SvelteHTMLElements["label"];
+
+export interface SelectableTileProps extends RestProps {
   /**
    * Set to `true` to select the tile
    * @default false

--- a/integration/carbon/types/Tile/Tile.svelte.d.ts
+++ b/integration/carbon/types/Tile/Tile.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TileProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TileProps extends RestProps {
   /**
    * Set to `true` to enable the light variant
    * @default false

--- a/integration/carbon/types/Tile/TileGroup.svelte.d.ts
+++ b/integration/carbon/types/Tile/TileGroup.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TileGroupProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {
+type RestProps = SvelteHTMLElements["fieldset"];
+
+export interface TileGroupProps extends RestProps {
   /**
    * Specify the selected tile value
    * @default undefined

--- a/integration/carbon/types/TimePicker/TimePicker.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePicker.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TimePickerProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TimePickerProps extends RestProps {
   /**
    * Specify the size of the input
    * @default undefined

--- a/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/integration/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TimePickerSelectProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TimePickerSelectProps extends RestProps {
   /**
    * Specify the select value
    * @default ""

--- a/integration/carbon/types/Toggle/Toggle.svelte.d.ts
+++ b/integration/carbon/types/Toggle/Toggle.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToggleProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ToggleProps extends RestProps {
   /**
    * Specify the toggle size
    * @default "default"

--- a/integration/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/integration/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToggleSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ToggleSkeletonProps extends RestProps {
   /**
    * Specify the toggle size
    * @default "default"

--- a/integration/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
+++ b/integration/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToggleSmallProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ToggleSmallProps extends RestProps {
   /**
    * Set to `true` to toggle the checkbox input
    * @default false

--- a/integration/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
+++ b/integration/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ToggleSmallSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface ToggleSmallSkeletonProps extends RestProps {
   /**
    * Specify the label text
    * @default ""

--- a/integration/carbon/types/Tooltip/Tooltip.svelte.d.ts
+++ b/integration/carbon/types/Tooltip/Tooltip.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TooltipProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TooltipProps extends RestProps {
   /**
    * Set the alignment of the tooltip relative to the icon
    * @default "center"

--- a/integration/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/integration/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TooltipDefinitionProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+type RestProps = SvelteHTMLElements["div"];
+
+export interface TooltipDefinitionProps extends RestProps {
   /**
    * Specify the tooltip text
    * @default ""

--- a/integration/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/integration/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface TooltipIconProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface TooltipIconProps extends RestProps {
   /**
    * Specify the tooltip text.
    * Alternatively, use the "text" slot

--- a/integration/carbon/types/UIShell/Content.svelte.d.ts
+++ b/integration/carbon/types/UIShell/Content.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ContentProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["main"]> {
+type RestProps = SvelteHTMLElements["main"];
+
+export interface ContentProps extends RestProps {
   /**
    * Specify the id for the main element
    * @default "main-content"
@@ -14,6 +15,6 @@ export interface ContentProps
 
 export default class Content extends SvelteComponentTyped<
   ContentProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface HeaderProps extends RestProps {
   /**
    * Set to `false` to hide the side nav by default
    * @default true

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export interface HeaderActionSlideTransition {
   delay?: number;
@@ -7,8 +7,9 @@ export interface HeaderActionSlideTransition {
   easing?: (t: number) => number;
 }
 
-export interface HeaderActionProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface HeaderActionProps extends RestProps {
   /**
    * Set to `true` to open the panel
    * @default false

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderActionLinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface HeaderActionLinkProps extends RestProps {
   /**
    * Set to `true` to use the active state
    * @default false
@@ -32,6 +33,6 @@ export interface HeaderActionLinkProps
 
 export default class HeaderActionLink extends SvelteComponentTyped<
   HeaderActionLinkProps,
-  {},
+  Record<string, any>,
   {}
 > {}

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderActionSearch.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderActionSearch.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderActionSearchProps {

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderNavProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
+type RestProps = SvelteHTMLElements["nav"];
+
+export interface HeaderNavProps extends RestProps {
   /**
    * Specify the ARIA label for the nav
    * @deprecated use "aria-label" instead
@@ -15,6 +16,6 @@ export interface HeaderNavProps
 
 export default class HeaderNav extends SvelteComponentTyped<
   HeaderNavProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderNavItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface HeaderNavItemProps extends RestProps {
   /**
    * Specify the `href` attribute
    * @default undefined

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderNavMenuProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface HeaderNavMenuProps extends RestProps {
   /**
    * Set to `true` to toggle the expanded state
    * @default false

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelDivider.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelDivider.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderPanelDividerProps {}
 
 export default class HeaderPanelDivider extends SvelteComponentTyped<
   HeaderPanelDividerProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderPanelLinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface HeaderPanelLinkProps extends RestProps {
   /**
    * Specify the `href` attribute
    * @default undefined

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLinks.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderPanelLinks.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderPanelLinksProps {}
 
 export default class HeaderPanelLinks extends SvelteComponentTyped<
   HeaderPanelLinksProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/GlobalHeader/HeaderUtilities.svelte.d.ts
+++ b/integration/carbon/types/UIShell/GlobalHeader/HeaderUtilities.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderUtilitiesProps {}
 
 export default class HeaderUtilities extends SvelteComponentTyped<
   HeaderUtilitiesProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/integration/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderGlobalActionProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface HeaderGlobalActionProps extends RestProps {
   /**
    * Set to `true` to use the active variant
    * @default false

--- a/integration/carbon/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/integration/carbon/types/UIShell/HeaderSearch.svelte.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export interface HeaderSearchResult {
   href: string;
@@ -7,8 +7,9 @@ export interface HeaderSearchResult {
   description?: string;
 }
 
-export interface HeaderSearchProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
+type RestProps = SvelteHTMLElements["input"];
+
+export interface HeaderSearchProps extends RestProps {
   /**
    * Specify the search input value
    * @default ""

--- a/integration/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SideNavProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
+type RestProps = SvelteHTMLElements["nav"];
+
+export interface SideNavProps extends RestProps {
   /**
    * Set to `true` to use the fixed variant
    * @default false
@@ -26,6 +27,6 @@ export interface SideNavProps
 
 export default class SideNav extends SvelteComponentTyped<
   SideNavProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/SideNav/SideNavItems.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavItems.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavItemsProps {}
 
 export default class SideNavItems extends SvelteComponentTyped<
   SideNavItemsProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SideNavLinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface SideNavLinkProps extends RestProps {
   /**
    * Set to `true` to select the current link
    * @default false

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SideNavMenuProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface SideNavMenuProps extends RestProps {
   /**
    * Set to `true` to toggle the expanded state
    * @default false

--- a/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SideNavMenuItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface SideNavMenuItemProps extends RestProps {
   /**
    * Set to `true` to select the item
    * @default undefined

--- a/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/integration/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface SkipToContentProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface SkipToContentProps extends RestProps {
   /**
    * Specify the `href` attribute
    * @default "#main-content"

--- a/integration/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/integration/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface UnorderedListProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
+type RestProps = SvelteHTMLElements["ul"];
+
+export interface UnorderedListProps extends RestProps {
   /**
    * Set to `true` to use the nested variant
    * @default false

--- a/integration/glob/types/button/Button.svelte.d.ts
+++ b/integration/glob/types/button/Button.svelte.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type tree = boolean;
 
@@ -12,8 +12,9 @@ export declare function findParentTreeNode(
   node: HTMLElement
 ): null | HTMLElement;
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button2"
    */

--- a/integration/multi-export-typed-ts-only/types/button/button.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/button/button.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button"
    */

--- a/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface LinkProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface QuoteProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
+type RestProps = SvelteHTMLElements["blockquote"];
+
+export interface QuoteProps extends RestProps {
   /**
    * @default ""
    */
@@ -18,6 +19,6 @@ export interface QuoteProps
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/multi-export-typed-ts-only/types/secondary-button/secondary-button.svelte.d.ts
+++ b/integration/multi-export-typed-ts-only/types/secondary-button/secondary-button.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { ButtonProps } from "../button/button.svelte";
 

--- a/integration/multi-export-typed/types/Button.svelte.d.ts
+++ b/integration/multi-export-typed/types/Button.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button"
    */

--- a/integration/multi-export-typed/types/Link.svelte.d.ts
+++ b/integration/multi-export-typed/types/Link.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface LinkProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/multi-export-typed/types/Quote.svelte.d.ts
+++ b/integration/multi-export-typed/types/Quote.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface QuoteProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
+type RestProps = SvelteHTMLElements["blockquote"];
+
+export interface QuoteProps extends RestProps {
   /**
    * @default ""
    */
@@ -18,6 +19,6 @@ export interface QuoteProps
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/multi-export-typed/types/SecondaryButton.svelte.d.ts
+++ b/integration/multi-export-typed/types/SecondaryButton.svelte.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 import type { ButtonProps } from "./Button.svelte";
 

--- a/integration/multi-export/types/Button.svelte.d.ts
+++ b/integration/multi-export/types/Button.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button"
    */

--- a/integration/multi-export/types/Link.svelte.d.ts
+++ b/integration/multi-export/types/Link.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface LinkProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/multi-export/types/Quote.svelte.d.ts
+++ b/integration/multi-export/types/Quote.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type Author = string;
 
-export interface QuoteProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
+type RestProps = SvelteHTMLElements["blockquote"];
+
+export interface QuoteProps extends RestProps {
   /**
    * @default ""
    */
@@ -20,6 +21,6 @@ export interface QuoteProps
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/multi-export/types/nested/Header.svelte.d.ts
+++ b/integration/multi-export/types/nested/Header.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderProps {}
 
 export default class Header extends SvelteComponentTyped<
   HeaderProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/multi-folders/types/Link.svelte.d.ts
+++ b/integration/multi-folders/types/Link.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface LinkProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 

--- a/integration/multi-folders/types/Quote.svelte.d.ts
+++ b/integration/multi-folders/types/Quote.svelte.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
 export type Author = string;
 
-export interface QuoteProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
+type RestProps = SvelteHTMLElements["blockquote"];
+
+export interface QuoteProps extends RestProps {
   /**
    * @default ""
    */
@@ -20,6 +21,6 @@ export interface QuoteProps
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/multi-folders/types/components/Button.svelte.d.ts
+++ b/integration/multi-folders/types/components/Button.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button"
    */

--- a/integration/multi-folders/types/components/Card.svelte.d.ts
+++ b/integration/multi-folders/types/components/Card.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface CardProps {}
 
 export default class Card extends SvelteComponentTyped<
   CardProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/multi-folders/types/nested/Header.svelte.d.ts
+++ b/integration/multi-folders/types/nested/Header.svelte.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderProps {}
 
 export default class Header extends SvelteComponentTyped<
   HeaderProps,
-  {},
+  Record<string, any>,
   { default: {} }
 > {}

--- a/integration/single-export-default-only/types/Button.svelte.d.ts
+++ b/integration/single-export-default-only/types/Button.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button"
    */

--- a/integration/single-export/types/Button.svelte.d.ts
+++ b/integration/single-export/types/Button.svelte.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface ButtonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface ButtonProps extends RestProps {
   /**
    * @default "button"
    */

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "^2.6.2",
     "rollup": "^2.70.2",
     "rollup-plugin-svelte": "^7.1.0",
-    "svelte": "^3.52.0",
+    "svelte": "^4.0.5",
     "svelte-preprocess": "^4.10.6",
     "typescript": "^4.8.4"
   },

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -1,3 +1,5 @@
+// TODO: upgrading to Svelte 4 shows a lot of TS errors. Ignore for now but resolve.
+// @ts-nocheck
 import { compile, walk, parse } from "svelte/compiler";
 import * as commentParser from "comment-parser";
 import { Ast, TemplateNode, Var } from "svelte/types/compiler/interfaces";
@@ -343,7 +345,7 @@ export default class ComponentParser {
     this.parseCustomTypes();
 
     if (this.parsed?.module) {
-      walk(this.parsed?.module, {
+      walk(this.parsed?.module as unknown as Node, {
         enter: (node) => {
           if (node.type === "ExportNamedDeclaration") {
             const {

--- a/tests/__snapshots__/writer-ts-definitions.test.ts.snap
+++ b/tests/__snapshots__/writer-ts-definitions.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`writerTsDefinition > "default" module name 1`] = `
 "
-  /// <reference types=\\"svelte\\" />
   import type { SvelteComponentTyped } from \\"svelte\\";
   
   
@@ -15,7 +14,7 @@ exports[`writerTsDefinition > "default" module name 1`] = `
   
   export default class  extends SvelteComponentTyped<
       defaultProps,
-      {},
+      Record<string, any>,
       {}
     > {
       
@@ -24,7 +23,6 @@ exports[`writerTsDefinition > "default" module name 1`] = `
 
 exports[`writerTsDefinition > writeTsDefinition 1`] = `
 "
-  /// <reference types=\\"svelte\\" />
   import type { SvelteComponentTyped } from \\"svelte\\";
   
   
@@ -61,7 +59,7 @@ exports[`writerTsDefinition > writeTsDefinition 1`] = `
   
   export default class ModuleName extends SvelteComponentTyped<
       ModuleNameProps,
-      {},
+      Record<string, any>,
       {default: {}
 ;}
     > {

--- a/tests/snapshots/anchor-props/output.d.ts
+++ b/tests/snapshots/anchor-props/output.d.ts
@@ -1,8 +1,10 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+type RestProps = SvelteHTMLElements["a"];
+
+export interface InputProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {}

--- a/tests/snapshots/bind-this-multiple/output.d.ts
+++ b/tests/snapshots/bind-this-multiple/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -18,4 +17,4 @@ export interface InputProps {
   propBool?: boolean;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {}

--- a/tests/snapshots/bind-this/output.d.ts
+++ b/tests/snapshots/bind-this/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -8,4 +7,4 @@ export interface InputProps {
   ref: null | HTMLButtonElement;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {}

--- a/tests/snapshots/component-comment-multi/output.d.ts
+++ b/tests/snapshots/component-comment-multi/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}
@@ -9,4 +8,4 @@ export interface InputProps {}
  *   Component comment
  * </div>
  */
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {}

--- a/tests/snapshots/component-comment-single/output.d.ts
+++ b/tests/snapshots/component-comment-single/output.d.ts
@@ -1,7 +1,6 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}
 
 /** Component comment */
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {}

--- a/tests/snapshots/context-module/output.d.ts
+++ b/tests/snapshots/context-module/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export type bool = string;
@@ -23,6 +22,6 @@ export declare function b3(): () => false;
 
 export interface InputProps {}
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {
   a: string;
 }

--- a/tests/snapshots/dispatched-events-dynamic/output.d.ts
+++ b/tests/snapshots/dispatched-events-dynamic/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}

--- a/tests/snapshots/dispatched-events-typed/output.d.ts
+++ b/tests/snapshots/dispatched-events-typed/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}

--- a/tests/snapshots/dispatched-events/output.d.ts
+++ b/tests/snapshots/dispatched-events/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}

--- a/tests/snapshots/empty-export/output.d.ts
+++ b/tests/snapshots/empty-export/output.d.ts
@@ -1,6 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {}

--- a/tests/snapshots/forwarded-events/output.d.ts
+++ b/tests/snapshots/forwarded-events/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}

--- a/tests/snapshots/function-declaration/output.d.ts
+++ b/tests/snapshots/function-declaration/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -8,7 +7,7 @@ export interface InputProps {
   fnA?: () => {};
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {
   fnB: () => {};
 
   add: () => any;

--- a/tests/snapshots/infer-basic/output.d.ts
+++ b/tests/snapshots/infer-basic/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -28,7 +27,7 @@ export interface InputProps {
   id?: string;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {
   propConst: { ["1"]: true };
 
   fn: () => any;

--- a/tests/snapshots/infer-with-types/output.d.ts
+++ b/tests/snapshots/infer-with-types/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -23,7 +22,7 @@ export interface InputProps {
   id?: string;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {} }> {
   propConst: { [key: string]: boolean };
 
   fn: () => any;

--- a/tests/snapshots/input-events/output.d.ts
+++ b/tests/snapshots/input-events/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}

--- a/tests/snapshots/mixed-events/output.d.ts
+++ b/tests/snapshots/mixed-events/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}

--- a/tests/snapshots/prop-comments/output.d.ts
+++ b/tests/snapshots/prop-comments/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -25,6 +24,6 @@ export interface InputProps {
 
 export default class Input extends SvelteComponentTyped<
   InputProps,
-  {},
+  Record<string, any>,
   { default: { prop: boolean | string; prop1: boolean; prop2: boolean | string } }
 > {}

--- a/tests/snapshots/renamed-props/output.d.ts
+++ b/tests/snapshots/renamed-props/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -9,4 +8,4 @@ export interface InputProps {
   class?: string | null;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {}

--- a/tests/snapshots/required/output.d.ts
+++ b/tests/snapshots/required/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -28,6 +27,6 @@ export interface InputProps {
 
 export default class Input extends SvelteComponentTyped<
   InputProps,
-  {},
+  Record<string, any>,
   { default: { prop: boolean; prop1: boolean | string; prop2: any; prop3: boolean } }
 > {}

--- a/tests/snapshots/rest-props-multiple/output.d.ts
+++ b/tests/snapshots/rest-props-multiple/output.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface InputProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["h1"]>,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
+type RestProps = SvelteHTMLElements["h1"] & SvelteHTMLElements["span"];
+
+export interface InputProps extends RestProps {
   /**
    * @default false
    */
@@ -17,4 +17,4 @@ export interface InputProps
   [key: `data-${string}`]: any;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {}

--- a/tests/snapshots/rest-props/output.d.ts
+++ b/tests/snapshots/rest-props/output.d.ts
@@ -1,8 +1,10 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface InputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["h1"]> {
+type RestProps = SvelteHTMLElements["h1"];
+
+export interface InputProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {}

--- a/tests/snapshots/slots-named/output.d.ts
+++ b/tests/snapshots/slots-named/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -10,6 +9,6 @@ export interface InputProps {
 
 export default class Input extends SvelteComponentTyped<
   InputProps,
-  {},
+  Record<string, any>,
   { default: {}; ["bold heading"]: { text: string }; subheading: { text: string }; text: { text: string } }
 > {}

--- a/tests/snapshots/slots-spread-typed/output.d.ts
+++ b/tests/snapshots/slots-spread-typed/output.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}
 
 export default class Input extends SvelteComponentTyped<
   InputProps,
-  {},
+  Record<string, any>,
   { default: { a: number }; text: { a: number } }
 > {}

--- a/tests/snapshots/slots-spread/output.d.ts
+++ b/tests/snapshots/slots-spread/output.d.ts
@@ -1,6 +1,5 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {}
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {}; text: {} }> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, { default: {}; text: {} }> {}

--- a/tests/snapshots/svg-props/output.d.ts
+++ b/tests/snapshots/svg-props/output.d.ts
@@ -1,8 +1,10 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface InputProps extends svelte.JSX.SVGAttributes<SVGSVGElement> {
+type RestProps = SvelteHTMLElements["svg"];
+
+export interface InputProps extends RestProps {
   [key: `data-${string}`]: any;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {}

--- a/tests/snapshots/typed-props/output.d.ts
+++ b/tests/snapshots/typed-props/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -27,4 +26,4 @@ export interface InputProps {
   prop4?: "red" | "blue";
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {}
+export default class Input extends SvelteComponentTyped<InputProps, Record<string, any>, {}> {}

--- a/tests/snapshots/typed-slots/output.d.ts
+++ b/tests/snapshots/typed-slots/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface InputProps {
@@ -10,7 +9,7 @@ export interface InputProps {
 
 export default class Input extends SvelteComponentTyped<
   InputProps,
-  {},
+  Record<string, any>,
   {
     default: { prop: number; doubled: number };
     /** description */

--- a/tests/snapshots/typedef/output.d.ts
+++ b/tests/snapshots/typedef/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface MyTypedef {
@@ -17,4 +16,8 @@ export interface InputProps {
   prop1?: MyTypedef;
 }
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: { prop1: MyTypedef } }> {}
+export default class Input extends SvelteComponentTyped<
+  InputProps,
+  Record<string, any>,
+  { default: { prop1: MyTypedef } }
+> {}

--- a/tests/snapshots/typedefs/output.d.ts
+++ b/tests/snapshots/typedefs/output.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
 export interface MyTypedef {
@@ -21,6 +20,6 @@ export interface InputProps {
 
 export default class Input extends SvelteComponentTyped<
   InputProps,
-  {},
+  Record<string, any>,
   { default: { prop1: MyTypedef; prop2: MyTypedefArray } }
 > {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
+  integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@esbuild/android-arm@0.15.11":
   version "0.15.11"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.11.tgz#bdd9c3e098183bdca97075aa4c3e0152ed3e10ee"
@@ -11,6 +19,43 @@
   version "0.15.11"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.11.tgz#2f4f9a1083dcb4fc65233b6f59003c406abf32e5"
   integrity sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==
+
+"@jridgewell/gen-mapping@^0.3.0":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/sourcemap-codec@1.4.14":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -91,6 +136,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
   integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
 
+"@types/estree@*", "@types/estree@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -135,10 +185,29 @@ acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
+acorn@^8.8.2, acorn@^8.9.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+
+aria-query@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+axobject-query@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.1.tgz#39c378a6e3b06ca679f29138151e45b2b32da62a"
+  integrity sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==
+  dependencies:
+    dequal "^2.0.3"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -204,6 +273,17 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
+code-red@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/code-red/-/code-red-1.0.3.tgz#bbd3b0a27dc53c9af13f6756120a9dbcdd68a5f2"
+  integrity sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+    "@types/estree" "^1.0.0"
+    acorn "^8.8.2"
+    estree-walker "^3.0.3"
+    periscopic "^3.1.0"
+
 codemirror@5.65.5:
   version "5.65.5"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.5.tgz#f38f0e29945c3464df0c81f946fcd9a063fa2024"
@@ -223,6 +303,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+css-tree@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -247,6 +335,11 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -401,6 +494,13 @@ estree-walker@^2.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.0, estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 fast-glob@^3.2.12:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
@@ -536,6 +636,13 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-reference@^3.0.0, is-reference@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.1.tgz#d400f4260f7e55733955e60d361d827eb4d3b831"
+  integrity sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==
+  dependencies:
+    "@types/estree" "*"
+
 kleur@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
@@ -545,6 +652,11 @@ local-pkg@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
   integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
+
+locate-character@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
+  integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
 
 loupe@^2.3.1:
   version "2.3.4"
@@ -566,6 +678,18 @@ magic-string@^0.26.5:
   integrity sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==
   dependencies:
     sourcemap-codec "^1.4.8"
+
+magic-string@^0.30.0:
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.1.tgz#ce5cd4b0a81a5d032bd69aab4522299b2166284d"
+  integrity sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
 
 merge2@^1.3.0:
   version "1.4.1"
@@ -635,6 +759,15 @@ pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
+periscopic@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-3.1.0.tgz#7e9037bf51c5855bd33b48928828db4afa79d97a"
+  integrity sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^3.0.0"
+    is-reference "^3.0.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -779,7 +912,7 @@ sorcery@^0.10.0:
     sander "^0.5.0"
     sourcemap-codec "^1.3.0"
 
-source-map-js@^1.0.2:
+source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -832,10 +965,24 @@ svelte-preprocess@^4.10.6, svelte-preprocess@^4.10.7:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.52.0:
-  version "3.52.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.52.0.tgz#08259eff20904c63882b66a5d409a55e8c6743b8"
-  integrity sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==
+svelte@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.0.5.tgz#4c4f418c38c5124be081d0720fb7efecfba501cc"
+  integrity sha512-PHKPWP1wiWHBtsE57nCb8xiWB3Ht7/3Kvi3jac0XIxUM2rep8alO7YoAtgWeGD7++tFy46krilOrPW0mG3Dx+A==
+  dependencies:
+    "@ampproject/remapping" "^2.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    acorn "^8.9.0"
+    aria-query "^5.3.0"
+    axobject-query "^3.2.1"
+    code-red "^1.0.3"
+    css-tree "^2.3.1"
+    estree-walker "^3.0.3"
+    is-reference "^3.0.1"
+    locate-character "^3.0.0"
+    magic-string "^0.30.0"
+    periscopic "^3.1.0"
 
 tinybench@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Closes #107, closes #108

Scoped down alternative to #108, which includes the following fixes to support Svelte 4:

* Use `SvelteHTMLElements` instead of the `svelte.JSX` namespace

* Default to `Record<string, any>` if a component does not have events