### PR TITLE
feat: passthrough JSDoc tags before `@slot` into emitted .d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ export default class Button extends SvelteComponentTyped<
   - [@typedef](#typedef)
   - [@callback](#callback)
   - [@slot / @snippet](#slot--snippet)
+    - [Extra JSDoc tags before `@slot`](#extra-jsdoc-tags-before-slot)
     - [Svelte 5 Snippet Compatibility](#svelte-5-snippet-compatibility)
   - [@event](#event)
   - [Context API](#context-api)
@@ -787,7 +788,7 @@ When `@returns` is omitted, the return type defaults to `void`. When no `@param`
 
 Use the `@slot` tag for typing component slots. For Svelte 5 runes components, `@snippet` is also supported as an alias. Both are non-standard JSDoc tags.
 
-Descriptions are optional for named slots. Currently, the default slot cannot have a description.
+Descriptions are optional for every slot, including the default slot: use prose lines in the same `/** */` block above `@slot` / `@snippet`, and/or an inline description on the `@slot` line for named slots.
 
 **Signature:**
 
@@ -852,6 +853,32 @@ Omit the `slot-name` to type the default slot.
   <slot name="body" {prop} />
 </p>
 ```
+
+#### Extra JSDoc tags before `@slot`
+
+Tags such as `@example`, `@deprecated`, `@see`, or `@since` that appear **after** the prose description and **before** the `@slot` / `@snippet` line are carried into generated `.d.ts` files: the emitted JSDoc above each slot’s snippet prop (and the traditional `SlotDefs` shape) contains the description, then those tags in source order. The same entries are available on each slot in JSON output as `tags: [{ "name", "body" }, ...]`.
+
+Put `@slot` / `@snippet` last in the block (`description` → optional extra tags → slot tag). Tags placed after `@slot` / `@snippet` in the same comment are not tied to that slot. Unknown tag names are passed through as-is (no allowlist). Markdown docs do not render slot descriptions or these tags yet; use TypeScript hover or JSON for that metadata.
+
+**Example (default slot with `@example` and `@deprecated`):**
+
+````svelte
+<script>
+  /**
+   * Spread `props` onto a custom element.
+   * @example
+   * ```svelte
+   * <Item let:props>
+   *   <a {...props} href="/">Home</a>
+   * </Item>
+   * ```
+   * @deprecated Prefer the `link` snippet.
+   * @slot {{ props?: { class: string } }}
+   */
+</script>
+
+<slot props={{ class: "bx--link" }} />
+````
 
 #### Svelte 5 Snippet Compatibility
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -379,6 +379,11 @@ interface ComponentSlot {
   slot_props?: string;
   /** Description extracted from JSDoc `@slot` or `@snippet` tags */
   description?: string;
+  /**
+   * JSDoc tags that appeared after the prose description and before `@slot` / `@snippet`
+   * (e.g. `@example`, `@deprecated`), in source order.
+   */
+  tags?: Array<{ name: string; body: string }>;
 }
 
 /**
@@ -2749,11 +2754,13 @@ export default class ComponentParser {
     slot_props,
     slot_fallback,
     slot_description,
+    slot_tags,
   }: {
     slot_name?: string;
     slot_props?: string;
     slot_fallback?: string;
     slot_description?: string;
+    slot_tags?: Array<{ name: string; body: string }>;
   }) {
     const default_slot = slot_name === undefined || slot_name === "";
     const name: ComponentSlotName = default_slot ? DEFAULT_SLOT_NAME : (slot_name ?? "");
@@ -2770,6 +2777,7 @@ export default class ComponentParser {
           fallback,
           slot_props: existing_slot.slot_props === undefined ? props : existing_slot.slot_props,
           description: existing_slot.description || description,
+          tags: existing_slot.tags || slot_tags,
         });
       }
     } else {
@@ -2779,6 +2787,7 @@ export default class ComponentParser {
         fallback,
         slot_props,
         description,
+        tags: slot_tags,
       });
     }
   }
@@ -2946,6 +2955,7 @@ export default class ComponentParser {
        */
       let commentDescriptionUsed = false;
       let isFirstTag = true;
+      const pendingTags: Array<{ name: string; body: string }> = [];
 
       /**
        * Build a map of line numbers to their description content (for lines without tags).
@@ -3052,6 +3062,26 @@ export default class ComponentParser {
            */
         }
         return descLines.length > 0 ? descLines.join("\n").trim() : undefined;
+      };
+
+      /**
+       * Verbatim JSDoc body for a passthrough tag (lines after `@tag` on the tag line, plus
+       * continuation lines until the next tag or end of block).
+       */
+      const getPassthroughTagBody = (tagSource: typeof blockSource): string => {
+        if (!tagSource || tagSource.length === 0) return "";
+        const parts: string[] = [];
+        for (const line of tagSource) {
+          const t = line.tokens;
+          if ((t.end ?? "").trim() === "*/") break;
+          if (t.tag) {
+            const inline = `${t.name}${t.postName}${t.description}`.trimEnd();
+            if (inline) parts.push(inline);
+          } else {
+            parts.push(`${t.postDelimiter}${t.description}`);
+          }
+        }
+        return parts.join("\n");
       };
 
       /**
@@ -3270,7 +3300,9 @@ export default class ComponentParser {
               slot_name: name,
               slot_props: type,
               slot_description: slotDesc || undefined,
+              slot_tags: pendingTags.length > 0 ? [...pendingTags] : undefined,
             });
+            pendingTags.length = 0;
             break;
           }
           case "event": {
@@ -3387,6 +3419,24 @@ export default class ComponentParser {
           case "generics":
             this.generics = [name, type];
             if (isFirstTag) isFirstTag = false;
+            break;
+          case "template":
+          case "enum":
+          case "class":
+          case "implements":
+          case "this":
+          case "namespace":
+          case "memberof":
+          case "module":
+          case "file":
+          case "overview":
+            /**
+             * JSDoc tags often used in the same block must be ignored
+             * as to not break the slot passthrough logic.
+             */
+            break;
+          default:
+            pendingTags.push({ name: tag, body: getPassthroughTagBody(tagSource) });
             break;
         }
       }

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -57,6 +57,29 @@ function formatMultiLineComment(description: string | undefined): string {
   return `/**\n * ${description.replace(NEWLINE_TO_COMMENT_REGEX, "\n * ")}\n */`;
 }
 
+function formatSlotJsDoc(
+  description: string | undefined,
+  tags: Array<{ name: string; body: string }> | undefined,
+): string {
+  const hasTags = tags && tags.length > 0;
+  if (!description && !hasTags) return "";
+  if (!hasTags) {
+    return description?.includes("\n") ? formatMultiLineComment(description) : formatSingleLineComment(description);
+  }
+  const lines: string[] = [];
+  if (description) lines.push(...description.split("\n"));
+  for (const { name, body } of tags ?? []) {
+    if (!body) {
+      lines.push(`@${name}`);
+    } else if (body.includes("\n")) {
+      lines.push(`@${name}`, ...body.split("\n"));
+    } else {
+      lines.push(`@${name} ${body}`);
+    }
+  }
+  return `/**\n * ${lines.join("\n * ")}\n */`;
+}
+
 export function formatTsProps(props?: string) {
   if (props === undefined) return ANY_TYPE;
   return `${props}\n`;
@@ -258,9 +281,8 @@ function genPropDef(
     .map((slot) => {
       const slotName = slot.name;
       const key = clampKey(slotName);
-      const description = slot.description
-        ? `${slot.description.includes("\n") ? formatMultiLineComment(slot.description) : formatSingleLineComment(slot.description)}\n      `
-        : "";
+      const slotComment = formatSlotJsDoc(slot.description, slot.tags);
+      const description = slotComment ? `${slotComment}\n      ` : "";
       /**
        * Use Snippet-compatible type: (this: void, ...args: [Props]) => void for slots with props
        * or (this: void) => void for slots without props.
@@ -280,9 +302,8 @@ function genPropDef(
   const children_snippet_prop =
     default_slot && !existingPropNames.has("children")
       ? (() => {
-          const description = default_slot.description
-            ? `${default_slot.description.includes("\n") ? formatMultiLineComment(default_slot.description) : formatSingleLineComment(default_slot.description)}\n      `
-            : "";
+          const defaultSlotComment = formatSlotJsDoc(default_slot.description, default_slot.tags);
+          const description = defaultSlotComment ? `${defaultSlotComment}\n      ` : "";
           const hasSlotProps = default_slot.slot_props && default_slot.slot_props !== "Record<string, never>";
           const snippetType = hasSlotProps
             ? `(this: void, ...args: [${default_slot.slot_props}]) => void`
@@ -460,9 +481,8 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
   const slotDefs = def.slots
     .map(({ name, slot_props, ...rest }) => {
       const key = rest.default || name === null ? "default" : clampKey(name ?? "");
-      const description = rest.description
-        ? `${rest.description.includes("\n") ? formatMultiLineComment(rest.description) : formatSingleLineComment(rest.description)}\n`
-        : "";
+      const slotDefComment = formatSlotJsDoc(rest.description, rest.tags);
+      const description = slotDefComment ? `${slotDefComment}\n` : "";
       return `${description}${clampKey(key)}: ${formatTsProps(slot_props)};`;
     })
     .join("\n");

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1,61 +1,5 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`fixtures (JSON) "slot-description-named-pair/input.svelte" 1`] = `
-"{
-  "props": [],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": "actions",
-      "default": false,
-      "slot_props": "{ compact: boolean }",
-      "description": "Toolbar: icon-only mode uses low-contrast - same as hover-state."
-    },
-    {
-      "name": "status",
-      "default": false,
-      "slot_props": "{ message: string }",
-      "description": "Status text for live regions; prefer \`aria-current=\\"page\\"\` on the active link, not \`aria-selected\`.\\nPair with \`aria-live=\\"polite\\"\` unless the update is urgent (then use \`assertive\`)."
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "slot-description-named-pair/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type SlotDescriptionNamedPairProps = {
-  /** Toolbar: icon-only mode uses low-contrast - same as hover-state. */
-  actions?: (this: void, ...args: [{ compact: boolean }]) => void;
-
-  /**
-   * Status text for live regions; prefer \`aria-current="page"\` on the active link, not \`aria-selected\`.
-   * Pair with \`aria-live="polite"\` unless the update is urgent (then use \`assertive\`).
-   */
-  status?: (this: void, ...args: [{ message: string }]) => void;
-};
-
-export default class SlotDescriptionNamedPair extends SvelteComponentTyped<
-  SlotDescriptionNamedPairProps,
-  Record<string, any>,
-  {
-    /** Toolbar: icon-only mode uses low-contrast - same as hover-state. */
-    actions: { compact: boolean };
-    /**
-     * Status text for live regions; prefer \`aria-current="page"\` on the active link, not \`aria-selected\`.
-     * Pair with \`aria-live="polite"\` unless the update is urgent (then use \`assertive\`).
-     */
-    status: { message: string };
-  }
-> {}
-"
-`;
-
 exports[`fixtures (JSON) "runes-callback-annotated/input.svelte" 1`] = `
 "{
   "props": [
@@ -316,6 +260,32 @@ exports[`fixtures (JSON) "context-empty/input.svelte" 1`] = `
       "properties": []
     }
   ]
+}
+"
+`;
+
+exports[`fixtures (JSON) "slot-jsdoc-example/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ props?: { \\"aria-current\\"?: string; class: \\"bx--link\\" } }",
+      "description": "\`\`\`svelte\\n<BreadcrumbItem let:props>\\n<a {...props} href=\\"/\\">Home</a>\\n</BreadcrumbItem>\\n\`\`\`",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`svelte\\n <BreadcrumbItem let:props>\\n   <a {...props} href=\\"/\\">Home</a>\\n </BreadcrumbItem>\\n \`\`\`"
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
 }
 "
 `;
@@ -1845,6 +1815,32 @@ exports[`fixtures (JSON) "runes-props-basic/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "slot-jsdoc-inheritdoc-before-slot/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "content",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "Tag with an empty body still emits a lone \`@inheritdoc\` line above the slot.",
+      "tags": [
+        {
+          "name": "inheritdoc",
+          "body": ""
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "unary-expression-defaults/input.svelte" 1`] = `
 "{
   "props": [
@@ -2504,6 +2500,57 @@ exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
       "name": "hover"
     }
   ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "slot-jsdoc-two-slots-one-block-order/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "alpha",
+      "default": false,
+      "slot_props": "{ n: number }",
+      "description": "First slot only should get \`@see\`; \`pendingTags\` clears after each \`@slot\`.",
+      "tags": [
+        {
+          "name": "see",
+          "body": "https://example.com/docs"
+        }
+      ]
+    },
+    {
+      "name": "beta",
+      "default": false,
+      "slot_props": "{ s: string }"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "slot-jsdoc-orphan-type-before-slot/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "row",
+      "default": false,
+      "slot_props": "{ flag: boolean }",
+      "description": "\`@type\` without a preceding \`@event\` is ignored for events and must not become a passthrough tag."
+    }
+  ],
+  "events": [],
   "typedefs": [],
   "generics": null,
   "contexts": []
@@ -3611,6 +3658,32 @@ exports[`fixtures (JSON) "arrow-function-with-jsdoc/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "slot-description-named-pair/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "actions",
+      "default": false,
+      "slot_props": "{ compact: boolean }",
+      "description": "Toolbar: icon-only mode uses low-contrast - same as hover-state."
+    },
+    {
+      "name": "status",
+      "default": false,
+      "slot_props": "{ message: string }",
+      "description": "Status text for live regions; prefer \`aria-current=\\"page\\"\` on the active link, not \`aria-selected\`.\\nPair with \`aria-live=\\"polite\\"\` unless the update is urgent (then use \`assertive\`)."
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "non-literal-defaults/input.svelte" 1`] = `
 "{
   "props": [
@@ -4078,6 +4151,36 @@ exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "slot-jsdoc-multiple-tags/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ props?: { \\"aria-current\\"?: string; class: \\"bx--link\\" } }",
+      "description": "Spread \`props\` onto a custom element to inherit the link class\\nand \`aria-current\` attribute when \`isCurrentPage\` is set.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`svelte\\n <BreadcrumbItem let:props>\\n   <a {...props} href=\\"/\\">Home</a>\\n </BreadcrumbItem>\\n \`\`\`"
+        },
+        {
+          "name": "deprecated",
+          "body": "Prefer the \`link\` snippet."
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "forwarded-from-component-to-native/input.svelte" 1`] = `
 "{
   "props": [],
@@ -4172,6 +4275,26 @@ exports[`fixtures (JSON) "call-expression-defaults/input.svelte" 1`] = `
   ],
   "moduleExports": [],
   "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "slot-jsdoc-enum-not-passthrough/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "item",
+      "default": false,
+      "slot_props": "{ id: string }",
+      "description": "\`@enum\` shares blocks with typedefs/slots in some codebases; it must not attach to the slot."
+    }
+  ],
   "events": [],
   "typedefs": [],
   "generics": null,
@@ -4891,6 +5014,26 @@ exports[`fixtures (JSON) "legacy-bind-component-ref/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "body",
+      "default": false,
+      "slot_props": "{ n: number }",
+      "description": "Body slot uses a generic from \`@template\`; that tag must not appear on the slot in output."
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "svelte-element-dynamic/input.svelte" 1`] = `
 "{
   "props": [
@@ -5209,6 +5352,44 @@ exports[`fixtures (JSON) "context-inline-functions/input.svelte" 1`] = `
       ]
     }
   ]
+}
+"
+`;
+
+exports[`fixtures (JSON) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
+"{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "actions",
+      "default": false,
+      "slot_props": "{ compact: boolean }",
+      "description": "\`\`\`svelte\\n<Toolbar><Icon /></Toolbar>\\n\`\`\`",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`svelte\\n <Toolbar><Icon /></Toolbar>\\n \`\`\`"
+        }
+      ]
+    },
+    {
+      "name": "status",
+      "default": false,
+      "slot_props": "{ message: string }",
+      "description": "Status text for live regions; prefer \`aria-current=\\"page\\"\` on the active link.",
+      "tags": [
+        {
+          "name": "deprecated",
+          "body": "Use the \`live\` region pattern instead."
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
 }
 "
 `;
@@ -5628,6 +5809,49 @@ export default class ContextEmpty extends SvelteComponentTyped<
   ContextEmptyProps,
   Record<string, any>,
   Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-jsdoc-example/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocExampleProps = {
+  /**
+   * \`\`\`svelte
+   * <BreadcrumbItem let:props>
+   * <a {...props} href="/">Home</a>
+   * </BreadcrumbItem>
+   * \`\`\`
+   * @example
+   *  \`\`\`svelte
+   *  <BreadcrumbItem let:props>
+   *    <a {...props} href="/">Home</a>
+   *  </BreadcrumbItem>
+   *  \`\`\`
+   */
+  children?: (this: void, ...args: [{ props?: { "aria-current"?: string; class: "bx--link" } }]) => void;
+};
+
+export default class SlotJsdocExample extends SvelteComponentTyped<
+  SlotJsdocExampleProps,
+  Record<string, any>,
+  {
+    /**
+     * \`\`\`svelte
+     * <BreadcrumbItem let:props>
+     * <a {...props} href="/">Home</a>
+     * </BreadcrumbItem>
+     * \`\`\`
+     * @example
+     *  \`\`\`svelte
+     *  <BreadcrumbItem let:props>
+     *    <a {...props} href="/">Home</a>
+     *  </BreadcrumbItem>
+     *  \`\`\`
+     */
+    default: { props?: { "aria-current"?: string; class: "bx--link" } };
+  }
 > {}
 "
 `;
@@ -6568,6 +6792,31 @@ export default class RunesPropsBasic extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "slot-jsdoc-inheritdoc-before-slot/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocInheritdocBeforeSlotProps = {
+  /**
+   * Tag with an empty body still emits a lone \`@inheritdoc\` line above the slot.
+   * @inheritdoc
+   */
+  content?: (this: void) => void;
+};
+
+export default class SlotJsdocInheritdocBeforeSlot extends SvelteComponentTyped<
+  SlotJsdocInheritdocBeforeSlotProps,
+  Record<string, any>,
+  {
+    /**
+     * Tag with an empty body still emits a lone \`@inheritdoc\` line above the slot.
+     * @inheritdoc
+     */
+    content: Record<string, never>;
+  }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "unary-expression-defaults/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -7012,6 +7261,53 @@ export default class DispatchedEvents extends SvelteComponentTyped<
     hover: CustomEvent<any>;
   },
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-jsdoc-two-slots-one-block-order/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocTwoSlotsOneBlockOrderProps = {
+  /**
+   * First slot only should get \`@see\`; \`pendingTags\` clears after each \`@slot\`.
+   * @see https://example.com/docs
+   */
+  alpha?: (this: void, ...args: [{ n: number }]) => void;
+
+  beta?: (this: void, ...args: [{ s: string }]) => void;
+};
+
+export default class SlotJsdocTwoSlotsOneBlockOrder extends SvelteComponentTyped<
+  SlotJsdocTwoSlotsOneBlockOrderProps,
+  Record<string, any>,
+  {
+    /**
+     * First slot only should get \`@see\`; \`pendingTags\` clears after each \`@slot\`.
+     * @see https://example.com/docs
+     */
+    alpha: { n: number };
+    beta: { s: string };
+  }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-jsdoc-orphan-type-before-slot/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocOrphanTypeBeforeSlotProps = {
+  /** \`@type\` without a preceding \`@event\` is ignored for events and must not become a passthrough tag. */
+  row?: (this: void, ...args: [{ flag: boolean }]) => void;
+};
+
+export default class SlotJsdocOrphanTypeBeforeSlot extends SvelteComponentTyped<
+  SlotJsdocOrphanTypeBeforeSlotProps,
+  Record<string, any>,
+  {
+    /** \`@type\` without a preceding \`@event\` is ignored for events and must not become a passthrough tag. */
+    row: { flag: boolean };
+  }
 > {}
 "
 `;
@@ -7661,6 +7957,36 @@ export default class ArrowFunctionWithJsdoc extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "slot-description-named-pair/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotDescriptionNamedPairProps = {
+  /** Toolbar: icon-only mode uses low-contrast - same as hover-state. */
+  actions?: (this: void, ...args: [{ compact: boolean }]) => void;
+
+  /**
+   * Status text for live regions; prefer \`aria-current="page"\` on the active link, not \`aria-selected\`.
+   * Pair with \`aria-live="polite"\` unless the update is urgent (then use \`assertive\`).
+   */
+  status?: (this: void, ...args: [{ message: string }]) => void;
+};
+
+export default class SlotDescriptionNamedPair extends SvelteComponentTyped<
+  SlotDescriptionNamedPairProps,
+  Record<string, any>,
+  {
+    /** Toolbar: icon-only mode uses low-contrast - same as hover-state. */
+    actions: { compact: boolean };
+    /**
+     * Status text for live regions; prefer \`aria-current="page"\` on the active link, not \`aria-selected\`.
+     * Pair with \`aria-live="polite"\` unless the update is urgent (then use \`assertive\`).
+     */
+    status: { message: string };
+  }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "non-literal-defaults/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -7947,6 +8273,45 @@ export default class RestPropsMultiple extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "slot-jsdoc-multiple-tags/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocMultipleTagsProps = {
+  /**
+   * Spread \`props\` onto a custom element to inherit the link class
+   * and \`aria-current\` attribute when \`isCurrentPage\` is set.
+   * @example
+   *  \`\`\`svelte
+   *  <BreadcrumbItem let:props>
+   *    <a {...props} href="/">Home</a>
+   *  </BreadcrumbItem>
+   *  \`\`\`
+   * @deprecated Prefer the \`link\` snippet.
+   */
+  children?: (this: void, ...args: [{ props?: { "aria-current"?: string; class: "bx--link" } }]) => void;
+};
+
+export default class SlotJsdocMultipleTags extends SvelteComponentTyped<
+  SlotJsdocMultipleTagsProps,
+  Record<string, any>,
+  {
+    /**
+     * Spread \`props\` onto a custom element to inherit the link class
+     * and \`aria-current\` attribute when \`isCurrentPage\` is set.
+     * @example
+     *  \`\`\`svelte
+     *  <BreadcrumbItem let:props>
+     *    <a {...props} href="/">Home</a>
+     *  </BreadcrumbItem>
+     *  \`\`\`
+     * @deprecated Prefer the \`link\` snippet.
+     */
+    default: { props?: { "aria-current"?: string; class: "bx--link" } };
+  }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "forwarded-from-component-to-native/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -7996,6 +8361,25 @@ export default class CallExpressionDefaults extends SvelteComponentTyped<
   CallExpressionDefaultsProps,
   Record<string, any>,
   Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-jsdoc-enum-not-passthrough/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocEnumNotPassthroughProps = {
+  /** \`@enum\` shares blocks with typedefs/slots in some codebases; it must not attach to the slot. */
+  item?: (this: void, ...args: [{ id: string }]) => void;
+};
+
+export default class SlotJsdocEnumNotPassthrough extends SvelteComponentTyped<
+  SlotJsdocEnumNotPassthroughProps,
+  Record<string, any>,
+  {
+    /** \`@enum\` shares blocks with typedefs/slots in some codebases; it must not attach to the slot. */
+    item: { id: string };
+  }
 > {}
 "
 `;
@@ -8516,6 +8900,25 @@ export default class LegacyBindComponentRef extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocTemplateNotPassthroughProps = {
+  /** Body slot uses a generic from \`@template\`; that tag must not appear on the slot in output. */
+  body?: (this: void, ...args: [{ n: number }]) => void;
+};
+
+export default class SlotJsdocTemplateNotPassthrough extends SvelteComponentTyped<
+  SlotJsdocTemplateNotPassthroughProps,
+  Record<string, any>,
+  {
+    /** Body slot uses a generic from \`@template\`; that tag must not appear on the slot in output. */
+    body: { n: number };
+  }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "svelte-element-dynamic/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
@@ -8768,6 +9171,52 @@ export default class ContextInlineFunctions extends SvelteComponentTyped<
   ContextInlineFunctionsProps,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocTagsNamedPairProps = {
+  /**
+   * \`\`\`svelte
+   * <Toolbar><Icon /></Toolbar>
+   * \`\`\`
+   * @example
+   *  \`\`\`svelte
+   *  <Toolbar><Icon /></Toolbar>
+   *  \`\`\`
+   */
+  actions?: (this: void, ...args: [{ compact: boolean }]) => void;
+
+  /**
+   * Status text for live regions; prefer \`aria-current="page"\` on the active link.
+   * @deprecated Use the \`live\` region pattern instead.
+   */
+  status?: (this: void, ...args: [{ message: string }]) => void;
+};
+
+export default class SlotJsdocTagsNamedPair extends SvelteComponentTyped<
+  SlotJsdocTagsNamedPairProps,
+  Record<string, any>,
+  {
+    /**
+     * \`\`\`svelte
+     * <Toolbar><Icon /></Toolbar>
+     * \`\`\`
+     * @example
+     *  \`\`\`svelte
+     *  <Toolbar><Icon /></Toolbar>
+     *  \`\`\`
+     */
+    actions: { compact: boolean };
+    /**
+     * Status text for live regions; prefer \`aria-current="page"\` on the active link.
+     * @deprecated Use the \`live\` region pattern instead.
+     */
+    status: { message: string };
+  }
 > {}
 "
 `;

--- a/tests/fixtures/slot-jsdoc-enum-not-passthrough/input.svelte
+++ b/tests/fixtures/slot-jsdoc-enum-not-passthrough/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  /**
+   * `@enum` shares blocks with typedefs/slots in some codebases; it must not attach to the slot.
+   * @enum {number}
+   * @slot {{ id: string }} item
+   */
+</script>
+
+<slot
+  name="item"
+  id=""
+/>

--- a/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.d.ts
@@ -1,0 +1,15 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocEnumNotPassthroughProps = {
+  /** `@enum` shares blocks with typedefs/slots in some codebases; it must not attach to the slot. */
+  item?: (this: void, ...args: [{ id: string }]) => void;
+};
+
+export default class SlotJsdocEnumNotPassthrough extends SvelteComponentTyped<
+  SlotJsdocEnumNotPassthroughProps,
+  Record<string, any>,
+  {
+    /** `@enum` shares blocks with typedefs/slots in some codebases; it must not attach to the slot. */
+    item: { id: string };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.json
+++ b/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.json
@@ -1,0 +1,16 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "item",
+      "default": false,
+      "slot_props": "{ id: string }",
+      "description": "`@enum` shares blocks with typedefs/slots in some codebases; it must not attach to the slot."
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-example/input.svelte
+++ b/tests/fixtures/slot-jsdoc-example/input.svelte
@@ -1,0 +1,15 @@
+<script>
+  /**
+   * Spread `props` onto a custom element to inherit the link class
+   * and `aria-current` attribute when `isCurrentPage` is set.
+   * @example
+   * ```svelte
+   * <BreadcrumbItem let:props>
+   *   <a {...props} href="/">Home</a>
+   * </BreadcrumbItem>
+   * ```
+   * @slot {{ props?: { "aria-current"?: string; class: "bx--link" } }}
+   */
+</script>
+
+<slot props={{ class: "bx--link", "aria-current": undefined }} />

--- a/tests/fixtures/slot-jsdoc-example/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-example/output.d.ts
@@ -1,0 +1,39 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocExampleProps = {
+  /**
+   * ```svelte
+   * <BreadcrumbItem let:props>
+   * <a {...props} href="/">Home</a>
+   * </BreadcrumbItem>
+   * ```
+   * @example
+   *  ```svelte
+   *  <BreadcrumbItem let:props>
+   *    <a {...props} href="/">Home</a>
+   *  </BreadcrumbItem>
+   *  ```
+   */
+  children?: (this: void, ...args: [{ props?: { "aria-current"?: string; class: "bx--link" } }]) => void;
+};
+
+export default class SlotJsdocExample extends SvelteComponentTyped<
+  SlotJsdocExampleProps,
+  Record<string, any>,
+  {
+    /**
+     * ```svelte
+     * <BreadcrumbItem let:props>
+     * <a {...props} href="/">Home</a>
+     * </BreadcrumbItem>
+     * ```
+     * @example
+     *  ```svelte
+     *  <BreadcrumbItem let:props>
+     *    <a {...props} href="/">Home</a>
+     *  </BreadcrumbItem>
+     *  ```
+     */
+    default: { props?: { "aria-current"?: string; class: "bx--link" } };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-example/output.json
+++ b/tests/fixtures/slot-jsdoc-example/output.json
@@ -1,0 +1,22 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ props?: { \"aria-current\"?: string; class: \"bx--link\" } }",
+      "description": "```svelte\n<BreadcrumbItem let:props>\n<a {...props} href=\"/\">Home</a>\n</BreadcrumbItem>\n```",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```svelte\n <BreadcrumbItem let:props>\n   <a {...props} href=\"/\">Home</a>\n </BreadcrumbItem>\n ```"
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/input.svelte
+++ b/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/input.svelte
@@ -1,0 +1,9 @@
+<script>
+  /**
+   * Tag with an empty body still emits a lone `@inheritdoc` line above the slot.
+   * @inheritdoc
+   * @slot {{}} content
+   */
+</script>
+
+<slot name="content" />

--- a/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.d.ts
@@ -1,0 +1,21 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocInheritdocBeforeSlotProps = {
+  /**
+   * Tag with an empty body still emits a lone `@inheritdoc` line above the slot.
+   * @inheritdoc
+   */
+  content?: (this: void) => void;
+};
+
+export default class SlotJsdocInheritdocBeforeSlot extends SvelteComponentTyped<
+  SlotJsdocInheritdocBeforeSlotProps,
+  Record<string, any>,
+  {
+    /**
+     * Tag with an empty body still emits a lone `@inheritdoc` line above the slot.
+     * @inheritdoc
+     */
+    content: Record<string, never>;
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
@@ -1,0 +1,22 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "content",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "Tag with an empty body still emits a lone `@inheritdoc` line above the slot.",
+      "tags": [
+        {
+          "name": "inheritdoc",
+          "body": ""
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-multiple-tags/input.svelte
+++ b/tests/fixtures/slot-jsdoc-multiple-tags/input.svelte
@@ -1,0 +1,16 @@
+<script>
+  /**
+   * Spread `props` onto a custom element to inherit the link class
+   * and `aria-current` attribute when `isCurrentPage` is set.
+   * @example
+   * ```svelte
+   * <BreadcrumbItem let:props>
+   *   <a {...props} href="/">Home</a>
+   * </BreadcrumbItem>
+   * ```
+   * @deprecated Prefer the `link` snippet.
+   * @slot {{ props?: { "aria-current"?: string; class: "bx--link" } }}
+   */
+</script>
+
+<slot props={{ class: "bx--link", "aria-current": undefined }} />

--- a/tests/fixtures/slot-jsdoc-multiple-tags/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-multiple-tags/output.d.ts
@@ -1,0 +1,35 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocMultipleTagsProps = {
+  /**
+   * Spread `props` onto a custom element to inherit the link class
+   * and `aria-current` attribute when `isCurrentPage` is set.
+   * @example
+   *  ```svelte
+   *  <BreadcrumbItem let:props>
+   *    <a {...props} href="/">Home</a>
+   *  </BreadcrumbItem>
+   *  ```
+   * @deprecated Prefer the `link` snippet.
+   */
+  children?: (this: void, ...args: [{ props?: { "aria-current"?: string; class: "bx--link" } }]) => void;
+};
+
+export default class SlotJsdocMultipleTags extends SvelteComponentTyped<
+  SlotJsdocMultipleTagsProps,
+  Record<string, any>,
+  {
+    /**
+     * Spread `props` onto a custom element to inherit the link class
+     * and `aria-current` attribute when `isCurrentPage` is set.
+     * @example
+     *  ```svelte
+     *  <BreadcrumbItem let:props>
+     *    <a {...props} href="/">Home</a>
+     *  </BreadcrumbItem>
+     *  ```
+     * @deprecated Prefer the `link` snippet.
+     */
+    default: { props?: { "aria-current"?: string; class: "bx--link" } };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-multiple-tags/output.json
+++ b/tests/fixtures/slot-jsdoc-multiple-tags/output.json
@@ -1,0 +1,26 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ props?: { \"aria-current\"?: string; class: \"bx--link\" } }",
+      "description": "Spread `props` onto a custom element to inherit the link class\nand `aria-current` attribute when `isCurrentPage` is set.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```svelte\n <BreadcrumbItem let:props>\n   <a {...props} href=\"/\">Home</a>\n </BreadcrumbItem>\n ```"
+        },
+        {
+          "name": "deprecated",
+          "body": "Prefer the `link` snippet."
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-orphan-type-before-slot/input.svelte
+++ b/tests/fixtures/slot-jsdoc-orphan-type-before-slot/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  /**
+   * `@type` without a preceding `@event` is ignored for events and must not become a passthrough tag.
+   * @type {string}
+   * @slot {{ flag: boolean }} row
+   */
+</script>
+
+<slot
+  name="row"
+  flag={false}
+/>

--- a/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.d.ts
@@ -1,0 +1,15 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocOrphanTypeBeforeSlotProps = {
+  /** `@type` without a preceding `@event` is ignored for events and must not become a passthrough tag. */
+  row?: (this: void, ...args: [{ flag: boolean }]) => void;
+};
+
+export default class SlotJsdocOrphanTypeBeforeSlot extends SvelteComponentTyped<
+  SlotJsdocOrphanTypeBeforeSlotProps,
+  Record<string, any>,
+  {
+    /** `@type` without a preceding `@event` is ignored for events and must not become a passthrough tag. */
+    row: { flag: boolean };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.json
@@ -1,0 +1,16 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "row",
+      "default": false,
+      "slot_props": "{ flag: boolean }",
+      "description": "`@type` without a preceding `@event` is ignored for events and must not become a passthrough tag."
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/input.svelte
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/input.svelte
@@ -1,0 +1,24 @@
+<script>
+  /**
+   * Toolbar: icon-only mode uses low-contrast - same as hover-state.
+   * @example
+   * ```svelte
+   * <Toolbar><Icon /></Toolbar>
+   * ```
+   * @slot {{ compact: boolean }} actions
+   */
+  /**
+   * Status text for live regions; prefer `aria-current="page"` on the active link.
+   * @deprecated Use the `live` region pattern instead.
+   * @slot {{ message: string }} status
+   */
+</script>
+
+<slot
+  name="actions"
+  compact={false}
+/>
+<slot
+  name="status"
+  message=""
+/>

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.d.ts
@@ -1,0 +1,42 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocTagsNamedPairProps = {
+  /**
+   * ```svelte
+   * <Toolbar><Icon /></Toolbar>
+   * ```
+   * @example
+   *  ```svelte
+   *  <Toolbar><Icon /></Toolbar>
+   *  ```
+   */
+  actions?: (this: void, ...args: [{ compact: boolean }]) => void;
+
+  /**
+   * Status text for live regions; prefer `aria-current="page"` on the active link.
+   * @deprecated Use the `live` region pattern instead.
+   */
+  status?: (this: void, ...args: [{ message: string }]) => void;
+};
+
+export default class SlotJsdocTagsNamedPair extends SvelteComponentTyped<
+  SlotJsdocTagsNamedPairProps,
+  Record<string, any>,
+  {
+    /**
+     * ```svelte
+     * <Toolbar><Icon /></Toolbar>
+     * ```
+     * @example
+     *  ```svelte
+     *  <Toolbar><Icon /></Toolbar>
+     *  ```
+     */
+    actions: { compact: boolean };
+    /**
+     * Status text for live regions; prefer `aria-current="page"` on the active link.
+     * @deprecated Use the `live` region pattern instead.
+     */
+    status: { message: string };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
@@ -1,0 +1,34 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "actions",
+      "default": false,
+      "slot_props": "{ compact: boolean }",
+      "description": "```svelte\n<Toolbar><Icon /></Toolbar>\n```",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```svelte\n <Toolbar><Icon /></Toolbar>\n ```"
+        }
+      ]
+    },
+    {
+      "name": "status",
+      "default": false,
+      "slot_props": "{ message: string }",
+      "description": "Status text for live regions; prefer `aria-current=\"page\"` on the active link.",
+      "tags": [
+        {
+          "name": "deprecated",
+          "body": "Use the `live` region pattern instead."
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-template-not-passthrough/input.svelte
+++ b/tests/fixtures/slot-jsdoc-template-not-passthrough/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  /**
+   * @template {string} T
+   * Body slot uses a generic from `@template`; that tag must not appear on the slot in output.
+   * @slot {{ n: number }} body
+   */
+</script>
+
+<slot
+  name="body"
+  n={0}
+/>

--- a/tests/fixtures/slot-jsdoc-template-not-passthrough/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-template-not-passthrough/output.d.ts
@@ -1,0 +1,15 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocTemplateNotPassthroughProps = {
+  /** Body slot uses a generic from `@template`; that tag must not appear on the slot in output. */
+  body?: (this: void, ...args: [{ n: number }]) => void;
+};
+
+export default class SlotJsdocTemplateNotPassthrough extends SvelteComponentTyped<
+  SlotJsdocTemplateNotPassthroughProps,
+  Record<string, any>,
+  {
+    /** Body slot uses a generic from `@template`; that tag must not appear on the slot in output. */
+    body: { n: number };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-template-not-passthrough/output.json
+++ b/tests/fixtures/slot-jsdoc-template-not-passthrough/output.json
@@ -1,0 +1,16 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "body",
+      "default": false,
+      "slot_props": "{ n: number }",
+      "description": "Body slot uses a generic from `@template`; that tag must not appear on the slot in output."
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/slot-jsdoc-two-slots-one-block-order/input.svelte
+++ b/tests/fixtures/slot-jsdoc-two-slots-one-block-order/input.svelte
@@ -1,0 +1,17 @@
+<script>
+  /**
+   * First slot only should get `@see`; `pendingTags` clears after each `@slot`.
+   * @see https://example.com/docs
+   * @slot {{ n: number }} alpha
+   * @slot {{ s: string }} beta
+   */
+</script>
+
+<slot
+  name="alpha"
+  n={0}
+/>
+<slot
+  name="beta"
+  s=""
+/>

--- a/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.d.ts
@@ -1,0 +1,24 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotJsdocTwoSlotsOneBlockOrderProps = {
+  /**
+   * First slot only should get `@see`; `pendingTags` clears after each `@slot`.
+   * @see https://example.com/docs
+   */
+  alpha?: (this: void, ...args: [{ n: number }]) => void;
+
+  beta?: (this: void, ...args: [{ s: string }]) => void;
+};
+
+export default class SlotJsdocTwoSlotsOneBlockOrder extends SvelteComponentTyped<
+  SlotJsdocTwoSlotsOneBlockOrderProps,
+  Record<string, any>,
+  {
+    /**
+     * First slot only should get `@see`; `pendingTags` clears after each `@slot`.
+     * @see https://example.com/docs
+     */
+    alpha: { n: number };
+    beta: { s: string };
+  }
+> {}

--- a/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.json
+++ b/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.json
@@ -1,0 +1,27 @@
+{
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "alpha",
+      "default": false,
+      "slot_props": "{ n: number }",
+      "description": "First slot only should get `@see`; `pendingTags` clears after each `@slot`.",
+      "tags": [
+        {
+          "name": "see",
+          "body": "https://example.com/docs"
+        }
+      ]
+    },
+    {
+      "name": "beta",
+      "default": false,
+      "slot_props": "{ s: string }"
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}


### PR DESCRIPTION
Slot JSDoc only kept prose before `@slot`; tags like `@example` were lost unlike props. Collect unknown tags into `ComponentSlot.tags` and emit them with `formatSlotJsDoc` so hover docs match the source block.