### PR TITLE
perf(playground): apply `optimizeCss` to remove unused styles

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "carbon-components-svelte": "^0.85.0",
-    "carbon-preprocess-svelte": "^0.11.0",
+    "carbon-preprocess-svelte": "^0.11.1",
     "codemirror": "^5.65.14",
     "prettier": "^2.8.8",
     "svelte-highlight": "^7.6.0",

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -1,5 +1,5 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
-import { optimizeImports } from "carbon-preprocess-svelte";
+import { optimizeCss, optimizeImports } from "carbon-preprocess-svelte";
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -7,6 +7,7 @@ export default defineConfig({
     svelte({
       preprocess: [optimizeImports()],
     }),
+    optimizeCss()
   ],
   optimizeDeps: {
     exclude: ["carbon-components-svelte"],

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -235,10 +235,10 @@ carbon-components-svelte@^0.85.0:
     "@ibm/telemetry-js" "^1.2.1"
     flatpickr "4.6.9"
 
-carbon-preprocess-svelte@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/carbon-preprocess-svelte/-/carbon-preprocess-svelte-0.11.0.tgz#cf9bd8c8ffb590ab5a0a9d74979a14af0ec30858"
-  integrity sha512-J0Y7yhUmtMWX+c9iLeoqFFY+Yz/neBka3JQNPMlJ1ucAqBkrCl+/9bJAHYYglK8YTfvxrMPdkSZPqyjEplF3Ww==
+carbon-preprocess-svelte@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/carbon-preprocess-svelte/-/carbon-preprocess-svelte-0.11.1.tgz#414329489e15f2129c384ccc176566e48f4446d8"
+  integrity sha512-0QvzakB52grWvYO6u2/CbucAOqPAmLtC3X/d7lq/UOT6DKpyJmYGBI62fHKnsJedjsEFSMjbXY0jP1xXGKC8uw==
   dependencies:
     magic-string "^0.30.8"
     postcss "^8.4.36"


### PR DESCRIPTION
Applying the `optimizeCss` plugin from `carbon-preprocess-svelte` can help optimize usage of pre-compiled Carbon CSS.

```sh
Optimized assets/index-Dy43zAwI.css
Before: 750.82 kB
After:  336.35 kB (-55.2%)

Optimized assets/CodeHighlighter-1BpQ5oIG.css
Before: 2.3 kB
After:  2.3 kB (-0%)
```

---

<img width="1493" alt="Screenshot 2024-04-07 at 8 16 12 PM" src="https://github.com/carbon-design-system/sveld/assets/10718366/f95c4b66-44d6-4bc3-bfb7-5a6fd492ad1b">
