### PR TITLE
feat(component-parser): support generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ export default class Button extends SvelteComponentTyped<
   - [@event](#event)
   - [@restProps](#restprops)
   - [@extends](#extends)
+  - [@generics](#generics)
   - [@component comments](#component-comments)
 - [Contributing](#contributing)
 - [License](#license)
@@ -500,6 +501,45 @@ Example:
 export const secondary = true;
 
 import Button from "./Button.svelte";
+```
+
+### `@generics`
+
+Currently, to define generics for a Svelte component, you must use [`generics` attribute](https://github.com/dummdidumm/rfcs/blob/bfb14dc56a70ec6ddafebf2242b8e1500e06a032/text/ts-typing-props-slots-events.md#generics) on the script tag. Note that this feature is [experimental](https://svelte.dev/docs/typescript#experimental-advanced-typings) and may change in the future.
+
+However, the `generics` attribute only works if using `lang="ts"`; the language server will produce an error if `generics` is used without specifying `lang="ts"`.
+
+```svelte
+<!-- This causes an error because `lang="ts"` must be used. -->
+<script generics="Row extends DataTableRow = any"></script>
+```
+
+Because `sveld` is designed to support JavaScript-only usage as a baseline, the API design to specify generics uses a custom JSDoc tag `@generics`.
+
+Signature:
+
+```js
+/**
+ * @generics {GenericParameter} GenericName
+ */
+```
+
+Example
+
+```js
+/**
+ * @generics {Row extends DataTableRow = any} Row
+ */
+```
+
+The generated TypeScript definition will resemble the following:
+
+```ts
+export default class Component<Row extends DataTableRow = any> extends SvelteComponentTyped<
+  ComponentProps<Row>,
+  Record<string, any>,
+  Record<string, any>
+> {}
 ```
 
 ### `@component` comments

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -81,6 +81,8 @@ interface TypeDef {
   ts: string;
 }
 
+type ComponentGenerics = [name: string, type: string];
+
 interface ComponentInlineElement {
   type: "InlineComponent";
   name: string;
@@ -108,6 +110,7 @@ export interface ParsedComponent {
   slots: ComponentSlot[];
   events: ComponentEvent[];
   typedefs: TypeDef[];
+  generics: null | ComponentGenerics;
   rest_props: RestProps;
   extends?: Extends;
   componentComment?: string;
@@ -128,6 +131,7 @@ export default class ComponentParser {
   private readonly slots: Map<ComponentSlotName, ComponentSlot> = new Map();
   private readonly events: Map<ComponentEventName, ComponentEvent> = new Map();
   private readonly typedefs: Map<TypeDefName, TypeDef> = new Map();
+  private readonly generics: ComponentGenerics = null;
   private readonly bindings: Map<ComponentPropName, ComponentPropBindings> = new Map();
 
   constructor(options?: ComponentParserOptions) {
@@ -311,6 +315,9 @@ export default class ComponentParser {
               ts: /(\}|\};)$/.test(type) ? `interface ${name} ${type}` : `type ${name} = ${type}`,
             });
             break;
+          case "generics":
+            this.generics = [name, type];
+            break;
         }
       });
     });
@@ -329,6 +336,7 @@ export default class ComponentParser {
     this.slots.clear();
     this.events.clear();
     this.typedefs.clear();
+    this.generics = null;
     this.bindings.clear();
   }
 
@@ -732,6 +740,7 @@ export default class ComponentParser {
         }),
       events: ComponentParser.mapToArray(this.events),
       typedefs: ComponentParser.mapToArray(this.typedefs),
+      generics: this.generics,
       rest_props: this.rest_props,
       extends: this.extends,
       componentComment: this.componentComment,

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1141,9 +1141,31 @@ exports[`fixtures (JSON) "typed-props/input.svelte" 1`] = `
 }"
 `;
 
+exports[`fixtures (JSON) "generics/Test.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null
+}"
+`;
+
 exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
 "{
   "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
     {
       "name": "rows",
       "kind": "let",
@@ -1167,9 +1189,19 @@ exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
   "events": [],
   "typedefs": [
     {
-      "type": "Record<string, any>",
+      "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "type DataTableRow = Record<string, any>"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \"id\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: string; }",
+      "name": "DataTableHeader<Row>",
+      "ts": "interface DataTableHeader<Row> { key: DataTableKey<Row>; value: string; }"
     }
   ],
   "generics": [
@@ -1796,12 +1828,36 @@ export default class TypedProps extends SvelteComponentTyped<TypedPropsProps, Re
 "
 `;
 
+exports[`fixtures (TypeScript) "generics/Test.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export interface GenericsProps {}
+
+export default class Generics extends SvelteComponentTyped<GenericsProps, Record<string, any>, {}> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "generics/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type DataTableRow = Record<string, any>;
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row> {
+  key: DataTableKey<Row>;
+  value: string;
+}
 
 export interface GenericsProps<Row> {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
+
   /**
    * @default []
    */
@@ -1813,5 +1869,71 @@ export default class Generics<Row extends DataTableRow = DataTableRow> extends S
   Record<string, any>,
   { default: { rows: ReadonlyArray<Row> } }
 > {}
+"
+`;
+
+exports[`fixtures (TypeScript) "svg-props/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type RestProps = SvelteHTMLElements["svg"];
+
+export interface SvgPropsProps extends RestProps {
+  [key: \`data-${string}\`]: any;
+}
+
+export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, {}> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "rest-props/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type RestProps = SvelteHTMLElements["h1"];
+
+export interface RestPropsProps extends RestProps {
+  [key: \`data-${string}\`]: any;
+}
+
+export default class RestProps extends SvelteComponentTyped<RestPropsProps, Record<string, any>, {}> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "rest-props-multiple/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type RestProps = SvelteHTMLElements["h1"] & SvelteHTMLElements["span"];
+
+export interface RestPropsMultipleProps extends RestProps {
+  /**
+   * @default false
+   */
+  edit?: boolean;
+
+  /**
+   * @default false
+   */
+  heading?: boolean;
+
+  [key: \`data-${string}\`]: any;
+}
+
+export default class RestPropsMultiple extends SvelteComponentTyped<RestPropsMultipleProps, Record<string, any>, {}> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "anchor-props/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type RestProps = SvelteHTMLElements["a"];
+
+export interface AnchorPropsProps extends RestProps {
+  [key: \`data-${string}\`]: any;
+}
+
+export default class AnchorProps extends SvelteComponentTyped<AnchorPropsProps, Record<string, any>, { default: {} }> {}
 "
 `;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -7,6 +7,7 @@ exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "svg"
@@ -57,7 +58,8 @@ exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -73,7 +75,8 @@ exports[`fixtures (JSON) "dispatched-events-dynamic/input.svelte" 1`] = `
       "detail": "{key: string;}"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -129,7 +132,8 @@ exports[`fixtures (JSON) "function-declaration/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -166,7 +170,8 @@ exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
       "element": "h1"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -187,7 +192,8 @@ exports[`fixtures (JSON) "mixed-events/input.svelte" 1`] = `
       "detail": "FocusEvent | CustomEvent<FocusEvent>"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -279,7 +285,8 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -289,7 +296,8 @@ exports[`fixtures (JSON) "empty-export/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -323,7 +331,8 @@ exports[`fixtures (JSON) "typed-slots/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -359,7 +368,8 @@ exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
       "detail": "null"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -409,7 +419,8 @@ exports[`fixtures (JSON) "typedefs/input.svelte" 1`] = `
       "name": "MyTypedefArray",
       "ts": "type MyTypedefArray = MyTypedef[]"
     }
-  ]
+  ],
+  "generics": null
 }"
 `;
 
@@ -436,7 +447,8 @@ exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -464,7 +476,8 @@ exports[`fixtures (JSON) "dispatched-events-typed/input.svelte" 1`] = `
       "detail": "null"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -490,7 +503,8 @@ exports[`fixtures (JSON) "input-events/input.svelte" 1`] = `
       "element": "input"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -550,7 +564,8 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -603,7 +618,8 @@ exports[`fixtures (JSON) "prop-comments/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -626,7 +642,8 @@ exports[`fixtures (JSON) "renamed-props/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -709,7 +726,8 @@ exports[`fixtures (JSON) "infer-with-types/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -811,7 +829,8 @@ exports[`fixtures (JSON) "context-module/input.svelte" 1`] = `
   ],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -822,6 +841,7 @@ exports[`fixtures (JSON) "rest-props/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "h1"
@@ -859,6 +879,7 @@ exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "h1 | span"
@@ -879,6 +900,7 @@ exports[`fixtures (JSON) "component-comment-single/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "componentComment": " Component comment"
 }"
 `;
@@ -927,7 +949,8 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -972,7 +995,8 @@ exports[`fixtures (JSON) "typedef/input.svelte" 1`] = `
       "name": "MyTypedef",
       "ts": "interface MyTypedef { [key: string]: boolean; }"
     }
-  ]
+  ],
+  "generics": null
 }"
 `;
 
@@ -989,6 +1013,7 @@ exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "a"
@@ -1009,6 +1034,7 @@ exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "componentComment": "\n@example\n<div>\n  Component comment\n</div>"
 }"
 `;
@@ -1031,7 +1057,8 @@ exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -1053,7 +1080,8 @@ exports[`fixtures (JSON) "slots-spread-typed/input.svelte" 1`] = `
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }"
 `;
 
@@ -1108,7 +1136,46 @@ exports[`fixtures (JSON) "typed-props/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
+}"
+`;
+
+exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{ rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "Record<string, any>",
+      "name": "DataTableRow",
+      "ts": "type DataTableRow = Record<string, any>"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ]
 }"
 `;
 
@@ -1729,68 +1796,22 @@ export default class TypedProps extends SvelteComponentTyped<TypedPropsProps, Re
 "
 `;
 
-exports[`fixtures (TypeScript) "svg-props/input.svelte" 1`] = `
+exports[`fixtures (TypeScript) "generics/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["svg"];
+export type DataTableRow = Record<string, any>;
 
-export interface SvgPropsProps extends RestProps {
-  [key: \`data-${string}\`]: any;
-}
-
-export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, {}> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "rest-props/input.svelte" 1`] = `
-"import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
-
-type RestProps = SvelteHTMLElements["h1"];
-
-export interface RestPropsProps extends RestProps {
-  [key: \`data-${string}\`]: any;
-}
-
-export default class RestProps extends SvelteComponentTyped<RestPropsProps, Record<string, any>, {}> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "rest-props-multiple/input.svelte" 1`] = `
-"import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
-
-type RestProps = SvelteHTMLElements["h1"] & SvelteHTMLElements["span"];
-
-export interface RestPropsMultipleProps extends RestProps {
+export interface GenericsProps<Row> {
   /**
-   * @default false
+   * @default []
    */
-  edit?: boolean;
-
-  /**
-   * @default false
-   */
-  heading?: boolean;
-
-  [key: \`data-${string}\`]: any;
+  rows?: ReadonlyArray<Row>;
 }
 
-export default class RestPropsMultiple extends SvelteComponentTyped<RestPropsMultipleProps, Record<string, any>, {}> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "anchor-props/input.svelte" 1`] = `
-"import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
-
-type RestProps = SvelteHTMLElements["a"];
-
-export interface AnchorPropsProps extends RestProps {
-  [key: \`data-${string}\`]: any;
-}
-
-export default class AnchorProps extends SvelteComponentTyped<AnchorPropsProps, Record<string, any>, { default: {} }> {}
+export default class Generics<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  GenericsProps<Row>,
+  Record<string, any>,
+  { default: { rows: ReadonlyArray<Row> } }
+> {}
 "
 `;

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -1888,7 +1888,7 @@
           "name": "headers",
           "kind": "let",
           "description": "Specify the data table headers",
-          "type": "DataTableHeader[]",
+          "type": "ReadonlyArray<DataTableHeader<Row>>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -1900,19 +1900,19 @@
           "name": "rows",
           "kind": "let",
           "description": "Specify the rows the data table should render\nkeys defined in `headers` are used for the row ids",
-          "type": "DataTableRow[]",
+          "type": "ReadonlyArray<Row>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
           "constant": false,
-          "reactive": true
+          "reactive": false
         },
         {
           "name": "size",
           "kind": "let",
           "description": "Set the size of the data table",
-          "type": "\"compact\" | \"short\" | \"tall\"",
+          "type": "\"compact\" | \"short\" | \"medium\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -1968,6 +1968,30 @@
           "reactive": false
         },
         {
+          "name": "sortKey",
+          "kind": "let",
+          "description": "Specify the header key to sort by",
+          "type": "DataTableKey",
+          "value": "null",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
+          "name": "sortDirection",
+          "kind": "let",
+          "description": "Specify the sort direction",
+          "type": "\"none\" | \"ascending\" | \"descending\"",
+          "value": "\"none\"",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
           "name": "expandable",
           "kind": "let",
           "description": "Set to `true` for the expandable variant\nAutomatically set to `true` if `batchExpansion` is `true`",
@@ -1995,13 +2019,25 @@
           "name": "expandedRowIds",
           "kind": "let",
           "description": "Specify the row ids to be expanded",
-          "type": "DataTableRowId[]",
+          "type": "ReadonlyArray<DataTableRowId>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
           "constant": false,
           "reactive": true
+        },
+        {
+          "name": "nonExpandableRowIds",
+          "kind": "let",
+          "description": "Specify the ids for rows that should not be expandable",
+          "type": "ReadonlyArray<DataTableRowId>",
+          "value": "[]",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
         },
         {
           "name": "radio",
@@ -2043,7 +2079,7 @@
           "name": "selectedRowIds",
           "kind": "let",
           "description": "Specify the row ids to be selected",
-          "type": "DataTableRowId[]",
+          "type": "ReadonlyArray<DataTableRowId>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -2052,11 +2088,59 @@
           "reactive": true
         },
         {
+          "name": "nonSelectableRowIds",
+          "kind": "let",
+          "description": "Specify the ids of rows that should not be selectable",
+          "type": "ReadonlyArray<DataTableRowId>",
+          "value": "[]",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "stickyHeader",
           "kind": "let",
           "description": "Set to `true` to enable a sticky header",
           "type": "boolean",
           "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "useStaticWidth",
+          "kind": "let",
+          "description": "Set to `true` to use static width",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "pageSize",
+          "kind": "let",
+          "description": "Specify the number of items to display in a page",
+          "type": "number",
+          "value": "0",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "page",
+          "kind": "let",
+          "description": "Set to `number` to set current page",
+          "type": "number",
+          "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -2070,8 +2154,8 @@
         {
           "name": "cell",
           "default": false,
-          "fallback": "{headers[j].display ? headers[j].display(cell.value) : cell.value}",
-          "slot_props": "{ row: DataTableRow; cell: DataTableCell; }"
+          "fallback": "{cell.display ? cell.display(cell.value, row) : cell.value}",
+          "slot_props": "{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }"
         },
         {
           "name": "cell-header",
@@ -2080,17 +2164,28 @@
           "slot_props": "{ header: DataTableNonEmptyHeader; }"
         },
         {
+          "name": "description",
+          "default": false,
+          "fallback": "{description}",
+          "slot_props": "{}"
+        },
+        {
           "name": "expanded-row",
           "default": false,
-          "slot_props": "{ row: DataTableRow; }",
-          "description": "The expanded row"
+          "slot_props": "{ row: Row; }"
+        },
+        {
+          "name": "title",
+          "default": false,
+          "fallback": "{title}",
+          "slot_props": "{}"
         }
       ],
       "events": [
         {
           "type": "dispatched",
           "name": "click",
-          "detail": "{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell; }"
+          "detail": "{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }"
         },
         {
           "type": "dispatched",
@@ -2100,35 +2195,37 @@
         {
           "type": "dispatched",
           "name": "click:header",
-          "detail": "{ header: DataTableHeader; sortDirection: \"ascending\" | \"descending\" | \"none\" }"
-        },
-        { "type": "dispatched", "name": "click:row", "detail": "DataTableRow" },
-        {
-          "type": "dispatched",
-          "name": "mouseenter:row",
-          "detail": "DataTableRow"
+          "detail": "{ header: DataTableHeader<Row>; sortDirection?: \"ascending\" | \"descending\" | \"none\" }"
         },
         {
           "type": "dispatched",
-          "name": "mouseleave:row",
-          "detail": "DataTableRow"
+          "name": "click:header--select",
+          "detail": "{ indeterminate: boolean; selected: boolean; }"
         },
+        { "type": "dispatched", "name": "click:row", "detail": "Row" },
+        { "type": "dispatched", "name": "mouseenter:row", "detail": "Row" },
+        { "type": "dispatched", "name": "mouseleave:row", "detail": "Row" },
         {
           "type": "dispatched",
           "name": "click:row--expand",
-          "detail": "{ expanded: boolean; row: DataTableRow; }"
+          "detail": "{ expanded: boolean; row: Row; }"
+        },
+        {
+          "type": "dispatched",
+          "name": "click:row--select",
+          "detail": "{ selected: boolean; row: Row; }"
         },
         {
           "type": "dispatched",
           "name": "click:cell",
-          "detail": "DataTableCell"
+          "detail": "DataTableCell<Row>"
         }
       ],
       "typedefs": [
         {
-          "type": "string",
-          "name": "DataTableKey",
-          "ts": "type DataTableKey = string"
+          "type": "Omit<keyof Row, \"id\">",
+          "name": "DataTableKey<Row>",
+          "ts": "type DataTableKey<Row> = Omit<keyof Row, \"id\">"
         },
         {
           "type": "any",
@@ -2136,19 +2233,19 @@
           "ts": "type DataTableValue = any"
         },
         {
-          "type": "{ key: DataTableKey; empty: boolean; display?: (item: Value) => DataTableValue; sort?: (a: DataTableValue, b: DataTableValue) => (0 | -1 | 1); columnMenu?: boolean; }",
-          "name": "DataTableEmptyHeader",
-          "ts": "interface DataTableEmptyHeader { key: DataTableKey; empty: boolean; display?: (item: Value) => DataTableValue; sort?: (a: DataTableValue, b: DataTableValue) => (0 | -1 | 1); columnMenu?: boolean; }"
+          "type": "{ key: DataTableKey<Row>; empty: boolean; display?: (item: Value, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
+          "name": "DataTableEmptyHeader<Row>",
+          "ts": "interface DataTableEmptyHeader<Row> { key: DataTableKey<Row>; empty: boolean; display?: (item: Value, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
         },
         {
-          "type": "{ key: DataTableKey; value: DataTableValue; display?: (item: Value) => DataTableValue; sort?: (a: DataTableValue, b: DataTableValue) => (0 | -1 | 1); columnMenu?: boolean; }",
-          "name": "DataTableNonEmptyHeader",
-          "ts": "interface DataTableNonEmptyHeader { key: DataTableKey; value: DataTableValue; display?: (item: Value) => DataTableValue; sort?: (a: DataTableValue, b: DataTableValue) => (0 | -1 | 1); columnMenu?: boolean; }"
+          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: Value, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
+          "name": "DataTableNonEmptyHeader<Row>",
+          "ts": "interface DataTableNonEmptyHeader<Row> { key: DataTableKey<Row>; value: DataTableValue; display?: (item: Value, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
         },
         {
-          "type": "DataTableNonEmptyHeader | DataTableEmptyHeader",
-          "name": "DataTableHeader",
-          "ts": "type DataTableHeader = DataTableNonEmptyHeader | DataTableEmptyHeader"
+          "type": "DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>",
+          "name": "DataTableHeader<Row>",
+          "ts": "type DataTableHeader<Row> = DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>"
         },
         {
           "type": "{ id: any; [key: string]: DataTableValue; }",
@@ -2156,18 +2253,18 @@
           "ts": "interface DataTableRow { id: any; [key: string]: DataTableValue; }"
         },
         {
-          "type": "string",
+          "type": "any",
           "name": "DataTableRowId",
-          "ts": "type DataTableRowId = string"
+          "ts": "type DataTableRowId = any"
         },
         {
-          "type": "{ key: DataTableKey; value: DataTableValue; }",
+          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: Value, row: DataTableRow) => DataTableValue; }",
           "name": "DataTableCell",
-          "ts": "interface DataTableCell { key: DataTableKey; value: DataTableValue; }"
+          "ts": "interface DataTableCell { key: DataTableKey<Row>; value: DataTableValue; display?: (item: Value, row: DataTableRow) => DataTableValue; }"
         }
       ],
-      "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "TableContainer" }
+      "generics": ["Row", "Row extends DataTableRow = DataTableRow"],
+      "rest_props": { "type": "Element", "name": "div" }
     },
     {
       "moduleName": "DataTableSkeleton",

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -78,6 +78,7 @@
         }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "AccordionSkeleton" },
       "extends": {
         "interface": "AccordionSkeletonProps",
@@ -157,6 +158,7 @@
         { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "li" },
       "componentComment": " `AccordionItem` is slottable"
     },
