### PR TITLE
test(fixtures): ensure `.ts` are type checked

### DIFF
--- a/tsconfig.fixtures.json
+++ b/tsconfig.fixtures.json
@@ -7,5 +7,5 @@
     "strict": true,
     "types": []
   },
-  "include": ["tests/fixtures/**/*.d.ts"]
+  "include": ["tests/fixtures/**/*.ts"]
 }


### PR DESCRIPTION
Currently, only type declaration files inside `tests/fixtures` are type checked.

There are a couple of `.ts` files that asserts type definitions that should also be tested.