### PR TITLE
feat(component-parser): support `setContext` API

### DIFF
--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -11,7 +11,8 @@ exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
   "rest_props": {
     "type": "Element",
     "name": "svg"
-  }
+  },
+  "contexts": []
 }"
 `;
 
@@ -59,7 +60,8 @@ exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -118,7 +120,8 @@ exports[`fixtures (JSON) "generics-multiple/input.svelte" 1`] = `
   "generics": [
     "Row,Header",
     "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
-  ]
+  ],
+  "contexts": []
 }"
 `;
 
@@ -153,7 +156,8 @@ exports[`fixtures (JSON) "mixed-event-types/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -170,7 +174,39 @@ exports[`fixtures (JSON) "dispatched-events-dynamic/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
+}"
+`;
+
+exports[`fixtures (JSON) "context-issue-103/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "my-logger",
+      "typeName": "MyLoggerContext",
+      "properties": [
+        {
+          "name": "log",
+          "type": "(message: string) => void",
+          "description": "Log a message to the console",
+          "optional": false
+        }
+      ]
+    }
+  ]
 }"
 `;
 
@@ -227,7 +263,8 @@ exports[`fixtures (JSON) "function-declaration/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -265,7 +302,8 @@ exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -287,7 +325,8 @@ exports[`fixtures (JSON) "mixed-events/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -380,7 +419,8 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -391,7 +431,8 @@ exports[`fixtures (JSON) "empty-export/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -426,7 +467,51 @@ exports[`fixtures (JSON) "typed-slots/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
+}"
+`;
+
+exports[`fixtures (JSON) "context-typedef/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "object",
+      "name": "TabData",
+      "ts": "type TabData = object"
+    }
+  ],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "tabs",
+      "typeName": "TabsContext",
+      "properties": [
+        {
+          "name": "addTab",
+          "type": "(tab: TabData) => void",
+          "description": "Register a new tab",
+          "optional": false
+        },
+        {
+          "name": "removeTab",
+          "type": "(id: string) => void",
+          "description": "Remove a tab by ID",
+          "optional": false
+        }
+      ]
+    }
+  ]
 }"
 `;
 
@@ -457,7 +542,8 @@ exports[`fixtures (JSON) "forwarded-events-typed/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -494,7 +580,8 @@ exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -545,7 +632,8 @@ exports[`fixtures (JSON) "typedefs/input.svelte" 1`] = `
       "ts": "type MyTypedefArray = MyTypedef[]"
     }
   ],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -608,7 +696,8 @@ exports[`fixtures (JSON) "generics-with-rest-props/input.svelte" 1`] = `
   "rest_props": {
     "type": "Element",
     "name": "div"
-  }
+  },
+  "contexts": []
 }"
 `;
 
@@ -636,7 +725,8 @@ exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -665,7 +755,8 @@ exports[`fixtures (JSON) "dispatched-events-typed/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -692,7 +783,8 @@ exports[`fixtures (JSON) "input-events/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -753,7 +845,45 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
+}"
+`;
+
+exports[`fixtures (JSON) "context-imported-type/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "object",
+      "name": "ModalAPI",
+      "ts": "type ModalAPI = object"
+    }
+  ],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "modal",
+      "typeName": "ModalContext",
+      "properties": [
+        {
+          "name": "modalAPI",
+          "type": "ModalAPI",
+          "description": "Modal API object",
+          "optional": false
+        }
+      ]
+    }
+  ]
 }"
 `;
 
@@ -807,7 +937,8 @@ exports[`fixtures (JSON) "prop-comments/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -846,7 +977,45 @@ exports[`fixtures (JSON) "forwarded-events-native-with-jsdoc/input.svelte" 1`] =
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
+}"
+`;
+
+exports[`fixtures (JSON) "context-simple/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "simple-modal",
+      "typeName": "SimpleModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props?: any) => void",
+          "description": "Open the modal with content",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => void",
+          "description": "Close the modal",
+          "optional": false
+        }
+      ]
+    }
+  ]
 }"
 `;
 
@@ -870,7 +1039,8 @@ exports[`fixtures (JSON) "renamed-props/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -954,7 +1124,8 @@ exports[`fixtures (JSON) "infer-with-types/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -973,7 +1144,8 @@ exports[`fixtures (JSON) "forwarded-native-with-detail/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1076,7 +1248,8 @@ exports[`fixtures (JSON) "context-module/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1103,7 +1276,8 @@ exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
   "rest_props": {
     "type": "Element",
     "name": "ul | ol"
-  }
+  },
+  "contexts": []
 }"
 `;
 
@@ -1145,7 +1319,8 @@ exports[`fixtures (JSON) "forwarded-from-component-to-native/input.svelte" 1`] =
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1156,7 +1331,8 @@ exports[`fixtures (JSON) "no-props/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1187,7 +1363,8 @@ exports[`fixtures (JSON) "event-explicit-null/input.svelte" 1`] = `
   "rest_props": {
     "type": "Element",
     "name": "input"
-  }
+  },
+  "contexts": []
 }"
 `;
 
@@ -1227,7 +1404,8 @@ exports[`fixtures (JSON) "forwarded-standard-event-custom-detail/input.svelte" 1
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1245,7 +1423,8 @@ exports[`fixtures (JSON) "component-comment-single/input.svelte" 1`] = `
   "events": [],
   "typedefs": [],
   "generics": null,
-  "componentComment": " Component comment"
+  "componentComment": " Component comment",
+  "contexts": []
 }"
 `;
 
@@ -1294,7 +1473,8 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1318,7 +1498,8 @@ exports[`fixtures (JSON) "forwarded-custom-events/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1364,7 +1545,8 @@ exports[`fixtures (JSON) "typedef/input.svelte" 1`] = `
       "ts": "interface MyTypedef { [key: string]: boolean; }"
     }
   ],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1379,7 +1561,8 @@ exports[`fixtures (JSON) "rest-props-simple/input.svelte" 1`] = `
   "rest_props": {
     "type": "Element",
     "name": "h1"
-  }
+  },
+  "contexts": []
 }"
 `;
 
@@ -1400,7 +1583,8 @@ exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
   "rest_props": {
     "type": "Element",
     "name": "a"
-  }
+  },
+  "contexts": []
 }"
 `;
 
@@ -1418,7 +1602,8 @@ exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
   "events": [],
   "typedefs": [],
   "generics": null,
-  "componentComment": "\\n@example\\n<div>\\n  Component comment\\n</div>"
+  "componentComment": "\\n@example\\n<div>\\n  Component comment\\n</div>",
+  "contexts": []
 }"
 `;
 
