### PR TITLE
fix(component-parser): prefer block prose for `@slot` over preceding lines

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -3286,14 +3286,18 @@ export default class ComponentParser {
           case "snippet": {
             /**
              * Prefer inline description (e.g., "@slot name - description" or "@snippet name - description"),
-             * fall back to preceding line description, then fall back to the
-             * comment block description (only for first tag if not already used).
+             * then comment block prose (when still eligible), then lines immediately above `@slot`
+             * only when no passthrough tags precede `@slot` (avoids treating `@example` fenced code
+             * as the slot description).
              */
             const inlineSlotDesc = cleanDescription(description);
-            let slotDesc = inlineSlotDesc || precedingDescription;
+            let slotDesc = inlineSlotDesc;
             if (!slotDesc && isFirstTag && !commentDescriptionUsed && commentDescription) {
               slotDesc = commentDescription;
               commentDescriptionUsed = true;
+            }
+            if (!slotDesc && pendingTags.length === 0) {
+              slotDesc = precedingDescription;
             }
             if (isFirstTag) isFirstTag = false;
             this.addSlot({

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -273,7 +273,7 @@ exports[`fixtures (JSON) "slot-jsdoc-example/input.svelte" 1`] = `
       "name": null,
       "default": true,
       "slot_props": "{ props?: { \\"aria-current\\"?: string; class: \\"bx--link\\" } }",
-      "description": "\`\`\`svelte\\n<BreadcrumbItem let:props>\\n<a {...props} href=\\"/\\">Home</a>\\n</BreadcrumbItem>\\n\`\`\`",
+      "description": "Spread \`props\` onto a custom element to inherit the link class\\nand \`aria-current\` attribute when \`isCurrentPage\` is set.",
       "tags": [
         {
           "name": "example",
@@ -5365,7 +5365,7 @@ exports[`fixtures (JSON) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
       "name": "actions",
       "default": false,
       "slot_props": "{ compact: boolean }",
-      "description": "\`\`\`svelte\\n<Toolbar><Icon /></Toolbar>\\n\`\`\`",
+      "description": "Toolbar: icon-only mode uses low-contrast - same as hover-state.",
       "tags": [
         {
           "name": "example",
@@ -5818,11 +5818,8 @@ exports[`fixtures (TypeScript) "slot-jsdoc-example/input.svelte" 1`] = `
 
 export type SlotJsdocExampleProps = {
   /**
-   * \`\`\`svelte
-   * <BreadcrumbItem let:props>
-   * <a {...props} href="/">Home</a>
-   * </BreadcrumbItem>
-   * \`\`\`
+   * Spread \`props\` onto a custom element to inherit the link class
+   * and \`aria-current\` attribute when \`isCurrentPage\` is set.
    * @example
    *  \`\`\`svelte
    *  <BreadcrumbItem let:props>
@@ -5838,11 +5835,8 @@ export default class SlotJsdocExample extends SvelteComponentTyped<
   Record<string, any>,
   {
     /**
-     * \`\`\`svelte
-     * <BreadcrumbItem let:props>
-     * <a {...props} href="/">Home</a>
-     * </BreadcrumbItem>
-     * \`\`\`
+     * Spread \`props\` onto a custom element to inherit the link class
+     * and \`aria-current\` attribute when \`isCurrentPage\` is set.
      * @example
      *  \`\`\`svelte
      *  <BreadcrumbItem let:props>
@@ -9180,9 +9174,7 @@ exports[`fixtures (TypeScript) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
 
 export type SlotJsdocTagsNamedPairProps = {
   /**
-   * \`\`\`svelte
-   * <Toolbar><Icon /></Toolbar>
-   * \`\`\`
+   * Toolbar: icon-only mode uses low-contrast - same as hover-state.
    * @example
    *  \`\`\`svelte
    *  <Toolbar><Icon /></Toolbar>
@@ -9202,9 +9194,7 @@ export default class SlotJsdocTagsNamedPair extends SvelteComponentTyped<
   Record<string, any>,
   {
     /**
-     * \`\`\`svelte
-     * <Toolbar><Icon /></Toolbar>
-     * \`\`\`
+     * Toolbar: icon-only mode uses low-contrast - same as hover-state.
      * @example
      *  \`\`\`svelte
      *  <Toolbar><Icon /></Toolbar>

--- a/tests/fixtures/slot-jsdoc-example/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-example/output.d.ts
@@ -2,11 +2,8 @@ import { SvelteComponentTyped } from "svelte";
 
 export type SlotJsdocExampleProps = {
   /**
-   * ```svelte
-   * <BreadcrumbItem let:props>
-   * <a {...props} href="/">Home</a>
-   * </BreadcrumbItem>
-   * ```
+   * Spread `props` onto a custom element to inherit the link class
+   * and `aria-current` attribute when `isCurrentPage` is set.
    * @example
    *  ```svelte
    *  <BreadcrumbItem let:props>
@@ -22,11 +19,8 @@ export default class SlotJsdocExample extends SvelteComponentTyped<
   Record<string, any>,
   {
     /**
-     * ```svelte
-     * <BreadcrumbItem let:props>
-     * <a {...props} href="/">Home</a>
-     * </BreadcrumbItem>
-     * ```
+     * Spread `props` onto a custom element to inherit the link class
+     * and `aria-current` attribute when `isCurrentPage` is set.
      * @example
      *  ```svelte
      *  <BreadcrumbItem let:props>

--- a/tests/fixtures/slot-jsdoc-example/output.json
+++ b/tests/fixtures/slot-jsdoc-example/output.json
@@ -6,7 +6,7 @@
       "name": null,
       "default": true,
       "slot_props": "{ props?: { \"aria-current\"?: string; class: \"bx--link\" } }",
-      "description": "```svelte\n<BreadcrumbItem let:props>\n<a {...props} href=\"/\">Home</a>\n</BreadcrumbItem>\n```",
+      "description": "Spread `props` onto a custom element to inherit the link class\nand `aria-current` attribute when `isCurrentPage` is set.",
       "tags": [
         {
           "name": "example",

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.d.ts
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.d.ts
@@ -2,9 +2,7 @@ import { SvelteComponentTyped } from "svelte";
 
 export type SlotJsdocTagsNamedPairProps = {
   /**
-   * ```svelte
-   * <Toolbar><Icon /></Toolbar>
-   * ```
+   * Toolbar: icon-only mode uses low-contrast - same as hover-state.
    * @example
    *  ```svelte
    *  <Toolbar><Icon /></Toolbar>
@@ -24,9 +22,7 @@ export default class SlotJsdocTagsNamedPair extends SvelteComponentTyped<
   Record<string, any>,
   {
     /**
-     * ```svelte
-     * <Toolbar><Icon /></Toolbar>
-     * ```
+     * Toolbar: icon-only mode uses low-contrast - same as hover-state.
      * @example
      *  ```svelte
      *  <Toolbar><Icon /></Toolbar>

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
@@ -6,7 +6,7 @@
       "name": "actions",
       "default": false,
       "slot_props": "{ compact: boolean }",
-      "description": "```svelte\n<Toolbar><Icon /></Toolbar>\n```",
+      "description": "Toolbar: icon-only mode uses low-contrast - same as hover-state.",
       "tags": [
         {
           "name": "example",


### PR DESCRIPTION
Slot JSDoc took lines above `@slot` before block prose, so fenced code under `@example` became `description` while `@example` stayed in `tags`. Prefer opening prose first; use preceding lines only if `pendingTags` is empty.