### PR TITLE
refactor(tests): use `find` instead of Glob API

### DIFF
--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -2223,9 +2223,9 @@
       ],
       "typedefs": [
         {
-          "type": "Omit<keyof Row, \"id\">",
+          "type": "Exclude<keyof Row, \"id\">",
           "name": "DataTableKey<Row>",
-          "ts": "type DataTableKey<Row> = Omit<keyof Row, \"id\">"
+          "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">"
         },
         {
           "type": "any",

--- a/tests/e2e/carbon/COMPONENT_INDEX.md
+++ b/tests/e2e/carbon/COMPONENT_INDEX.md
@@ -762,7 +762,7 @@ None.
 ### Types
 
 ```ts
-export type DataTableKey<Row> = Omit<keyof Row, "id">;
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
 
 export type DataTableValue = any;
 

--- a/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type DataTableKey<Row> = Omit<keyof Row, "id">;
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
 
 export type DataTableValue = any;
 

--- a/tests/test-e2e.ts
+++ b/tests/test-e2e.ts
@@ -1,15 +1,9 @@
-import { Glob, $ } from "bun";
+import { $ } from "bun";
 import { name } from "../package.json";
 
 await $`bun link`;
 
-const dirs = new Glob("*").scanSync({
-  cwd: "tests/e2e",
-  onlyFiles: false,
-  absolute: true,
-});
-
-for await (const dir of dirs) {
+for await (const dir of $`find tests/e2e -maxdepth 1`.lines()) {
   await $`cd ${dir} && rm -rf types`;
   await $`cd ${dir} && bun link ${name}`;
   await $`cd ${dir} && bun install`;


### PR DESCRIPTION
The script that executes the `e2e` tests can be refactored to use Shell instead of Glob.

```sh
find tests/e2e -maxdepth 1

tests/e2e
tests/e2e/single-export
tests/e2e/multi-export-typed
tests/e2e/carbon
tests/e2e/multi-export
tests/e2e/multi-folders
tests/e2e/single-export-default-only
tests/e2e/glob
tests/e2e/multi-export-typed-ts-only
```