### PR TITLE
ci: use `paths-ignore` in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "playground/**"
   push:
     branches:
       - main
+    paths-ignore:
+      - "playground/**"
 
 jobs:
   build:


### PR DESCRIPTION
Any changes in `playground/**` are independent (downstream) of checks in the CI workflow and can be ignored.