### PR TITLE
chore(playground): fix dropdown reactivity

### DIFF
--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -60,6 +60,10 @@
       parse_error = error;
     }
   }
+
+  $: if (value && codemirror) {
+    codemirror.setValue(value);
+  }
 </script>
 
 <Header>
@@ -74,9 +78,6 @@
             id: datum.moduleName,
             text: datum.moduleName,
           }))}
-          on:select={() => {
-            codemirror.setValue(value);
-          }}
         />
         <CodeEditor
           bind:code={value}


### PR DESCRIPTION
This is a regression.

Changing the value in the "Svelte code" dropdown does not update the value in the CodeMirror component.

![Screenshot 2023-09-01 at 2 09 12 PM](https://github.com/carbon-design-system/sveld/assets/10718366/8d8cc545-8b6e-4e92-9c6f-5c03e58c0c41)
