### PR TITLE
fix(writer): only print `outFile` name instead of resolved path

### DIFF
--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -133,7 +133,7 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
 
   if (opts?.markdown) {
     writeMarkdown(result.components, {
-      outFile: path.join(process.cwd(), "COMPONENT_INDEX.md"),
+      outFile: "COMPONENT_INDEX.md",
       ...opts?.markdownOptions,
     });
   }

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -132,7 +132,8 @@ export default async function writeMarkdown(components: ComponentDocs, options: 
   });
 
   if (write) {
-    await document.write(options.outFile, document.end());
+    const outFile = path.join(process.cwd(), options.outFile);
+    await document.write(outFile, document.end());
     console.log(`created "${options.outFile}".`);
   }
 


### PR DESCRIPTION
If no custom `markdownOptions.outFile` is specified, the fully resolved path to the default file is printed.

For consistency, only the raw `outFile` should be printed out.

```sh
- created "<user>/<folder>/COMPONENT_INDEX.md".
+ created "COMPONENT_INDEX.md".
```