### PR TITLE
fix(component-parser): restore slot props type inference

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -644,7 +644,7 @@ export default class ComponentParser {
                 replace: false,
               };
 
-              if (value === undefined) return {};
+              if (value === undefined) return slot_props;
 
               if (value[0]) {
                 const { type, expression, raw, start, end } = value[0];
@@ -816,16 +816,8 @@ export default class ComponentParser {
                 slot_props[key].value = this.props.get(slot_props[key].value)?.type;
               }
 
-              let propValue = slot_props[key].value;
-              if (propValue === undefined) {
-                propValue = "any";
-              } else if (typeof propValue === "string" && propValue.startsWith("{")) {
-                // If the value starts with {, it's a complex expression
-                // Use 'any' to avoid invalid TypeScript syntax
-                propValue = "any";
-              }
-
-              new_props.push(`${key}: ${propValue}`);
+              if (slot_props[key].value === undefined) slot_props[key].value = "any";
+              new_props.push(`${key}: ${slot_props[key].value}`);
             });
 
             const formatted_slot_props = new_props.length === 0 ? "{}" : `{ ${new_props.join(", ")} }`;

--- a/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -139,7 +139,7 @@ export default class ComboBox extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    clear: WindowEventMap["clear"];
+    clear: CustomEvent<any>;
     scroll: WindowEventMap["scroll"];
   },
   {}

--- a/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -181,7 +181,7 @@ export type MultiSelectProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class MultiSelect extends SvelteComponentTyped<
   MultiSelectProps,
   {
-    clear: WindowEventMap["clear"];
+    clear: CustomEvent<any>;
     keydown: WindowEventMap["keydown"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];


### PR DESCRIPTION
Two regressions caused slot props to lose type information:

1. Line 647 returned `{}` instead of `slot_props`, losing accumulated
   properties when attributes had undefined values
2. Lines 821-825 converted object literals like `{ class: "..." }` to
   `any`, preventing valid TypeScript types from being preserved

This restores behavior from commit 8bc6ff2 where slot props like `{ props: { class: "bx--progress-label" } }` are correctly inferred instead of being widened to `any`.