@@ -221,6 +223,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "ul" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "ul" }
     },
     {
@@ -244,6 +247,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -300,6 +304,7 @@
         }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "BreadcrumbSkeleton" },
       "extends": {
         "interface": "BreadcrumbSkeletonProps",
@@ -349,6 +354,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "li" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "li" }
     },
     {
@@ -389,6 +395,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -588,6 +595,7 @@
         }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button | a | div" },
       "extends": {
         "interface": "ButtonSkeletonProps",
@@ -615,6 +623,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -666,6 +675,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "a" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -838,6 +848,7 @@
         { "type": "forwarded", "name": "change", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "CheckboxSkeleton" }
     },
     {
@@ -853,6 +864,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -905,6 +917,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "a" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -1146,6 +1159,7 @@
         { "type": "forwarded", "name": "animationend", "element": "CopyButton" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "CodeSnippetSkeleton" }
     },
     {
@@ -1174,6 +1188,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -1333,6 +1348,7 @@
           "ts": "type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -1586,6 +1602,7 @@
           "ts": "interface ComboBoxItem { id: string; text: string; }"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -1689,6 +1706,7 @@
         { "type": "dispatched", "name": "open", "detail": "null" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -1712,6 +1730,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "main" }
     },
     {
@@ -1769,6 +1788,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -1826,6 +1846,7 @@
         { "type": "forwarded", "name": "animationend", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -1852,6 +1873,7 @@
         { "type": "forwarded", "name": "animationend", "element": "Copy" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Copy" },
       "extends": {
         "interface": "CopyProps",
@@ -2144,6 +2166,7 @@
           "ts": "interface DataTableCell { key: DataTableKey; value: DataTableValue; }"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "TableContainer" }
     },
     {
@@ -2243,6 +2266,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "table" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" },
       "extends": {
         "interface": "DataTableHeader",
@@ -2383,6 +2407,7 @@
         { "type": "dispatched", "name": "change" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -2552,6 +2577,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -2592,6 +2618,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -2861,6 +2888,7 @@
           "ts": "interface DropdownItem { id: DropdownItemId; text: DropdownItemText; }"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -2889,6 +2917,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -3041,6 +3070,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -3197,6 +3227,7 @@
         { "type": "forwarded", "name": "keydown", "element": "Filename" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -3344,6 +3375,7 @@
         { "type": "forwarded", "name": "click", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "input" }
     },
     {
@@ -3483,6 +3515,7 @@
         { "type": "forwarded", "name": "click", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -3583,6 +3616,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "span" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "span" }
     },
     {
@@ -3598,6 +3632,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -3648,6 +3683,7 @@
         { "type": "forwarded", "name": "keydown", "element": "Close16" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Loading" }
     },
     {
@@ -3658,6 +3694,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "submit", "element": "Form" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Form" }
     },
     {
@@ -3674,6 +3711,7 @@
         { "type": "forwarded", "name": "submit", "element": "form" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "form" }
     },
     {
@@ -3738,6 +3776,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "fieldset" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "fieldset" }
     },
     {
@@ -3753,6 +3792,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -3781,6 +3821,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "label" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "label" }
     },
     {
@@ -3894,6 +3935,7 @@
       ],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -4007,6 +4049,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -4093,6 +4136,7 @@
           "ts": "interface HeaderActionSlideTransition { delay?: number; duration?: number; easing?: (t: number) => number; }"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -4150,6 +4194,7 @@
       "slots": [],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -4184,7 +4229,8 @@
           "detail": "null"
         }
       ],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "HeaderGlobalAction",
@@ -4237,6 +4283,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -4259,6 +4306,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "nav" }
     },
     {
@@ -4313,6 +4361,7 @@
         { "type": "forwarded", "name": "blur", "element": "a" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -4392,6 +4441,7 @@
         { "type": "forwarded", "name": "blur", "element": "a" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -4401,7 +4451,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "HeaderPanelLink",
@@ -4435,6 +4486,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -4444,7 +4496,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "HeaderSearch",
@@ -4542,6 +4595,7 @@
           "ts": "interface HeaderSearchResult { href: string; text: string; description?: string; }"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "input" }
     },
     {
@@ -4551,7 +4605,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "Icon",
@@ -4594,6 +4649,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "IconSkeleton" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "svg" },
       "extends": {
         "interface": "IconSkeletonProps",
@@ -4626,6 +4682,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -4689,6 +4746,7 @@
         { "type": "dispatched", "name": "success", "detail": "null" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -4809,6 +4867,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -4895,6 +4954,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "p" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a | p" }
     },
     {
@@ -5016,6 +5076,7 @@
         { "type": "forwarded", "name": "click", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5124,6 +5185,7 @@
           "ts": "type ListBoxFieldTranslationId = \"close\" | \"open\""
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5159,6 +5221,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "scroll", "element": "div" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5212,6 +5275,7 @@
           "ts": "type ListBoxMenuIconTranslationId = \"close\" | \"open\""
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5251,6 +5315,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5327,6 +5392,7 @@
           "ts": "type ListBoxSelectionTranslationId = \"clearAll\" | \"clearSelection\""
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5342,6 +5408,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "li" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "li" }
     },
     {
@@ -5413,6 +5480,7 @@
       "slots": [],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5676,6 +5744,7 @@
         { "type": "dispatched", "name": "open", "detail": "null" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5711,6 +5780,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5792,6 +5862,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -5887,6 +5958,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -6229,6 +6301,7 @@
           "ts": "interface MultiSelectItem { id: MultiSelectItemId; text: MultiSelectItemText; }"
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -6244,6 +6317,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "Button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Button" }
     },
     {
@@ -6306,6 +6380,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -6352,7 +6427,8 @@
       "moduleExports": [],
       "slots": [],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "NotificationTextDetails",
@@ -6410,7 +6486,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "NumberInput",
@@ -6713,6 +6790,7 @@
           "ts": "type NumberInputTranslationId = \"increment\" | \"decrement\""
         }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -6741,6 +6819,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -6781,6 +6860,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "ol" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "ol" }
     },
     {
@@ -6796,6 +6876,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "Link" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Link" },
       "extends": { "interface": "LinkProps", "import": "\"./Link.svelte\"" }
     },