@@ -1444,7 +1629,8 @@ exports[`fixtures (JSON) "forwarded-custom-event-null/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1474,7 +1660,8 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1497,7 +1684,8 @@ exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1514,7 +1702,8 @@ exports[`fixtures (JSON) "forwarded-and-dispatched-events/input.svelte" 1`] = `
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1537,7 +1726,43 @@ exports[`fixtures (JSON) "slots-spread-typed/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
+}"
+`;
+
+exports[`fixtures (JSON) "context-inline-functions/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "modal",
+      "typeName": "ModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props: any) => any",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => any",
+          "optional": false
+        }
+      ]
+    }
+  ]
 }"
 `;
 
@@ -1593,7 +1818,8 @@ exports[`fixtures (JSON) "typed-props/input.svelte" 1`] = `
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }"
 `;
 
@@ -1652,7 +1878,8 @@ exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"
-  ]
+  ],
+  "contexts": []
 }"
 `;
 
@@ -1761,6 +1988,24 @@ export default class DispatchedEventsDynamic extends SvelteComponentTyped<
   DispatchedEventsDynamicProps,
   { KEY: CustomEvent<{ key: string }> },
   Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-issue-103/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export type MyLoggerContext = {
+  /** Log a message to the console */
+  log: (message: string) => void;
+};
+
+export type ContextIssue103Props = Record<string, never>;
+
+export default class ContextIssue103 extends SvelteComponentTyped<
+  ContextIssue103Props,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -1896,6 +2141,27 @@ export default class TypedSlots extends SvelteComponentTyped<
     /** description */
     description: { props: { class?: string } };
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-typedef/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export type TabData = object;
+export type TabsContext = {
+  /** Register a new tab */
+  addTab: (tab: TabData) => void;
+  /** Remove a tab by ID */
+  removeTab: (id: string) => void;
+};
+
+export type ContextTypedefProps = Record<string, never>;
+
+export default class ContextTypedef extends SvelteComponentTyped<
+  ContextTypedefProps,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -2090,6 +2356,25 @@ export default class Required extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "context-imported-type/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export type ModalAPI = object;
+export type ModalContext = {
+  /** Modal API object */
+  modalAPI: ModalAPI;
+};
+
+export type ContextImportedTypeProps = Record<string, never>;
+
+export default class ContextImportedType extends SvelteComponentTyped<
+  ContextImportedTypeProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "prop-comments/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
@@ -2137,6 +2422,26 @@ export default class ForwardedEventsNativeWithJsdoc extends SvelteComponentTyped
     /** Fired when the button loses focus */
     blur: WindowEventMap["blur"];
   },
+  { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-simple/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export type SimpleModalContext = {
+  /** Open the modal with content */
+  open: (component: any, props?: any) => void;
+  /** Close the modal */
+  close: () => void;
+};
+
+export type ContextSimpleProps = Record<string, never>;
+
+export default class ContextSimple extends SvelteComponentTyped<
+  ContextSimpleProps,
+  Record<string, any>,
   { default: Record<string, never> }
 > {}
 "
@@ -2563,6 +2868,24 @@ export default class SlotsSpreadTyped extends SvelteComponentTyped<
   SlotsSpreadTypedProps,
   Record<string, any>,
   { default: { a: number }; text: { a: number } }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-inline-functions/input.svelte" 1`] = `
+"import type { SvelteComponentTyped } from "svelte";
+
+export type ModalContext = {
+  open: (component: any, props: any) => any;
+  close: () => any;
+};
+
+export type ContextInlineFunctionsProps = Record<string, never>;
+
+export default class ContextInlineFunctions extends SvelteComponentTyped<
+  ContextInlineFunctionsProps,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;

--- a/tests/__snapshots__/writer-ts-definitions.test.ts.snap
+++ b/tests/__snapshots__/writer-ts-definitions.test.ts.snap
@@ -7,6 +7,7 @@ exports[`writerTsDefinition writeTsDefinition 1`] = `
   
   
   
