### PR TITLE
fix(writer)!: change default slot name from "__default__" to null

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -36,12 +36,12 @@ interface ComponentProp {
   reactive: boolean;
 }
 
-const DEFAULT_SLOT_NAME = "__default__";
+const DEFAULT_SLOT_NAME = null;
 
 type ComponentSlotName = typeof DEFAULT_SLOT_NAME | string;
 
 interface ComponentSlot {
-  name?: string;
+  name?: string | null;
   default: boolean;
   fallback?: string;
   slot_props?: string;

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -143,7 +143,7 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
 
   const slotDefs = def.slots
     .map(({ name, slot_props, ...rest }) => {
-      const key = rest.default ? "default" : clampKey(name ?? "");
+      const key = rest.default || name === null ? "default" : clampKey(name ?? "");
       const description = rest.description ? `/** ${rest.description} */\n` : "";
       return `${description}${clampKey(key)}: ${formatTsProps(slot_props)};`;
     })

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -33,7 +33,7 @@ exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "Default text",
       "slot_props": "Record<string, never>"
@@ -92,7 +92,7 @@ exports[`fixtures (JSON) "generics-multiple/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row, Header>>, rows: ReadonlyArray<Row> }"
     }
@@ -237,7 +237,7 @@ exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -372,7 +372,7 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "{name}",
       "slot_props": "Record<string, never>"
@@ -413,7 +413,7 @@ exports[`fixtures (JSON) "typed-slots/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop: number; doubled: number; }"
     },
@@ -467,7 +467,7 @@ exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -527,7 +527,7 @@ exports[`fixtures (JSON) "typedefs/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop1: MyTypedef, prop2: MyTypedefArray }"
     }
@@ -578,7 +578,7 @@ exports[`fixtures (JSON) "generics-with-rest-props/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
     }
@@ -629,7 +629,7 @@ exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -646,7 +646,7 @@ exports[`fixtures (JSON) "dispatched-events-typed/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -746,7 +746,7 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop: boolean, prop1: boolean | string, prop2: any, prop3: boolean }"
     }
@@ -800,7 +800,7 @@ exports[`fixtures (JSON) "prop-comments/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop: boolean | string, prop1: boolean, prop2: boolean | string }"
     }
@@ -817,7 +817,7 @@ exports[`fixtures (JSON) "forwarded-events-native-with-jsdoc/input.svelte" 1`] =
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -946,7 +946,7 @@ exports[`fixtures (JSON) "infer-with-types/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "{name}",
       "slot_props": "Record<string, never>"
@@ -1237,7 +1237,7 @@ exports[`fixtures (JSON) "component-comment-single/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -1287,7 +1287,7 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -1351,7 +1351,7 @@ exports[`fixtures (JSON) "typedef/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop1: MyTypedef }"
     }
@@ -1389,7 +1389,7 @@ exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -1410,7 +1410,7 @@ exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }
@@ -1454,7 +1454,7 @@ exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "Default text",
       "slot_props": "Record<string, never>"