@@ -6967,6 +7048,7 @@
         { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -7096,6 +7178,7 @@
         { "type": "forwarded", "name": "keydown", "element": "a" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "li" }
     },
     {
@@ -7305,6 +7388,7 @@
         }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -7404,6 +7488,7 @@
         }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "nav" }
     },
     {
@@ -7419,6 +7504,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -7654,6 +7740,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "input" }
     },
     {
@@ -7719,6 +7806,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "ul" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "ul" }
     },
     {
@@ -7759,6 +7847,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "ul" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "ul" }
     },
     {
@@ -7879,6 +7968,7 @@
         { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "li" }
     },
     {
@@ -7998,6 +8088,7 @@
       "slots": [],
       "events": [{ "type": "forwarded", "name": "change", "element": "input" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8073,6 +8164,7 @@
         { "type": "dispatched", "name": "change" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8088,6 +8180,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8190,6 +8283,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "label" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "label" }
     },
     {
@@ -8291,6 +8385,7 @@
       ],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8493,6 +8588,7 @@
         { "type": "dispatched", "name": "clear", "detail": "null" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "SearchSkeleton" }
     },
     {
@@ -8533,6 +8629,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8712,6 +8809,7 @@
         { "type": "forwarded", "name": "blur", "element": "select" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8770,7 +8868,8 @@
       "moduleExports": [],
       "slots": [],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "SelectItemGroup",
@@ -8805,6 +8904,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "optgroup" }
     },
     {
@@ -8833,6 +8933,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -8958,6 +9059,7 @@
         { "type": "forwarded", "name": "keydown", "element": "label" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "label" }
     },
     {
@@ -9004,6 +9106,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "nav" }
     },
     {
@@ -9013,7 +9116,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "SideNavLink",
@@ -9081,6 +9185,7 @@
       "slots": [],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -9138,6 +9243,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -9194,6 +9300,7 @@
       "slots": [],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -9209,6 +9316,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9273,6 +9381,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9315,6 +9424,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -9536,6 +9646,7 @@
         { "type": "dispatched", "name": "change" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9564,6 +9675,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9616,6 +9728,7 @@
         { "type": "dispatched", "name": "change" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9631,6 +9744,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9671,6 +9785,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9686,6 +9801,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9769,6 +9885,7 @@
       "slots": [],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "input" }
     },
     {
@@ -9822,6 +9939,7 @@
         { "type": "forwarded", "name": "keydown", "element": "label" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "label" }
     },
     {
@@ -9862,6 +9980,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -9946,6 +10065,7 @@
         { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -10041,6 +10161,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "li" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "li" }
     },
     {
@@ -10064,6 +10185,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -10146,6 +10268,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "section" }
     },
     {
@@ -10156,6 +10279,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "tbody" }
     },
     {
@@ -10171,6 +10295,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "td" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "td" }
     },
     {
@@ -10218,6 +10343,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -10233,6 +10359,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "thead" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "thead" }
     },
     {
@@ -10285,6 +10412,7 @@
         { "type": "forwarded", "name": "click", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "th" }
     },
     {
@@ -10300,6 +10428,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "tr" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "tr" }
     },
     {
@@ -10366,6 +10495,7 @@
         { "type": "dispatched", "name": "change" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -10394,6 +10524,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -10499,6 +10630,7 @@
         { "type": "dispatched", "name": "close", "detail": "null" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div | span" }
     },
     {
@@ -10514,6 +10646,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "span" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "span" }
     },
     {
@@ -10701,6 +10834,7 @@
         { "type": "forwarded", "name": "blur", "element": "textarea" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "textarea" }
     },
     {
@@ -10729,6 +10863,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -10964,6 +11099,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "input" }
     },
     {
@@ -10992,6 +11128,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11020,6 +11157,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11066,6 +11204,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [{ "type": "dispatched", "name": "select" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "fieldset" }
     },
     {
@@ -11264,6 +11403,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11375,6 +11515,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11504,6 +11645,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11624,6 +11766,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11676,6 +11819,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11779,6 +11923,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11819,6 +11964,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11842,6 +11988,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "section" }
     },
     {
@@ -11865,6 +12012,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -11874,7 +12022,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "ToolbarMenu",
@@ -11884,6 +12033,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "OverflowMenu" },
       "extends": {
         "interface": "OverflowMenuProps",
@@ -11905,6 +12055,7 @@
         }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "OverflowMenuItem" },
       "extends": {
         "interface": "OverflowMenuItemProps",
@@ -11985,6 +12136,7 @@
         { "type": "forwarded", "name": "blur", "element": "Search" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Search" }
     },
     {
@@ -12180,6 +12332,7 @@
         { "type": "forwarded", "name": "mousedown", "element": "div" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -12265,6 +12418,7 @@
         { "type": "forwarded", "name": "focus", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "div" }
     },
     {
@@ -12350,6 +12504,7 @@
         { "type": "forwarded", "name": "focus", "element": "button" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -12378,6 +12533,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "ul" }
       ],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "ul" }
     }
   ]