+  
     export type ModuleNameProps =  {
       
       /**
@@ -51,6 +52,7 @@ exports[`writerTsDefinition writeTsDefinition 1`] = `
 exports[`writerTsDefinition "default" module name 1`] = `
 "
   import type { SvelteComponentTyped } from "svelte";
+  
   
   
   

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -86,7 +86,16 @@
         "interface": "AccordionSkeletonProps",
         "import": "\"./AccordionSkeleton.svelte\""
       },
-      "componentComment": "\n@example\n<Accordion>\n  <AccordionItem>...</AccordionItem>\n</Accordion>"
+      "componentComment": "\n@example\n<Accordion>\n  <AccordionItem>...</AccordionItem>\n</Accordion>",
+      "contexts": [
+        {
+          "key": "Accordion",
+          "typeName": "AccordionContext",
+          "properties": [
+            { "name": "disableItems", "type": "any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "AccordionItem",
@@ -162,7 +171,8 @@
       "typedefs": [],
       "generics": null,
       "rest_props": { "type": "Element", "name": "li" },
-      "componentComment": " `AccordionItem` is slottable"
+      "componentComment": " `AccordionItem` is slottable",
+      "contexts": []
     },
     {
       "moduleName": "AccordionSkeleton",
@@ -226,7 +236,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": { "type": "Element", "name": "ul" },
+      "contexts": []
     },
     {
       "moduleName": "AspectRatio",
@@ -252,7 +263,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Breadcrumb",
@@ -315,7 +327,8 @@
       "extends": {
         "interface": "BreadcrumbSkeletonProps",
         "import": "\"./BreadcrumbSkeleton.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "BreadcrumbItem",
@@ -361,7 +374,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": { "type": "Element", "name": "li" },
+      "contexts": []
     },
     {
       "moduleName": "BreadcrumbSkeleton",
@@ -402,7 +416,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Button",
@@ -606,7 +621,8 @@
       "extends": {
         "interface": "ButtonSkeletonProps",
         "import": "\"./ButtonSkeleton.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "ButtonSet",
@@ -632,7 +648,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ButtonSkeleton",
@@ -684,7 +701,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "Checkbox",
@@ -857,7 +875,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "CheckboxSkeleton" }
+      "rest_props": { "type": "InlineComponent", "name": "CheckboxSkeleton" },
+      "contexts": []
     },
     {
       "moduleName": "CheckboxSkeleton",
@@ -873,7 +892,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ClickableTile",
@@ -928,7 +948,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "CodeSnippet",
@@ -1170,7 +1191,11 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "CodeSnippetSkeleton" }
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "CodeSnippetSkeleton"
+      },
+      "contexts": []
     },
     {
       "moduleName": "CodeSnippetSkeleton",
@@ -1199,7 +1224,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Column",
@@ -1359,7 +1385,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ComboBox",
@@ -1613,7 +1640,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ComposedModal",
@@ -1719,7 +1747,18 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "ComposedModal",
+          "typeName": "ComposedModalContext",
+          "properties": [
+            { "name": "closeModal", "type": "() => any", "optional": false },
+            { "name": "submit", "type": "() => any", "optional": false },
+            { "name": "declareRef", "type": "(ref) => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "Content",
@@ -1745,7 +1784,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "main" }
+      "rest_props": { "type": "Element", "name": "main" },
+      "contexts": []
     },
     {
       "moduleName": "ContentSwitcher",
@@ -1805,7 +1845,23 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "ContentSwitcher",
+          "typeName": "ContentSwitcherContext",
+          "properties": [
+            { "name": "currentId", "type": "any", "optional": false },
+            { "name": "add", "type": "(arg) => any", "optional": false },
+            { "name": "update", "type": "(id) => any", "optional": false },
+            {
+              "name": "change",
+              "type": "(direction) => any",
+              "optional": false
+            }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "Copy",
@@ -1863,7 +1919,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "CopyButton",
@@ -1894,7 +1951,8 @@
       "extends": {
         "interface": "CopyProps",
         "import": "\"../Copy/Copy.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "DataTable",
@@ -2280,7 +2338,22 @@
         }
       ],
       "generics": ["Row", "Row extends DataTableRow = DataTableRow"],
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "DataTable",
+          "typeName": "DataTableContext",
+          "properties": [
+            { "name": "batchSelectedIds", "type": "any", "optional": false },
+            { "name": "tableRows", "type": "any", "optional": false },
+            {
+              "name": "resetSelectedRowIds",
+              "type": "() => any",
+              "optional": false
+            }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "DataTableSkeleton",
@@ -2384,7 +2457,8 @@
       "extends": {
         "interface": "DataTableHeader",
         "import": "\"../DataTable/DataTable.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "DatePicker",
@@ -2523,7 +2597,32 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "DatePicker",
+          "typeName": "DatePickerContext",
+          "properties": [
+            { "name": "range", "type": "any", "optional": false },
+            { "name": "inputValue", "type": "any", "optional": false },
+            { "name": "hasCalendar", "type": "any", "optional": false },
+            { "name": "add", "type": "(data) => any", "optional": false },
+            { "name": "declareRef", "type": "(arg) => any", "optional": false },
+            {
+              "name": "updateValue",
+              "type": "(arg) => any",
+              "optional": false
+            },
+            {
+              "name": "blurInput",
+              "type": "(relatedTarget) => any",
+              "optional": false
+            },
+            { "name": "openCalendar", "type": "() => any", "optional": false },
+            { "name": "focusCalendar", "type": "() => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "DatePickerInput",
@@ -2693,7 +2792,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "DatePickerSkeleton",
@@ -2734,7 +2834,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Dropdown",
@@ -3004,7 +3105,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "DropdownSkeleton",
@@ -3033,7 +3135,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ExpandableTile",
@@ -3194,7 +3297,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "FileUploader",
@@ -3351,7 +3455,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "FileUploaderButton",
@@ -3499,7 +3604,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": { "type": "Element", "name": "input" },
+      "contexts": []
     },
     {
       "moduleName": "FileUploaderDropContainer",
@@ -3639,7 +3745,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "FileUploaderItem",
@@ -3740,7 +3847,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "span" }
+      "rest_props": { "type": "Element", "name": "span" },
+      "contexts": []
     },
     {
       "moduleName": "FileUploaderSkeleton",
@@ -3756,7 +3864,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Filename",
@@ -3807,7 +3916,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Loading" }
+      "rest_props": { "type": "InlineComponent", "name": "Loading" },
+      "contexts": []
     },
     {
       "moduleName": "FluidForm",
@@ -3820,7 +3930,16 @@
       "events": [{ "type": "forwarded", "name": "submit", "element": "Form" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Form" }
+      "rest_props": { "type": "InlineComponent", "name": "Form" },
+      "contexts": [
+        {
+          "key": "Form",
+          "typeName": "FormContext",
+          "properties": [
+            { "name": "isFluid", "type": "boolean", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "Form",
@@ -3839,7 +3958,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "form" }
+      "rest_props": { "type": "Element", "name": "form" },
+      "contexts": []
     },
     {
       "moduleName": "FormGroup",
@@ -3906,7 +4026,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "fieldset" }
+      "rest_props": { "type": "Element", "name": "fieldset" },
+      "contexts": []
     },
     {
       "moduleName": "FormItem",
@@ -3924,7 +4045,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "FormLabel",
@@ -3955,7 +4077,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": { "type": "Element", "name": "label" },
+      "contexts": []
     },
     {
       "moduleName": "Grid",
@@ -4069,7 +4192,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Header",
@@ -4187,7 +4311,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderAction",
@@ -4274,7 +4399,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderActionLink",
@@ -4332,7 +4458,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderActionSearch",
@@ -4367,7 +4494,8 @@
         }
       ],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "HeaderGlobalAction",
@@ -4421,7 +4549,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderNav",
@@ -4446,7 +4575,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "nav" }
+      "rest_props": { "type": "Element", "name": "nav" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderNavItem",
@@ -4501,7 +4631,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderNavMenu",
@@ -4583,7 +4714,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderPanelDivider",
@@ -4595,7 +4727,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "HeaderPanelLink",
@@ -4632,7 +4765,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderPanelLinks",
@@ -4644,7 +4778,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "HeaderSearch",
@@ -4743,7 +4878,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": { "type": "Element", "name": "input" },
+      "contexts": []
     },
     {
       "moduleName": "HeaderUtilities",
@@ -4755,7 +4891,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "Icon",
@@ -4803,7 +4940,8 @@
       "extends": {
         "interface": "IconSkeletonProps",
         "import": "\"./IconSkeleton.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "IconSkeleton",
@@ -4832,7 +4970,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "InlineLoading",
@@ -4896,7 +5035,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "InlineNotification",
@@ -5025,7 +5165,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Link",
@@ -5114,7 +5255,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a | p" }
+      "rest_props": { "type": "Element", "name": "a | p" },
+      "contexts": []
     },
     {
       "moduleName": "ListBox",
@@ -5238,7 +5380,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ListBoxField",
@@ -5349,7 +5492,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ListBoxMenu",
@@ -5387,7 +5531,8 @@
       "events": [{ "type": "forwarded", "name": "scroll", "element": "div" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ListBoxMenuIcon",
@@ -5441,7 +5586,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ListBoxMenuItem",
@@ -5483,7 +5629,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ListBoxSelection",
@@ -5560,7 +5707,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ListItem",
@@ -5578,7 +5726,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": { "type": "Element", "name": "li" },
+      "contexts": []
     },
     {
       "moduleName": "Loading",
@@ -5650,7 +5799,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Modal",
@@ -5914,7 +6064,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ModalBody",
@@ -5952,7 +6103,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ModalFooter",
@@ -6036,7 +6188,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ModalHeader",
@@ -6134,7 +6287,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "MultiSelect",
@@ -6477,7 +6631,16 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "MultiSelect",
+          "typeName": "MultiSelectContext",
+          "properties": [
+            { "name": "declareRef", "type": "(arg) => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "NotificationActionButton",
@@ -6495,7 +6658,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Button" }
+      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "contexts": []
     },
     {
       "moduleName": "NotificationButton",
@@ -6558,7 +6722,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "NotificationIcon",
@@ -6605,7 +6770,8 @@
       "slots": [],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "NotificationTextDetails",
@@ -6666,7 +6832,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "NumberInput",
@@ -6970,7 +7137,8 @@
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "NumberInputSkeleton",
@@ -6999,7 +7167,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "OrderedList",
@@ -7042,7 +7211,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ol" }
+      "rest_props": { "type": "Element", "name": "ol" },
+      "contexts": []
     },
     {
       "moduleName": "OutboundLink",
@@ -7061,7 +7231,8 @@
       "typedefs": [],
       "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Link" },
-      "extends": { "interface": "LinkProps", "import": "\"./Link.svelte\"" }
+      "extends": { "interface": "LinkProps", "import": "\"./Link.svelte\"" },
+      "contexts": []
     },
     {
       "moduleName": "OverflowMenu",
@@ -7232,7 +7403,23 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": [
+        {
+          "key": "OverflowMenu",
+          "typeName": "OverflowMenuContext",
+          "properties": [
+            { "name": "focusedId", "type": "any", "optional": false },
+            { "name": "add", "type": "(arg) => any", "optional": false },
+            { "name": "update", "type": "(id) => any", "optional": false },
+            {
+              "name": "change",
+              "type": "(direction) => any",
+              "optional": false
+            }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "OverflowMenuItem",
@@ -7362,7 +7549,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": { "type": "Element", "name": "li" },
+      "contexts": []
     },
     {
       "moduleName": "Pagination",
@@ -7572,7 +7760,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "PaginationNav",
@@ -7672,7 +7861,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "nav" }
+      "rest_props": { "type": "Element", "name": "nav" },
+      "contexts": []
     },
     {
       "moduleName": "PaginationSkeleton",
@@ -7688,7 +7878,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "PasswordInput",
@@ -7924,7 +8115,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": { "type": "Element", "name": "input" },
+      "contexts": []
     },
     {
       "moduleName": "ProgressIndicator",
@@ -7992,7 +8184,19 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": { "type": "Element", "name": "ul" },
+      "contexts": [
+        {
+          "key": "ProgressIndicator",
+          "typeName": "ProgressIndicatorContext",
+          "properties": [
+            { "name": "steps", "type": "any", "optional": false },
+            { "name": "stepsById", "type": "any", "optional": false },
+            { "name": "add", "type": "(step) => any", "optional": false },
+            { "name": "change", "type": "(index) => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "ProgressIndicatorSkeleton",
@@ -8033,7 +8237,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": { "type": "Element", "name": "ul" },
+      "contexts": []
     },
     {
       "moduleName": "ProgressStep",
@@ -8154,7 +8359,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": { "type": "Element", "name": "li" },
+      "contexts": []
     },
     {
       "moduleName": "RadioButton",
@@ -8274,7 +8480,8 @@
       "events": [{ "type": "forwarded", "name": "change", "element": "input" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "RadioButtonGroup",
@@ -8352,7 +8559,18 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "RadioButtonGroup",
+          "typeName": "RadioButtonGroupContext",
+          "properties": [
+            { "name": "selectedValue", "type": "any", "optional": false },
+            { "name": "add", "type": "(arg) => any", "optional": false },
+            { "name": "update", "type": "(value) => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "RadioButtonSkeleton",
@@ -8368,7 +8586,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "RadioTile",
@@ -8473,7 +8692,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": { "type": "Element", "name": "label" },
+      "contexts": []
     },
     {
       "moduleName": "Row",
@@ -8575,7 +8795,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Search",
@@ -8778,7 +8999,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "SearchSkeleton" }
+      "rest_props": { "type": "InlineComponent", "name": "SearchSkeleton" },
+      "contexts": []
     },
     {
       "moduleName": "SearchSkeleton",
@@ -8819,7 +9041,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Select",
@@ -9001,7 +9224,16 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "Select",
+          "typeName": "SelectContext",
+          "properties": [
+            { "name": "selectedValue", "type": "any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "SelectItem",
@@ -9060,7 +9292,8 @@
       "slots": [],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "SelectItemGroup",
@@ -9098,7 +9331,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "optgroup" }
+      "rest_props": { "type": "Element", "name": "optgroup" },
+      "contexts": []
     },
     {
       "moduleName": "SelectSkeleton",
@@ -9127,7 +9361,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "SelectableTile",
@@ -9255,7 +9490,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": { "type": "Element", "name": "label" },
+      "contexts": []
     },
     {
       "moduleName": "SideNav",
@@ -9304,7 +9540,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "nav" }
+      "rest_props": { "type": "Element", "name": "nav" },
+      "contexts": []
     },
     {
       "moduleName": "SideNavItems",
@@ -9316,7 +9553,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "SideNavLink",
@@ -9385,7 +9623,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "SideNavMenu",
@@ -9445,7 +9684,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "SideNavMenuItem",
@@ -9502,7 +9742,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "SkeletonPlaceholder",
@@ -9518,7 +9759,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "SkeletonText",
@@ -9583,7 +9825,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "SkipToContent",
@@ -9626,7 +9869,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "Slider",
@@ -9848,7 +10092,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "SliderSkeleton",
@@ -9877,7 +10122,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "StructuredList",
@@ -9932,7 +10178,17 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "StructuredListWrapper",
+          "typeName": "StructuredListWrapperContext",
+          "properties": [
+            { "name": "selectedValue", "type": "any", "optional": false },
+            { "name": "update", "type": "(value) => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "StructuredListBody",
@@ -9950,7 +10206,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "StructuredListCell",
@@ -9993,7 +10250,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "StructuredListHead",
@@ -10011,7 +10269,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "StructuredListInput",
@@ -10095,7 +10354,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": { "type": "Element", "name": "input" },
+      "contexts": []
     },
     {
       "moduleName": "StructuredListRow",
@@ -10151,7 +10411,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": { "type": "Element", "name": "label" },
+      "contexts": []
     },
     {
       "moduleName": "StructuredListSkeleton",
@@ -10192,7 +10453,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Switch",
@@ -10277,7 +10539,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "Tab",
@@ -10373,7 +10636,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": { "type": "Element", "name": "li" },
+      "contexts": []
     },
     {
       "moduleName": "TabContent",
@@ -10399,7 +10663,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Table",
@@ -10484,7 +10749,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "section" }
+      "rest_props": { "type": "Element", "name": "section" },
+      "contexts": []
     },
     {
       "moduleName": "TableBody",
@@ -10497,7 +10763,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "tbody" }
+      "rest_props": { "type": "Element", "name": "tbody" },
+      "contexts": []
     },
     {
       "moduleName": "TableCell",
@@ -10515,7 +10782,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "td" }
+      "rest_props": { "type": "Element", "name": "td" },
+      "contexts": []
     },
     {
       "moduleName": "TableContainer",
@@ -10565,7 +10833,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "TableHead",
@@ -10583,7 +10852,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "thead" }
+      "rest_props": { "type": "Element", "name": "thead" },
+      "contexts": []
     },
     {
       "moduleName": "TableHeader",
@@ -10638,7 +10908,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "th" }
+      "rest_props": { "type": "Element", "name": "th" },
+      "contexts": []
     },
     {
       "moduleName": "TableRow",
@@ -10656,7 +10927,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "tr" }
+      "rest_props": { "type": "Element", "name": "tr" },
+      "contexts": []
     },
     {
       "moduleName": "Tabs",
@@ -10731,7 +11003,31 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "Tabs",
+          "typeName": "TabsContext",
+          "properties": [
+            { "name": "tabs", "type": "any", "optional": false },
+            { "name": "contentById", "type": "any", "optional": false },
+            { "name": "selectedTab", "type": "any", "optional": false },
+            { "name": "selectedContent", "type": "any", "optional": false },
+            { "name": "add", "type": "(data) => any", "optional": false },
+            {
+              "name": "addContent",
+              "type": "(data) => any",
+              "optional": false
+            },
+            { "name": "update", "type": "(id) => any", "optional": false },
+            {
+              "name": "change",
+              "type": "(direction) => any",
+              "optional": false
+            }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "TabsSkeleton",
@@ -10760,7 +11056,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Tag",
@@ -10866,7 +11163,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div | span" }
+      "rest_props": { "type": "Element", "name": "div | span" },
+      "contexts": []
     },
     {
       "moduleName": "TagSkeleton",
@@ -10882,7 +11180,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "span" }
+      "rest_props": { "type": "Element", "name": "span" },
+      "contexts": []
     },
     {
       "moduleName": "TextArea",
@@ -11070,7 +11369,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "textarea" }
+      "rest_props": { "type": "Element", "name": "textarea" },
+      "contexts": []
     },
     {
       "moduleName": "TextAreaSkeleton",
@@ -11099,7 +11399,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "TextInput",
@@ -11335,7 +11636,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": { "type": "Element", "name": "input" },
+      "contexts": []
     },
     {
       "moduleName": "TextInputSkeleton",
@@ -11364,7 +11666,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Tile",
@@ -11395,7 +11698,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "TileGroup",
@@ -11444,7 +11748,18 @@
       "events": [{ "type": "dispatched", "name": "select" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "fieldset" }
+      "rest_props": { "type": "Element", "name": "fieldset" },
+      "contexts": [
+        {
+          "key": "TileGroup",
+          "typeName": "TileGroupContext",
+          "properties": [
+            { "name": "selectedValue", "type": "any", "optional": false },
+            { "name": "add", "type": "(arg) => any", "optional": false },
+            { "name": "update", "type": "(value) => any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "TimePicker",
@@ -11645,7 +11960,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "TimePickerSelect",
@@ -11759,7 +12075,16 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": [
+        {
+          "key": "TimePickerSelect",
+          "typeName": "TimePickerSelectContext",
+          "properties": [
+            { "name": "selectedValue", "type": "any", "optional": false }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "ToastNotification",
@@ -11891,7 +12216,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Toggle",
@@ -12012,7 +12338,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ToggleSkeleton",
@@ -12065,7 +12392,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ToggleSmall",
@@ -12169,7 +12497,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ToggleSmallSkeleton",
@@ -12210,7 +12539,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "Toolbar",
@@ -12236,7 +12566,21 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "section" }
+      "rest_props": { "type": "Element", "name": "section" },
+      "contexts": [
+        {
+          "key": "Toolbar",
+          "typeName": "ToolbarContext",
+          "properties": [
+            { "name": "overflowVisible", "type": "any", "optional": false },
+            {
+              "name": "setOverflowVisible",
+              "type": "(visible) => any",
+              "optional": false
+            }
+          ]
+        }
+      ]
     },
     {
       "moduleName": "ToolbarBatchActions",
@@ -12262,7 +12606,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "ToolbarContent",
@@ -12274,7 +12619,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "ToolbarMenu",
@@ -12291,7 +12637,8 @@
       "extends": {
         "interface": "OverflowMenuProps",
         "import": "\"../OverflowMenu/OverflowMenu.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "ToolbarMenuItem",
@@ -12315,7 +12662,8 @@
       "extends": {
         "interface": "OverflowMenuItemProps",
         "import": "\"../OverflowMenu/OverflowMenuItem.svelte\""
-      }
+      },
+      "contexts": []
     },
     {
       "moduleName": "ToolbarSearch",
@@ -12392,7 +12740,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Search" }
+      "rest_props": { "type": "InlineComponent", "name": "Search" },
+      "contexts": []
     },
     {
       "moduleName": "Tooltip",
@@ -12588,7 +12937,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "TooltipDefinition",
@@ -12678,7 +13028,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "contexts": []
     },
     {
       "moduleName": "TooltipIcon",
@@ -12764,7 +13115,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "UnorderedList",
@@ -12795,7 +13147,8 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": { "type": "Element", "name": "ul" },
+      "contexts": []
     }
   ]
 }

--- a/tests/e2e/carbon/types/Accordion/Accordion.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/Accordion.svelte.d.ts
@@ -1,6 +1,10 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { AccordionSkeletonProps } from "./AccordionSkeleton.svelte";
 
+export type AccordionContext = {
+  disableItems: any;
+};
+
 export type AccordionProps = AccordionSkeletonProps & {
   /**
    * Specify alignment of accordion item chevron icon

--- a/tests/e2e/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -1,6 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type ComposedModalContext = {
+  closeModal: () => any;
+  submit: () => any;
+  declareRef: (ref) => any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/tests/e2e/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -1,6 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type ContentSwitcherContext = {
+  currentId: any;
+  add: (arg) => any;
+  update: (id) => any;
+  change: (direction) => any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -41,6 +41,11 @@ export interface DataTableCell {
   value: DataTableValue;
   display?: (item: Value, row: DataTableRow) => DataTableValue;
 }
+export type DataTableContext = {
+  batchSelectedIds: any;
+  tableRows: any;
+  resetSelectedRowIds: () => any;
+};
 
 type $RestProps = SvelteHTMLElements["div"];
 

--- a/tests/e2e/carbon/types/DataTable/Toolbar.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/Toolbar.svelte.d.ts
@@ -1,6 +1,11 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type ToolbarContext = {
+  overflowVisible: any;
+  setOverflowVisible: (visible) => any;
+};
+
 type $RestProps = SvelteHTMLElements["section"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/DatePicker/DatePicker.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePicker.svelte.d.ts
@@ -1,6 +1,18 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type DatePickerContext = {
+  range: any;
+  inputValue: any;
+  hasCalendar: any;
+  add: (data) => any;
+  declareRef: (arg) => any;
+  updateValue: (arg) => any;
+  blurInput: (relatedTarget) => any;
+  openCalendar: () => any;
+  focusCalendar: () => any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/FluidForm/FluidForm.svelte.d.ts
+++ b/tests/e2e/carbon/types/FluidForm/FluidForm.svelte.d.ts
@@ -1,5 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
+export type FormContext = {
+  isFluid: boolean;
+};
+
 export type FluidFormProps = Record<string, never>;
 
 export default class FluidForm extends SvelteComponentTyped<

--- a/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -9,6 +9,9 @@ export interface MultiSelectItem {
   id: MultiSelectItemId;
   text: MultiSelectItemText;
 }
+export type MultiSelectContext = {
+  declareRef: (arg) => any;
+};
 
 type $RestProps = SvelteHTMLElements["div"];
 

--- a/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -1,6 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type OverflowMenuContext = {
+  focusedId: any;
+  add: (arg) => any;
+  update: (id) => any;
+  change: (direction) => any;
+};
+
 type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -1,6 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type ProgressIndicatorContext = {
+  steps: any;
+  stepsById: any;
+  add: (step) => any;
+  change: (index) => any;
+};
+
 type $RestProps = SvelteHTMLElements["ul"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -1,6 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type RadioButtonGroupContext = {
+  selectedValue: any;
+  add: (arg) => any;
+  update: (value) => any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/Select/Select.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/Select.svelte.d.ts
@@ -1,6 +1,10 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type SelectContext = {
+  selectedValue: any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/StructuredList/StructuredList.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredList.svelte.d.ts
@@ -1,6 +1,11 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type StructuredListWrapperContext = {
+  selectedValue: any;
+  update: (value) => any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/Tabs/Tabs.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/Tabs.svelte.d.ts
@@ -1,6 +1,17 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type TabsContext = {
+  tabs: any;
+  contentById: any;
+  selectedTab: any;
+  selectedContent: any;
+  add: (data) => any;
+  addContent: (data) => any;
+  update: (id) => any;
+  change: (direction) => any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/Tile/TileGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/TileGroup.svelte.d.ts
@@ -1,6 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type TileGroupContext = {
+  selectedValue: any;
+  add: (arg) => any;
+  update: (value) => any;
+};
+
 type $RestProps = SvelteHTMLElements["fieldset"];
 
 type $Props = {

--- a/tests/e2e/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -1,6 +1,10 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
+export type TimePickerSelectContext = {
+  selectedValue: any;
+};
+
 type $RestProps = SvelteHTMLElements["div"];
 
 type $Props = {

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -75,7 +75,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     }
   ]
 }

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -41,7 +41,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "Link",
@@ -59,7 +60,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "Quote",
@@ -100,7 +102,8 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "blockquote" }
+      "rest_props": { "type": "Element", "name": "blockquote" },
+      "contexts": []
     },
     {
       "moduleName": "SecondaryButton",
@@ -131,7 +134,11 @@
       "typedefs": [],
       "generics": null,
       "rest_props": { "type": "InlineComponent", "name": "Button" },
-      "extends": { "interface": "ButtonProps", "import": "\"./Button.svelte\"" }
+      "extends": {
+        "interface": "ButtonProps",
+        "import": "\"./Button.svelte\""
+      },
+      "contexts": []
     }
   ]
 }

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -51,7 +51,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "Header",
@@ -63,7 +64,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "Link",
@@ -81,7 +83,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "Quote",
@@ -124,7 +127,8 @@
         { "type": "string", "name": "Author", "ts": "type Author = string" }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "blockquote" }
+      "rest_props": { "type": "Element", "name": "blockquote" },
+      "contexts": []
     }
   ]
 }

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -41,7 +41,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     },
     {
       "moduleName": "Card",
@@ -53,7 +54,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "Header",
@@ -65,7 +67,8 @@
       ],
       "events": [],
       "typedefs": [],
-      "generics": null
+      "generics": null,
+      "contexts": []
     },
     {
       "moduleName": "Link",
@@ -83,7 +86,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": { "type": "Element", "name": "a" },
+      "contexts": []
     },
     {
       "moduleName": "Quote",
@@ -126,7 +130,8 @@
         { "type": "string", "name": "Author", "ts": "type Author = string" }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "blockquote" }
+      "rest_props": { "type": "Element", "name": "blockquote" },
+      "contexts": []
     }
   ]
 }

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -40,7 +40,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     }
   ]
 }

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -40,7 +40,8 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
     }
   ]
 }

--- a/tests/fixtures/anchor-props/output.json
+++ b/tests/fixtures/anchor-props/output.json
@@ -14,5 +14,6 @@
   "rest_props": {
     "type": "Element",
     "name": "a"
-  }
+  },
+  "contexts": []
 }

--- a/tests/fixtures/bind-this-multiple/output.json
+++ b/tests/fixtures/bind-this-multiple/output.json
@@ -42,5 +42,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/bind-this/output.json
+++ b/tests/fixtures/bind-this/output.json
@@ -21,5 +21,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/component-comment-multi/output.json
+++ b/tests/fixtures/component-comment-multi/output.json
@@ -11,5 +11,6 @@
   "events": [],
   "typedefs": [],
   "generics": null,
-  "componentComment": "\n@example\n<div>\n  Component comment\n</div>"
+  "componentComment": "\n@example\n<div>\n  Component comment\n</div>",
+  "contexts": []
 }

--- a/tests/fixtures/component-comment-single/output.json
+++ b/tests/fixtures/component-comment-single/output.json
@@ -11,5 +11,6 @@
   "events": [],
   "typedefs": [],
   "generics": null,
-  "componentComment": " Component comment"
+  "componentComment": " Component comment",
+  "contexts": []
 }

--- a/tests/fixtures/context-imported-type/input.svelte
+++ b/tests/fixtures/context-imported-type/input.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { setContext } from 'svelte';
+
+  /**
+   * @typedef {object} ModalAPI
+   * @property {() => void} open
+   * @property {() => void} close
+   */
+
+  /**
+   * Modal API object
+   * @type {ModalAPI}
+   */
+  const modalAPI = {
+    open: () => {
+      console.log('Opening modal');
+    },
+    close: () => {
+      console.log('Closing modal');
+    }
+  };
+
+  setContext('modal', modalAPI);
+</script>
+
+<div class="modal-wrapper">
+  <slot />
+</div>

--- a/tests/fixtures/context-imported-type/output.d.ts
+++ b/tests/fixtures/context-imported-type/output.d.ts
@@ -1,0 +1,15 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export type ModalAPI = object;
+export type ModalContext = {
+  /** Modal API object */
+  modalAPI: ModalAPI;
+};
+
+export type ContextImportedTypeProps = Record<string, never>;
+
+export default class ContextImportedType extends SvelteComponentTyped<
+  ContextImportedTypeProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-imported-type/output.json
+++ b/tests/fixtures/context-imported-type/output.json
@@ -1,0 +1,34 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "object",
+      "name": "ModalAPI",
+      "ts": "type ModalAPI = object"
+    }
+  ],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "modal",
+      "typeName": "ModalContext",
+      "properties": [
+        {
+          "name": "modalAPI",
+          "type": "ModalAPI",
+          "description": "Modal API object",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/context-inline-functions/input.svelte
+++ b/tests/fixtures/context-inline-functions/input.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { setContext } from 'svelte';
+
+  // Direct object literal with inline functions (no explicit types)
+  setContext('modal', {
+    open: (component, props) => {
+      console.log('Opening', component, props);
+    },
+    close: () => {
+      console.log('Closing');
+    }
+  });
+</script>
+
+<div class="modal">
+  <slot />
+</div>

--- a/tests/fixtures/context-inline-functions/output.d.ts
+++ b/tests/fixtures/context-inline-functions/output.d.ts
@@ -1,0 +1,14 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export type ModalContext = {
+  open: (component: any, props: any) => any;
+  close: () => any;
+};
+
+export type ContextInlineFunctionsProps = Record<string, never>;
+
+export default class ContextInlineFunctions extends SvelteComponentTyped<
+  ContextInlineFunctionsProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-inline-functions/output.json
+++ b/tests/fixtures/context-inline-functions/output.json
@@ -1,0 +1,32 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "modal",
+      "typeName": "ModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props: any) => any",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => any",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/context-issue-103/input.svelte
+++ b/tests/fixtures/context-issue-103/input.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { setContext } from 'svelte';
+
+  /**
+   * Log a message to the console
+   * @type {(message: string) => void}
+   */
+  const log = (message) => {
+    console.log(message);
+  };
+
+  setContext('my-logger', log);
+</script>
+
+<div>
+  <slot />
+</div>

--- a/tests/fixtures/context-issue-103/output.d.ts
+++ b/tests/fixtures/context-issue-103/output.d.ts
@@ -1,0 +1,14 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export type MyLoggerContext = {
+  /** Log a message to the console */
+  log: (message: string) => void;
+};
+
+export type ContextIssue103Props = Record<string, never>;
+
+export default class ContextIssue103 extends SvelteComponentTyped<
+  ContextIssue103Props,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-issue-103/output.json
+++ b/tests/fixtures/context-issue-103/output.json
@@ -1,0 +1,28 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "my-logger",
+      "typeName": "MyLoggerContext",
+      "properties": [
+        {
+          "name": "log",
+          "type": "(message: string) => void",
+          "description": "Log a message to the console",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/context-module/output.json
+++ b/tests/fixtures/context-module/output.json
@@ -96,5 +96,6 @@
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/context-simple/input.svelte
+++ b/tests/fixtures/context-simple/input.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { setContext } from 'svelte';
+
+  /**
+   * Close the modal
+   * @type {() => void}
+   */
+  const close = () => {};
+
+  /**
+   * Open the modal with content
+   * @type {(component: any, props?: any) => void}
+   */
+  const open = (component, props) => {};
+
+  setContext('simple-modal', { open, close });
+</script>
+
+<div class="modal">
+  <slot />
+</div>

--- a/tests/fixtures/context-simple/output.d.ts
+++ b/tests/fixtures/context-simple/output.d.ts
@@ -1,0 +1,16 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export type SimpleModalContext = {
+  /** Open the modal with content */
+  open: (component: any, props?: any) => void;
+  /** Close the modal */
+  close: () => void;
+};
+
+export type ContextSimpleProps = Record<string, never>;
+
+export default class ContextSimple extends SvelteComponentTyped<
+  ContextSimpleProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-simple/output.json
+++ b/tests/fixtures/context-simple/output.json
@@ -1,0 +1,34 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "simple-modal",
+      "typeName": "SimpleModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props?: any) => void",
+          "description": "Open the modal with content",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => void",
+          "description": "Close the modal",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/context-typedef/input.svelte
+++ b/tests/fixtures/context-typedef/input.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { setContext } from 'svelte';
+
+  /**
+   * @typedef {object} TabData
+   * @property {string} id
+   * @property {string} label
+   * @property {boolean} [disabled]
+   */
+
+  /**
+   * Register a new tab
+   * @type {(tab: TabData) => void}
+   */
+  const addTab = (tab) => {
+    console.log('Adding tab', tab);
+  };
+
+  /**
+   * Remove a tab by ID
+   * @type {(id: string) => void}
+   */
+  const removeTab = (id) => {
+    console.log('Removing tab', id);
+  };
+
+  setContext('tabs', { addTab, removeTab });
+</script>
+
+<div class="tabs">
+  <slot />
+</div>

--- a/tests/fixtures/context-typedef/output.d.ts
+++ b/tests/fixtures/context-typedef/output.d.ts
@@ -1,0 +1,17 @@
+import type { SvelteComponentTyped } from "svelte";
+
+export type TabData = object;
+export type TabsContext = {
+  /** Register a new tab */
+  addTab: (tab: TabData) => void;
+  /** Remove a tab by ID */
+  removeTab: (id: string) => void;
+};
+
+export type ContextTypedefProps = Record<string, never>;
+
+export default class ContextTypedef extends SvelteComponentTyped<
+  ContextTypedefProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-typedef/output.json
+++ b/tests/fixtures/context-typedef/output.json
@@ -1,0 +1,40 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "object",
+      "name": "TabData",
+      "ts": "type TabData = object"
+    }
+  ],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "tabs",
+      "typeName": "TabsContext",
+      "properties": [
+        {
+          "name": "addTab",
+          "type": "(tab: TabData) => void",
+          "description": "Register a new tab",
+          "optional": false
+        },
+        {
+          "name": "removeTab",
+          "type": "(id: string) => void",
+          "description": "Remove a tab by ID",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/dispatched-events-dynamic/output.json
+++ b/tests/fixtures/dispatched-events-dynamic/output.json
@@ -10,5 +10,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.json
@@ -23,5 +23,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/dispatched-events-typed/output.json
+++ b/tests/fixtures/dispatched-events-typed/output.json
@@ -22,5 +22,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -30,5 +30,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/empty-export/output.json
+++ b/tests/fixtures/empty-export/output.json
@@ -4,5 +4,6 @@
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/event-explicit-null/output.json
+++ b/tests/fixtures/event-explicit-null/output.json
@@ -24,5 +24,6 @@
   "rest_props": {
     "type": "Element",
     "name": "input"
-  }
+  },
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-and-dispatched-events/output.json
+++ b/tests/fixtures/forwarded-and-dispatched-events/output.json
@@ -10,5 +10,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-custom-event-null/output.json
+++ b/tests/fixtures/forwarded-custom-event-null/output.json
@@ -19,5 +19,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-custom-events/output.json
+++ b/tests/fixtures/forwarded-custom-events/output.json
@@ -17,5 +17,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
+++ b/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
@@ -32,5 +32,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-events-typed/output.json
+++ b/tests/fixtures/forwarded-events-typed/output.json
@@ -24,5 +24,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-events/output.json
+++ b/tests/fixtures/forwarded-events/output.json
@@ -31,5 +31,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-from-component-to-native/output.json
+++ b/tests/fixtures/forwarded-from-component-to-native/output.json
@@ -35,5 +35,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-native-with-detail/output.json
+++ b/tests/fixtures/forwarded-native-with-detail/output.json
@@ -12,5 +12,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/forwarded-standard-event-custom-detail/output.json
+++ b/tests/fixtures/forwarded-standard-event-custom-detail/output.json
@@ -33,5 +33,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/function-declaration/output.json
+++ b/tests/fixtures/function-declaration/output.json
@@ -50,5 +50,6 @@
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/generics-multiple/output.json
+++ b/tests/fixtures/generics-multiple/output.json
@@ -52,5 +52,6 @@
   "generics": [
     "Row,Header",
     "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
-  ]
+  ],
+  "contexts": []
 }

--- a/tests/fixtures/generics-with-rest-props/output.json
+++ b/tests/fixtures/generics-with-rest-props/output.json
@@ -56,5 +56,6 @@
   "rest_props": {
     "type": "Element",
     "name": "div"
-  }
+  },
+  "contexts": []
 }

