### PR TITLE
fix(component-parser): forwarded events should use `@event` tags

### DIFF
--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -154,7 +154,7 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
   const events_map = def.events
     .map((event) => {
       let description = "";
-      if (event.type === "dispatched" && event.description) {
+      if (event.description) {
         description = `/** ${event.description} */\n`;
       }
       return `${description}${clampKey(event.name)}: ${

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
 "{
@@ -390,6 +390,35 @@ exports[`fixtures (JSON) "typed-slots/input.svelte" 1`] = `
     }
   ],
   "events": [],
+  "typedefs": [],
+  "generics": null
+}"
+`;
+
+exports[`fixtures (JSON) "forwarded-events-typed/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "forwarded",
+      "name": "click",
+      "element": "button",
+      "description": "Fired when the button is clicked"
+    },
+    {
+      "type": "forwarded",
+      "name": "focus",
+      "element": "button",
+      "description": "Fired when the button receives focus"
+    },
+    {
+      "type": "forwarded",
+      "name": "blur",
+      "element": "button"
+    }
+  ],
   "typedefs": [],
   "generics": null
 }"
@@ -1530,6 +1559,24 @@ export default class TypedSlots extends SvelteComponentTyped<
     /** description */
     description: { props: { class?: string } };
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "forwarded-events-typed/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export type ForwardedEventsTypedProps = {};
+
+export default class ForwardedEventsTyped extends SvelteComponentTyped<
+  ForwardedEventsTypedProps,
+  {
+    /** Fired when the button is clicked */ click: WindowEventMap["click"];
+    /** Fired when the button receives focus */
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
 > {}
 "
 `;

--- a/tests/__snapshots__/writer-ts-definitions.test.ts.snap
+++ b/tests/__snapshots__/writer-ts-definitions.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`writerTsDefinition writeTsDefinition 1`] = `
 "

--- a/tests/fixtures/forwarded-events-typed/input.svelte
+++ b/tests/fixtures/forwarded-events-typed/input.svelte
@@ -1,0 +1,8 @@
+<script>
+  /**
+   * @event click - Fired when the button is clicked
+   * @event focus - Fired when the button receives focus
+   */
+</script>
+
+<button type="button" on:click on:focus on:blur />

--- a/tests/fixtures/forwarded-events-typed/output.d.ts
+++ b/tests/fixtures/forwarded-events-typed/output.d.ts
@@ -1,0 +1,14 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export type ForwardedEventsTypedProps = {};
+
+export default class ForwardedEventsTyped extends SvelteComponentTyped<
+  ForwardedEventsTypedProps,
+  {
+    /** Fired when the button is clicked */ click: WindowEventMap["click"];
+    /** Fired when the button receives focus */
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/tests/fixtures/forwarded-events-typed/output.json
+++ b/tests/fixtures/forwarded-events-typed/output.json
@@ -1,0 +1,26 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "forwarded",
+      "name": "click",
+      "element": "button",
+      "description": "Fired when the button is clicked"
+    },
+    {
+      "type": "forwarded",
+      "name": "focus",
+      "element": "button",
+      "description": "Fired when the button receives focus"
+    },
+    {
+      "type": "forwarded",
+      "name": "blur",
+      "element": "button"
+    }
+  ],
+  "typedefs": [],
+  "generics": null
+}


### PR DESCRIPTION
Fixes #102


This commit addresses the issue where @event JSDoc tags on forwarded events incorrectly changed the event type from "forwarded" to "dispatched" and lost the element metadata.

**Changes**
- Add `description` field to ForwardedEvent interface to support JSDoc descriptions
- Track event descriptions separately during JSDoc parsing
- Update writer to include descriptions for all event types (not just dispatched)

**Expected behavior**
1. Forwarded events with `@event` descriptions remain type "forwarded" with element metadata
2. Dispatched events keep type "dispatched" with detail info
3. Mixed events (both forwarded and dispatched) correctly prioritize dispatched type
4. Descriptions are preserved in JSON output and TypeScript definitions

## Input

```ts
<script>
  /**
   * @event click - Fired when the button is clicked
   * @event focus - Fired when the button receives focus
   */
</script>
<button on:click on:focus />
```

## Output

```json
{
  "type": "forwarded",
  "name": "click",
  "element": "button",
  "description": "Fired when the button is clicked"
}
```