--- a/tests/e2e/carbon/COMPONENT_INDEX.md
+++ b/tests/e2e/carbon/COMPONENT_INDEX.md
@@ -762,82 +762,100 @@ None.
 ### Types
 
 ```ts
-export type DataTableKey = string;
+export type DataTableKey<Row> = Omit<keyof Row, "id">;
 
 export type DataTableValue = any;
 
-export interface DataTableEmptyHeader {
-  key: DataTableKey;
+export interface DataTableEmptyHeader<Row> {
+  key: DataTableKey<Row>;
   empty: boolean;
-  display?: (item: Value) => DataTableValue;
-  sort?: (a: DataTableValue, b: DataTableValue) => 0 | -1 | 1;
+  display?: (item: Value, row: Row) => DataTableValue;
+  sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
+  width?: string;
+  minWidth?: string;
 }
 
-export interface DataTableNonEmptyHeader {
-  key: DataTableKey;
+export interface DataTableNonEmptyHeader<Row> {
+  key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: Value) => DataTableValue;
-  sort?: (a: DataTableValue, b: DataTableValue) => 0 | -1 | 1;
+  display?: (item: Value, row: Row) => DataTableValue;
+  sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
+  width?: string;
+  minWidth?: string;
 }
 
-export type DataTableHeader = DataTableNonEmptyHeader | DataTableEmptyHeader;
+export type DataTableHeader<Row> =
+  | DataTableNonEmptyHeader<Row>
+  | DataTableEmptyHeader<Row>;
 
 export interface DataTableRow {
   id: any;
   [key: string]: DataTableValue;
 }
 
-export type DataTableRowId = string;
+export type DataTableRowId = any;
 
 export interface DataTableCell {
-  key: DataTableKey;
+  key: DataTableKey<Row>;
   value: DataTableValue;
+  display?: (item: Value, row: DataTableRow) => DataTableValue;
 }
 ```
 
 ### Props
 