--- a/tests/fixtures/generics/output.json
+++ b/tests/fixtures/generics/output.json
@@ -52,5 +52,6 @@
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"
-  ]
+  ],
+  "contexts": []
 }

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -86,5 +86,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/infer-with-types/output.json
+++ b/tests/fixtures/infer-with-types/output.json
@@ -77,5 +77,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/input-events/output.json
+++ b/tests/fixtures/input-events/output.json
@@ -20,5 +20,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/mixed-event-types/output.json
+++ b/tests/fixtures/mixed-event-types/output.json
@@ -28,5 +28,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/mixed-events/output.json
+++ b/tests/fixtures/mixed-events/output.json
@@ -15,5 +15,6 @@
     }
   ],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/no-props/output.json
+++ b/tests/fixtures/no-props/output.json
@@ -4,5 +4,6 @@
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -47,5 +47,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/renamed-props/output.json
+++ b/tests/fixtures/renamed-props/output.json
@@ -17,5 +17,6 @@
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/required/output.json
+++ b/tests/fixtures/required/output.json
@@ -54,5 +54,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/rest-props-multiple/output.json
+++ b/tests/fixtures/rest-props-multiple/output.json
@@ -20,5 +20,6 @@
   "rest_props": {
     "type": "Element",
     "name": "ul | ol"
-  }
+  },
+  "contexts": []
 }