@@ -1494,7 +1494,7 @@ exports[`fixtures (JSON) "slots-spread-typed/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "Default text",
       "slot_props": "{ a: number; }"
@@ -1596,7 +1596,7 @@ exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
     }

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -55,11 +55,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         {
@@ -148,16 +144,12 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "title",
           "default": false,
           "fallback": "{title}",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "animationend", "element": "li" },
@@ -255,11 +247,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -297,11 +285,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         {
@@ -364,7 +348,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "{props?: { [\"aria-current\"]?: string; class: \"bx--link\"; }}"
         }
@@ -593,7 +577,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "{ props: { role: \"button\"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } }"
         }
@@ -643,11 +627,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -937,11 +917,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "a" },
@@ -1163,7 +1139,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{code}",
           "slot_props": "Record<string, never>"
@@ -1359,7 +1335,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "{props: { class: string; [key: string]: any; }}"
         }
@@ -1729,11 +1705,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -1768,11 +1740,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -1821,11 +1789,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         {
@@ -1887,7 +1851,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{#if animation}{feedback || $$restProps[\"aria-label\"]}{/if}",
           "slot_props": "Record<string, never>"
@@ -2203,11 +2167,6 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "cell",
           "default": false,
           "fallback": "{cell.display ? cell.display(cell.value, row) : cell.value}",
@@ -2235,7 +2194,8 @@
           "default": false,
           "fallback": "{title}",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         {
@@ -2552,11 +2512,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -3859,11 +3815,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "forwarded", "name": "submit", "element": "Form" }],
       "typedefs": [],
@@ -3876,11 +3828,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "form" },
@@ -3948,11 +3896,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "fieldset" },
@@ -3970,11 +3914,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -4005,11 +3945,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
@@ -4125,7 +4061,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "{ props: { class: string; [key: string]: any; } }"
         }
@@ -4236,11 +4172,6 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "platform",
           "default": false,
           "fallback": "{platformName}",
@@ -4250,7 +4181,8 @@
           "name": "skip-to-content",
           "default": false,
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
@@ -4323,16 +4255,12 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "text",
           "default": false,
           "fallback": "{#if text}<span>{text}</span>{/if}",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "button" },
@@ -4484,7 +4412,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "<svelte:component this={icon} />",
           "slot_props": "Record<string, never>"
@@ -4513,11 +4441,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -4645,11 +4569,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "a" },
@@ -4671,11 +4591,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -4711,11 +4627,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
@@ -4728,11 +4640,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -4806,7 +4714,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{result.text}\n              {#if result.description}<span>– {result.description}</span>{/if}",
           "slot_props": "{ result: HeaderSearchResult; index: number }"
@@ -4843,11 +4751,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -5098,7 +5002,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "Record<string, never>"
         },
@@ -5200,11 +5104,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "p" },
@@ -5330,11 +5230,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "div" },
@@ -5435,11 +5331,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -5490,11 +5382,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "forwarded", "name": "scroll", "element": "div" }],
       "typedefs": [],
@@ -5586,11 +5474,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -5684,11 +5568,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "li" },
@@ -6004,11 +5884,6 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "heading",
           "default": false,
           "fallback": "{modalHeading}",
@@ -6019,7 +5894,8 @@
           "default": false,
           "fallback": "{modalLabel}",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "div" },
@@ -6071,11 +5947,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -6159,11 +6031,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -6261,11 +6129,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
@@ -6621,11 +6485,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Button" },
@@ -6802,11 +6662,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -7176,11 +7032,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ol" },
@@ -7198,11 +7050,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Link" },
@@ -7363,16 +7211,12 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "menu",
           "default": false,
           "fallback": "<svelte:component\n      this={icon}\n      aria-label={iconDescription}\n      title={iconDescription}\n      class=\"bx--overflow-menu__icon {iconClass}\"\n    />",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         {
@@ -7506,7 +7350,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "<div class:bx--overflow-menu-options__option-content={true}>\n          {text}\n        </div>",
           "slot_props": "Record<string, never>"
@@ -8137,11 +7981,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "number" },
@@ -8299,7 +8139,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "<p class:bx--progress-label={true}>{label}</p>",
           "slot_props": "{ props: { class: \"bx--progress-label\" } }"
@@ -8501,11 +8341,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -8625,11 +8461,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "change", "element": "input" },
@@ -8735,7 +8567,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "{ props: { class: string; [key: string]: any; } }"
         }
@@ -9161,11 +8993,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "string" },
@@ -9265,11 +9093,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -9420,11 +9244,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
@@ -9479,11 +9299,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -9496,11 +9312,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -9628,11 +9440,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
@@ -9809,7 +9617,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Skip to main content",
           "slot_props": "Record<string, never>"
@@ -10113,11 +9921,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10136,11 +9940,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10183,11 +9983,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10205,11 +10001,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -10348,11 +10140,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
@@ -10474,7 +10262,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{text}",
           "slot_props": "Record<string, never>"
@@ -10571,7 +10359,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{label}",
           "slot_props": "Record<string, never>"
@@ -10606,11 +10394,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -10695,11 +10479,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -10712,11 +10492,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -10729,11 +10505,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "td" },
@@ -10788,11 +10560,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -10805,11 +10573,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "thead" },
@@ -10864,11 +10628,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "mouseover", "element": "th" },
@@ -10886,11 +10646,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "tr" },
@@ -10958,7 +10714,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "Record<string, never>"
         },
@@ -11096,7 +10852,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "{ props: { class: \"bx--tag__label\" } }"
         }
@@ -11629,11 +11385,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -11687,11 +11439,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [{ "type": "dispatched", "name": "select" }],
       "typedefs": [],
@@ -11883,11 +11631,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -12005,11 +11749,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -12136,11 +11876,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         {
@@ -12495,11 +12231,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -12525,11 +12257,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -12542,11 +12270,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -12558,11 +12282,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -12579,11 +12299,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "OverflowMenuItem" },
@@ -12853,11 +12569,6 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "icon",
           "default": false,
           "fallback": "<svelte:component this={icon} name={iconName} />",
@@ -12868,7 +12579,8 @@
           "default": false,
           "fallback": "{triggerText}",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
@@ -12946,7 +12658,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "slot_props": "Record<string, never>"
         },
@@ -13036,16 +12748,12 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        },
-        {
           "name": "text",
           "default": false,
           "fallback": "{tooltipText}",
           "slot_props": "Record<string, never>"
-        }
+        },
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "button" },
@@ -13077,11 +12785,7 @@
       ],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ul" },

--- a/tests/e2e/carbon/COMPONENT_INDEX.md
+++ b/tests/e2e/carbon/COMPONENT_INDEX.md
@@ -204,8 +204,8 @@
 
 | Slot name | Default | Props                               | Fallback             |
 | :-------- | :------ | :---------------------------------- | :------------------- |
-| --        | Yes     | <code>Record<string, never> </code> | --                   |
 | title     | No      | <code>Record<string, never> </code> | <code>{title}</code> |
+| --        | Yes     | <code>Record<string, never> </code> | --                   |
 
 ### Events
 
@@ -835,12 +835,12 @@ export interface DataTableCell {
 
 | Slot name    | Default | Props                                                                                      | Fallback                                                                 |
 | :----------- | :------ | :----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
-| --           | Yes     | <code>Record<string, never> </code>                                                        | --                                                                       |
 | cell         | No      | <code>{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; } </code> | <code>{cell.display ? cell.display(cell.value, row) : cell.value}</code> |
 | cell-header  | No      | <code>{ header: DataTableNonEmptyHeader; } </code>                                         | <code>{header.value}</code>                                              |
 | description  | No      | <code>Record<string, never> </code>                                                        | <code>{description}</code>                                               |
 | expanded-row | No      | <code>{ row: Row; } </code>                                                                | --                                                                       |
 | title        | No      | <code>Record<string, never> </code>                                                        | <code>{title}</code>                                                     |
+| --           | Yes     | <code>Record<string, never> </code>                                                        | --                                                                       |
 
 ### Events
 
@@ -1396,9 +1396,9 @@ None.
 
 | Slot name       | Default | Props                               | Fallback                    |
 | :-------------- | :------ | :---------------------------------- | :-------------------------- |
-| --              | Yes     | <code>Record<string, never> </code> | --                          |
 | platform        | No      | <code>Record<string, never> </code> | <code>{platformName}</code> |
 | skip-to-content | No      | <code>Record<string, never> </code> | --                          |
+| --              | Yes     | <code>Record<string, never> </code> | --                          |
 
 ### Events
 
@@ -1432,8 +1432,8 @@ export interface HeaderActionSlideTransition {
 
 | Slot name | Default | Props                               | Fallback                                                    |
 | :-------- | :------ | :---------------------------------- | :---------------------------------------------------------- |
-| --        | Yes     | <code>Record<string, never> </code> | --                                                          |
 | text      | No      | <code>Record<string, never> </code> | <code>{#if text}&lt;span&gt;{text}&lt;/span&gt;{/if}</code> |
+| --        | Yes     | <code>Record<string, never> </code> | --                                                          |
 
 ### Events
 
@@ -2053,9 +2053,9 @@ None.
 
 | Slot name | Default | Props                               | Fallback                    |
 | :-------- | :------ | :---------------------------------- | :-------------------------- |
-| --        | Yes     | <code>Record<string, never> </code> | --                          |
 | heading   | No      | <code>Record<string, never> </code> | <code>{modalHeading}</code> |
 | label     | No      | <code>Record<string, never> </code> | <code>{modalLabel}</code>   |
+| --        | Yes     | <code>Record<string, never> </code> | --                          |
 
 ### Events
 
@@ -2425,8 +2425,8 @@ None.
 
 | Slot name | Default | Props                               | Fallback                                                                                                                                                                             |
 | :-------- | :------ | :---------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| --        | Yes     | <code>Record<string, never> </code> | --                                                                                                                                                                                   |
 | menu      | No      | <code>Record<string, never> </code> | <code>&lt;svelte:component<br /> this={icon}<br /> aria-label={iconDescription}<br /> title={iconDescription}<br /> class="bx--overflow-menu\_\_icon {iconClass}"<br /> /&gt;</code> |
+| --        | Yes     | <code>Record<string, never> </code> | --                                                                                                                                                                                   |
 
 ### Events
 
@@ -4203,9 +4203,9 @@ None.
 
 | Slot name   | Default | Props                               | Fallback                                                            |
 | :---------- | :------ | :---------------------------------- | :------------------------------------------------------------------ |
-| --          | Yes     | <code>Record<string, never> </code> | --                                                                  |
 | icon        | No      | <code>Record<string, never> </code> | <code>&lt;svelte:component this={icon} name={iconName} /&gt;</code> |
 | triggerText | No      | <code>Record<string, never> </code> | <code>{triggerText}</code>                                          |
+| --          | Yes     | <code>Record<string, never> </code> | --                                                                  |
 
 ### Events
 
@@ -4259,8 +4259,8 @@ None.
 
 | Slot name | Default | Props                               | Fallback                   |
 | :-------- | :------ | :---------------------------------- | :------------------------- |
-| --        | Yes     | <code>Record<string, never> </code> | --                         |
 | text      | No      | <code>Record<string, never> </code> | <code>{tooltipText}</code> |
+| --        | Yes     | <code>Record<string, never> </code> | --                         |
 
 ### Events
 

--- a/tests/e2e/carbon/types/Accordion/AccordionItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/AccordionItem.svelte.d.ts
@@ -45,5 +45,5 @@ export default class AccordionItem extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: Record<string, never>; title: Record<string, never> }
+  { title: Record<string, never>; default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -213,7 +213,6 @@ export default class DataTable<
     "click:cell": CustomEvent<DataTableCell<Row>>;
   },
   {
-    default: Record<string, never>;
     cell: {
       row: Row;
       cell: DataTableCell<Row>;
@@ -224,5 +223,6 @@ export default class DataTable<
     description: Record<string, never>;
     "expanded-row": { row: Row };
     title: Record<string, never>;
+    default: Record<string, never>;
   }
 > {}

--- a/tests/e2e/carbon/types/Modal/Modal.svelte.d.ts
+++ b/tests/e2e/carbon/types/Modal/Modal.svelte.d.ts
@@ -137,8 +137,8 @@ export default class Modal extends SvelteComponentTyped<
     open: CustomEvent<null>;
   },
   {
-    default: Record<string, never>;
     heading: Record<string, never>;
     label: Record<string, never>;
+    default: Record<string, never>;
   }
 > {}

--- a/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -91,5 +91,5 @@ export default class OverflowMenu extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: Record<string, never>; menu: Record<string, never> }
+  { menu: Record<string, never>; default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tooltip/Tooltip.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tooltip/Tooltip.svelte.d.ts
@@ -98,8 +98,8 @@ export default class Tooltip extends SvelteComponentTyped<
   TooltipProps,
   { click: WindowEventMap["click"]; mousedown: WindowEventMap["mousedown"] },
   {
-    default: Record<string, never>;
     icon: Record<string, never>;
     triggerText: Record<string, never>;
+    default: Record<string, never>;
   }
 > {}

--- a/tests/e2e/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -49,5 +49,5 @@ export default class TooltipIcon extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     focus: WindowEventMap["focus"];
   },
-  { default: Record<string, never>; text: Record<string, never> }
+  { text: Record<string, never>; default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -62,8 +62,8 @@ export default class Header extends SvelteComponentTyped<
   HeaderProps,
   { click: WindowEventMap["click"] },
   {
-    default: Record<string, never>;
     platform: Record<string, never>;
     "skip-to-content": Record<string, never>;
+    default: Record<string, never>;
   }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -50,5 +50,5 @@ export type HeaderActionProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class HeaderAction extends SvelteComponentTyped<
   HeaderActionProps,
   { click: WindowEventMap["click"]; close: CustomEvent<null> },
-  { default: Record<string, never>; text: Record<string, never> }
+  { text: Record<string, never>; default: Record<string, never> }
 > {}

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -66,7 +66,7 @@
       ],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -32,7 +32,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"
@@ -50,7 +50,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Link text",
           "slot_props": "Record<string, never>"
@@ -91,7 +91,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{quote}",
           "slot_props": "Record<string, never>"
@@ -121,7 +121,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -42,7 +42,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"
@@ -59,11 +59,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -76,7 +72,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Link text",
           "slot_props": "Record<string, never>"
@@ -117,7 +113,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{quote}",
           "slot_props": "Record<string, never>"

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -32,7 +32,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"
@@ -49,11 +49,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -65,11 +61,7 @@
       "props": [],
       "moduleExports": [],
       "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "slot_props": "Record<string, never>"
-        }
+        { "name": null, "default": true, "slot_props": "Record<string, never>" }
       ],
       "events": [],
       "typedefs": [],
@@ -82,7 +74,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Link text",
           "slot_props": "Record<string, never>"
@@ -123,7 +115,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "{quote}",
           "slot_props": "Record<string, never>"

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -31,7 +31,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -31,7 +31,7 @@
       "moduleExports": [],
       "slots": [
         {
-          "name": "__default__",
+          "name": null,
           "default": true,
           "fallback": "Click me",
           "slot_props": "Record<string, never>"

--- a/tests/fixtures/anchor-props/output.json
+++ b/tests/fixtures/anchor-props/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/bind-this-multiple/output.json
+++ b/tests/fixtures/bind-this-multiple/output.json
@@ -35,7 +35,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/bind-this/output.json
+++ b/tests/fixtures/bind-this/output.json
@@ -14,7 +14,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/component-comment-multi/output.json
+++ b/tests/fixtures/component-comment-multi/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/component-comment-single/output.json
+++ b/tests/fixtures/component-comment-single/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/dispatched-events-typed/output.json
+++ b/tests/fixtures/dispatched-events-typed/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
+++ b/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/forwarded-events/output.json
+++ b/tests/fixtures/forwarded-events/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "Record<string, never>"
     }

--- a/tests/fixtures/generics-multiple/output.json
+++ b/tests/fixtures/generics-multiple/output.json
@@ -26,7 +26,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row, Header>>, rows: ReadonlyArray<Row> }"
     }

--- a/tests/fixtures/generics-with-rest-props/output.json
+++ b/tests/fixtures/generics-with-rest-props/output.json
@@ -26,7 +26,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
     }

--- a/tests/fixtures/generics/output.json
+++ b/tests/fixtures/generics/output.json
@@ -26,7 +26,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
     }

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -78,7 +78,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "{name}",
       "slot_props": "Record<string, never>"

--- a/tests/fixtures/infer-with-types/output.json
+++ b/tests/fixtures/infer-with-types/output.json
@@ -69,7 +69,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "{name}",
       "slot_props": "Record<string, never>"

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -40,7 +40,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop: boolean | string, prop1: boolean, prop2: boolean | string }"
     }

--- a/tests/fixtures/required/output.json
+++ b/tests/fixtures/required/output.json
@@ -47,7 +47,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop: boolean, prop1: boolean | string, prop2: any, prop3: boolean }"
     }

--- a/tests/fixtures/slots-named/output.json
+++ b/tests/fixtures/slots-named/output.json
@@ -15,7 +15,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "Default text",
       "slot_props": "Record<string, never>"

--- a/tests/fixtures/slots-spread-typed/output.json
+++ b/tests/fixtures/slots-spread-typed/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "Default text",
       "slot_props": "{ a: number; }"

--- a/tests/fixtures/slots-spread/output.json
+++ b/tests/fixtures/slots-spread/output.json
@@ -3,7 +3,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "fallback": "Default text",
       "slot_props": "Record<string, never>"

--- a/tests/fixtures/typed-slots/output.json
+++ b/tests/fixtures/typed-slots/output.json
@@ -15,7 +15,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop: number; doubled: number; }"
     },

--- a/tests/fixtures/typedef/output.json
+++ b/tests/fixtures/typedef/output.json
@@ -26,7 +26,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop1: MyTypedef }"
     }

--- a/tests/fixtures/typedefs/output.json
+++ b/tests/fixtures/typedefs/output.json
@@ -26,7 +26,7 @@
   "moduleExports": [],
   "slots": [
     {
-      "name": "__default__",
+      "name": null,
       "default": true,
       "slot_props": "{ prop1: MyTypedef, prop2: MyTypedefArray }"
     }


### PR DESCRIPTION
Closes #74

Previously, `__default__` was used as a sentinel value to signify the default slot. This was intended for internal usage, but it affects the JSON output. There is also the edge case where a consumer may have named a slot "__default__," which would clash with that (this is very unlikely).

This fix correctly tracks the default slot as `null`. This is a breaking change, as it impacts the generated JSON API.

```diff
- if (slot.name === "__default__") { ... }
+ if (slot.default === true) { ... }
```

## Before

```json
{
  "slots": [
    {
      "name": "__default__",  // The actual unnamed slot
      "default": true,
      "fallback": "Default content"
    },
    {
      "name": "__default__",  // The named slot "__default__"
      "default": false,       // This is NOT the default slot
      "fallback": "Fallback for __default__"
    }
  ]
}
```

## After

```json
{
  "slots": [
    {
      "name": null,           // The actual unnamed slot - uses null
      "default": true,
      "fallback": "Default content"
    },
    {
      "name": "__default__",  // The named slot - uses the string
      "default": false,
      "fallback": "Fallback for __default__"
    }
  ]
}
```