-| Prop name      | Required | Kind             | Reactive | Type                                                | Default value          | Description                                                                                                         |
-| :------------- | :------- | :--------------- | :------- | --------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| selectedRowIds | No       | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
-| selectable     | No       | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
-| expandedRowIds | No       | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                       | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
-| expandable     | No       | <code>let</code> | Yes      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
-| rows           | No       | <code>let</code> | Yes      | <code>DataTableRow[]</code>                         | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
-| headers        | No       | <code>let</code> | No       | <code>DataTableHeader[]</code>                      | <code>[]</code>        | Specify the data table headers                                                                                      |
-| size           | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
-| title          | No       | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
-| description    | No       | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the description of the data table                                                                           |
-| zebra          | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
-| sortable       | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
-| batchExpansion | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
-| radio          | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
-| batchSelection | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
-| stickyHeader   | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
+| Prop name           | Required | Kind             | Reactive | Type                                                                | Default value          | Description                                                                                                         |
+| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| selectedRowIds      | No       | <code>let</code> | Yes      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
+| selectable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
+| expandedRowIds      | No       | <code>let</code> | Yes      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
+| expandable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
+| sortDirection       | No       | <code>let</code> | Yes      | <code>"none" &#124; "ascending" &#124; "descending"</code>          | <code>"none"</code>    | Specify the sort direction                                                                                          |
+| sortKey             | No       | <code>let</code> | Yes      | <code>DataTableKey</code>                                           | <code>null</code>      | Specify the header key to sort by                                                                                   |
+| headers             | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableHeader<Row>></code>                    | <code>[]</code>        | Specify the data table headers                                                                                      |
+| rows                | No       | <code>let</code> | No       | <code>ReadonlyArray<Row></code>                                     | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
+| size                | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
+| title               | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
+| description         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the description of the data table                                                                           |
+| zebra               | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
+| sortable            | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
+| batchExpansion      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
+| nonExpandableRowIds | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the ids for rows that should not be expandable                                                              |
+| radio               | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
+| batchSelection      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
+| nonSelectableRowIds | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the ids of rows that should not be selectable                                                               |
+| stickyHeader        | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
+| useStaticWidth      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width                                                                                   |
+| pageSize            | No       | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Specify the number of items to display in a page                                                                    |
+| page                | No       | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Set to `number` to set current page                                                                                 |
 
 ### Slots
 
