### PR TITLE
fix(writer): rename internal `RestProps` --> `$RestProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The generated definition extends the official `SvelteComponentTyped` interface e
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -57,7 +57,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
@@ -85,7 +85,7 @@ The accompanying JSDoc annotations would generate the following:
 ```ts
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -100,7 +100,7 @@ type $Props = {
   primary?: boolean;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -89,14 +89,14 @@ function genPropDef(def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleN
     const dataAttributes = "[key: `data-${string}`]: any;";
 
     prop_def = `
-    ${extend_tag_map ? `type RestProps = ${extend_tag_map};\n` : ""}
+    ${extend_tag_map ? `type $RestProps = ${extend_tag_map};\n` : ""}
     type $Props${genericsName} = {
       ${props}
       
       ${dataAttributes}
     };
 
-    export type ${props_name}${genericsName} = Omit<RestProps, keyof $Props${genericsName}> & $Props${genericsName};
+    export type ${props_name}${genericsName} = Omit<$RestProps, keyof $Props${genericsName}> & $Props${genericsName};
   `;
   } else {
     prop_def = `

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1326,13 +1326,13 @@ exports[`fixtures (TypeScript) "svg-props/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["svg"];
+type $RestProps = SvelteHTMLElements["svg"];
 
 type $Props = {
   [key: \`data-${string}\`]: any;
 };
 
-export type SvgPropsProps = Omit<RestProps, keyof $Props> & $Props;
+export type SvgPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, {}> {}
 "
@@ -1597,7 +1597,7 @@ export interface DataTableHeader<Row = DataTableRow> {
   value: string;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props<Row> = {
   /**
@@ -1613,7 +1613,7 @@ type $Props<Row> = {
   [key: \`data-${string}\`]: any;
 };
 
-export type GenericsWithRestPropsProps<Row> = Omit<RestProps, keyof $Props<Row>> & $Props<Row>;
+export type GenericsWithRestPropsProps<Row> = Omit<$RestProps, keyof $Props<Row>> & $Props<Row>;
 
 export default class GenericsWithRestProps<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
   GenericsWithRestPropsProps<Row>,
@@ -1822,7 +1822,7 @@ exports[`fixtures (TypeScript) "rest-props-multiple/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
+type $RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 
 type $Props = {
   /**
@@ -1833,7 +1833,7 @@ type $Props = {
   [key: \`data-${string}\`]: any;
 };
 
-export type RestPropsMultipleProps = Omit<RestProps, keyof $Props> & $Props;
+export type RestPropsMultipleProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RestPropsMultiple extends SvelteComponentTyped<RestPropsMultipleProps, Record<string, any>, {}> {}
 "
@@ -1921,13 +1921,13 @@ exports[`fixtures (TypeScript) "rest-props-simple/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["h1"];
+type $RestProps = SvelteHTMLElements["h1"];
 
 type $Props = {
   [key: \`data-${string}\`]: any;
 };
 
-export type RestPropsSimpleProps = Omit<RestProps, keyof $Props> & $Props;
+export type RestPropsSimpleProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RestPropsSimple extends SvelteComponentTyped<RestPropsSimpleProps, Record<string, any>, {}> {}
 "
@@ -1937,13 +1937,13 @@ exports[`fixtures (TypeScript) "anchor-props/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   [key: \`data-${string}\`]: any;
 };
 
-export type AnchorPropsProps = Omit<RestProps, keyof $Props> & $Props;
+export type AnchorPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AnchorProps extends SvelteComponentTyped<AnchorPropsProps, Record<string, any>, { default: {} }> {}
 "

--- a/tests/e2e/carbon/types/Accordion/AccordionItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/AccordionItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
 type $Props = {
   /**
@@ -32,7 +32,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type AccordionItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type AccordionItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 /** `AccordionItem` is slottable */
 export default class AccordionItem extends SvelteComponentTyped<

--- a/tests/e2e/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type AccordionSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type AccordionSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AccordionSkeleton extends SvelteComponentTyped<
   AccordionSkeletonProps,

--- a/tests/e2e/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/tests/e2e/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type AspectRatioProps = Omit<RestProps, keyof $Props> & $Props;
+export type AspectRatioProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AspectRatio extends SvelteComponentTyped<
   AspectRatioProps,

--- a/tests/e2e/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type BreadcrumbItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type BreadcrumbItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class BreadcrumbItem extends SvelteComponentTyped<
   BreadcrumbItemProps,

--- a/tests/e2e/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type BreadcrumbSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type BreadcrumbSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class BreadcrumbSkeleton extends SvelteComponentTyped<
   BreadcrumbSkeletonProps,

--- a/tests/e2e/carbon/types/Button/Button.svelte.d.ts
+++ b/tests/e2e/carbon/types/Button/Button.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 import type { ButtonSkeletonProps } from "./ButtonSkeleton.svelte";
 
-type RestProps = SvelteHTMLElements["button"] &
+type $RestProps = SvelteHTMLElements["button"] &
   SvelteHTMLElements["a"] &
   SvelteHTMLElements["div"];
 
@@ -105,7 +105,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/carbon/types/Button/ButtonSet.svelte.d.ts
+++ b/tests/e2e/carbon/types/Button/ButtonSet.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonSetProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonSetProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ButtonSet extends SvelteComponentTyped<
   ButtonSetProps,

--- a/tests/e2e/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -26,7 +26,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ButtonSkeleton extends SvelteComponentTyped<
   ButtonSkeletonProps,

--- a/tests/e2e/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type CheckboxSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type CheckboxSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class CheckboxSkeleton extends SvelteComponentTyped<
   CheckboxSkeletonProps,

--- a/tests/e2e/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type CodeSnippetSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type CodeSnippetSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class CodeSnippetSkeleton extends SvelteComponentTyped<
   CodeSnippetSkeletonProps,

--- a/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -6,7 +6,7 @@ export interface ComboBoxItem {
   text: string;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -126,7 +126,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ComboBoxProps = Omit<RestProps, keyof $Props> & $Props;
+export type ComboBoxProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ComboBox extends SvelteComponentTyped<
   ComboBoxProps,

--- a/tests/e2e/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -49,7 +49,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ComposedModalProps = Omit<RestProps, keyof $Props> & $Props;
+export type ComposedModalProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ComposedModal extends SvelteComponentTyped<
   ComposedModalProps,

--- a/tests/e2e/carbon/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ModalBody.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ModalBodyProps = Omit<RestProps, keyof $Props> & $Props;
+export type ModalBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ModalBody extends SvelteComponentTyped<
   ModalBodyProps,

--- a/tests/e2e/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -43,7 +43,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ModalFooterProps = Omit<RestProps, keyof $Props> & $Props;
+export type ModalFooterProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ModalFooter extends SvelteComponentTyped<
   ModalFooterProps,

--- a/tests/e2e/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -49,7 +49,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ModalHeaderProps = Omit<RestProps, keyof $Props> & $Props;
+export type ModalHeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ModalHeader extends SvelteComponentTyped<
   ModalHeaderProps,

--- a/tests/e2e/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/tests/e2e/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ContentSwitcherProps = Omit<RestProps, keyof $Props> & $Props;
+export type ContentSwitcherProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ContentSwitcher extends SvelteComponentTyped<
   ContentSwitcherProps,

--- a/tests/e2e/carbon/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/tests/e2e/carbon/types/ContentSwitcher/Switch.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -38,7 +38,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SwitchProps = Omit<RestProps, keyof $Props> & $Props;
+export type SwitchProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Switch extends SvelteComponentTyped<
   SwitchProps,

--- a/tests/e2e/carbon/types/Copy/Copy.svelte.d.ts
+++ b/tests/e2e/carbon/types/Copy/Copy.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type CopyProps = Omit<RestProps, keyof $Props> & $Props;
+export type CopyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Copy extends SvelteComponentTyped<
   CopyProps,

--- a/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -42,7 +42,7 @@ export interface DataTableCell {
   display?: (item: Value, row: DataTableRow) => DataTableValue;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props<Row> = {
   /**
@@ -183,7 +183,7 @@ type $Props<Row> = {
   [key: `data-${string}`]: any;
 };
 
-export type DataTableProps<Row> = Omit<RestProps, keyof $Props<Row>> &
+export type DataTableProps<Row> = Omit<$RestProps, keyof $Props<Row>> &
   $Props<Row>;
 
 export default class DataTable<

--- a/tests/e2e/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 import type { DataTableHeader } from "../DataTable/DataTable.svelte";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -53,7 +53,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DataTableSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type DataTableSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DataTableSkeleton extends SvelteComponentTyped<
   DataTableSkeletonProps,

--- a/tests/e2e/carbon/types/DataTable/Table.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/Table.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["section"];
+type $RestProps = SvelteHTMLElements["section"];
 
 type $Props = {
   /**
@@ -43,7 +43,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Table extends SvelteComponentTyped<
   TableProps,

--- a/tests/e2e/carbon/types/DataTable/TableBody.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableBody.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["tbody"];
+type $RestProps = SvelteHTMLElements["tbody"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableBodyProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableBody extends SvelteComponentTyped<
   TableBodyProps,

--- a/tests/e2e/carbon/types/DataTable/TableCell.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableCell.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["td"];
+type $RestProps = SvelteHTMLElements["td"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableCellProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableCellProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableCell extends SvelteComponentTyped<
   TableCellProps,

--- a/tests/e2e/carbon/types/DataTable/TableContainer.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableContainer.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableContainerProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableContainerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableContainer extends SvelteComponentTyped<
   TableContainerProps,

--- a/tests/e2e/carbon/types/DataTable/TableHead.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableHead.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["thead"];
+type $RestProps = SvelteHTMLElements["thead"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableHeadProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableHeadProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableHead extends SvelteComponentTyped<
   TableHeadProps,

--- a/tests/e2e/carbon/types/DataTable/TableHeader.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableHeader.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["th"];
+type $RestProps = SvelteHTMLElements["th"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableHeaderProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableHeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableHeader extends SvelteComponentTyped<
   TableHeaderProps,

--- a/tests/e2e/carbon/types/DataTable/TableRow.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableRow.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["tr"];
+type $RestProps = SvelteHTMLElements["tr"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TableRowProps = Omit<RestProps, keyof $Props> & $Props;
+export type TableRowProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableRow extends SvelteComponentTyped<
   TableRowProps,

--- a/tests/e2e/carbon/types/DataTable/Toolbar.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/Toolbar.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["section"];
+type $RestProps = SvelteHTMLElements["section"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToolbarProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToolbarProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Toolbar extends SvelteComponentTyped<
   ToolbarProps,

--- a/tests/e2e/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToolbarBatchActionsProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToolbarBatchActionsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<
   ToolbarBatchActionsProps,

--- a/tests/e2e/carbon/types/DatePicker/DatePicker.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePicker.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -67,7 +67,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DatePickerProps = Omit<RestProps, keyof $Props> & $Props;
+export type DatePickerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DatePicker extends SvelteComponentTyped<
   DatePickerProps,

--- a/tests/e2e/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -85,7 +85,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DatePickerInputProps = Omit<RestProps, keyof $Props> & $Props;
+export type DatePickerInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DatePickerInput extends SvelteComponentTyped<
   DatePickerInputProps,

--- a/tests/e2e/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DatePickerSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type DatePickerSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DatePickerSkeleton extends SvelteComponentTyped<
   DatePickerSkeletonProps,

--- a/tests/e2e/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/tests/e2e/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -10,7 +10,7 @@ export interface DropdownItem {
   text: DropdownItemText;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -137,7 +137,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DropdownProps = Omit<RestProps, keyof $Props> & $Props;
+export type DropdownProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Dropdown extends SvelteComponentTyped<
   DropdownProps,

--- a/tests/e2e/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DropdownSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type DropdownSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DropdownSkeleton extends SvelteComponentTyped<
   DropdownSkeletonProps,

--- a/tests/e2e/carbon/types/FileUploader/FileUploader.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploader.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -67,7 +67,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FileUploaderProps = Omit<RestProps, keyof $Props> & $Props;
+export type FileUploaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploader extends SvelteComponentTyped<
   FileUploaderProps,

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
 type $Props = {
   /**
@@ -73,7 +73,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FileUploaderButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type FileUploaderButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploaderButton extends SvelteComponentTyped<
   FileUploaderButtonProps,

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -68,7 +68,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FileUploaderDropContainerProps = Omit<RestProps, keyof $Props> &
+export type FileUploaderDropContainerProps = Omit<$RestProps, keyof $Props> &
   $Props;
 
 export default class FileUploaderDropContainer extends SvelteComponentTyped<

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["span"];
 
 type $Props = {
   /**
@@ -49,7 +49,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FileUploaderItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type FileUploaderItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploaderItem extends SvelteComponentTyped<
   FileUploaderItemProps,

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FileUploaderSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type FileUploaderSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploaderSkeleton extends SvelteComponentTyped<
   FileUploaderSkeletonProps,

--- a/tests/e2e/carbon/types/Form/Form.svelte.d.ts
+++ b/tests/e2e/carbon/types/Form/Form.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["form"];
+type $RestProps = SvelteHTMLElements["form"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FormProps = Omit<RestProps, keyof $Props> & $Props;
+export type FormProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Form extends SvelteComponentTyped<
   FormProps,

--- a/tests/e2e/carbon/types/FormGroup/FormGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/FormGroup/FormGroup.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["fieldset"];
+type $RestProps = SvelteHTMLElements["fieldset"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FormGroupProps = Omit<RestProps, keyof $Props> & $Props;
+export type FormGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FormGroup extends SvelteComponentTyped<
   FormGroupProps,

--- a/tests/e2e/carbon/types/FormItem/FormItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/FormItem/FormItem.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FormItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type FormItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FormItem extends SvelteComponentTyped<
   FormItemProps,

--- a/tests/e2e/carbon/types/FormLabel/FormLabel.svelte.d.ts
+++ b/tests/e2e/carbon/types/FormLabel/FormLabel.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type FormLabelProps = Omit<RestProps, keyof $Props> & $Props;
+export type FormLabelProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FormLabel extends SvelteComponentTyped<
   FormLabelProps,

--- a/tests/e2e/carbon/types/Grid/Column.svelte.d.ts
+++ b/tests/e2e/carbon/types/Grid/Column.svelte.d.ts
@@ -10,7 +10,7 @@ export interface ColumnSizeDescriptor {
 
 export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -83,7 +83,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ColumnProps = Omit<RestProps, keyof $Props> & $Props;
+export type ColumnProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Column extends SvelteComponentTyped<
   ColumnProps,

--- a/tests/e2e/carbon/types/Grid/Grid.svelte.d.ts
+++ b/tests/e2e/carbon/types/Grid/Grid.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -56,7 +56,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type GridProps = Omit<RestProps, keyof $Props> & $Props;
+export type GridProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Grid extends SvelteComponentTyped<
   GridProps,

--- a/tests/e2e/carbon/types/Grid/Row.svelte.d.ts
+++ b/tests/e2e/carbon/types/Grid/Row.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -50,7 +50,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RowProps = Omit<RestProps, keyof $Props> & $Props;
+export type RowProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Row extends SvelteComponentTyped<
   RowProps,

--- a/tests/e2e/carbon/types/Icon/Icon.svelte.d.ts
+++ b/tests/e2e/carbon/types/Icon/Icon.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 import type { IconSkeletonProps } from "./IconSkeleton.svelte";
 
-type RestProps = SvelteHTMLElements["svg"];
+type $RestProps = SvelteHTMLElements["svg"];
 
 type $Props = {
   /**
@@ -21,7 +21,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type IconProps = Omit<RestProps, keyof $Props> & $Props;
+export type IconProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Icon extends SvelteComponentTyped<
   IconProps,

--- a/tests/e2e/carbon/types/Icon/IconSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Icon/IconSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type IconSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type IconSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class IconSkeleton extends SvelteComponentTyped<
   IconSkeletonProps,

--- a/tests/e2e/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/tests/e2e/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type InlineLoadingProps = Omit<RestProps, keyof $Props> & $Props;
+export type InlineLoadingProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class InlineLoading extends SvelteComponentTyped<
   InlineLoadingProps,

--- a/tests/e2e/carbon/types/Link/Link.svelte.d.ts
+++ b/tests/e2e/carbon/types/Link/Link.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"] & SvelteHTMLElements["p"];
+type $RestProps = SvelteHTMLElements["a"] & SvelteHTMLElements["p"];
 
 type $Props = {
   /**
@@ -43,7 +43,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type LinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/tests/e2e/carbon/types/ListBox/ListBox.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBox.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -61,7 +61,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListBoxProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListBoxProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBox extends SvelteComponentTyped<
   ListBoxProps,

--- a/tests/e2e/carbon/types/ListBox/ListBoxField.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxField.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxFieldTranslationId = "close" | "open";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -45,7 +45,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListBoxFieldProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListBoxFieldProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxField extends SvelteComponentTyped<
   ListBoxFieldProps,

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListBoxMenuProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListBoxMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxMenu extends SvelteComponentTyped<
   ListBoxMenuProps,

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxMenuIconTranslationId = "close" | "open";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -21,7 +21,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListBoxMenuIconProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListBoxMenuIconProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxMenuIcon extends SvelteComponentTyped<
   ListBoxMenuIconProps,

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListBoxMenuItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListBoxMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxMenuItem extends SvelteComponentTyped<
   ListBoxMenuItemProps,

--- a/tests/e2e/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -33,7 +33,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListBoxSelectionProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListBoxSelectionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxSelection extends SvelteComponentTyped<
   ListBoxSelectionProps,

--- a/tests/e2e/carbon/types/ListItem/ListItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListItem/ListItem.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ListItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type ListItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListItem extends SvelteComponentTyped<
   ListItemProps,

--- a/tests/e2e/carbon/types/Loading/Loading.svelte.d.ts
+++ b/tests/e2e/carbon/types/Loading/Loading.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -37,7 +37,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type LoadingProps = Omit<RestProps, keyof $Props> & $Props;
+export type LoadingProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Loading extends SvelteComponentTyped<
   LoadingProps,

--- a/tests/e2e/carbon/types/Modal/Modal.svelte.d.ts
+++ b/tests/e2e/carbon/types/Modal/Modal.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -121,7 +121,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ModalProps = Omit<RestProps, keyof $Props> & $Props;
+export type ModalProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Modal extends SvelteComponentTyped<
   ModalProps,

--- a/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -10,7 +10,7 @@ export interface MultiSelectItem {
   text: MultiSelectItemText;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -176,7 +176,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type MultiSelectProps = Omit<RestProps, keyof $Props> & $Props;
+export type MultiSelectProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class MultiSelect extends SvelteComponentTyped<
   MultiSelectProps,

--- a/tests/e2e/carbon/types/Notification/InlineNotification.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/InlineNotification.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -61,7 +61,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type InlineNotificationProps = Omit<RestProps, keyof $Props> & $Props;
+export type InlineNotificationProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class InlineNotification extends SvelteComponentTyped<
   InlineNotificationProps,

--- a/tests/e2e/carbon/types/Notification/NotificationButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/NotificationButton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type NotificationButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type NotificationButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class NotificationButton extends SvelteComponentTyped<
   NotificationButtonProps,

--- a/tests/e2e/carbon/types/Notification/ToastNotification.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/ToastNotification.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -67,7 +67,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToastNotificationProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToastNotificationProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToastNotification extends SvelteComponentTyped<
   ToastNotificationProps,

--- a/tests/e2e/carbon/types/NumberInput/NumberInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/NumberInput/NumberInput.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type NumberInputTranslationId = "increment" | "decrement";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -141,7 +141,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type NumberInputProps = Omit<RestProps, keyof $Props> & $Props;
+export type NumberInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class NumberInput extends SvelteComponentTyped<
   NumberInputProps,

--- a/tests/e2e/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type NumberInputSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type NumberInputSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class NumberInputSkeleton extends SvelteComponentTyped<
   NumberInputSkeletonProps,

--- a/tests/e2e/carbon/types/OrderedList/OrderedList.svelte.d.ts
+++ b/tests/e2e/carbon/types/OrderedList/OrderedList.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ol"];
+type $RestProps = SvelteHTMLElements["ol"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type OrderedListProps = Omit<RestProps, keyof $Props> & $Props;
+export type OrderedListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class OrderedList extends SvelteComponentTyped<
   OrderedListProps,

--- a/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -79,7 +79,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type OverflowMenuProps = Omit<RestProps, keyof $Props> & $Props;
+export type OverflowMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class OverflowMenu extends SvelteComponentTyped<
   OverflowMenuProps,

--- a/tests/e2e/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
 type $Props = {
   /**
@@ -62,7 +62,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type OverflowMenuItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type OverflowMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class OverflowMenuItem extends SvelteComponentTyped<
   OverflowMenuItemProps,

--- a/tests/e2e/carbon/types/Pagination/Pagination.svelte.d.ts
+++ b/tests/e2e/carbon/types/Pagination/Pagination.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -103,7 +103,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type PaginationProps = Omit<RestProps, keyof $Props> & $Props;
+export type PaginationProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Pagination extends SvelteComponentTyped<
   PaginationProps,

--- a/tests/e2e/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type PaginationSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type PaginationSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class PaginationSkeleton extends SvelteComponentTyped<
   PaginationSkeletonProps,

--- a/tests/e2e/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/tests/e2e/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["nav"];
+type $RestProps = SvelteHTMLElements["nav"];
 
 type $Props = {
   /**
@@ -43,7 +43,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type PaginationNavProps = Omit<RestProps, keyof $Props> & $Props;
+export type PaginationNavProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class PaginationNav extends SvelteComponentTyped<
   PaginationNavProps,

--- a/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ProgressIndicatorProps = Omit<RestProps, keyof $Props> & $Props;
+export type ProgressIndicatorProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ProgressIndicator extends SvelteComponentTyped<
   ProgressIndicatorProps,

--- a/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ProgressIndicatorSkeletonProps = Omit<RestProps, keyof $Props> &
+export type ProgressIndicatorSkeletonProps = Omit<$RestProps, keyof $Props> &
   $Props;
 
 export default class ProgressIndicatorSkeleton extends SvelteComponentTyped<

--- a/tests/e2e/carbon/types/ProgressIndicator/ProgressStep.svelte.d.ts
+++ b/tests/e2e/carbon/types/ProgressIndicator/ProgressStep.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
 type $Props = {
   /**
@@ -55,7 +55,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ProgressStepProps = Omit<RestProps, keyof $Props> & $Props;
+export type ProgressStepProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ProgressStep extends SvelteComponentTyped<
   ProgressStepProps,

--- a/tests/e2e/carbon/types/RadioButton/RadioButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButton/RadioButton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -61,7 +61,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RadioButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type RadioButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButton extends SvelteComponentTyped<
   RadioButtonProps,

--- a/tests/e2e/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RadioButtonSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type RadioButtonSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButtonSkeleton extends SvelteComponentTyped<
   RadioButtonSkeletonProps,

--- a/tests/e2e/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -37,7 +37,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RadioButtonGroupProps = Omit<RestProps, keyof $Props> & $Props;
+export type RadioButtonGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButtonGroup extends SvelteComponentTyped<
   RadioButtonGroupProps,

--- a/tests/e2e/carbon/types/Search/SearchSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Search/SearchSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -20,7 +20,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SearchSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type SearchSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SearchSkeleton extends SvelteComponentTyped<
   SearchSkeletonProps,

--- a/tests/e2e/carbon/types/Select/Select.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/Select.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -91,7 +91,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SelectProps = Omit<RestProps, keyof $Props> & $Props;
+export type SelectProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Select extends SvelteComponentTyped<
   SelectProps,

--- a/tests/e2e/carbon/types/Select/SelectItemGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/SelectItemGroup.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["optgroup"];
+type $RestProps = SvelteHTMLElements["optgroup"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SelectItemGroupProps = Omit<RestProps, keyof $Props> & $Props;
+export type SelectItemGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SelectItemGroup extends SvelteComponentTyped<
   SelectItemGroupProps,

--- a/tests/e2e/carbon/types/Select/SelectSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/SelectSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SelectSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type SelectSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SelectSkeleton extends SvelteComponentTyped<
   SelectSkeletonProps,

--- a/tests/e2e/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/tests/e2e/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SkeletonPlaceholderProps = Omit<RestProps, keyof $Props> & $Props;
+export type SkeletonPlaceholderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SkeletonPlaceholder extends SvelteComponentTyped<
   SkeletonPlaceholderProps,

--- a/tests/e2e/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/tests/e2e/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SkeletonTextProps = Omit<RestProps, keyof $Props> & $Props;
+export type SkeletonTextProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SkeletonText extends SvelteComponentTyped<
   SkeletonTextProps,

--- a/tests/e2e/carbon/types/Slider/Slider.svelte.d.ts
+++ b/tests/e2e/carbon/types/Slider/Slider.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -109,7 +109,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SliderProps = Omit<RestProps, keyof $Props> & $Props;
+export type SliderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Slider extends SvelteComponentTyped<
   SliderProps,

--- a/tests/e2e/carbon/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Slider/SliderSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SliderSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type SliderSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SliderSkeleton extends SvelteComponentTyped<
   SliderSkeletonProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredList.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredList.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListProps = Omit<RestProps, keyof $Props> & $Props;
+export type StructuredListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredList extends SvelteComponentTyped<
   StructuredListProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListBodyProps = Omit<RestProps, keyof $Props> & $Props;
+export type StructuredListBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListBody extends SvelteComponentTyped<
   StructuredListBodyProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListCellProps = Omit<RestProps, keyof $Props> & $Props;
+export type StructuredListCellProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListCell extends SvelteComponentTyped<
   StructuredListCellProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListHeadProps = Omit<RestProps, keyof $Props> & $Props;
+export type StructuredListHeadProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListHead extends SvelteComponentTyped<
   StructuredListHeadProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
 type $Props = {
   /**
@@ -43,7 +43,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListInputProps = Omit<RestProps, keyof $Props> & $Props;
+export type StructuredListInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListInput extends SvelteComponentTyped<
   StructuredListInputProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListRowProps = Omit<RestProps, keyof $Props> & $Props;
+export type StructuredListRowProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListRow extends SvelteComponentTyped<
   StructuredListRowProps,

--- a/tests/e2e/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type StructuredListSkeletonProps = Omit<RestProps, keyof $Props> &
+export type StructuredListSkeletonProps = Omit<$RestProps, keyof $Props> &
   $Props;
 
 export default class StructuredListSkeleton extends SvelteComponentTyped<

--- a/tests/e2e/carbon/types/Tabs/Tab.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/Tab.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
 type $Props = {
   /**
@@ -44,7 +44,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TabProps = Omit<RestProps, keyof $Props> & $Props;
+export type TabProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tab extends SvelteComponentTyped<
   TabProps,

--- a/tests/e2e/carbon/types/Tabs/TabContent.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/TabContent.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TabContentProps = Omit<RestProps, keyof $Props> & $Props;
+export type TabContentProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TabContent extends SvelteComponentTyped<
   TabContentProps,

--- a/tests/e2e/carbon/types/Tabs/Tabs.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/Tabs.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TabsProps = Omit<RestProps, keyof $Props> & $Props;
+export type TabsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tabs extends SvelteComponentTyped<
   TabsProps,

--- a/tests/e2e/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TabsSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type TabsSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TabsSkeleton extends SvelteComponentTyped<
   TabsSkeletonProps,

--- a/tests/e2e/carbon/types/Tag/Tag.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tag/Tag.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"] & SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["div"] & SvelteHTMLElements["span"];
 
 type $Props = {
   /**
@@ -60,7 +60,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TagProps = Omit<RestProps, keyof $Props> & $Props;
+export type TagProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tag extends SvelteComponentTyped<
   TagProps,

--- a/tests/e2e/carbon/types/Tag/TagSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tag/TagSkeleton.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["span"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TagSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type TagSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TagSkeleton extends SvelteComponentTyped<
   TagSkeletonProps,

--- a/tests/e2e/carbon/types/TextArea/TextArea.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextArea/TextArea.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["textarea"];
+type $RestProps = SvelteHTMLElements["textarea"];
 
 type $Props = {
   /**
@@ -91,7 +91,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TextAreaProps = Omit<RestProps, keyof $Props> & $Props;
+export type TextAreaProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextArea extends SvelteComponentTyped<
   TextAreaProps,

--- a/tests/e2e/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TextAreaSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type TextAreaSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextAreaSkeleton extends SvelteComponentTyped<
   TextAreaSkeletonProps,

--- a/tests/e2e/carbon/types/TextInput/PasswordInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextInput/PasswordInput.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
 type $Props = {
   /**
@@ -115,7 +115,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type PasswordInputProps = Omit<RestProps, keyof $Props> & $Props;
+export type PasswordInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class PasswordInput extends SvelteComponentTyped<
   PasswordInputProps,

--- a/tests/e2e/carbon/types/TextInput/TextInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextInput/TextInput.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
 type $Props = {
   /**
@@ -115,7 +115,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TextInputProps = Omit<RestProps, keyof $Props> & $Props;
+export type TextInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextInput extends SvelteComponentTyped<
   TextInputProps,

--- a/tests/e2e/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TextInputSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type TextInputSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextInputSkeleton extends SvelteComponentTyped<
   TextInputSkeletonProps,

--- a/tests/e2e/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ClickableTileProps = Omit<RestProps, keyof $Props> & $Props;
+export type ClickableTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ClickableTile extends SvelteComponentTyped<
   ClickableTileProps,

--- a/tests/e2e/carbon/types/Tile/ExpandableTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/ExpandableTile.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -73,7 +73,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ExpandableTileProps = Omit<RestProps, keyof $Props> & $Props;
+export type ExpandableTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ExpandableTile extends SvelteComponentTyped<
   ExpandableTileProps,

--- a/tests/e2e/carbon/types/Tile/RadioTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/RadioTile.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
 type $Props = {
   /**
@@ -49,7 +49,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RadioTileProps = Omit<RestProps, keyof $Props> & $Props;
+export type RadioTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioTile extends SvelteComponentTyped<
   RadioTileProps,

--- a/tests/e2e/carbon/types/Tile/SelectableTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/SelectableTile.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
 type $Props = {
   /**
@@ -61,7 +61,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SelectableTileProps = Omit<RestProps, keyof $Props> & $Props;
+export type SelectableTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SelectableTile extends SvelteComponentTyped<
   SelectableTileProps,

--- a/tests/e2e/carbon/types/Tile/Tile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/Tile.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TileProps = Omit<RestProps, keyof $Props> & $Props;
+export type TileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tile extends SvelteComponentTyped<
   TileProps,

--- a/tests/e2e/carbon/types/Tile/TileGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/TileGroup.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["fieldset"];
+type $RestProps = SvelteHTMLElements["fieldset"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TileGroupProps = Omit<RestProps, keyof $Props> & $Props;
+export type TileGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TileGroup extends SvelteComponentTyped<
   TileGroupProps,

--- a/tests/e2e/carbon/types/TimePicker/TimePicker.svelte.d.ts
+++ b/tests/e2e/carbon/types/TimePicker/TimePicker.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -97,7 +97,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TimePickerProps = Omit<RestProps, keyof $Props> & $Props;
+export type TimePickerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TimePicker extends SvelteComponentTyped<
   TimePickerProps,

--- a/tests/e2e/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -56,7 +56,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TimePickerSelectProps = Omit<RestProps, keyof $Props> & $Props;
+export type TimePickerSelectProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TimePickerSelect extends SvelteComponentTyped<
   TimePickerSelectProps,

--- a/tests/e2e/carbon/types/Toggle/Toggle.svelte.d.ts
+++ b/tests/e2e/carbon/types/Toggle/Toggle.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -55,7 +55,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToggleProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToggleProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Toggle extends SvelteComponentTyped<
   ToggleProps,

--- a/tests/e2e/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToggleSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToggleSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToggleSkeleton extends SvelteComponentTyped<
   ToggleSkeletonProps,

--- a/tests/e2e/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
+++ b/tests/e2e/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -49,7 +49,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToggleSmallProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToggleSmallProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToggleSmall extends SvelteComponentTyped<
   ToggleSmallProps,

--- a/tests/e2e/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ToggleSmallSkeletonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ToggleSmallSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToggleSmallSkeleton extends SvelteComponentTyped<
   ToggleSmallSkeletonProps,

--- a/tests/e2e/carbon/types/Tooltip/Tooltip.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tooltip/Tooltip.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -92,7 +92,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TooltipProps = Omit<RestProps, keyof $Props> & $Props;
+export type TooltipProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tooltip extends SvelteComponentTyped<
   TooltipProps,

--- a/tests/e2e/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/tests/e2e/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {
   /**
@@ -37,7 +37,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TooltipDefinitionProps = Omit<RestProps, keyof $Props> & $Props;
+export type TooltipDefinitionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TooltipDefinition extends SvelteComponentTyped<
   TooltipDefinitionProps,

--- a/tests/e2e/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -38,7 +38,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TooltipIconProps = Omit<RestProps, keyof $Props> & $Props;
+export type TooltipIconProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TooltipIcon extends SvelteComponentTyped<
   TooltipIconProps,

--- a/tests/e2e/carbon/types/UIShell/Content.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/Content.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["main"];
+type $RestProps = SvelteHTMLElements["main"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ContentProps = Omit<RestProps, keyof $Props> & $Props;
+export type ContentProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Content extends SvelteComponentTyped<
   ContentProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -56,7 +56,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Header extends SvelteComponentTyped<
   HeaderProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -7,7 +7,7 @@ export interface HeaderActionSlideTransition {
   easing?: (t: number) => number;
 }
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -45,7 +45,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderActionProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderActionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderAction extends SvelteComponentTyped<
   HeaderActionProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderActionLinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderActionLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderActionLink extends SvelteComponentTyped<
   HeaderActionLinkProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["nav"];
+type $RestProps = SvelteHTMLElements["nav"];
 
 type $Props = {
   /**
@@ -14,7 +14,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderNavProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderNavProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderNav extends SvelteComponentTyped<
   HeaderNavProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderNavItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderNavItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderNavItem extends SvelteComponentTyped<
   HeaderNavItemProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -37,7 +37,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderNavMenuProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderNavMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderNavMenu extends SvelteComponentTyped<
   HeaderNavMenuProps,

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderPanelLinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderPanelLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderPanelLink extends SvelteComponentTyped<
   HeaderPanelLinkProps,

--- a/tests/e2e/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderGlobalActionProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderGlobalActionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderGlobalAction extends SvelteComponentTyped<
   HeaderGlobalActionProps,

--- a/tests/e2e/carbon/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/HeaderSearch.svelte.d.ts
@@ -7,7 +7,7 @@ export interface HeaderSearchResult {
   description?: string;
 }
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
 type $Props = {
   /**
@@ -43,7 +43,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type HeaderSearchProps = Omit<RestProps, keyof $Props> & $Props;
+export type HeaderSearchProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderSearch extends SvelteComponentTyped<
   HeaderSearchProps,

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["nav"];
+type $RestProps = SvelteHTMLElements["nav"];
 
 type $Props = {
   /**
@@ -25,7 +25,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SideNavProps = Omit<RestProps, keyof $Props> & $Props;
+export type SideNavProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNav extends SvelteComponentTyped<
   SideNavProps,

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -37,7 +37,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SideNavLinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type SideNavLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavLink extends SvelteComponentTyped<
   SideNavLinkProps,

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SideNavMenuProps = Omit<RestProps, keyof $Props> & $Props;
+export type SideNavMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavMenu extends SvelteComponentTyped<
   SideNavMenuProps,

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -31,7 +31,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SideNavMenuItemProps = Omit<RestProps, keyof $Props> & $Props;
+export type SideNavMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavMenuItem extends SvelteComponentTyped<
   SideNavMenuItemProps,

--- a/tests/e2e/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SkipToContentProps = Omit<RestProps, keyof $Props> & $Props;
+export type SkipToContentProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SkipToContent extends SvelteComponentTyped<
   SkipToContentProps,

--- a/tests/e2e/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/tests/e2e/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
 type $Props = {
   /**
@@ -13,7 +13,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type UnorderedListProps = Omit<RestProps, keyof $Props> & $Props;
+export type UnorderedListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class UnorderedList extends SvelteComponentTyped<
   UnorderedListProps,

--- a/tests/e2e/glob/types/button/Button.svelte.d.ts
+++ b/tests/e2e/glob/types/button/Button.svelte.d.ts
@@ -12,7 +12,7 @@ export declare function findParentTreeNode(
   node: HTMLElement
 ): null | HTMLElement;
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -28,7 +28,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/multi-export-typed-ts-only/types/button/button.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/button/button.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -18,7 +18,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type LinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/tests/e2e/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["blockquote"];
+type $RestProps = SvelteHTMLElements["blockquote"];
 
 type $Props = {
   /**
@@ -17,7 +17,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type QuoteProps = Omit<RestProps, keyof $Props> & $Props;
+export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,

--- a/tests/e2e/multi-export-typed/types/Button.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/Button.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -18,7 +18,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/multi-export-typed/types/Link.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/Link.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type LinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/tests/e2e/multi-export-typed/types/Quote.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/Quote.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["blockquote"];
+type $RestProps = SvelteHTMLElements["blockquote"];
 
 type $Props = {
   /**
@@ -17,7 +17,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type QuoteProps = Omit<RestProps, keyof $Props> & $Props;
+export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,

--- a/tests/e2e/multi-export/types/Button.svelte.d.ts
+++ b/tests/e2e/multi-export/types/Button.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -17,7 +17,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/multi-export/types/Link.svelte.d.ts
+++ b/tests/e2e/multi-export/types/Link.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type LinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/tests/e2e/multi-export/types/Quote.svelte.d.ts
+++ b/tests/e2e/multi-export/types/Quote.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type Author = string;
 
-type RestProps = SvelteHTMLElements["blockquote"];
+type $RestProps = SvelteHTMLElements["blockquote"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type QuoteProps = Omit<RestProps, keyof $Props> & $Props;
+export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,

--- a/tests/e2e/multi-folders/types/Link.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/Link.svelte.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type LinkProps = Omit<RestProps, keyof $Props> & $Props;
+export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/tests/e2e/multi-folders/types/Quote.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/Quote.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type Author = string;
 
-type RestProps = SvelteHTMLElements["blockquote"];
+type $RestProps = SvelteHTMLElements["blockquote"];
 
 type $Props = {
   /**
@@ -19,7 +19,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type QuoteProps = Omit<RestProps, keyof $Props> & $Props;
+export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,

--- a/tests/e2e/multi-folders/types/components/Button.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/components/Button.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -18,7 +18,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/single-export-default-only/types/Button.svelte.d.ts
+++ b/tests/e2e/single-export-default-only/types/Button.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -17,7 +17,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/e2e/single-export/types/Button.svelte.d.ts
+++ b/tests/e2e/single-export/types/Button.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
   /**
@@ -17,7 +17,7 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type ButtonProps = Omit<RestProps, keyof $Props> & $Props;
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/tests/fixtures/anchor-props/output.d.ts
+++ b/tests/fixtures/anchor-props/output.d.ts
@@ -1,12 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type AnchorPropsProps = Omit<RestProps, keyof $Props> & $Props;
+export type AnchorPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AnchorProps extends SvelteComponentTyped<AnchorPropsProps, Record<string, any>, { default: {} }> {}

--- a/tests/fixtures/generics-with-rest-props/output.d.ts
+++ b/tests/fixtures/generics-with-rest-props/output.d.ts
@@ -13,7 +13,7 @@ export interface DataTableHeader<Row = DataTableRow> {
   value: string;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
 type $Props<Row> = {
   /**
@@ -29,7 +29,7 @@ type $Props<Row> = {
   [key: `data-${string}`]: any;
 };
 
-export type GenericsWithRestPropsProps<Row> = Omit<RestProps, keyof $Props<Row>> & $Props<Row>;
+export type GenericsWithRestPropsProps<Row> = Omit<$RestProps, keyof $Props<Row>> & $Props<Row>;
 
 export default class GenericsWithRestProps<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
   GenericsWithRestPropsProps<Row>,

--- a/tests/fixtures/rest-props-multiple/output.d.ts
+++ b/tests/fixtures/rest-props-multiple/output.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
+type $RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 
 type $Props = {
   /**
@@ -12,6 +12,6 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RestPropsMultipleProps = Omit<RestProps, keyof $Props> & $Props;
+export type RestPropsMultipleProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RestPropsMultiple extends SvelteComponentTyped<RestPropsMultipleProps, Record<string, any>, {}> {}

--- a/tests/fixtures/rest-props-simple/output.d.ts
+++ b/tests/fixtures/rest-props-simple/output.d.ts
@@ -1,12 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["h1"];
+type $RestProps = SvelteHTMLElements["h1"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type RestPropsSimpleProps = Omit<RestProps, keyof $Props> & $Props;
+export type RestPropsSimpleProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RestPropsSimple extends SvelteComponentTyped<RestPropsSimpleProps, Record<string, any>, {}> {}

--- a/tests/fixtures/svg-props/output.d.ts
+++ b/tests/fixtures/svg-props/output.d.ts
@@ -1,12 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["svg"];
+type $RestProps = SvelteHTMLElements["svg"];
 
 type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type SvgPropsProps = Omit<RestProps, keyof $Props> & $Props;
+export type SvgPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, {}> {}


### PR DESCRIPTION
Fixes #147

Rename the internal `RestProps` type to `$RestProps` to avoid potentially clashing with a component named `Rest.svelte`.