### PR TITLE
fix(writer): replace `{}` type with `Record<string, never>`

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -820,7 +820,8 @@ export default class ComponentParser {
               new_props.push(`${key}: ${slot_props[key].value}`);
             });
 
-            const formatted_slot_props = new_props.length === 0 ? "{}" : `{ ${new_props.join(", ")} }`;
+            const formatted_slot_props =
+              new_props.length === 0 ? "Record<string, never>" : `{ ${new_props.join(", ")} }`;
 
             return { ...slot, slot_props: formatted_slot_props };
           } catch (_e) {

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -36,7 +36,7 @@ exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
       "name": "__default__",
       "default": true,
       "fallback": "Default text",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     },
     {
       "name": "bold heading",
@@ -239,7 +239,7 @@ exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [
@@ -375,7 +375,7 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
       "name": "__default__",
       "default": true,
       "fallback": "{name}",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -469,7 +469,7 @@ exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [
@@ -631,7 +631,7 @@ exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -648,7 +648,7 @@ exports[`fixtures (JSON) "dispatched-events-typed/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [
@@ -819,7 +819,7 @@ exports[`fixtures (JSON) "forwarded-events-native-with-jsdoc/input.svelte" 1`] =
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [
@@ -949,7 +949,7 @@ exports[`fixtures (JSON) "infer-with-types/input.svelte" 1`] = `
       "name": "__default__",
       "default": true,
       "fallback": "{name}",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -1239,7 +1239,7 @@ exports[`fixtures (JSON) "component-comment-single/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -1289,7 +1289,7 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -1391,7 +1391,7 @@ exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -1412,7 +1412,7 @@ exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -1457,12 +1457,12 @@ exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
       "name": "__default__",
       "default": true,
       "fallback": "Default text",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     },
     {
       "name": "text",
       "default": false,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],
@@ -1638,7 +1638,7 @@ type $Props = {
 
 export type SvgPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, {}> {}
+export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, Record<string, never>> {}
 "
 `;
 
@@ -1655,7 +1655,12 @@ export type SlotsNamedProps = {
 export default class SlotsNamed extends SvelteComponentTyped<
   SlotsNamedProps,
   Record<string, any>,
-  { default: {}; "bold heading": { text: string }; subheading: { text: string }; text: { text: string } }
+  {
+    default: Record<string, never>;
+    "bold heading": { text: string };
+    subheading: { text: string };
+    text: { text: string };
+  }
 > {}
 "
 `;
@@ -1701,7 +1706,7 @@ export default class GenericsMultiple<
 exports[`fixtures (TypeScript) "mixed-event-types/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type MixedEventTypesProps = {};
+export type MixedEventTypesProps = Record<string, never>;
 
 export default class MixedEventTypes extends SvelteComponentTyped<
   MixedEventTypesProps,
@@ -1712,7 +1717,7 @@ export default class MixedEventTypes extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     submit: CustomEvent<any>;
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -1720,12 +1725,12 @@ export default class MixedEventTypes extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "dispatched-events-dynamic/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type DispatchedEventsDynamicProps = {};
+export type DispatchedEventsDynamicProps = Record<string, never>;
 
 export default class DispatchedEventsDynamic extends SvelteComponentTyped<
   DispatchedEventsDynamicProps,
   { KEY: CustomEvent<{ key: string }> },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -1743,7 +1748,7 @@ export type FunctionDeclarationProps = {
 export default class FunctionDeclaration extends SvelteComponentTyped<
   FunctionDeclarationProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {
   fnB: () => {};
 
@@ -1760,7 +1765,7 @@ export default class FunctionDeclaration extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-events/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedEventsProps = {};
+export type ForwardedEventsProps = Record<string, never>;
 
 export default class ForwardedEvents extends SvelteComponentTyped<
   ForwardedEventsProps,
@@ -1770,7 +1775,7 @@ export default class ForwardedEvents extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     mouseover: WindowEventMap["mouseover"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -1778,12 +1783,12 @@ export default class ForwardedEvents extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "mixed-events/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type MixedEventsProps = {};
+export type MixedEventsProps = Record<string, never>;
 
 export default class MixedEvents extends SvelteComponentTyped<
   MixedEventsProps,
   { "custom-focus": CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -1818,7 +1823,11 @@ export type InferBasicProps = {
   id?: string;
 };
 
-export default class InferBasic extends SvelteComponentTyped<InferBasicProps, Record<string, any>, { default: {} }> {
+export default class InferBasic extends SvelteComponentTyped<
+  InferBasicProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {
   propConst: { ["1"]: true };
 
   fn: () => any;
@@ -1829,9 +1838,13 @@ export default class InferBasic extends SvelteComponentTyped<InferBasicProps, Re
 exports[`fixtures (TypeScript) "empty-export/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type EmptyExportProps = {};
+export type EmptyExportProps = Record<string, never>;
 
-export default class EmptyExport extends SvelteComponentTyped<EmptyExportProps, Record<string, any>, {}> {}
+export default class EmptyExport extends SvelteComponentTyped<
+  EmptyExportProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
 "
 `;
 
@@ -1860,7 +1873,7 @@ export default class TypedSlots extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-events-typed/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedEventsTypedProps = {};
+export type ForwardedEventsTypedProps = Record<string, never>;
 
 export default class ForwardedEventsTyped extends SvelteComponentTyped<
   ForwardedEventsTypedProps,
@@ -1870,7 +1883,7 @@ export default class ForwardedEventsTyped extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -1878,7 +1891,7 @@ export default class ForwardedEventsTyped extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "dispatched-events/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type DispatchedEventsProps = {};
+export type DispatchedEventsProps = Record<string, never>;
 
 export default class DispatchedEvents extends SvelteComponentTyped<
   DispatchedEventsProps,
@@ -1888,7 +1901,7 @@ export default class DispatchedEvents extends SvelteComponentTyped<
     "destroy--component": CustomEvent<null>;
     "destroy:component": CustomEvent<null>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -1974,14 +1987,18 @@ export type BindThisProps = {
   ref: null | HTMLButtonElement;
 };
 
-export default class BindThis extends SvelteComponentTyped<BindThisProps, Record<string, any>, { default: {} }> {}
+export default class BindThis extends SvelteComponentTyped<
+  BindThisProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
 "
 `;
 
 exports[`fixtures (TypeScript) "dispatched-events-typed/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type DispatchedEventsTypedProps = {};
+export type DispatchedEventsTypedProps = Record<string, never>;
 
 export default class DispatchedEventsTyped extends SvelteComponentTyped<
   DispatchedEventsTypedProps,
@@ -1989,7 +2006,7 @@ export default class DispatchedEventsTyped extends SvelteComponentTyped<
     /** Fired on mouseover. */ hover: CustomEvent<{ h1: boolean }>;
     destroy: CustomEvent<null>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -1997,12 +2014,12 @@ export default class DispatchedEventsTyped extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "input-events/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type InputEventsProps = {};
+export type InputEventsProps = Record<string, never>;
 
 export default class InputEvents extends SvelteComponentTyped<
   InputEventsProps,
   { input: WindowEventMap["input"]; change: WindowEventMap["change"]; paste: WindowEventMap["paste"] },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2079,7 +2096,7 @@ export default class PropComments extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-events-native-with-jsdoc/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedEventsNativeWithJsdocProps = {};
+export type ForwardedEventsNativeWithJsdocProps = Record<string, never>;
 
 export default class ForwardedEventsNativeWithJsdoc extends SvelteComponentTyped<
   ForwardedEventsNativeWithJsdocProps,
@@ -2090,7 +2107,7 @@ export default class ForwardedEventsNativeWithJsdoc extends SvelteComponentTyped
     /** Fired when the button loses focus */
     blur: WindowEventMap["blur"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -2106,7 +2123,11 @@ export type RenamedPropsProps = {
   class?: string | null;
 };
 
-export default class RenamedProps extends SvelteComponentTyped<RenamedPropsProps, Record<string, any>, {}> {}
+export default class RenamedProps extends SvelteComponentTyped<
+  RenamedPropsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
 "
 `;
 
@@ -2138,7 +2159,7 @@ export type InferWithTypesProps = {
 export default class InferWithTypes extends SvelteComponentTyped<
   InferWithTypesProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {
   propConst: { [key: string]: boolean };
 
@@ -2150,14 +2171,14 @@ export default class InferWithTypes extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-native-with-detail/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedNativeWithDetailProps = {};
+export type ForwardedNativeWithDetailProps = Record<string, never>;
 
 export default class ForwardedNativeWithDetail extends SvelteComponentTyped<
   ForwardedNativeWithDetailProps,
   {
     /** The input value when changed */ change: CustomEvent<string>;
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2185,9 +2206,13 @@ export declare function b2(): () => {};
 
 export declare function b3(): () => false;
 
-export type ContextModuleProps = {};
+export type ContextModuleProps = Record<string, never>;
 
-export default class ContextModule extends SvelteComponentTyped<ContextModuleProps, Record<string, any>, {}> {
+export default class ContextModule extends SvelteComponentTyped<
+  ContextModuleProps,
+  Record<string, any>,
+  Record<string, never>
+> {
   a: string;
 }
 "
@@ -2210,14 +2235,18 @@ type $Props = {
 
 export type RestPropsMultipleProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class RestPropsMultiple extends SvelteComponentTyped<RestPropsMultipleProps, Record<string, any>, {}> {}
+export default class RestPropsMultiple extends SvelteComponentTyped<
+  RestPropsMultipleProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
 "
 `;
 
 exports[`fixtures (TypeScript) "forwarded-from-component-to-native/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedFromComponentToNativeProps = {};
+export type ForwardedFromComponentToNativeProps = Record<string, never>;
 
 export default class ForwardedFromComponentToNative extends SvelteComponentTyped<
   ForwardedFromComponentToNativeProps,
@@ -2229,7 +2258,7 @@ export default class ForwardedFromComponentToNative extends SvelteComponentTyped
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2237,9 +2266,9 @@ export default class ForwardedFromComponentToNative extends SvelteComponentTyped
 exports[`fixtures (TypeScript) "no-props/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type NoPropsProps = {};
+export type NoPropsProps = Record<string, never>;
 
-export default class NoProps extends SvelteComponentTyped<NoPropsProps, Record<string, any>, {}> {}
+export default class NoProps extends SvelteComponentTyped<NoPropsProps, Record<string, any>, Record<string, never>> {}
 "
 `;
 
@@ -2258,7 +2287,7 @@ export type EventExplicitNullProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class EventExplicitNull extends SvelteComponentTyped<
   EventExplicitNullProps,
   { clear: CustomEvent<null>; change: WindowEventMap["change"]; input: WindowEventMap["input"] },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2280,7 +2309,7 @@ export default class ForwardedStandardEventCustomDetail extends SvelteComponentT
     remove: CustomEvent<ReadonlyArray<File>>;
     change: CustomEvent<ReadonlyArray<File>>;
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2288,13 +2317,13 @@ export default class ForwardedStandardEventCustomDetail extends SvelteComponentT
 exports[`fixtures (TypeScript) "component-comment-single/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ComponentCommentSingleProps = {};
+export type ComponentCommentSingleProps = Record<string, never>;
 
 /** Component comment */
 export default class ComponentCommentSingle extends SvelteComponentTyped<
   ComponentCommentSingleProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -2322,7 +2351,7 @@ export type BindThisMultipleProps = {
 export default class BindThisMultiple extends SvelteComponentTyped<
   BindThisMultipleProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -2330,7 +2359,7 @@ export default class BindThisMultiple extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-custom-events/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedCustomEventsProps = {};
+export type ForwardedCustomEventsProps = Record<string, never>;
 
 export default class ForwardedCustomEvents extends SvelteComponentTyped<
   ForwardedCustomEventsProps,
@@ -2338,7 +2367,7 @@ export default class ForwardedCustomEvents extends SvelteComponentTyped<
     /** Fired when clear button is clicked */ clear: CustomEvent<KeyboardEvent | MouseEvent>;
     click: WindowEventMap["click"];
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2382,7 +2411,11 @@ type $Props = {
 
 export type RestPropsSimpleProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class RestPropsSimple extends SvelteComponentTyped<RestPropsSimpleProps, Record<string, any>, {}> {}
+export default class RestPropsSimple extends SvelteComponentTyped<
+  RestPropsSimpleProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
 "
 `;
 
@@ -2398,14 +2431,18 @@ type $Props = {
 
 export type AnchorPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class AnchorProps extends SvelteComponentTyped<AnchorPropsProps, Record<string, any>, { default: {} }> {}
+export default class AnchorProps extends SvelteComponentTyped<
+  AnchorPropsProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
 "
 `;
 
 exports[`fixtures (TypeScript) "component-comment-multi/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ComponentCommentMultiProps = {};
+export type ComponentCommentMultiProps = Record<string, never>;
 
 /**
  * @example
@@ -2416,7 +2453,7 @@ export type ComponentCommentMultiProps = {};
 export default class ComponentCommentMulti extends SvelteComponentTyped<
   ComponentCommentMultiProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -2424,7 +2461,7 @@ export default class ComponentCommentMulti extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-custom-event-null/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedCustomEventNullProps = {};
+export type ForwardedCustomEventNullProps = Record<string, never>;
 
 export default class ForwardedCustomEventNull extends SvelteComponentTyped<
   ForwardedCustomEventNullProps,
@@ -2433,7 +2470,7 @@ export default class ForwardedCustomEventNull extends SvelteComponentTyped<
     /** Search query changed */
     search: CustomEvent<string>;
   },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2441,12 +2478,12 @@ export default class ForwardedCustomEventNull extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "slots-spread/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type SlotsSpreadProps = {};
+export type SlotsSpreadProps = Record<string, never>;
 
 export default class SlotsSpread extends SvelteComponentTyped<
   SlotsSpreadProps,
   Record<string, any>,
-  { default: {}; text: {} }
+  { default: Record<string, never>; text: Record<string, never> }
 > {}
 "
 `;
@@ -2454,12 +2491,12 @@ export default class SlotsSpread extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "forwarded-and-dispatched-events/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedAndDispatchedEventsProps = {};
+export type ForwardedAndDispatchedEventsProps = Record<string, never>;
 
 export default class ForwardedAndDispatchedEvents extends SvelteComponentTyped<
   ForwardedAndDispatchedEventsProps,
   { change: WindowEventMap["change"] },
-  {}
+  Record<string, never>
 > {}
 "
 `;
@@ -2467,7 +2504,7 @@ export default class ForwardedAndDispatchedEvents extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "slots-spread-typed/input.svelte" 1`] = `
 "import type { SvelteComponentTyped } from "svelte";
 
-export type SlotsSpreadTypedProps = {};
+export type SlotsSpreadTypedProps = Record<string, never>;
 
 export default class SlotsSpreadTyped extends SvelteComponentTyped<
   SlotsSpreadTypedProps,
@@ -2506,7 +2543,11 @@ export type TypedPropsProps = {
   prop4?: "red" | "blue";
 };
 
-export default class TypedProps extends SvelteComponentTyped<TypedPropsProps, Record<string, any>, {}> {}
+export default class TypedProps extends SvelteComponentTyped<
+  TypedPropsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
 "
 `;
 

--- a/tests/__snapshots__/writer-ts-definitions.test.ts.snap
+++ b/tests/__snapshots__/writer-ts-definitions.test.ts.snap
@@ -55,15 +55,13 @@ exports[`writerTsDefinition "default" module name 1`] = `
   
   
   
-    export type defaultProps =  {
-      
-    }
+    export type defaultProps = Record<string, never>;
   
   
   export default class  extends SvelteComponentTyped<
       defaultProps,
       Record<string, any>,
-      {}
+      Record<string, never>
     > {
       
     }"

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -54,7 +54,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         {
           "type": "forwarded",
@@ -141,12 +147,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "title",
           "default": false,
           "fallback": "{title}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -244,7 +254,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -280,7 +296,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         {
           "type": "forwarded",
@@ -620,7 +642,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -908,7 +936,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "a" },
         { "type": "forwarded", "name": "keydown", "element": "a" },
@@ -1132,7 +1166,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{code}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -1694,7 +1728,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -1727,7 +1767,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -1774,7 +1820,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
@@ -1838,7 +1890,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{#if animation}{feedback || $$restProps[\"aria-label\"]}{/if}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -2150,7 +2202,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "cell",
           "default": false,
@@ -2167,7 +2223,7 @@
           "name": "description",
           "default": false,
           "fallback": "{description}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         },
         {
           "name": "expanded-row",
@@ -2178,7 +2234,7 @@
           "name": "title",
           "default": false,
           "fallback": "{title}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -2495,7 +2551,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -3156,8 +3218,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "above", "default": false, "slot_props": "{}" },
-        { "name": "below", "default": false, "slot_props": "{}" }
+        {
+          "name": "above",
+          "default": false,
+          "slot_props": "Record<string, never>"
+        },
+        {
+          "name": "below",
+          "default": false,
+          "slot_props": "Record<string, never>"
+        }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "button" },
@@ -3788,7 +3858,13 @@
       "filePath": "src/FluidForm/FluidForm.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [{ "type": "forwarded", "name": "submit", "element": "Form" }],
       "typedefs": [],
       "generics": null,
@@ -3799,7 +3875,13 @@
       "filePath": "src/Form/Form.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "form" },
         { "type": "forwarded", "name": "mouseover", "element": "form" },
@@ -3865,7 +3947,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "fieldset" },
         { "type": "forwarded", "name": "mouseover", "element": "fieldset" },
@@ -3881,7 +3969,13 @@
       "filePath": "src/FormItem/FormItem.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -3910,7 +4004,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
         { "type": "forwarded", "name": "mouseover", "element": "label" },
@@ -4135,14 +4235,22 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "platform",
           "default": false,
           "fallback": "{platformName}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         },
-        { "name": "skip-to-content", "default": false, "slot_props": "{}" }
+        {
+          "name": "skip-to-content",
+          "default": false,
+          "slot_props": "Record<string, never>"
+        }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
@@ -4214,12 +4322,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "text",
           "default": false,
           "fallback": "{#if text}<span>{text}</span>{/if}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -4375,7 +4487,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "<svelte:component this={icon} />",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
@@ -4400,7 +4512,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -4526,7 +4644,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "a" },
         { "type": "forwarded", "name": "click", "element": "a" },
@@ -4546,7 +4670,13 @@
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelDivider.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -4580,7 +4710,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "generics": null,
@@ -4591,7 +4727,13 @@
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelLinks.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -4700,7 +4842,13 @@
       "filePath": "src/UIShell/GlobalHeader/HeaderUtilities.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -4949,8 +5097,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
-        { "name": "actions", "default": false, "slot_props": "{}" }
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
+        {
+          "name": "actions",
+          "default": false,
+          "slot_props": "Record<string, never>"
+        }
       ],
       "events": [
         {
@@ -5043,7 +5199,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "p" },
         { "type": "forwarded", "name": "mouseover", "element": "p" },
@@ -5167,7 +5329,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "div" },
         { "type": "forwarded", "name": "click", "element": "div" }
@@ -5266,7 +5434,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -5315,7 +5489,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [{ "type": "forwarded", "name": "scroll", "element": "div" }],
       "typedefs": [],
       "generics": null,
@@ -5405,7 +5585,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
@@ -5497,7 +5683,13 @@
       "filePath": "src/ListItem/ListItem.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "li" },
         { "type": "forwarded", "name": "mouseover", "element": "li" },
@@ -5811,18 +6003,22 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "heading",
           "default": false,
           "fallback": "{modalHeading}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         },
         {
           "name": "label",
           "default": false,
           "fallback": "{modalLabel}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -5874,7 +6070,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -5956,7 +6158,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -6052,7 +6260,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
@@ -6406,7 +6620,13 @@
       "filePath": "src/Notification/NotificationActionButton.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Button" },
         { "type": "forwarded", "name": "mouseover", "element": "Button" },
@@ -6581,7 +6801,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -6869,7 +7095,7 @@
           "name": "label",
           "default": false,
           "fallback": "{label}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -6949,7 +7175,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ol" },
         { "type": "forwarded", "name": "mouseover", "element": "ol" },
@@ -6965,7 +7197,13 @@
       "filePath": "src/Link/OutboundLink.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "Link" },
         { "type": "forwarded", "name": "mouseover", "element": "Link" },
@@ -7124,12 +7362,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "menu",
           "default": false,
           "fallback": "<svelte:component\n      this={icon}\n      aria-label={iconDescription}\n      title={iconDescription}\n      class=\"bx--overflow-menu__icon {iconClass}\"\n    />",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -7267,7 +7509,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "<div class:bx--overflow-menu-options__option-content={true}>\n          {text}\n        </div>",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -7894,7 +8136,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "number" },
         { "type": "forwarded", "name": "click", "element": "ul" },
@@ -8252,7 +8500,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -8370,7 +8624,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "change", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
@@ -8900,7 +9160,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "string" },
         { "type": "forwarded", "name": "blur", "element": "select" }
@@ -8998,7 +9264,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -9147,7 +9419,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
         { "type": "forwarded", "name": "mouseover", "element": "label" },
@@ -9200,7 +9478,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -9211,7 +9495,13 @@
       "filePath": "src/UIShell/SideNav/SideNavItems.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -9337,7 +9627,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "generics": null,
@@ -9516,7 +9812,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Skip to main content",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
@@ -9816,7 +10112,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -9833,7 +10135,13 @@
       "filePath": "src/StructuredList/StructuredListBody.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -9874,7 +10182,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -9890,7 +10204,13 @@
       "filePath": "src/StructuredList/StructuredListHead.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -10027,7 +10347,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "label" },
         { "type": "forwarded", "name": "mouseover", "element": "label" },
@@ -10151,7 +10477,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{text}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -10248,7 +10574,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{label}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -10279,7 +10605,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -10362,7 +10694,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -10373,7 +10711,13 @@
       "filePath": "src/DataTable/TableBody.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -10384,7 +10728,13 @@
       "filePath": "src/DataTable/TableCell.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "td" },
         { "type": "forwarded", "name": "mouseover", "element": "td" },
@@ -10437,7 +10787,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -10448,7 +10804,13 @@
       "filePath": "src/DataTable/TableHead.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "thead" },
         { "type": "forwarded", "name": "mouseover", "element": "thead" },
@@ -10501,7 +10863,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "mouseover", "element": "th" },
         { "type": "forwarded", "name": "mouseenter", "element": "th" },
@@ -10517,7 +10885,13 @@
       "filePath": "src/DataTable/TableRow.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "tr" },
         { "type": "forwarded", "name": "mouseover", "element": "tr" },
@@ -10583,8 +10957,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
-        { "name": "content", "default": false, "slot_props": "{}" }
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
+        {
+          "name": "content",
+          "default": false,
+          "slot_props": "Record<string, never>"
+        }
       ],
       "events": [
         { "type": "forwarded", "name": "keypress", "element": "div" },
@@ -11246,7 +11628,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -11298,7 +11686,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [{ "type": "dispatched", "name": "select" }],
       "typedefs": [],
       "generics": null,
@@ -11488,7 +11882,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -11604,7 +12004,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -11729,7 +12135,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
@@ -12082,7 +12494,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -12106,7 +12524,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -12117,7 +12541,13 @@
       "filePath": "src/DataTable/ToolbarContent.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -12127,7 +12557,13 @@
       "filePath": "src/DataTable/ToolbarMenu.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
@@ -12142,7 +12578,13 @@
       "filePath": "src/DataTable/ToolbarMenuItem.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "OverflowMenuItem" },
         {
@@ -12410,18 +12852,22 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "icon",
           "default": false,
           "fallback": "<svelte:component this={icon} name={iconName} />",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         },
         {
           "name": "triggerText",
           "default": false,
           "fallback": "{triggerText}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -12499,12 +12945,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "tooltip",
           "default": false,
           "fallback": "{tooltipText}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -12585,12 +13035,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        },
         {
           "name": "text",
           "default": false,
           "fallback": "{tooltipText}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [
@@ -12622,7 +13076,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ul" },
         { "type": "forwarded", "name": "mouseover", "element": "ul" },

--- a/tests/e2e/carbon/COMPONENT_INDEX.md
+++ b/tests/e2e/carbon/COMPONENT_INDEX.md
@@ -176,9 +176,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -202,10 +202,10 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback             |
-| :-------- | :------ | :---- | :------------------- |
-| --        | Yes     | --    | --                   |
-| title     | No      | --    | <code>{title}</code> |
+| Slot name | Default | Props                               | Fallback             |
+| :-------- | :------ | :---------------------------------- | :------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | --                   |
+| title     | No      | <code>Record<string, never> </code> | <code>{title}</code> |
 
 ### Events
 
@@ -252,9 +252,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -271,9 +271,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -376,9 +376,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -472,9 +472,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -512,9 +512,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback            |
-| :-------- | :------ | :---- | :------------------ |
-| --        | Yes     | --    | <code>{code}</code> |
+| Slot name | Default | Props                               | Fallback            |
+| :-------- | :------ | :---------------------------------- | :------------------ |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{code}</code> |
 
 ### Events
 
@@ -654,9 +654,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -681,9 +681,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -701,9 +701,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -727,9 +727,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                                                                           |
-| :-------- | :------ | :---- | :--------------------------------------------------------------------------------- |
-| --        | Yes     | --    | <code>{#if animation}{feedback &#124;&#124; $$restProps["aria-label"]}{/if}</code> |
+| Slot name | Default | Props                               | Fallback                                                                           |
+| :-------- | :------ | :---------------------------------- | :--------------------------------------------------------------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{#if animation}{feedback &#124;&#124; $$restProps["aria-label"]}{/if}</code> |
 
 ### Events
 
@@ -835,12 +835,12 @@ export interface DataTableCell {
 
 | Slot name    | Default | Props                                                                                      | Fallback                                                                 |
 | :----------- | :------ | :----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
-| --           | Yes     | --                                                                                         | --                                                                       |
+| --           | Yes     | <code>Record<string, never> </code>                                                        | --                                                                       |
 | cell         | No      | <code>{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; } </code> | <code>{cell.display ? cell.display(cell.value, row) : cell.value}</code> |
 | cell-header  | No      | <code>{ header: DataTableNonEmptyHeader; } </code>                                         | <code>{header.value}</code>                                              |
-| description  | No      | --                                                                                         | <code>{description}</code>                                               |
+| description  | No      | <code>Record<string, never> </code>                                                        | <code>{description}</code>                                               |
 | expanded-row | No      | <code>{ row: Row; } </code>                                                                | --                                                                       |
-| title        | No      | --                                                                                         | <code>{title}</code>                                                     |
+| title        | No      | <code>Record<string, never> </code>                                                        | <code>{title}</code>                                                     |
 
 ### Events
 
@@ -903,9 +903,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1062,10 +1062,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| above     | No      | --    | --       |
-| below     | No      | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| above     | No      | <code>Record<string, never> </code> | --       |
+| below     | No      | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1250,9 +1250,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1268,9 +1268,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1295,9 +1295,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1316,9 +1316,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1339,9 +1339,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1394,11 +1394,11 @@ None.
 
 ### Slots
 
-| Slot name       | Default | Props | Fallback                    |
-| :-------------- | :------ | :---- | :-------------------------- |
-| --              | Yes     | --    | --                          |
-| platform        | No      | --    | <code>{platformName}</code> |
-| skip-to-content | No      | --    | --                          |
+| Slot name       | Default | Props                               | Fallback                    |
+| :-------------- | :------ | :---------------------------------- | :-------------------------- |
+| --              | Yes     | <code>Record<string, never> </code> | --                          |
+| platform        | No      | <code>Record<string, never> </code> | <code>{platformName}</code> |
+| skip-to-content | No      | <code>Record<string, never> </code> | --                          |
 
 ### Events
 
@@ -1430,10 +1430,10 @@ export interface HeaderActionSlideTransition {
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                                                    |
-| :-------- | :------ | :---- | :---------------------------------------------------------- |
-| --        | Yes     | --    | --                                                          |
-| text      | No      | --    | <code>{#if text}&lt;span&gt;{text}&lt;/span&gt;{/if}</code> |
+| Slot name | Default | Props                               | Fallback                                                    |
+| :-------- | :------ | :---------------------------------- | :---------------------------------------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | --                                                          |
+| text      | No      | <code>Record<string, never> </code> | <code>{#if text}&lt;span&gt;{text}&lt;/span&gt;{/if}</code> |
 
 ### Events
 
@@ -1493,9 +1493,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                                            |
-| :-------- | :------ | :---- | :-------------------------------------------------- |
-| --        | Yes     | --    | <code>&lt;svelte:component this={icon} /&gt;</code> |
+| Slot name | Default | Props                               | Fallback                                            |
+| :-------- | :------ | :---------------------------------- | :-------------------------------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>&lt;svelte:component this={icon} /&gt;</code> |
 
 ### Events
 
@@ -1513,9 +1513,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1562,9 +1562,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1587,9 +1587,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1606,9 +1606,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1624,9 +1624,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1682,9 +1682,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1775,10 +1775,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
-| actions   | No      | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
+| actions   | No      | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1805,9 +1805,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1836,9 +1836,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1869,9 +1869,9 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1895,9 +1895,9 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1942,9 +1942,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -1990,9 +1990,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2051,11 +2051,11 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                    |
-| :-------- | :------ | :---- | :-------------------------- |
-| --        | Yes     | --    | --                          |
-| heading   | No      | --    | <code>{modalHeading}</code> |
-| label     | No      | --    | <code>{modalLabel}</code>   |
+| Slot name | Default | Props                               | Fallback                    |
+| :-------- | :------ | :---------------------------------- | :-------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | --                          |
+| heading   | No      | <code>Record<string, never> </code> | <code>{modalHeading}</code> |
+| label     | No      | <code>Record<string, never> </code> | <code>{modalLabel}</code>   |
 
 ### Events
 
@@ -2082,9 +2082,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2105,9 +2105,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2129,9 +2129,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2207,9 +2207,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2275,9 +2275,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2321,9 +2321,9 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Slots
 
-| Slot name | Default | Props | Fallback             |
-| :-------- | :------ | :---- | :------------------- |
-| label     | No      | --    | <code>{label}</code> |
+| Slot name | Default | Props                               | Fallback             |
+| :-------- | :------ | :---------------------------------- | :------------------- |
+| label     | No      | <code>Record<string, never> </code> | <code>{label}</code> |
 
 ### Events
 
@@ -2368,9 +2368,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2389,9 +2389,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2423,10 +2423,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                                                                                                                                                                             |
-| :-------- | :------ | :---- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| --        | Yes     | --    | --                                                                                                                                                                                   |
-| menu      | No      | --    | <code>&lt;svelte:component<br /> this={icon}<br /> aria-label={iconDescription}<br /> title={iconDescription}<br /> class="bx--overflow-menu\_\_icon {iconClass}"<br /> /&gt;</code> |
+| Slot name | Default | Props                               | Fallback                                                                                                                                                                             |
+| :-------- | :------ | :---------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | --                                                                                                                                                                                   |
+| menu      | No      | <code>Record<string, never> </code> | <code>&lt;svelte:component<br /> this={icon}<br /> aria-label={iconDescription}<br /> title={iconDescription}<br /> class="bx--overflow-menu\_\_icon {iconClass}"<br /> /&gt;</code> |
 
 ### Events
 
@@ -2457,9 +2457,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                                                                                                          |
-| :-------- | :------ | :---- | :---------------------------------------------------------------------------------------------------------------- |
-| --        | Yes     | --    | <code>&lt;div class:bx--overflow-menu-options\_\_option-content={true}&gt;<br /> {text}<br /> &lt;/div&gt;</code> |
+| Slot name | Default | Props                               | Fallback                                                                                                          |
+| :-------- | :------ | :---------------------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>&lt;div class:bx--overflow-menu-options\_\_option-content={true}&gt;<br /> {text}<br /> &lt;/div&gt;</code> |
 
 ### Events
 
@@ -2601,9 +2601,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2708,9 +2708,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2757,9 +2757,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2881,9 +2881,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2922,9 +2922,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2969,9 +2969,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -2995,9 +2995,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3011,9 +3011,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3054,9 +3054,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3139,9 +3139,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                          |
-| :-------- | :------ | :---- | :-------------------------------- |
-| --        | Yes     | --    | <code>Skip to main content</code> |
+| Slot name | Default | Props                               | Fallback                          |
+| :-------- | :------ | :---------------------------------- | :-------------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Skip to main content</code> |
 
 ### Events
 
@@ -3220,9 +3220,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3242,9 +3242,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3266,9 +3266,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3287,9 +3287,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3333,9 +3333,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3383,9 +3383,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback            |
-| :-------- | :------ | :---- | :------------------ |
-| --        | Yes     | --    | <code>{text}</code> |
+| Slot name | Default | Props                               | Fallback            |
+| :-------- | :------ | :---------------------------------- | :------------------ |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{text}</code> |
 
 ### Events
 
@@ -3412,9 +3412,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback             |
-| :-------- | :------ | :---- | :------------------- |
-| --        | Yes     | --    | <code>{label}</code> |
+| Slot name | Default | Props                               | Fallback             |
+| :-------- | :------ | :---------------------------------- | :------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{label}</code> |
 
 ### Events
 
@@ -3435,9 +3435,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3458,9 +3458,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3474,9 +3474,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3490,9 +3490,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3515,9 +3515,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3531,9 +3531,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3556,9 +3556,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3577,9 +3577,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3603,10 +3603,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
-| content   | No      | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
+| content   | No      | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3819,9 +3819,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3844,9 +3844,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3878,9 +3878,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3912,9 +3912,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -3943,9 +3943,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -4076,9 +4076,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -4094,9 +4094,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -4110,9 +4110,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -4126,9 +4126,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -4142,9 +4142,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -4201,11 +4201,11 @@ None.
 
 ### Slots
 
-| Slot name   | Default | Props | Fallback                                                            |
-| :---------- | :------ | :---- | :------------------------------------------------------------------ |
-| --          | Yes     | --    | --                                                                  |
-| icon        | No      | --    | <code>&lt;svelte:component this={icon} name={iconName} /&gt;</code> |
-| triggerText | No      | --    | <code>{triggerText}</code>                                          |
+| Slot name   | Default | Props                               | Fallback                                                            |
+| :---------- | :------ | :---------------------------------- | :------------------------------------------------------------------ |
+| --          | Yes     | <code>Record<string, never> </code> | --                                                                  |
+| icon        | No      | <code>Record<string, never> </code> | <code>&lt;svelte:component this={icon} name={iconName} /&gt;</code> |
+| triggerText | No      | <code>Record<string, never> </code> | <code>{triggerText}</code>                                          |
 
 ### Events
 
@@ -4228,10 +4228,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                   |
-| :-------- | :------ | :---- | :------------------------- |
-| --        | Yes     | --    | --                         |
-| tooltip   | No      | --    | <code>{tooltipText}</code> |
+| Slot name | Default | Props                               | Fallback                   |
+| :-------- | :------ | :---------------------------------- | :------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | --                         |
+| tooltip   | No      | <code>Record<string, never> </code> | <code>{tooltipText}</code> |
 
 ### Events
 
@@ -4257,10 +4257,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                   |
-| :-------- | :------ | :---- | :------------------------- |
-| --        | Yes     | --    | --                         |
-| text      | No      | --    | <code>{tooltipText}</code> |
+| Slot name | Default | Props                               | Fallback                   |
+| :-------- | :------ | :---------------------------------- | :------------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | --                         |
+| text      | No      | <code>Record<string, never> </code> | <code>{tooltipText}</code> |
 
 ### Events
 
@@ -4282,9 +4282,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 

--- a/tests/e2e/carbon/types/Accordion/Accordion.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/Accordion.svelte.d.ts
@@ -41,5 +41,5 @@ export default class Accordion extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Accordion/AccordionItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/AccordionItem.svelte.d.ts
@@ -45,5 +45,5 @@ export default class AccordionItem extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: {}; title: {} }
+  { default: Record<string, never>; title: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -41,5 +41,5 @@ export default class AccordionSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/tests/e2e/carbon/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -18,5 +18,5 @@ export type AspectRatioProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class AspectRatio extends SvelteComponentTyped<
   AspectRatioProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Breadcrumb/Breadcrumb.svelte.d.ts
+++ b/tests/e2e/carbon/types/Breadcrumb/Breadcrumb.svelte.d.ts
@@ -23,5 +23,5 @@ export default class Breadcrumb extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -29,5 +29,5 @@ export default class BreadcrumbSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Button/ButtonSet.svelte.d.ts
+++ b/tests/e2e/carbon/types/Button/ButtonSet.svelte.d.ts
@@ -18,5 +18,5 @@ export type ButtonSetProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ButtonSet extends SvelteComponentTyped<
   ButtonSetProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Button/ButtonSkeleton.svelte.d.ts
@@ -36,5 +36,5 @@ export default class ButtonSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Checkbox/Checkbox.svelte.d.ts
+++ b/tests/e2e/carbon/types/Checkbox/Checkbox.svelte.d.ts
@@ -80,5 +80,5 @@ export default class Checkbox extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: WindowEventMap["change"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -17,5 +17,5 @@ export default class CheckboxSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/tests/e2e/carbon/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -118,5 +118,5 @@ export default class CodeSnippet extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     animationend: WindowEventMap["animationend"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class CodeSnippetSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -142,5 +142,5 @@ export default class ComboBox extends SvelteComponentTyped<
     clear: CustomEvent<any>;
     scroll: WindowEventMap["scroll"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -63,5 +63,5 @@ export default class ComposedModal extends SvelteComponentTyped<
     close: CustomEvent<null>;
     open: CustomEvent<null>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ModalBody.svelte.d.ts
@@ -24,5 +24,5 @@ export type ModalBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ModalBody extends SvelteComponentTyped<
   ModalBodyProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -48,5 +48,5 @@ export type ModalFooterProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ModalFooter extends SvelteComponentTyped<
   ModalFooterProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -54,5 +54,5 @@ export type ModalHeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ModalHeader extends SvelteComponentTyped<
   ModalHeaderProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/tests/e2e/carbon/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -37,5 +37,5 @@ export default class ContentSwitcher extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/tests/e2e/carbon/types/ContentSwitcher/Switch.svelte.d.ts
@@ -49,5 +49,5 @@ export default class Switch extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Copy/Copy.svelte.d.ts
+++ b/tests/e2e/carbon/types/Copy/Copy.svelte.d.ts
@@ -33,5 +33,5 @@ export default class Copy extends SvelteComponentTyped<
     click: WindowEventMap["click"];
     animationend: WindowEventMap["animationend"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/CopyButton/CopyButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/CopyButton/CopyButton.svelte.d.ts
@@ -15,5 +15,5 @@ export default class CopyButton extends SvelteComponentTyped<
     click: WindowEventMap["click"];
     animationend: WindowEventMap["animationend"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTable.svelte.d.ts
@@ -196,33 +196,33 @@ export default class DataTable<
       row?: Row;
       cell?: DataTableCell<Row>;
     }>;
-    ["click:header--expand"]: CustomEvent<{ expanded: boolean }>;
-    ["click:header"]: CustomEvent<{
+    "click:header--expand": CustomEvent<{ expanded: boolean }>;
+    "click:header": CustomEvent<{
       header: DataTableHeader<Row>;
       sortDirection?: "ascending" | "descending" | "none";
     }>;
-    ["click:header--select"]: CustomEvent<{
+    "click:header--select": CustomEvent<{
       indeterminate: boolean;
       selected: boolean;
     }>;
-    ["click:row"]: CustomEvent<Row>;
-    ["mouseenter:row"]: CustomEvent<Row>;
-    ["mouseleave:row"]: CustomEvent<Row>;
-    ["click:row--expand"]: CustomEvent<{ expanded: boolean; row: Row }>;
-    ["click:row--select"]: CustomEvent<{ selected: boolean; row: Row }>;
-    ["click:cell"]: CustomEvent<DataTableCell<Row>>;
+    "click:row": CustomEvent<Row>;
+    "mouseenter:row": CustomEvent<Row>;
+    "mouseleave:row": CustomEvent<Row>;
+    "click:row--expand": CustomEvent<{ expanded: boolean; row: Row }>;
+    "click:row--select": CustomEvent<{ selected: boolean; row: Row }>;
+    "click:cell": CustomEvent<DataTableCell<Row>>;
   },
   {
-    default: {};
+    default: Record<string, never>;
     cell: {
       row: Row;
       cell: DataTableCell<Row>;
       rowIndex: number;
       cellIndex: number;
     };
-    ["cell-header"]: { header: DataTableNonEmptyHeader };
-    description: {};
-    ["expanded-row"]: { row: Row };
-    title: {};
+    "cell-header": { header: DataTableNonEmptyHeader };
+    description: Record<string, never>;
+    "expanded-row": { row: Row };
+    title: Record<string, never>;
   }
 > {}

--- a/tests/e2e/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -68,5 +68,5 @@ export default class DataTableSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/DataTable/Table.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/Table.svelte.d.ts
@@ -48,5 +48,5 @@ export type TableProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Table extends SvelteComponentTyped<
   TableProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/TableBody.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableBody.svelte.d.ts
@@ -12,5 +12,5 @@ export type TableBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class TableBody extends SvelteComponentTyped<
   TableBodyProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/TableCell.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableCell.svelte.d.ts
@@ -17,5 +17,5 @@ export default class TableCell extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/TableContainer.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableContainer.svelte.d.ts
@@ -30,5 +30,5 @@ export type TableContainerProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class TableContainer extends SvelteComponentTyped<
   TableContainerProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/TableHead.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableHead.svelte.d.ts
@@ -17,5 +17,5 @@ export default class TableHead extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/TableHeader.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableHeader.svelte.d.ts
@@ -35,5 +35,5 @@ export default class TableHeader extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     click: WindowEventMap["click"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/TableRow.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableRow.svelte.d.ts
@@ -17,5 +17,5 @@ export default class TableRow extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/Toolbar.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/Toolbar.svelte.d.ts
@@ -18,5 +18,5 @@ export type ToolbarProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Toolbar extends SvelteComponentTyped<
   ToolbarProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -18,5 +18,5 @@ export type ToolbarBatchActionsProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ToolbarBatchActions extends SvelteComponentTyped<
   ToolbarBatchActionsProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/ToolbarContent.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarContent.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ToolbarContentProps = {};
+export type ToolbarContentProps = Record<string, never>;
 
 export default class ToolbarContent extends SvelteComponentTyped<
   ToolbarContentProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/ToolbarMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarMenu.svelte.d.ts
@@ -6,5 +6,5 @@ export type ToolbarMenuProps = OverflowMenuProps & {};
 export default class ToolbarMenu extends SvelteComponentTyped<
   ToolbarMenuProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/ToolbarMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarMenuItem.svelte.d.ts
@@ -6,5 +6,5 @@ export type ToolbarMenuItemProps = OverflowMenuItemProps & {};
 export default class ToolbarMenuItem extends SvelteComponentTyped<
   ToolbarMenuItemProps,
   { click: WindowEventMap["click"]; keydown: WindowEventMap["keydown"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -40,5 +40,5 @@ export default class ToolbarSearch extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/DatePicker/DatePicker.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePicker.svelte.d.ts
@@ -78,5 +78,5 @@ export default class DatePicker extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: CustomEvent<any>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -94,5 +94,5 @@ export default class DatePickerInput extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -29,5 +29,5 @@ export default class DatePickerSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/tests/e2e/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -148,5 +148,5 @@ export default class Dropdown extends SvelteComponentTyped<
       selectedItem: DropdownItem;
     }>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class DropdownSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/FileUploader/FileUploader.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploader.svelte.d.ts
@@ -81,7 +81,7 @@ export default class FileUploader extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     keydown: WindowEventMap["keydown"];
   },
-  {}
+  Record<string, never>
 > {
   /**
    * Override the default behavior of clearing the array of uploaded files

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -82,5 +82,5 @@ export default class FileUploaderButton extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     click: WindowEventMap["click"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -82,5 +82,5 @@ export default class FileUploaderDropContainer extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     click: WindowEventMap["click"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -59,5 +59,5 @@ export default class FileUploaderItem extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -17,5 +17,5 @@ export default class FileUploaderSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/FileUploader/Filename.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/Filename.svelte.d.ts
@@ -23,5 +23,5 @@ export type FilenameProps = {
 export default class Filename extends SvelteComponentTyped<
   FilenameProps,
   { click: WindowEventMap["click"]; keydown: WindowEventMap["keydown"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/FluidForm/FluidForm.svelte.d.ts
+++ b/tests/e2e/carbon/types/FluidForm/FluidForm.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type FluidFormProps = {};
+export type FluidFormProps = Record<string, never>;
 
 export default class FluidForm extends SvelteComponentTyped<
   FluidFormProps,
   { submit: WindowEventMap["submit"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Form/Form.svelte.d.ts
+++ b/tests/e2e/carbon/types/Form/Form.svelte.d.ts
@@ -18,5 +18,5 @@ export default class Form extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     submit: WindowEventMap["submit"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/FormGroup/FormGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/FormGroup/FormGroup.svelte.d.ts
@@ -41,5 +41,5 @@ export default class FormGroup extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/FormItem/FormItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/FormItem/FormItem.svelte.d.ts
@@ -17,5 +17,5 @@ export default class FormItem extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/FormLabel/FormLabel.svelte.d.ts
+++ b/tests/e2e/carbon/types/FormLabel/FormLabel.svelte.d.ts
@@ -23,5 +23,5 @@ export default class FormLabel extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Icon/Icon.svelte.d.ts
+++ b/tests/e2e/carbon/types/Icon/Icon.svelte.d.ts
@@ -33,5 +33,5 @@ export default class Icon extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Icon/IconSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Icon/IconSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class IconSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/tests/e2e/carbon/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -42,5 +42,5 @@ export default class InlineLoading extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     success: CustomEvent<null>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Link/Link.svelte.d.ts
+++ b/tests/e2e/carbon/types/Link/Link.svelte.d.ts
@@ -53,5 +53,5 @@ export default class Link extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Link/OutboundLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/Link/OutboundLink.svelte.d.ts
@@ -11,5 +11,5 @@ export default class OutboundLink extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ListBox/ListBox.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBox.svelte.d.ts
@@ -66,5 +66,5 @@ export type ListBoxProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ListBox extends SvelteComponentTyped<
   ListBoxProps,
   { keydown: WindowEventMap["keydown"]; click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ListBox/ListBoxField.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxField.svelte.d.ts
@@ -57,7 +57,7 @@ export default class ListBoxField extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     blur: WindowEventMap["blur"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {
   /**
    * Default translation ids

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -24,5 +24,5 @@ export type ListBoxMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ListBoxMenu extends SvelteComponentTyped<
   ListBoxMenuProps,
   { scroll: WindowEventMap["scroll"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -26,7 +26,7 @@ export type ListBoxMenuIconProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ListBoxMenuIcon extends SvelteComponentTyped<
   ListBoxMenuIconProps,
   { click: WindowEventMap["click"] },
-  {}
+  Record<string, never>
 > {
   /**
    * Default translation ids

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -28,5 +28,5 @@ export default class ListBoxMenuItem extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -38,7 +38,7 @@ export type ListBoxSelectionProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class ListBoxSelection extends SvelteComponentTyped<
   ListBoxSelectionProps,
   { clear: CustomEvent<any> },
-  {}
+  Record<string, never>
 > {
   /**
    * Default translation ids

--- a/tests/e2e/carbon/types/ListItem/ListItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListItem/ListItem.svelte.d.ts
@@ -17,5 +17,5 @@ export default class ListItem extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Loading/Loading.svelte.d.ts
+++ b/tests/e2e/carbon/types/Loading/Loading.svelte.d.ts
@@ -42,5 +42,5 @@ export type LoadingProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Loading extends SvelteComponentTyped<
   LoadingProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Modal/Modal.svelte.d.ts
+++ b/tests/e2e/carbon/types/Modal/Modal.svelte.d.ts
@@ -132,9 +132,13 @@ export default class Modal extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
     submit: CustomEvent<null>;
-    ["click:button--secondary"]: CustomEvent<null>;
+    "click:button--secondary": CustomEvent<null>;
     close: CustomEvent<null>;
     open: CustomEvent<null>;
   },
-  { default: {}; heading: {}; label: {} }
+  {
+    default: Record<string, never>;
+    heading: Record<string, never>;
+    label: Record<string, never>;
+  }
 > {}

--- a/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -187,5 +187,5 @@ export default class MultiSelect extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     select: CustomEvent<any>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Notification/InlineNotification.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/InlineNotification.svelte.d.ts
@@ -72,5 +72,5 @@ export default class InlineNotification extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {}; actions: {} }
+  { default: Record<string, never>; actions: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Notification/NotificationActionButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/NotificationActionButton.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type NotificationActionButtonProps = {};
+export type NotificationActionButtonProps = Record<string, never>;
 
 export default class NotificationActionButton extends SvelteComponentTyped<
   NotificationActionButtonProps,
@@ -10,5 +10,5 @@ export default class NotificationActionButton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Notification/NotificationButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/NotificationButton.svelte.d.ts
@@ -41,5 +41,5 @@ export default class NotificationButton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Notification/NotificationIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/NotificationIcon.svelte.d.ts
@@ -29,5 +29,5 @@ export type NotificationIconProps = {
 export default class NotificationIcon extends SvelteComponentTyped<
   NotificationIconProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Notification/NotificationTextDetails.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/NotificationTextDetails.svelte.d.ts
@@ -29,5 +29,5 @@ export type NotificationTextDetailsProps = {
 export default class NotificationTextDetails extends SvelteComponentTyped<
   NotificationTextDetailsProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Notification/ToastNotification.svelte.d.ts
+++ b/tests/e2e/carbon/types/Notification/ToastNotification.svelte.d.ts
@@ -78,5 +78,5 @@ export default class ToastNotification extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/NumberInput/NumberInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/NumberInput/NumberInput.svelte.d.ts
@@ -153,7 +153,7 @@ export default class NumberInput extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     input: WindowEventMap["input"];
   },
-  { label: {} }
+  { label: Record<string, never> }
 > {
   /**
    * Default translation ids

--- a/tests/e2e/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class NumberInputSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/OrderedList/OrderedList.svelte.d.ts
+++ b/tests/e2e/carbon/types/OrderedList/OrderedList.svelte.d.ts
@@ -29,5 +29,5 @@ export default class OrderedList extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -91,5 +91,5 @@ export default class OverflowMenu extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: {}; menu: {} }
+  { default: Record<string, never>; menu: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -67,5 +67,5 @@ export type OverflowMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class OverflowMenuItem extends SvelteComponentTyped<
   OverflowMenuItemProps,
   { click: WindowEventMap["click"]; keydown: WindowEventMap["keydown"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Pagination/Pagination.svelte.d.ts
+++ b/tests/e2e/carbon/types/Pagination/Pagination.svelte.d.ts
@@ -108,5 +108,5 @@ export type PaginationProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Pagination extends SvelteComponentTyped<
   PaginationProps,
   { update: CustomEvent<{ pageSize: number; page: number }> },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -17,5 +17,5 @@ export default class PaginationSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/tests/e2e/carbon/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -49,8 +49,8 @@ export default class PaginationNav extends SvelteComponentTyped<
   PaginationNavProps,
   {
     change: CustomEvent<{ page: number }>;
-    ["click:button--previous"]: CustomEvent<{ page: number }>;
-    ["click:button--next"]: CustomEvent<{ page: number }>;
+    "click:button--previous": CustomEvent<{ page: number }>;
+    "click:button--next": CustomEvent<{ page: number }>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -42,5 +42,5 @@ export default class ProgressIndicator extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -30,5 +30,5 @@ export default class ProgressIndicatorSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/RadioButton/RadioButton.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButton/RadioButton.svelte.d.ts
@@ -66,5 +66,5 @@ export type RadioButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class RadioButton extends SvelteComponentTyped<
   RadioButtonProps,
   { change: WindowEventMap["change"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -17,5 +17,5 @@ export default class RadioButtonSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -48,5 +48,5 @@ export default class RadioButtonGroup extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: CustomEvent<any>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Search/Search.svelte.d.ts
+++ b/tests/e2e/carbon/types/Search/Search.svelte.d.ts
@@ -101,5 +101,5 @@ export default class Search extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     clear: CustomEvent<null>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Search/SearchSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Search/SearchSkeleton.svelte.d.ts
@@ -30,5 +30,5 @@ export default class SearchSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Select/Select.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/Select.svelte.d.ts
@@ -96,5 +96,5 @@ export type SelectProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Select extends SvelteComponentTyped<
   SelectProps,
   { change: CustomEvent<string>; blur: WindowEventMap["blur"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Select/SelectItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/SelectItem.svelte.d.ts
@@ -29,5 +29,5 @@ export type SelectItemProps = {
 export default class SelectItem extends SvelteComponentTyped<
   SelectItemProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Select/SelectItemGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/SelectItemGroup.svelte.d.ts
@@ -24,5 +24,5 @@ export type SelectItemGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class SelectItemGroup extends SvelteComponentTyped<
   SelectItemGroupProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Select/SelectSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Select/SelectSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class SelectSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/tests/e2e/carbon/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -17,5 +17,5 @@ export default class SkeletonPlaceholder extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/tests/e2e/carbon/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -41,5 +41,5 @@ export default class SkeletonText extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Slider/Slider.svelte.d.ts
+++ b/tests/e2e/carbon/types/Slider/Slider.svelte.d.ts
@@ -120,5 +120,5 @@ export default class Slider extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: CustomEvent<any>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Slider/SliderSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class SliderSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredList.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredList.svelte.d.ts
@@ -36,5 +36,5 @@ export default class StructuredList extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: CustomEvent<any>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -17,5 +17,5 @@ export default class StructuredListBody extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -29,5 +29,5 @@ export default class StructuredListCell extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -17,5 +17,5 @@ export default class StructuredListHead extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -48,5 +48,5 @@ export type StructuredListInputProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class StructuredListInput extends SvelteComponentTyped<
   StructuredListInputProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -36,5 +36,5 @@ export default class StructuredListRow extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -30,5 +30,5 @@ export default class StructuredListSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Tabs/Tab.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/Tab.svelte.d.ts
@@ -54,5 +54,5 @@ export default class Tab extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tabs/TabContent.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/TabContent.svelte.d.ts
@@ -18,5 +18,5 @@ export type TabContentProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class TabContent extends SvelteComponentTyped<
   TabContentProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tabs/Tabs.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/Tabs.svelte.d.ts
@@ -40,5 +40,5 @@ export default class Tabs extends SvelteComponentTyped<
     click: WindowEventMap["click"];
     change: CustomEvent<any>;
   },
-  { default: {}; content: {} }
+  { default: Record<string, never>; content: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class TabsSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Tag/TagSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tag/TagSkeleton.svelte.d.ts
@@ -17,5 +17,5 @@ export default class TagSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/TextArea/TextArea.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextArea/TextArea.svelte.d.ts
@@ -105,5 +105,5 @@ export default class TextArea extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class TextAreaSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/TextInput/PasswordInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextInput/PasswordInput.svelte.d.ts
@@ -130,5 +130,5 @@ export default class PasswordInput extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/TextInput/TextInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextInput/TextInput.svelte.d.ts
@@ -130,5 +130,5 @@ export default class TextInput extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -23,5 +23,5 @@ export default class TextInputSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Tile/ClickableTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/ClickableTile.svelte.d.ts
@@ -36,5 +36,5 @@ export default class ClickableTile extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tile/ExpandableTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/ExpandableTile.svelte.d.ts
@@ -84,5 +84,5 @@ export default class ExpandableTile extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { above: {}; below: {} }
+  { above: Record<string, never>; below: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tile/RadioTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/RadioTile.svelte.d.ts
@@ -61,5 +61,5 @@ export default class RadioTile extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tile/SelectableTile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/SelectableTile.svelte.d.ts
@@ -72,5 +72,5 @@ export default class SelectableTile extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     keydown: WindowEventMap["keydown"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tile/Tile.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/Tile.svelte.d.ts
@@ -23,5 +23,5 @@ export default class Tile extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Tile/TileGroup.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tile/TileGroup.svelte.d.ts
@@ -30,5 +30,5 @@ export type TileGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class TileGroup extends SvelteComponentTyped<
   TileGroupProps,
   { select: CustomEvent<any> },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/TimePicker/TimePicker.svelte.d.ts
+++ b/tests/e2e/carbon/types/TimePicker/TimePicker.svelte.d.ts
@@ -111,5 +111,5 @@ export default class TimePicker extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -66,5 +66,5 @@ export default class TimePickerSelect extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/Toggle/Toggle.svelte.d.ts
+++ b/tests/e2e/carbon/types/Toggle/Toggle.svelte.d.ts
@@ -70,5 +70,5 @@ export default class Toggle extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -35,5 +35,5 @@ export default class ToggleSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
+++ b/tests/e2e/carbon/types/ToggleSmall/ToggleSmall.svelte.d.ts
@@ -63,5 +63,5 @@ export default class ToggleSmall extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
+++ b/tests/e2e/carbon/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
@@ -29,5 +29,5 @@ export default class ToggleSmallSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/Tooltip/Tooltip.svelte.d.ts
+++ b/tests/e2e/carbon/types/Tooltip/Tooltip.svelte.d.ts
@@ -97,5 +97,9 @@ export type TooltipProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Tooltip extends SvelteComponentTyped<
   TooltipProps,
   { click: WindowEventMap["click"]; mousedown: WindowEventMap["mousedown"] },
-  { default: {}; icon: {}; triggerText: {} }
+  {
+    default: Record<string, never>;
+    icon: Record<string, never>;
+    triggerText: Record<string, never>;
+  }
 > {}

--- a/tests/e2e/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/tests/e2e/carbon/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -48,5 +48,5 @@ export default class TooltipDefinition extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     focus: WindowEventMap["focus"];
   },
-  { default: {}; tooltip: {} }
+  { default: Record<string, never>; tooltip: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -49,5 +49,5 @@ export default class TooltipIcon extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     focus: WindowEventMap["focus"];
   },
-  { default: {}; text: {} }
+  { default: Record<string, never>; text: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/Content.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/Content.svelte.d.ts
@@ -18,5 +18,5 @@ export type ContentProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Content extends SvelteComponentTyped<
   ContentProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/Header.svelte.d.ts
@@ -61,5 +61,9 @@ export type HeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Header extends SvelteComponentTyped<
   HeaderProps,
   { click: WindowEventMap["click"] },
-  { default: {}; platform: {}; ["skip-to-content"]: {} }
+  {
+    default: Record<string, never>;
+    platform: Record<string, never>;
+    "skip-to-content": Record<string, never>;
+  }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -50,5 +50,5 @@ export type HeaderActionProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class HeaderAction extends SvelteComponentTyped<
   HeaderActionProps,
   { click: WindowEventMap["click"]; close: CustomEvent<null> },
-  { default: {}; text: {} }
+  { default: Record<string, never>; text: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderActionLink.svelte.d.ts
@@ -36,5 +36,5 @@ export type HeaderActionLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class HeaderActionLink extends SvelteComponentTyped<
   HeaderActionLinkProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderActionSearch.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderActionSearch.svelte.d.ts
@@ -15,5 +15,5 @@ export default class HeaderActionSearch extends SvelteComponentTyped<
     focusInputSearch: CustomEvent<null>;
     focusOutInputSearch: CustomEvent<null>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNav.svelte.d.ts
@@ -19,5 +19,5 @@ export type HeaderNavProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class HeaderNav extends SvelteComponentTyped<
   HeaderNavProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavItem.svelte.d.ts
@@ -39,5 +39,5 @@ export default class HeaderNavItem extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderNavMenu.svelte.d.ts
@@ -51,5 +51,5 @@ export default class HeaderNavMenu extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelDivider.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelDivider.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type HeaderPanelDividerProps = {};
+export type HeaderPanelDividerProps = Record<string, never>;
 
 export default class HeaderPanelDivider extends SvelteComponentTyped<
   HeaderPanelDividerProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelLink.svelte.d.ts
@@ -24,5 +24,5 @@ export type HeaderPanelLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class HeaderPanelLink extends SvelteComponentTyped<
   HeaderPanelLinkProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelLinks.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderPanelLinks.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type HeaderPanelLinksProps = {};
+export type HeaderPanelLinksProps = Record<string, never>;
 
 export default class HeaderPanelLinks extends SvelteComponentTyped<
   HeaderPanelLinksProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderUtilities.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/GlobalHeader/HeaderUtilities.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type HeaderUtilitiesProps = {};
+export type HeaderUtilitiesProps = Record<string, never>;
 
 export default class HeaderUtilities extends SvelteComponentTyped<
   HeaderUtilitiesProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -30,5 +30,5 @@ export type HeaderGlobalActionProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class HeaderGlobalAction extends SvelteComponentTyped<
   HeaderGlobalActionProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNav.svelte.d.ts
@@ -30,5 +30,5 @@ export type SideNavProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class SideNav extends SvelteComponentTyped<
   SideNavProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavItems.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavItems.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type SideNavItemsProps = {};
+export type SideNavItemsProps = Record<string, never>;
 
 export default class SideNavItems extends SvelteComponentTyped<
   SideNavItemsProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -42,5 +42,5 @@ export type SideNavLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class SideNavLink extends SvelteComponentTyped<
   SideNavLinkProps,
   { click: WindowEventMap["click"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenu.svelte.d.ts
@@ -36,5 +36,5 @@ export type SideNavMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class SideNavMenu extends SvelteComponentTyped<
   SideNavMenuProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SideNav/SideNavMenuItem.svelte.d.ts
@@ -36,5 +36,5 @@ export type SideNavMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class SideNavMenuItem extends SvelteComponentTyped<
   SideNavMenuItemProps,
   { click: WindowEventMap["click"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/e2e/carbon/types/UIShell/SkipToContent.svelte.d.ts
+++ b/tests/e2e/carbon/types/UIShell/SkipToContent.svelte.d.ts
@@ -24,5 +24,5 @@ export type SkipToContentProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class SkipToContent extends SvelteComponentTyped<
   SkipToContentProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/tests/e2e/carbon/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -23,5 +23,5 @@ export default class UnorderedList extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -69,7 +69,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],

--- a/tests/e2e/glob/COMPONENT_INDEX.md
+++ b/tests/e2e/glob/COMPONENT_INDEX.md
@@ -19,9 +19,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 

--- a/tests/e2e/glob/types/button/Button.svelte.d.ts
+++ b/tests/e2e/glob/types/button/Button.svelte.d.ts
@@ -33,5 +33,5 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed-ts-only/types/button/button.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/button/button.svelte.d.ts
@@ -23,5 +23,5 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed-ts-only/types/link/link.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/link/link.svelte.d.ts
@@ -12,5 +12,5 @@ export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Link extends SvelteComponentTyped<
   LinkProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/quote/quote.svelte.d.ts
@@ -22,5 +22,5 @@ export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed-ts-only/types/secondary-button/secondary-button.svelte.d.ts
+++ b/tests/e2e/multi-export-typed-ts-only/types/secondary-button/secondary-button.svelte.d.ts
@@ -6,7 +6,7 @@ export type SecondaryButtonProps = ButtonProps & {};
 export default class SecondaryButton extends SvelteComponentTyped<
   SecondaryButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {
   secondary: boolean;
 }

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -35,7 +35,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
@@ -53,7 +53,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Link text",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
@@ -94,7 +94,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{quote}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [],
@@ -124,7 +124,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "Button" }],

--- a/tests/e2e/multi-export-typed/COMPONENT_INDEX.md
+++ b/tests/e2e/multi-export-typed/COMPONENT_INDEX.md
@@ -22,9 +22,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 
@@ -40,9 +40,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback               |
-| :-------- | :------ | :---- | :--------------------- |
-| --        | Yes     | --    | <code>Link text</code> |
+| Slot name | Default | Props                               | Fallback               |
+| :-------- | :------ | :---------------------------------- | :--------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Link text</code> |
 
 ### Events
 
@@ -61,9 +61,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback             |
-| :-------- | :------ | :---- | :------------------- |
-| --        | Yes     | --    | <code>{quote}</code> |
+| Slot name | Default | Props                               | Fallback             |
+| :-------- | :------ | :---------------------------------- | :------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{quote}</code> |
 
 ### Events
 
@@ -79,9 +79,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 

--- a/tests/e2e/multi-export-typed/types/Button.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/Button.svelte.d.ts
@@ -23,5 +23,5 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed/types/Link.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/Link.svelte.d.ts
@@ -12,5 +12,5 @@ export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Link extends SvelteComponentTyped<
   LinkProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed/types/Quote.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/Quote.svelte.d.ts
@@ -22,5 +22,5 @@ export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export-typed/types/SecondaryButton.svelte.d.ts
+++ b/tests/e2e/multi-export-typed/types/SecondaryButton.svelte.d.ts
@@ -6,7 +6,7 @@ export type SecondaryButtonProps = ButtonProps & {};
 export default class SecondaryButton extends SvelteComponentTyped<
   SecondaryButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {
   secondary: boolean;
 }

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -45,7 +45,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
@@ -58,7 +58,13 @@
       "filePath": "src/nested/Header.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -73,7 +79,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Link text",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
@@ -114,7 +120,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{quote}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [],

--- a/tests/e2e/multi-export/COMPONENT_INDEX.md
+++ b/tests/e2e/multi-export/COMPONENT_INDEX.md
@@ -23,9 +23,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 
@@ -41,9 +41,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -57,9 +57,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback               |
-| :-------- | :------ | :---- | :--------------------- |
-| --        | Yes     | --    | <code>Link text</code> |
+| Slot name | Default | Props                               | Fallback               |
+| :-------- | :------ | :---------------------------------- | :--------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Link text</code> |
 
 ### Events
 
@@ -84,9 +84,9 @@ export type Author = string;
 
 ### Slots
 
-| Slot name | Default | Props | Fallback             |
-| :-------- | :------ | :---- | :------------------- |
-| --        | Yes     | --    | <code>{quote}</code> |
+| Slot name | Default | Props                               | Fallback             |
+| :-------- | :------ | :---------------------------------- | :------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{quote}</code> |
 
 ### Events
 

--- a/tests/e2e/multi-export/types/Button.svelte.d.ts
+++ b/tests/e2e/multi-export/types/Button.svelte.d.ts
@@ -22,7 +22,7 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {
   print: () => any;
 }

--- a/tests/e2e/multi-export/types/Link.svelte.d.ts
+++ b/tests/e2e/multi-export/types/Link.svelte.d.ts
@@ -12,5 +12,5 @@ export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Link extends SvelteComponentTyped<
   LinkProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export/types/Quote.svelte.d.ts
+++ b/tests/e2e/multi-export/types/Quote.svelte.d.ts
@@ -24,5 +24,5 @@ export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-export/types/nested/Header.svelte.d.ts
+++ b/tests/e2e/multi-export/types/nested/Header.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type HeaderProps = {};
+export type HeaderProps = Record<string, never>;
 
 export default class Header extends SvelteComponentTyped<
   HeaderProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -35,7 +35,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
@@ -48,7 +48,13 @@
       "filePath": "src/components/Card.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -58,7 +64,13 @@
       "filePath": "src/nested/Header.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "Record<string, never>"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -73,7 +85,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Link text",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
@@ -114,7 +126,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{quote}",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [],

--- a/tests/e2e/multi-folders/COMPONENT_INDEX.md
+++ b/tests/e2e/multi-folders/COMPONENT_INDEX.md
@@ -23,9 +23,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 
@@ -41,9 +41,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -57,9 +57,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props                               | Fallback |
+| :-------- | :------ | :---------------------------------- | :------- |
+| --        | Yes     | <code>Record<string, never> </code> | --       |
 
 ### Events
 
@@ -73,9 +73,9 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback               |
-| :-------- | :------ | :---- | :--------------------- |
-| --        | Yes     | --    | <code>Link text</code> |
+| Slot name | Default | Props                               | Fallback               |
+| :-------- | :------ | :---------------------------------- | :--------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Link text</code> |
 
 ### Events
 
@@ -100,9 +100,9 @@ export type Author = string;
 
 ### Slots
 
-| Slot name | Default | Props | Fallback             |
-| :-------- | :------ | :---- | :------------------- |
-| --        | Yes     | --    | <code>{quote}</code> |
+| Slot name | Default | Props                               | Fallback             |
+| :-------- | :------ | :---------------------------------- | :------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>{quote}</code> |
 
 ### Events
 

--- a/tests/e2e/multi-folders/types/Link.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/Link.svelte.d.ts
@@ -12,5 +12,5 @@ export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Link extends SvelteComponentTyped<
   LinkProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-folders/types/Quote.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/Quote.svelte.d.ts
@@ -24,5 +24,5 @@ export type QuoteProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Quote extends SvelteComponentTyped<
   QuoteProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-folders/types/components/Button.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/components/Button.svelte.d.ts
@@ -23,5 +23,5 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-folders/types/components/Card.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/components/Card.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type CardProps = {};
+export type CardProps = Record<string, never>;
 
 export default class Card extends SvelteComponentTyped<
   CardProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/multi-folders/types/nested/Header.svelte.d.ts
+++ b/tests/e2e/multi-folders/types/nested/Header.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type HeaderProps = {};
+export type HeaderProps = Record<string, never>;
 
 export default class Header extends SvelteComponentTyped<
   HeaderProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -34,7 +34,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],

--- a/tests/e2e/single-export-default-only/COMPONENT_INDEX.md
+++ b/tests/e2e/single-export-default-only/COMPONENT_INDEX.md
@@ -19,9 +19,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 

--- a/tests/e2e/single-export-default-only/types/Button.svelte.d.ts
+++ b/tests/e2e/single-export-default-only/types/Button.svelte.d.ts
@@ -22,5 +22,5 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -34,7 +34,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "Click me",
-          "slot_props": "{}"
+          "slot_props": "Record<string, never>"
         }
       ],
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],

--- a/tests/e2e/single-export/COMPONENT_INDEX.md
+++ b/tests/e2e/single-export/COMPONENT_INDEX.md
@@ -19,9 +19,9 @@
 
 ### Slots
 
-| Slot name | Default | Props | Fallback              |
-| :-------- | :------ | :---- | :-------------------- |
-| --        | Yes     | --    | <code>Click me</code> |
+| Slot name | Default | Props                               | Fallback              |
+| :-------- | :------ | :---------------------------------- | :-------------------- |
+| --        | Yes     | <code>Record<string, never> </code> | <code>Click me</code> |
 
 ### Events
 

--- a/tests/e2e/single-export/types/Button.svelte.d.ts
+++ b/tests/e2e/single-export/types/Button.svelte.d.ts
@@ -22,5 +22,5 @@ export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class Button extends SvelteComponentTyped<
   ButtonProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/anchor-props/output.d.ts
+++ b/tests/fixtures/anchor-props/output.d.ts
@@ -9,4 +9,8 @@ type $Props = {
 
 export type AnchorPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class AnchorProps extends SvelteComponentTyped<AnchorPropsProps, Record<string, any>, { default: {} }> {}
+export default class AnchorProps extends SvelteComponentTyped<
+  AnchorPropsProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/anchor-props/output.json
+++ b/tests/fixtures/anchor-props/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/bind-this-multiple/output.d.ts
+++ b/tests/fixtures/bind-this-multiple/output.d.ts
@@ -20,5 +20,5 @@ export type BindThisMultipleProps = {
 export default class BindThisMultiple extends SvelteComponentTyped<
   BindThisMultipleProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/bind-this-multiple/output.json
+++ b/tests/fixtures/bind-this-multiple/output.json
@@ -37,7 +37,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/bind-this/output.d.ts
+++ b/tests/fixtures/bind-this/output.d.ts
@@ -7,4 +7,8 @@ export type BindThisProps = {
   ref: null | HTMLButtonElement;
 };
 
-export default class BindThis extends SvelteComponentTyped<BindThisProps, Record<string, any>, { default: {} }> {}
+export default class BindThis extends SvelteComponentTyped<
+  BindThisProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/bind-this/output.json
+++ b/tests/fixtures/bind-this/output.json
@@ -16,7 +16,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/component-comment-multi/output.d.ts
+++ b/tests/fixtures/component-comment-multi/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ComponentCommentMultiProps = {};
+export type ComponentCommentMultiProps = Record<string, never>;
 
 /**
  * @example
@@ -11,5 +11,5 @@ export type ComponentCommentMultiProps = {};
 export default class ComponentCommentMulti extends SvelteComponentTyped<
   ComponentCommentMultiProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/component-comment-multi/output.json
+++ b/tests/fixtures/component-comment-multi/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/component-comment-single/output.d.ts
+++ b/tests/fixtures/component-comment-single/output.d.ts
@@ -1,10 +1,10 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ComponentCommentSingleProps = {};
+export type ComponentCommentSingleProps = Record<string, never>;
 
 /** Component comment */
 export default class ComponentCommentSingle extends SvelteComponentTyped<
   ComponentCommentSingleProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/component-comment-single/output.json
+++ b/tests/fixtures/component-comment-single/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/context-module/output.d.ts
+++ b/tests/fixtures/context-module/output.d.ts
@@ -20,8 +20,12 @@ export declare function b2(): () => {};
 
 export declare function b3(): () => false;
 
-export type ContextModuleProps = {};
+export type ContextModuleProps = Record<string, never>;
 
-export default class ContextModule extends SvelteComponentTyped<ContextModuleProps, Record<string, any>, {}> {
+export default class ContextModule extends SvelteComponentTyped<
+  ContextModuleProps,
+  Record<string, any>,
+  Record<string, never>
+> {
   a: string;
 }

--- a/tests/fixtures/dispatched-events-dynamic/output.d.ts
+++ b/tests/fixtures/dispatched-events-dynamic/output.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type DispatchedEventsDynamicProps = {};
+export type DispatchedEventsDynamicProps = Record<string, never>;
 
 export default class DispatchedEventsDynamic extends SvelteComponentTyped<
   DispatchedEventsDynamicProps,
   { KEY: CustomEvent<{ key: string }> },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/dispatched-events-typed/output.d.ts
+++ b/tests/fixtures/dispatched-events-typed/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type DispatchedEventsTypedProps = {};
+export type DispatchedEventsTypedProps = Record<string, never>;
 
 export default class DispatchedEventsTyped extends SvelteComponentTyped<
   DispatchedEventsTypedProps,
@@ -8,5 +8,5 @@ export default class DispatchedEventsTyped extends SvelteComponentTyped<
     /** Fired on mouseover. */ hover: CustomEvent<{ h1: boolean }>;
     destroy: CustomEvent<null>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/dispatched-events-typed/output.json
+++ b/tests/fixtures/dispatched-events-typed/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [

--- a/tests/fixtures/dispatched-events/output.d.ts
+++ b/tests/fixtures/dispatched-events/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type DispatchedEventsProps = {};
+export type DispatchedEventsProps = Record<string, never>;
 
 export default class DispatchedEvents extends SvelteComponentTyped<
   DispatchedEventsProps,
@@ -10,5 +10,5 @@ export default class DispatchedEvents extends SvelteComponentTyped<
     "destroy--component": CustomEvent<null>;
     "destroy:component": CustomEvent<null>;
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [

--- a/tests/fixtures/empty-export/output.d.ts
+++ b/tests/fixtures/empty-export/output.d.ts
@@ -1,5 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type EmptyExportProps = {};
+export type EmptyExportProps = Record<string, never>;
 
-export default class EmptyExport extends SvelteComponentTyped<EmptyExportProps, Record<string, any>, {}> {}
+export default class EmptyExport extends SvelteComponentTyped<
+  EmptyExportProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/event-explicit-null/output.d.ts
+++ b/tests/fixtures/event-explicit-null/output.d.ts
@@ -12,5 +12,5 @@ export type EventExplicitNullProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class EventExplicitNull extends SvelteComponentTyped<
   EventExplicitNullProps,
   { clear: CustomEvent<null>; change: WindowEventMap["change"]; input: WindowEventMap["input"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-and-dispatched-events/output.d.ts
+++ b/tests/fixtures/forwarded-and-dispatched-events/output.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedAndDispatchedEventsProps = {};
+export type ForwardedAndDispatchedEventsProps = Record<string, never>;
 
 export default class ForwardedAndDispatchedEvents extends SvelteComponentTyped<
   ForwardedAndDispatchedEventsProps,
   { change: WindowEventMap["change"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-custom-event-null/output.d.ts
+++ b/tests/fixtures/forwarded-custom-event-null/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedCustomEventNullProps = {};
+export type ForwardedCustomEventNullProps = Record<string, never>;
 
 export default class ForwardedCustomEventNull extends SvelteComponentTyped<
   ForwardedCustomEventNullProps,
@@ -9,5 +9,5 @@ export default class ForwardedCustomEventNull extends SvelteComponentTyped<
     /** Search query changed */
     search: CustomEvent<string>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-custom-events/output.d.ts
+++ b/tests/fixtures/forwarded-custom-events/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedCustomEventsProps = {};
+export type ForwardedCustomEventsProps = Record<string, never>;
 
 export default class ForwardedCustomEvents extends SvelteComponentTyped<
   ForwardedCustomEventsProps,
@@ -8,5 +8,5 @@ export default class ForwardedCustomEvents extends SvelteComponentTyped<
     /** Fired when clear button is clicked */ clear: CustomEvent<KeyboardEvent | MouseEvent>;
     click: WindowEventMap["click"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-events-native-with-jsdoc/output.d.ts
+++ b/tests/fixtures/forwarded-events-native-with-jsdoc/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedEventsNativeWithJsdocProps = {};
+export type ForwardedEventsNativeWithJsdocProps = Record<string, never>;
 
 export default class ForwardedEventsNativeWithJsdoc extends SvelteComponentTyped<
   ForwardedEventsNativeWithJsdocProps,
@@ -11,5 +11,5 @@ export default class ForwardedEventsNativeWithJsdoc extends SvelteComponentTyped
     /** Fired when the button loses focus */
     blur: WindowEventMap["blur"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
+++ b/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [

--- a/tests/fixtures/forwarded-events-typed/output.d.ts
+++ b/tests/fixtures/forwarded-events-typed/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedEventsTypedProps = {};
+export type ForwardedEventsTypedProps = Record<string, never>;
 
 export default class ForwardedEventsTyped extends SvelteComponentTyped<
   ForwardedEventsTypedProps,
@@ -10,5 +10,5 @@ export default class ForwardedEventsTyped extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-events/output.d.ts
+++ b/tests/fixtures/forwarded-events/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedEventsProps = {};
+export type ForwardedEventsProps = Record<string, never>;
 
 export default class ForwardedEvents extends SvelteComponentTyped<
   ForwardedEventsProps,
@@ -10,5 +10,5 @@ export default class ForwardedEvents extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     mouseover: WindowEventMap["mouseover"];
   },
-  { default: {} }
+  { default: Record<string, never> }
 > {}

--- a/tests/fixtures/forwarded-events/output.json
+++ b/tests/fixtures/forwarded-events/output.json
@@ -5,7 +5,7 @@
     {
       "name": "__default__",
       "default": true,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [

--- a/tests/fixtures/forwarded-from-component-to-native/output.d.ts
+++ b/tests/fixtures/forwarded-from-component-to-native/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedFromComponentToNativeProps = {};
+export type ForwardedFromComponentToNativeProps = Record<string, never>;
 
 export default class ForwardedFromComponentToNative extends SvelteComponentTyped<
   ForwardedFromComponentToNativeProps,
@@ -12,5 +12,5 @@ export default class ForwardedFromComponentToNative extends SvelteComponentTyped
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-native-with-detail/output.d.ts
+++ b/tests/fixtures/forwarded-native-with-detail/output.d.ts
@@ -1,11 +1,11 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type ForwardedNativeWithDetailProps = {};
+export type ForwardedNativeWithDetailProps = Record<string, never>;
 
 export default class ForwardedNativeWithDetail extends SvelteComponentTyped<
   ForwardedNativeWithDetailProps,
   {
     /** The input value when changed */ change: CustomEvent<string>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/forwarded-standard-event-custom-detail/output.d.ts
+++ b/tests/fixtures/forwarded-standard-event-custom-detail/output.d.ts
@@ -14,5 +14,5 @@ export default class ForwardedStandardEventCustomDetail extends SvelteComponentT
     remove: CustomEvent<ReadonlyArray<File>>;
     change: CustomEvent<ReadonlyArray<File>>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/function-declaration/output.d.ts
+++ b/tests/fixtures/function-declaration/output.d.ts
@@ -10,7 +10,7 @@ export type FunctionDeclarationProps = {
 export default class FunctionDeclaration extends SvelteComponentTyped<
   FunctionDeclarationProps,
   Record<string, any>,
-  {}
+  Record<string, never>
 > {
   fnB: () => {};
 

--- a/tests/fixtures/infer-basic/output.d.ts
+++ b/tests/fixtures/infer-basic/output.d.ts
@@ -27,7 +27,11 @@ export type InferBasicProps = {
   id?: string;
 };
 
-export default class InferBasic extends SvelteComponentTyped<InferBasicProps, Record<string, any>, { default: {} }> {
+export default class InferBasic extends SvelteComponentTyped<
+  InferBasicProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {
   propConst: { ["1"]: true };
 
   fn: () => any;

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -81,7 +81,7 @@
       "name": "__default__",
       "default": true,
       "fallback": "{name}",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/infer-with-types/output.d.ts
+++ b/tests/fixtures/infer-with-types/output.d.ts
@@ -25,7 +25,7 @@ export type InferWithTypesProps = {
 export default class InferWithTypes extends SvelteComponentTyped<
   InferWithTypesProps,
   Record<string, any>,
-  { default: {} }
+  { default: Record<string, never> }
 > {
   propConst: { [key: string]: boolean };
 

--- a/tests/fixtures/infer-with-types/output.json
+++ b/tests/fixtures/infer-with-types/output.json
@@ -72,7 +72,7 @@
       "name": "__default__",
       "default": true,
       "fallback": "{name}",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/input-events/output.d.ts
+++ b/tests/fixtures/input-events/output.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type InputEventsProps = {};
+export type InputEventsProps = Record<string, never>;
 
 export default class InputEvents extends SvelteComponentTyped<
   InputEventsProps,
   { input: WindowEventMap["input"]; change: WindowEventMap["change"]; paste: WindowEventMap["paste"] },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/mixed-event-types/output.d.ts
+++ b/tests/fixtures/mixed-event-types/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type MixedEventTypesProps = {};
+export type MixedEventTypesProps = Record<string, never>;
 
 export default class MixedEventTypes extends SvelteComponentTyped<
   MixedEventTypesProps,
@@ -11,5 +11,5 @@ export default class MixedEventTypes extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     submit: CustomEvent<any>;
   },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/mixed-events/output.d.ts
+++ b/tests/fixtures/mixed-events/output.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type MixedEventsProps = {};
+export type MixedEventsProps = Record<string, never>;
 
 export default class MixedEvents extends SvelteComponentTyped<
   MixedEventsProps,
   { "custom-focus": CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
-  {}
+  Record<string, never>
 > {}

--- a/tests/fixtures/no-props/output.d.ts
+++ b/tests/fixtures/no-props/output.d.ts
@@ -1,5 +1,5 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type NoPropsProps = {};
+export type NoPropsProps = Record<string, never>;
 
-export default class NoProps extends SvelteComponentTyped<NoPropsProps, Record<string, any>, {}> {}
+export default class NoProps extends SvelteComponentTyped<NoPropsProps, Record<string, any>, Record<string, never>> {}

--- a/tests/fixtures/renamed-props/output.d.ts
+++ b/tests/fixtures/renamed-props/output.d.ts
@@ -8,4 +8,8 @@ export type RenamedPropsProps = {
   class?: string | null;
 };
 
-export default class RenamedProps extends SvelteComponentTyped<RenamedPropsProps, Record<string, any>, {}> {}
+export default class RenamedProps extends SvelteComponentTyped<
+  RenamedPropsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/rest-props-multiple/output.d.ts
+++ b/tests/fixtures/rest-props-multiple/output.d.ts
@@ -14,4 +14,8 @@ type $Props = {
 
 export type RestPropsMultipleProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class RestPropsMultiple extends SvelteComponentTyped<RestPropsMultipleProps, Record<string, any>, {}> {}
+export default class RestPropsMultiple extends SvelteComponentTyped<
+  RestPropsMultipleProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/rest-props-simple/output.d.ts
+++ b/tests/fixtures/rest-props-simple/output.d.ts
@@ -9,4 +9,8 @@ type $Props = {
 
 export type RestPropsSimpleProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class RestPropsSimple extends SvelteComponentTyped<RestPropsSimpleProps, Record<string, any>, {}> {}
+export default class RestPropsSimple extends SvelteComponentTyped<
+  RestPropsSimpleProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/slots-named/output.d.ts
+++ b/tests/fixtures/slots-named/output.d.ts
@@ -10,5 +10,10 @@ export type SlotsNamedProps = {
 export default class SlotsNamed extends SvelteComponentTyped<
   SlotsNamedProps,
   Record<string, any>,
-  { default: {}; "bold heading": { text: string }; subheading: { text: string }; text: { text: string } }
+  {
+    default: Record<string, never>;
+    "bold heading": { text: string };
+    subheading: { text: string };
+    text: { text: string };
+  }
 > {}

--- a/tests/fixtures/slots-named/output.json
+++ b/tests/fixtures/slots-named/output.json
@@ -18,7 +18,7 @@
       "name": "__default__",
       "default": true,
       "fallback": "Default text",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     },
     {
       "name": "bold heading",

--- a/tests/fixtures/slots-spread-typed/output.d.ts
+++ b/tests/fixtures/slots-spread-typed/output.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type SlotsSpreadTypedProps = {};
+export type SlotsSpreadTypedProps = Record<string, never>;
 
 export default class SlotsSpreadTyped extends SvelteComponentTyped<
   SlotsSpreadTypedProps,

--- a/tests/fixtures/slots-spread/output.d.ts
+++ b/tests/fixtures/slots-spread/output.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export type SlotsSpreadProps = {};
+export type SlotsSpreadProps = Record<string, never>;
 
 export default class SlotsSpread extends SvelteComponentTyped<
   SlotsSpreadProps,
   Record<string, any>,
-  { default: {}; text: {} }
+  { default: Record<string, never>; text: Record<string, never> }
 > {}

--- a/tests/fixtures/slots-spread/output.json
+++ b/tests/fixtures/slots-spread/output.json
@@ -6,12 +6,12 @@
       "name": "__default__",
       "default": true,
       "fallback": "Default text",
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     },
     {
       "name": "text",
       "default": false,
-      "slot_props": "{}"
+      "slot_props": "Record<string, never>"
     }
   ],
   "events": [],

--- a/tests/fixtures/svg-props/output.d.ts
+++ b/tests/fixtures/svg-props/output.d.ts
@@ -9,4 +9,4 @@ type $Props = {
 
 export type SvgPropsProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, {}> {}
+export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record<string, any>, Record<string, never>> {}

--- a/tests/fixtures/typed-props/output.d.ts
+++ b/tests/fixtures/typed-props/output.d.ts
@@ -26,4 +26,8 @@ export type TypedPropsProps = {
   prop4?: "red" | "blue";
 };
 
-export default class TypedProps extends SvelteComponentTyped<TypedPropsProps, Record<string, any>, {}> {}
+export default class TypedProps extends SvelteComponentTyped<
+  TypedPropsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}


### PR DESCRIPTION
Fixes #175

Replaces empty object type `{}` with `Record<string, never>` to comply with Biome linter rule `noBannedTypes`. This applies to empty props types, empty slots objects, and individual slot props with no members. Follows existing pattern of using `Record<string, any>` for events.