-| Slot name    | Default | Props                                                     | Fallback                                                                        |
-| :----------- | :------ | :-------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| --           | Yes     | --                                                        | --                                                                              |
-| cell         | No      | <code>{ row: DataTableRow; cell: DataTableCell; } </code> | <code>{headers[j].display ? headers[j].display(cell.value) : cell.value}</code> |
-| cell-header  | No      | <code>{ header: DataTableNonEmptyHeader; } </code>        | <code>{header.value}</code>                                                     |
-| expanded-row | No      | <code>{ row: DataTableRow; } </code>                      | --                                                                              |
+| Slot name    | Default | Props                                                                                      | Fallback                                                                 |
+| :----------- | :------ | :----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
+| --           | Yes     | --                                                                                         | --                                                                       |
+| cell         | No      | <code>{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; } </code> | <code>{cell.display ? cell.display(cell.value, row) : cell.value}</code> |
+| cell-header  | No      | <code>{ header: DataTableNonEmptyHeader; } </code>                                         | <code>{header.value}</code>                                              |
+| description  | No      | --                                                                                         | <code>{description}</code>                                               |
+| expanded-row | No      | <code>{ row: Row; } </code>                                                                | --                                                                       |
+| title        | No      | --                                                                                         | <code>{title}</code>                                                     |
 
 ### Events
 
