### PR TITLE
test: use `vitest` globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest -r tests",
     "test:integration": "node tests/test-integration",
     "format": "prettier --write \"{src,tests,playground}/**/*.{js,ts,svelte,md}\" --ignore-path \".gitignore\"",
-    "prepack": "tsc"
+    "prepack": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.2.1",

--- a/tests/Writer.test.ts
+++ b/tests/Writer.test.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
 import Writer from "../src/writer/Writer";
 
 describe("Writer", () => {

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -1,4 +1,3 @@
-import { test, expect } from "vitest";
 import WriterMarkdown from "../src/writer/WriterMarkdown";
 import type { AppendType } from "../src/writer/WriterMarkdown";
 

--- a/tests/create-exports.test.ts
+++ b/tests/create-exports.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { convertSvelteExt, createExports, removeSvelteExt } from "../src/create-exports";
 
 describe("createExports", () => {

--- a/tests/element-tag-map.test.ts
+++ b/tests/element-tag-map.test.ts
@@ -1,4 +1,3 @@
-import { test, expect } from "vitest";
 import { getElementByTag } from "../src/element-tag-map";
 
 test("getElementByTag", () => {

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -1,7 +1,6 @@
 import fg from "fast-glob";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
 import ComponentParser from "../src/ComponentParser";
 import Writer from "../src/writer/Writer";
 import { writeTsDefinition } from "../src/writer/writer-ts-definitions";

--- a/tests/parse-exports.test.ts
+++ b/tests/parse-exports.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { parseExports } from "../src/parse-exports";
 
 describe("parseExports", () => {

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, test } from "vitest";
-import { ParsedComponent } from "../src/ComponentParser";
-import { ComponentDocApi } from "../src/rollup-plugin";
+import type { ParsedComponent } from "../src/ComponentParser";
+import type { ComponentDocApi } from "../src/rollup-plugin";
 import { formatTsProps, getTypeDefs, writeTsDefinition } from "../src/writer/writer-ts-definitions";
 
 describe("writerTsDefinition", () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "module": "CommonJS",
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "declaration": true,
-    "module": "CommonJS",
+    "module": "ESNext",
+    "target": "ESNext",
     "moduleResolution": "node",
     "outDir": "lib",
     "skipLibCheck": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["vitest/globals"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
Using globals means that direct `vitest` imports can be removed.