--- a/tests/fixtures/rest-props-simple/output.json
+++ b/tests/fixtures/rest-props-simple/output.json
@@ -8,5 +8,6 @@
   "rest_props": {
     "type": "Element",
     "name": "h1"
-  }
+  },
+  "contexts": []
 }

--- a/tests/fixtures/slots-named/output.json
+++ b/tests/fixtures/slots-named/output.json
@@ -41,5 +41,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/slots-spread-typed/output.json
+++ b/tests/fixtures/slots-spread-typed/output.json
@@ -16,5 +16,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/slots-spread/output.json
+++ b/tests/fixtures/slots-spread/output.json
@@ -16,5 +16,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/svg-props/output.json
+++ b/tests/fixtures/svg-props/output.json
@@ -8,5 +8,6 @@
   "rest_props": {
     "type": "Element",
     "name": "svg"
-  }
+  },
+  "contexts": []
 }

--- a/tests/fixtures/typed-props/output.json
+++ b/tests/fixtures/typed-props/output.json
@@ -49,5 +49,6 @@
   "slots": [],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/typed-slots/output.json
+++ b/tests/fixtures/typed-slots/output.json
@@ -28,5 +28,6 @@
   ],
   "events": [],
   "typedefs": [],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/typedef/output.json
+++ b/tests/fixtures/typedef/output.json
@@ -39,5 +39,6 @@
       "ts": "interface MyTypedef { [key: string]: boolean; }"
     }
   ],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }

--- a/tests/fixtures/typedefs/output.json
+++ b/tests/fixtures/typedefs/output.json
@@ -44,5 +44,6 @@
       "ts": "type MyTypedefArray = MyTypedef[]"
     }
   ],
-  "generics": null
+  "generics": null,
+  "contexts": []
 }


### PR DESCRIPTION
Closes #103

Adds automatic TypeScript definition generation for Svelte's `setContext`/`getContext` API by extracting types from JSDoc annotations.

When `setContext` is called, sveld detects the call, extracts the context key, finds JSDoc `@type` annotations on variables, and generates TypeScript type exports.

**Example:**

```svelte
<script>
  import { setContext } from 'svelte';

  /** @type {() => void} */
  const close = () => {};

  /** @type {(component: any, props?: any) => void} */
  const open = (component, props) => {};

  setContext('simple-modal', { open, close });
</script>
```

**Generates:**

```typescript
export type SimpleModalContext = {
  /** Open the modal with content */
  open: (component: any, props?: any) => void;
  /** Close the modal */
  close: () => void;
};
```

**Consumer usage:**

```svelte
<script>
  import { getContext } from 'svelte';
  import type { SimpleModalContext } from 'modal-library/Modal.svelte';

  const { close, open } = getContext<SimpleModalContext>('simple-modal');
</script>
```

**Explicit typing approaches:**

1. **Inline JSDoc** (recommended): `/** @type {() => void} */ const close = () => {};`
2. **`@typedef` for complex types**: Define reusable types with `@typedef`, reference in function signatures
3. **Imported type references**: `/** @type {typeof import("./types").ModalAPI} */`
4. **Inline functions**: Direct object literals infer as `(arg: any) => any`

**Details:**

- Context keys must be string literals
- Generated type names: `"simple-modal"` → `SimpleModalContext`
- Untyped values default to `any` (warning shown in verbose mode)
- Fully backward compatible with comprehensive fixture test coverage