-| Event name           | Type       | Detail                                                                                                 |
-| :------------------- | :--------- | :----------------------------------------------------------------------------------------------------- |
-| click                | dispatched | <code>{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell; }</code>                   |
-| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                    |
-| click:header         | dispatched | <code>{ header: DataTableHeader; sortDirection: "ascending" &#124; "descending" &#124; "none" }</code> |
-| click:row            | dispatched | <code>DataTableRow</code>                                                                              |
-| mouseenter:row       | dispatched | <code>DataTableRow</code>                                                                              |
-| mouseleave:row       | dispatched | <code>DataTableRow</code>                                                                              |
-| click:row--expand    | dispatched | <code>{ expanded: boolean; row: DataTableRow; }</code>                                                 |
-| click:cell           | dispatched | <code>DataTableCell</code>                                                                             |
+| Event name           | Type       | Detail                                                                                                       |
+| :------------------- | :--------- | :----------------------------------------------------------------------------------------------------------- |
+| click                | dispatched | <code>{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }</code>                        |
+| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                          |
+| click:header         | dispatched | <code>{ header: DataTableHeader<Row>; sortDirection?: "ascending" &#124; "descending" &#124; "none" }</code> |
+| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                                  |
+| click:row            | dispatched | <code>Row</code>                                                                                             |
+| mouseenter:row       | dispatched | <code>Row</code>                                                                                             |
+| mouseleave:row       | dispatched | <code>Row</code>                                                                                             |
+| click:row--expand    | dispatched | <code>{ expanded: boolean; row: Row; }</code>                                                                |
+| click:row--select    | dispatched | <code>{ selected: boolean; row: Row; }</code>                                                                |
+| click:cell           | dispatched | <code>DataTableCell<Row></code>                                                                              |
 
 ## `DataTableSkeleton`
 

--- a/tests/e2e/carbon/package.json
+++ b/tests/e2e/carbon/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/index.mjs",
   "types": "./types/index.d.ts",
   "scripts": {
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "dependencies": {

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -74,6 +74,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     }
   ]

--- a/tests/e2e/glob/package.json
+++ b/tests/e2e/glob/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/index.mjs",
   "types": "./types/index.d.ts",
   "scripts": {
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/e2e/multi-export-typed-ts-only/package.json
+++ b/tests/e2e/multi-export-typed-ts-only/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/index.mjs",
   "types": "./types/index.d.ts",
   "scripts": {
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -40,6 +40,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -57,6 +58,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -97,6 +99,7 @@
       ],
       "events": [],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "blockquote" }
     },
     {
@@ -126,6 +129,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "Button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Button" },
       "extends": { "interface": "ButtonProps", "import": "\"./Button.svelte\"" }
     }

--- a/tests/e2e/multi-export-typed/package.json
+++ b/tests/e2e/multi-export-typed/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/index.mjs",
   "types": "./types/index.d.ts",
   "scripts": {
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -50,6 +50,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -59,7 +60,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "Link",
@@ -76,6 +78,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -118,6 +121,7 @@
       "typedefs": [
         { "type": "string", "name": "Author", "ts": "type Author = string" }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "blockquote" }
     }
   ]

--- a/tests/e2e/multi-export/package.json
+++ b/tests/e2e/multi-export/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/index.mjs",
   "types": "./types/index.d.ts",
   "scripts": {
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -40,6 +40,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
@@ -49,7 +50,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "Header",
@@ -58,7 +60,8 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "generics": null
     },
     {
       "moduleName": "Link",
@@ -75,6 +78,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "a" }
     },
     {
@@ -117,6 +121,7 @@
       "typedefs": [
         { "type": "string", "name": "Author", "ts": "type Author = string" }
       ],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "blockquote" }
     }
   ]

--- a/tests/e2e/multi-folders/package.json
+++ b/tests/e2e/multi-folders/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/index.mjs",
   "types": "./types/index.d.ts",
   "scripts": {
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -39,6 +39,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     }
   ]

--- a/tests/e2e/single-export-default-only/package.json
+++ b/tests/e2e/single-export-default-only/package.json
@@ -7,7 +7,7 @@
   "types": "./types/index.d.ts",
   "scripts": {
     "sveld": "node ../../cli",
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -39,6 +39,7 @@
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
+      "generics": null,
       "rest_props": { "type": "Element", "name": "button" }
     }
   ]

--- a/tests/e2e/single-export/package.json
+++ b/tests/e2e/single-export/package.json
@@ -7,7 +7,7 @@
   "types": "./types/index.d.ts",
   "scripts": {
     "sveld": "node ../../cli",
-    "svelte-check": "svelte-check --workspace test/*",
+    "svelte-check": "svelte-check --workspace test",
     "build": "rollup -c"
   },
   "devDependencies": {

--- a/tests/fixtures/anchor-props/output.json
+++ b/tests/fixtures/anchor-props/output.json
@@ -10,6 +10,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "a"

--- a/tests/fixtures/bind-this-multiple/output.json
+++ b/tests/fixtures/bind-this-multiple/output.json
@@ -41,5 +41,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/bind-this/output.json
+++ b/tests/fixtures/bind-this/output.json
@@ -20,5 +20,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/component-comment-multi/output.json
+++ b/tests/fixtures/component-comment-multi/output.json
@@ -10,5 +10,6 @@
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "componentComment": "\n@example\n<div>\n  Component comment\n</div>"
 }

--- a/tests/fixtures/component-comment-single/output.json
+++ b/tests/fixtures/component-comment-single/output.json
@@ -10,5 +10,6 @@
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "componentComment": " Component comment"
 }

--- a/tests/fixtures/context-module/output.json
+++ b/tests/fixtures/context-module/output.json
@@ -95,5 +95,6 @@
   ],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/dispatched-events-dynamic/output.json
+++ b/tests/fixtures/dispatched-events-dynamic/output.json
@@ -9,5 +9,6 @@
       "detail": "{key: string;}"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/dispatched-events-typed/output.json
+++ b/tests/fixtures/dispatched-events-typed/output.json
@@ -21,5 +21,6 @@
       "detail": "null"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -29,5 +29,6 @@
       "detail": "null"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/empty-export/output.json
+++ b/tests/fixtures/empty-export/output.json
@@ -3,5 +3,6 @@
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/forwarded-events/output.json
+++ b/tests/fixtures/forwarded-events/output.json
@@ -30,5 +30,6 @@
       "element": "h1"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/function-declaration/output.json
