### PR TITLE
test(fixtures): fix `generics-multiple` example

### DIFF
--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -111,13 +111,13 @@ exports[`fixtures (JSON) "generics-multiple/input.svelte" 1`] = `
     },
     {
       "type": "{ key: DataTableKey<Row>; value: Header; }",
-      "name": "DataTableHeader<Row=DataTableRow,Header>",
-      "ts": "interface DataTableHeader<Row=DataTableRow,Header> { key: DataTableKey<Row>; value: Header; }"
+      "name": "DataTableHeader<Row=DataTableRow,Header=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow,Header=DataTableRow> { key: DataTableKey<Row>; value: Header; }"
     }
   ],
   "generics": [
     "Row,Header",
-    "Row extends DataTableRow = DataTableRow, Header extends DataTableRow"
+    "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
   ]
 }"
 `;
@@ -1301,7 +1301,7 @@ export interface DataTableRow {
 
 export type DataTableKey<Row> = Exclude<keyof Row, "id">;
 
-export interface DataTableHeader<Row = DataTableRow, Header> {
+export interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> {
   key: DataTableKey<Row>;
   value: Header;
 }
@@ -1320,7 +1320,7 @@ export interface GenericsMultipleProps<Row, Header> {
 
 export default class GenericsMultiple<
   Row extends DataTableRow = DataTableRow,
-  Header extends DataTableRow
+  Header extends DataTableRow = DataTableRow
 > extends SvelteComponentTyped<
   GenericsMultipleProps<Row, Header>,
   Record<string, any>,

--- a/tests/fixtures/generics-multiple/input.svelte
+++ b/tests/fixtures/generics-multiple/input.svelte
@@ -2,9 +2,9 @@
   /**
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
-   * @typedef {{ key: DataTableKey<Row>; value: Header; }} DataTableHeader<Row=DataTableRow,Header>
+   * @typedef {{ key: DataTableKey<Row>; value: Header; }} DataTableHeader<Row=DataTableRow,Header=DataTableRow>
    * @template {DataTableRow} <Row extends DataTableRow = DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow, Header extends DataTableRow} Row,Header
+   * @generics {Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow} Row,Header
    */
 
   /** @type {ReadonlyArray<DataTableHeader<Row, Header>>} */

--- a/tests/fixtures/generics-multiple/output.d.ts
+++ b/tests/fixtures/generics-multiple/output.d.ts
@@ -7,7 +7,7 @@ export interface DataTableRow {
 
 export type DataTableKey<Row> = Exclude<keyof Row, "id">;
 
-export interface DataTableHeader<Row = DataTableRow, Header> {
+export interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> {
   key: DataTableKey<Row>;
   value: Header;
 }
@@ -26,7 +26,7 @@ export interface GenericsMultipleProps<Row, Header> {
 
 export default class GenericsMultiple<
   Row extends DataTableRow = DataTableRow,
-  Header extends DataTableRow
+  Header extends DataTableRow = DataTableRow
 > extends SvelteComponentTyped<
   GenericsMultipleProps<Row, Header>,
   Record<string, any>,

--- a/tests/fixtures/generics-multiple/output.json
+++ b/tests/fixtures/generics-multiple/output.json
@@ -45,12 +45,12 @@
     },
     {
       "type": "{ key: DataTableKey<Row>; value: Header; }",
-      "name": "DataTableHeader<Row=DataTableRow,Header>",
-      "ts": "interface DataTableHeader<Row=DataTableRow,Header> { key: DataTableKey<Row>; value: Header; }"
+      "name": "DataTableHeader<Row=DataTableRow,Header=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow,Header=DataTableRow> { key: DataTableKey<Row>; value: Header; }"
     }
   ],
   "generics": [
     "Row,Header",
-    "Row extends DataTableRow = DataTableRow, Header extends DataTableRow"
+    "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
   ]
 }


### PR DESCRIPTION
Avoid the "required param after optional param" error by fixing the example.