### PR TITLE
fix(writer): use literal keys in TypeScript definitions

### DIFF
--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -22,7 +22,7 @@ export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">) {
 
 function clampKey(key: string) {
   if (/(-|\s+|:)/.test(key)) {
-    return /("|')/.test(key) ? key : `["${key}"]`;
+    return /("|')/.test(key) ? key : `"${key}"`;
   }
 
   return key;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1404,7 +1404,7 @@ export type SlotsNamedProps = {
 export default class SlotsNamed extends SvelteComponentTyped<
   SlotsNamedProps,
   Record<string, any>,
-  { default: {}; ["bold heading"]: { text: string }; subheading: { text: string }; text: { text: string } }
+  { default: {}; "bold heading": { text: string }; subheading: { text: string }; text: { text: string } }
 > {}
 "
 `;
@@ -1512,7 +1512,7 @@ export type MixedEventsProps = {};
 
 export default class MixedEvents extends SvelteComponentTyped<
   MixedEventsProps,
-  { ["custom-focus"]: CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
+  { "custom-focus": CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
   {}
 > {}
 "
@@ -1615,8 +1615,8 @@ export default class DispatchedEvents extends SvelteComponentTyped<
   {
     hover: CustomEvent<any>;
     destroy: CustomEvent<null>;
-    ["destroy--component"]: CustomEvent<null>;
-    ["destroy:component"]: CustomEvent<null>;
+    "destroy--component": CustomEvent<null>;
+    "destroy:component": CustomEvent<null>;
   },
   { default: {} }
 > {}

--- a/tests/fixtures/dispatched-events/output.d.ts
+++ b/tests/fixtures/dispatched-events/output.d.ts
@@ -7,8 +7,8 @@ export default class DispatchedEvents extends SvelteComponentTyped<
   {
     hover: CustomEvent<any>;
     destroy: CustomEvent<null>;
-    ["destroy--component"]: CustomEvent<null>;
-    ["destroy:component"]: CustomEvent<null>;
+    "destroy--component": CustomEvent<null>;
+    "destroy:component": CustomEvent<null>;
   },
   { default: {} }
 > {}

--- a/tests/fixtures/mixed-events/output.d.ts
+++ b/tests/fixtures/mixed-events/output.d.ts
@@ -4,6 +4,6 @@ export type MixedEventsProps = {};
 
 export default class MixedEvents extends SvelteComponentTyped<
   MixedEventsProps,
-  { ["custom-focus"]: CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
+  { "custom-focus": CustomEvent<FocusEvent | number>; blur: FocusEvent | CustomEvent<FocusEvent> },
   {}
 > {}

--- a/tests/fixtures/slots-named/output.d.ts
+++ b/tests/fixtures/slots-named/output.d.ts
@@ -10,5 +10,5 @@ export type SlotsNamedProps = {
 export default class SlotsNamed extends SvelteComponentTyped<
   SlotsNamedProps,
   Record<string, any>,
-  { default: {}; ["bold heading"]: { text: string }; subheading: { text: string }; text: { text: string } }
+  { default: {}; "bold heading": { text: string }; subheading: { text: string }; text: { text: string } }
 > {}


### PR DESCRIPTION
Fixes #174

Changes event and slot key syntax from bracket notation (e.g., `["click:overlay"]`) to string literal syntax (e.g., `"click:overlay"`) in generated `.d.ts` files.

This aligns with Biome's `useLiteralKeys` rule, reducing complexity while maintaining valid TypeScript syntax for keys containing special characters like colons and hyphens.