### PR TITLE
fix(writer): use `WindowEventMap` for cut/copy/paste events

### DIFF
--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -124,11 +124,8 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
     .join("\n");
 }
 
-const mapEvent = (name: string) => {
-  if (["cut", "copy", "paste"].includes(name)) {
-    return "DocumentAndElementEventHandlersEventMap";
-  }
-
+const mapEvent = () => {
+  // lib.dom.d.ts should map event types by name.
   return "WindowEventMap";
 };
 
@@ -147,7 +144,7 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
         description = "/** " + event.description + " */\n";
       }
       return `${description}${clampKey(event.name)}: ${
-        event.type === "dispatched" ? createDispatchedEvent(event.detail) : `${mapEvent(event.name)}["${event.name}"]`
+        event.type === "dispatched" ? createDispatchedEvent(event.detail) : `${mapEvent()}["${event.name}"]`
       };\n`;
     })
     .join("");

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1553,11 +1553,7 @@ export interface InputEventsProps {}
 
 export default class InputEvents extends SvelteComponentTyped<
   InputEventsProps,
-  {
-    input: WindowEventMap["input"];
-    change: WindowEventMap["change"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
-  },
+  { input: WindowEventMap["input"]; change: WindowEventMap["change"]; paste: WindowEventMap["paste"] },
   {}
 > {}
 "

--- a/tests/fixtures/input-events/output.d.ts
+++ b/tests/fixtures/input-events/output.d.ts
@@ -4,10 +4,6 @@ export interface InputEventsProps {}
 
 export default class InputEvents extends SvelteComponentTyped<
   InputEventsProps,
-  {
-    input: WindowEventMap["input"];
-    change: WindowEventMap["change"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
-  },
+  { input: WindowEventMap["input"]; change: WindowEventMap["change"]; paste: WindowEventMap["paste"] },
   {}
 > {}


### PR DESCRIPTION
Fixes #139 

#92 added a workaround to map cut/copy/paste events as they previously did not exist on `WindowEventMap`.

Now that these are mapped in the `WindowEventMap` interface in TypeScript `lib.dom.d.ts` definitions, fix this to avoid TS errors.