### PR TITLE
chore(playground): fix cursor resetting in codemirror

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html lang="en" theme="g100" style="color-scheme: dark">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
-    <meta name="description" content="Generate TypeScript definitions for your Svelte components." />
-  </head>
-  <body>
-    <script type="module">
-      import App from "./src/App.svelte";
 
-      const app = new App({ target: document.body });
-    </script>
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+  <meta name="description" content="Generate TypeScript definitions for your Svelte components." />
+</head>
+
+<body>
+  <script type="module" src="./src/index.js">
+  </script>
+</body>
+
 </html>

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -1,6 +1,5 @@
 <script>
   // @ts-check
-  import "carbon-components-svelte/css/all.css";
   import Header from "./Header.svelte";
   import {
     FormLabel,

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -12,7 +12,7 @@
     TabContent,
     InlineLoading,
   } from "carbon-components-svelte";
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import ComponentParser from "../../src/ComponentParser";
   import CodeEditor from "./CodeEditor.svelte";
   import data from "./data";
@@ -60,10 +60,6 @@
       parse_error = error;
     }
   }
-
-  $: if (value && codemirror) {
-    codemirror.setValue(value);
-  }
 </script>
 
 <Header>
@@ -73,19 +69,22 @@
         <Dropdown
           size="xl"
           titleText="Svelte code"
-          bind:selectedId
+          {selectedId}
           items={data.map((datum) => ({
             id: datum.moduleName,
             text: datum.moduleName,
           }))}
-        />
-        <CodeEditor
-          bind:code={value}
-          bind:codemirror
-          on:change={(e) => {
-            value = e.detail;
+          on:select={(e) => {
+            selectedId = e.detail.selectedId;
+
+            tick().then(() => {
+              codemirror.setValue(selected.code);
+            });
           }}
         />
+        <CodeEditor bind:code={value} bind:codemirror on:change={(e) => {
+            value = e.detail;
+          }} />
       </Column>
       <Column xlg={9} lg={10} sm={8}>
         <FormLabel id="output">Sveld output</FormLabel>

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -41,9 +41,7 @@
 
   $: selected = data.find((datum) => datum.moduleName === selectedId);
   $: value = selected.code;
-
-  // TODO: use module name from selected
-  $: moduleName = "Component";
+  $: moduleName = selected.moduleName;
 
   let parsed_component = {};
   let parse_error = null;

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import "carbon-components-svelte/css/all.css";
   import Header from "./Header.svelte";
   import {

--- a/playground/src/CodeEditor.svelte
+++ b/playground/src/CodeEditor.svelte
@@ -1,11 +1,14 @@
+<script context="module">
+  import CodeMirror from "codemirror";
+  import "codemirror/mode/htmlmixed/htmlmixed";
+  import "codemirror/theme/zenburn.css";
+</script>
+
 <script>
   // @ts-check
   export let code = "";
   export let codemirror = null;
 
-  import CodeMirror from "codemirror";
-  import "codemirror/mode/htmlmixed/htmlmixed";
-  import "codemirror/theme/zenburn.css";
   import { onMount, createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();

--- a/playground/src/CodeEditor.svelte
+++ b/playground/src/CodeEditor.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   export let code = "";
   export let codemirror = null;
 
@@ -17,7 +18,7 @@
       mode: "htmlmixed",
       theme: "zenburn",
     });
-    codemirror.on("change", () => {
+    codemirror.doc.on("change", () => {
       dispatch("change", codemirror.getValue());
     });
 

--- a/playground/src/CodeEditor.svelte
+++ b/playground/src/CodeEditor.svelte
@@ -11,7 +11,7 @@
 
   let ref;
 
-  $: if (ref && !codemirror) {
+  onMount(() => {
     codemirror = CodeMirror(ref, {
       value: code,
       mode: "htmlmixed",
@@ -20,9 +20,7 @@
     codemirror.on("change", () => {
       dispatch("change", codemirror.getValue());
     });
-  }
 
-  onMount(() => {
     return () => {
       codemirror = null;
     };

--- a/playground/src/CodeHighlighter.svelte
+++ b/playground/src/CodeHighlighter.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+  // @ts-check
   import json from "svelte-highlight/languages/json";
   import typescript from "svelte-highlight/languages/typescript";
   import markdown from "svelte-highlight/languages/markdown";
@@ -11,6 +12,7 @@
 </script>
 
 <script>
+  // @ts-check
   export let code = "";
   export let language = "typescript";
   export let noWrap = false;

--- a/playground/src/Header.svelte
+++ b/playground/src/Header.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import { Header, Content, HeaderUtilities, HeaderActionLink, SkipToContent } from "carbon-components-svelte";
   import LogoGithub20 from "./LogoGithub20.svelte";
   import pkg from "../../package.json";

--- a/playground/src/TabContentOverlay.svelte
+++ b/playground/src/TabContentOverlay.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   export let title = "";
 
   /** @type {"error" | "warning"} */

--- a/playground/src/TabJson.svelte
+++ b/playground/src/TabJson.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   export let parsed_component = {};
 
   import CodeHighlighter from "./CodeHighlighter.svelte";

--- a/playground/src/TabMarkdown.svelte
+++ b/playground/src/TabMarkdown.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   export let parsed_component = {};
   export let moduleName = "";
 

--- a/playground/src/TabTypeScript.svelte
+++ b/playground/src/TabTypeScript.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   export let parsed_component = {};
   export let moduleName = "";
 

--- a/playground/src/data.js
+++ b/playground/src/data.js
@@ -1,4 +1,5 @@
-export const button = {
+const button = {
+  name: "Button",
   moduleName: "Button",
   code: `<script>
   export let type = "button";
@@ -10,8 +11,9 @@ export const button = {
 </button>`,
 };
 
-export const dynamic_dispatched_events = {
-  moduleName: "Dispatched events",
+const dynamic_dispatched_events = {
+  name: "Dispatched events",
+  moduleName: "DispatchedEvents",
   code: `<script>
   import { onDestroy, createEventDispatcher } from "svelte";
 
@@ -35,8 +37,9 @@ export const dynamic_dispatched_events = {
 `,
 };
 
-export const forwarded_events = {
-  moduleName: "Forwarded events",
+const forwarded_events = {
+  name: "Forwarded events",
+  moduleName: "ForwardedEvents",
   code: `<button type="button" on:click on:focus on:blur />
 <h1 on:mouseover on:mouseover={() => {}}>
   <slot />
@@ -44,7 +47,8 @@ export const forwarded_events = {
 `,
 };
 
-export const generics = {
+const generics = {
+  name: "Generics",
   moduleName: "Generics",
   code: `<script>
   /**

--- a/playground/src/data.js
+++ b/playground/src/data.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const button = {
   name: "Button",
   moduleName: "Button",

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -1,0 +1,4 @@
+import "carbon-components-svelte/css/all.css";
+import App from "./App.svelte";
+
+new App({ target: document.body });


### PR DESCRIPTION
The cursor in the codemirror instance is resetting on type.

The fix is to imperatively call `setValue` on `codemirror` when the file selection changes. Otherwise, `setValue` is called whenever `value` changes.