+++ b/tests/fixtures/function-declaration/output.json
@@ -49,5 +49,6 @@
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/generics/Test.svelte
+++ b/tests/fixtures/generics/Test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Generics from "./output";
+</script>
+
+<Generics
+  headers={[
+    {
+      key: "name",
+      value: "Name",
+    },
+    {
+      key: "port",
+      value: "Port",
+    },
+  ]}
+  rows={[
+    { id: 1, name: "Name 1", port: 3000 },
+    { id: 2, name: "Name 2", port: 3000 },
+    { id: 3, name: "Name 3", port: 3000 },
+  ]}
+  let:rows
+>
+  {#each rows as row}
+    {row.name}
+  {/each}
+</Generics>

--- a/tests/fixtures/generics/input.svelte
+++ b/tests/fixtures/generics/input.svelte
@@ -1,0 +1,17 @@
+<script>
+  /**
+   * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
+   * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
+   * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row>
+   * @template {DataTableRow} Row
+   * @generics {Row extends DataTableRow = DataTableRow} Row
+   */
+
+  /** @type {ReadonlyArray<DataTableHeader<Row>>} */
+   export let headers = [];
+
+  /** @type {ReadonlyArray<Row>} */
+  export let rows = [];
+</script>
+
+<slot {rows} />

--- a/tests/fixtures/generics/output.d.ts
+++ b/tests/fixtures/generics/output.d.ts
@@ -1,0 +1,31 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row> {
+  key: DataTableKey<Row>;
+  value: string;
+}
+
+export interface GenericsProps<Row> {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+}
+
+export default class Generics<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  GenericsProps<Row>,
+  Record<string, any>,
+  { default: { rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/generics/output.json
+++ b/tests/fixtures/generics/output.json
@@ -1,0 +1,56 @@
+{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "__default__",
+      "default": true,
+      "slot_props": "{ rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \"id\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: string; }",
+      "name": "DataTableHeader<Row>",
+      "ts": "interface DataTableHeader<Row> { key: DataTableKey<Row>; value: string; }"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ]
+}

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -85,5 +85,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/infer-with-types/output.json
+++ b/tests/fixtures/infer-with-types/output.json
@@ -76,5 +76,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/input-events/output.json
+++ b/tests/fixtures/input-events/output.json
@@ -19,5 +19,6 @@
       "element": "input"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/mixed-events/output.json
+++ b/tests/fixtures/mixed-events/output.json
@@ -14,5 +14,6 @@
       "detail": "FocusEvent | CustomEvent<FocusEvent>"
     }
   ],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -46,5 +46,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/renamed-props/output.json
+++ b/tests/fixtures/renamed-props/output.json
@@ -16,5 +16,6 @@
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/required/output.json
+++ b/tests/fixtures/required/output.json
@@ -53,5 +53,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/rest-props-multiple/output.json
+++ b/tests/fixtures/rest-props-multiple/output.json
@@ -27,6 +27,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "h1 | span"

--- a/tests/fixtures/rest-props/output.json
+++ b/tests/fixtures/rest-props/output.json
@@ -4,6 +4,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "h1"

--- a/tests/fixtures/slots-named/output.json
+++ b/tests/fixtures/slots-named/output.json
@@ -40,5 +40,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/slots-spread-typed/output.json
+++ b/tests/fixtures/slots-spread-typed/output.json
@@ -15,5 +15,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/slots-spread/output.json
+++ b/tests/fixtures/slots-spread/output.json
@@ -15,5 +15,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/svg-props/output.json
+++ b/tests/fixtures/svg-props/output.json
@@ -4,6 +4,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "generics": null,
   "rest_props": {
     "type": "Element",
     "name": "svg"

--- a/tests/fixtures/typed-props/output.json
+++ b/tests/fixtures/typed-props/output.json
@@ -48,5 +48,6 @@
   "moduleExports": [],
   "slots": [],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/typed-slots/output.json
+++ b/tests/fixtures/typed-slots/output.json
@@ -27,5 +27,6 @@
     }
   ],
   "events": [],
-  "typedefs": []
+  "typedefs": [],
+  "generics": null
 }

--- a/tests/fixtures/typedef/output.json
+++ b/tests/fixtures/typedef/output.json
@@ -38,5 +38,6 @@
       "name": "MyTypedef",
       "ts": "interface MyTypedef { [key: string]: boolean; }"
     }
-  ]
+  ],
+  "generics": null
 }

--- a/tests/fixtures/typedefs/output.json
+++ b/tests/fixtures/typedefs/output.json
@@ -43,5 +43,6 @@
       "name": "MyTypedefArray",
       "ts": "type MyTypedefArray = MyTypedef[]"
     }
-  ]
+  ],
+  "generics": null
 }

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -98,6 +98,7 @@ describe("writerTsDefinition", () => {
       ],
       events: [],
       typedefs: [],
+      generics: null,
       rest_props: undefined,
     };
 
@@ -119,6 +120,7 @@ describe("writerTsDefinition", () => {
       slots: [],
       events: [],
       typedefs: [],
+      generics: null,
       rest_props: undefined,
     };
 


### PR DESCRIPTION
Currently, to define generics for a Svelte component, you must use [`generics` attribute](https://github.com/dummdidumm/rfcs/blob/bfb14dc56a70ec6ddafebf2242b8e1500e06a032/text/ts-typing-props-slots-events.md#generics) on the script tag. Note that this feature is [experimental](https://svelte.dev/docs/typescript#experimental-advanced-typings) and may change in the future.

However, the `generics` attribute only works if using `lang="ts"`; the language server will produce an error if `generics` is used without specifying `lang="ts"`.

```svelte
<!-- This causes an error because `lang="ts"` must be used. -->
<script generics="Row extends DataTableRow = any"></script>
```

Because `sveld` is designed to support JavaScript-only usage as a baseline, the API design to specify generics uses a custom JSDoc tag `@generics`.

Signature:

```js
/**
 * @generics {GenericParameter} GenericName
 */
```

Example

```js
/**
 * @generics {Row extends DataTableRow = any} Row
 */
```

The generated TypeScript definition will resemble the following:

```ts
export default class Component<Row extends DataTableRow = any> extends SvelteComponentTyped<
  ComponentProps<Row>,
  Record<string, any>,
  Record<string, any>
> {}
```