### PR TITLE
test(fixtures): update `rest-props-multiple` to repro #138

### DIFF
--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -897,21 +897,10 @@ exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
 "{
   "props": [
     {
-      "name": "edit",
+      "name": "type",
       "kind": "let",
-      "type": "boolean",
-      "value": "false",
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false
-    },
-    {
-      "name": "heading",
-      "kind": "let",
-      "type": "boolean",
-      "value": "false",
+      "type": " \"ordered\" | \"unordered\" ",
+      "value": "\"ordered\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -926,7 +915,7 @@ exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
   "generics": null,
   "rest_props": {
     "type": "Element",
-    "name": "h1 | span"
+    "name": "ul | ol"
   }
 }"
 `;
@@ -1715,18 +1704,13 @@ exports[`fixtures (TypeScript) "rest-props-multiple/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["h1"] & SvelteHTMLElements["span"];
+type RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 
 export interface RestPropsMultipleProps extends RestProps {
   /**
-   * @default false
+   * @default "ordered"
    */
-  edit?: boolean;
-
-  /**
-   * @default false
-   */
-  heading?: boolean;
+  type?: "ordered" | "unordered";
 
   [key: \`data-${string}\`]: any;
 }

--- a/tests/fixtures/rest-props-multiple/input.svelte
+++ b/tests/fixtures/rest-props-multiple/input.svelte
@@ -1,14 +1,12 @@
 <script>
-  /** @restProps {h1 | span} */
-  export let edit = false;
-  export let heading = false;
-
-  import Button from "../";
+  /** @restProps {ul | ol} */
+  /** @type { "ordered" | "unordered" } */
+  export let type = "ordered";
 </script>
 
-{#if edit}
-  <Button {...$$restProps} />
-{:else if heading}
-  <!-- svelte-ignore a11y-missing-content -->
-  <h1 {...$$restProps} />
-{:else}<span {...$$restProps} />{/if}
+
+{#if type==='ordered'}
+  <ol {...$$restProps} {type} />
+{:else if type === "unordered"}
+  <ul {...$$restProps} {type} />
+{/if}

--- a/tests/fixtures/rest-props-multiple/output.d.ts
+++ b/tests/fixtures/rest-props-multiple/output.d.ts
@@ -1,18 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["h1"] & SvelteHTMLElements["span"];
+type RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 
 export interface RestPropsMultipleProps extends RestProps {
   /**
-   * @default false
+   * @default "ordered"
    */
-  edit?: boolean;
-
-  /**
-   * @default false
-   */
-  heading?: boolean;
+  type?: "ordered" | "unordered";
 
   [key: `data-${string}`]: any;
 }

--- a/tests/fixtures/rest-props-multiple/output.json
+++ b/tests/fixtures/rest-props-multiple/output.json
@@ -1,21 +1,10 @@
 {
   "props": [
     {
-      "name": "edit",
+      "name": "type",
       "kind": "let",
-      "type": "boolean",
-      "value": "false",
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false
-    },
-    {
-      "name": "heading",
-      "kind": "let",
-      "type": "boolean",
-      "value": "false",
+      "type": " \"ordered\" | \"unordered\" ",
+      "value": "\"ordered\"",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -30,6 +19,6 @@
   "generics": null,
   "rest_props": {
     "type": "Element",
-    "name": "h1 | span"
+    "name": "ul | ol"
   }
 }


### PR DESCRIPTION
To reliably repro the bug in #138, update the `rest-props-multiple` example. Merge before #138 to validate the fix.

This can occur when using an intersection and also have a prop name that incorrectly extends the `restProps`.

```sh
$ bun --bun tsc --project tsconfig.fixtures.json
tests/fixtures/rest-props-multiple/output.d.ts:6:18 - error TS2430: Interface 'RestPropsMultipleProps' incorrectly extends interface 'HTMLAttributes<HTMLUListElement> & HTMLOlAttributes'.
  Type 'RestPropsMultipleProps' is not assignable to type 'HTMLOlAttributes'.
    Types of property 'type' are incompatible.
      Type '"ordered" | "unordered" | undefined' is not assignable to type '"a" | "i" | "1" | "A" | "I" | null | undefined'.
        Type '"ordered"' is not assignable to type '"a" | "i" | "1" | "A" | "I" | null | undefined'.

6 export interface RestPropsMultipleProps extends RestProps {
```