### PR TITLE
feat(component-parser): support `@template` tag for generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ export default class Button extends SvelteComponentTyped<
   - [Context API](#context-api)
   - [@restProps](#restprops)
   - [@extendProps](#extendprops)
+  - [@template](#template)
   - [@generics](#generics)
   - [@component comments](#component-comments)
   - [Accessor Props](#accessor-props)
@@ -1544,24 +1545,22 @@ export const secondary = true;
 import Button from "./Button.svelte";
 ```
 
-### `@generics`
+### `@template`
 
-Currently, to define generics for a Svelte component, you must use [`generics` attribute](https://github.com/dummdidumm/rfcs/blob/bfb14dc56a70ec6ddafebf2242b8e1500e06a032/text/ts-typing-props-slots-events.md#generics) on the script tag. Note that this feature is [experimental](https://svelte.dev/docs/typescript#experimental-advanced-typings) and may change in the future.
-
-However, the `generics` attribute only works if using `lang="ts"`; the language server will produce an error if `generics` is used without specifying `lang="ts"`.
+Svelte supports defining generics via the [`generics` attribute](https://svelte.dev/docs/svelte/typescript) on the script tag, but this requires `lang="ts"`.
 
 ```svelte
-<!-- This causes an error because `lang="ts"` must be used. -->
-<script generics="Row extends DataTableRow = any"></script>
+<!-- Requires lang="ts" -->
+<script lang="ts" generics="Row extends DataTableRow = any"></script>
 ```
 
-Because `sveld` is designed to support JavaScript-only usage as a baseline, the API design to specify generics uses a custom JSDoc tag `@generics`.
+Because `sveld` is designed to support JavaScript-only usage as a baseline, the API design to specify generics uses the standard JSDoc `@template` tag. The `@generics` tag is also supported as an alias.
 
-**Signature:**
+**Signature:** Uses standard [JSDoc `@template` syntax](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template):
 
 ```js
 /**
- * @generics {GenericParameter} GenericName
+ * @template {Constraint} [Name=Default]
  */
 ```
 
@@ -1569,7 +1568,7 @@ Because `sveld` is designed to support JavaScript-only usage as a baseline, the 
 
 ```js
 /**
- * @generics {Row extends DataTableRow = any} Row
+ * @template {DataTableRow} [Row=DataTableRow]
  */
 ```
 
@@ -1624,13 +1623,12 @@ Because `sveld` is designed to support JavaScript-only usage as a baseline, the 
 The generated TypeScript definition will resemble the following:
 
 ```ts
-// Props type includes the full constraint, enabling indexed access types like Row["id"]
-export type ComponentProps<Row extends DataTableRow = any> = {
+export type ComponentProps<Row extends DataTableRow = DataTableRow> = {
   rows?: ReadonlyArray<Row>;
 };
 
 export default class Component<
-  Row extends DataTableRow = any,
+  Row extends DataTableRow = DataTableRow,
 > extends SvelteComponentTyped<
   ComponentProps<Row>,
   Record<string, any>,
@@ -1638,22 +1636,55 @@ export default class Component<
 > {}
 ```
 
-For a parameter list, the name should be comma-separated but not include spaces.
+For multiple generics, use separate `@template` tags:
 
 ```js
 /**
- * @generics {Param1, Param2} Name1,Name2
+ * @template {DataTableRow} [Row=DataTableRow]
+ * @template {DataTableRow} [Header=DataTableRow]
  */
 ```
 
 ```ts
-export type ComponentProps<Param1, Param2> = { ... };
+export type ComponentProps<
+  Row extends DataTableRow = DataTableRow,
+  Header extends DataTableRow = DataTableRow,
+> = { ... };
 
-export default class Component<Param1, Param2> extends SvelteComponentTyped<
-  ComponentProps<Name1, Name2>,
+export default class Component<
+  Row extends DataTableRow = DataTableRow,
+  Header extends DataTableRow = DataTableRow,
+> extends SvelteComponentTyped<
+  ComponentProps<Row, Header>,
   Record<string, any>,
   Record<string, any>
 > {}
+```
+
+### `@generics`
+
+As an alternative to `@template`, sveld also supports a custom `@generics` tag. Unlike `@template`, which is [officially supported by JSDoc/TypeScript](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template), `@generics` is sveld-specific. However, its syntax can be more readable since the full constraint is written inline:
+
+```js
+/**
+ * @generics {Row extends DataTableRow = DataTableRow} Row
+ */
+```
+
+This is equivalent to:
+
+```js
+/**
+ * @template {DataTableRow} [Row=DataTableRow]
+ */
+```
+
+For multiple generics, use a single `@generics` tag with comma-separated names:
+
+```js
+/**
+ * @generics {Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow} Row,Header
+ */
 ```
 
 ### `@component` comments

--- a/playground/src/data.ts
+++ b/playground/src/data.ts
@@ -456,8 +456,7 @@ const genericsLegacy: Example = {
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @template {DataTableRow} <Row extends DataTableRow = DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
    */
 
   /** @type {ReadonlyArray<DataTableHeader<Row>>} */

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -3233,6 +3233,13 @@ export default class ComponentParser {
         }
       };
 
+      /**
+       * `@template` in the same block as `@slot` / `@snippet` is slot documentation only
+       * (e.g. describing a generic for prose); it must not set component-level generics or
+       * passthrough to slot output.
+       */
+      const blockHasSlotOrSnippetTag = tags.some((t) => t.tag === "slot" || t.tag === "snippet");
+
       for (const {
         tag,
         type: tagType,
@@ -3424,7 +3431,27 @@ export default class ComponentParser {
             this.generics = [name, type];
             if (isFirstTag) isFirstTag = false;
             break;
-          case "template":
+          case "template": {
+            if (blockHasSlotOrSnippetTag) break;
+
+            // Build constraint from standard JSDoc @template syntax:
+            //   @template T              → type="", name="T", default=undefined
+            //   @template {string} T     → type="string", name="T", default=undefined
+            //   @template [T=string]     → type="", name="T", default="string"
+            //   @template {Foo} [T=Foo]  → type="Foo", name="T", default="Foo"
+            let constraint = name;
+            if (type) constraint = `${name} extends ${type}`;
+            if (defaultValue) constraint += ` = ${defaultValue}`;
+
+            if (this.generics) {
+              // Accumulate multiple @template tags
+              this.generics = [`${this.generics[0]},${name}`, `${this.generics[1]}, ${constraint}`];
+            } else {
+              this.generics = [name, constraint];
+            }
+            if (isFirstTag) isFirstTag = false;
+            break;
+          }
           case "enum":
           case "class":
           case "implements":

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -701,6 +701,67 @@ exports[`fixtures (JSON) "legacy-bind-component-selected/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "template-tag-multiple/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row, Header>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row, Header>>, rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \\"id\\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \\"id\\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: Header; }",
+      "name": "DataTableHeader<Row=DataTableRow,Header=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow,Header=DataTableRow> { key: DataTableKey<Row>; value: Header; }"
+    }
+  ],
+  "generics": [
+    "Row,Header",
+    "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
+  ],
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-props-intersection/input.svelte" 1`] = `
 "{
   "props": [
@@ -2000,6 +2061,67 @@ exports[`fixtures (JSON) "slot-prop-dotted-access/input.svelte" 1`] = `
   "events": [],
   "typedefs": [],
   "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "template-tag/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \\"id\\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \\"id\\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: string; }",
+      "name": "DataTableHeader<Row=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow> { key: DataTableKey<Row>; value: string; }"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
   "contexts": []
 }
 "
@@ -4652,6 +4774,83 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "context-template-tag/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "rows",
+      "kind": "let",
+      "description": "Specify the rows the data table should render.",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: any; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: any; [key: string]: any; }"
+    },
+    {
+      "type": "any",
+      "name": "DataTableRowId",
+      "ts": "type DataTableRowId = any"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [
+    {
+      "key": "DataTable",
+      "typeName": "DataTableContext",
+      "properties": [
+        {
+          "name": "batchSelectedIds",
+          "type": "import(\\"svelte/store\\").Writable<ReadonlyArray<DataTableRowId>>",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "tableRows",
+          "type": "import(\\"svelte/store\\").Writable<ReadonlyArray<Row>>",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "resetSelectedRowIds",
+          "type": "() => void",
+          "description": "Reset selected row ids",
+          "optional": false
+        },
+        {
+          "name": "filterRows",
+          "type": "(searchValue: string, customFilter?: (row: Row, value: string) => boolean) => ReadonlyArray<DataTableRowId>",
+          "description": "Filter rows by search value",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-whole-props-imported/input.svelte" 1`] = `
 "{
   "props": [],
@@ -5270,6 +5469,71 @@ exports[`fixtures (JSON) "extend-props/input.svelte" 1`] = `
   "extends": {
     "interface": "ButtonProps",
     "import": "\\"./Button.svelte\\""
+  },
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "template-tag-with-rest-props/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \\"id\\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \\"id\\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: string; }",
+      "name": "DataTableHeader<Row=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow> { key: DataTableKey<Row>; value: string; }"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "rest_props": {
+    "type": "Element",
+    "name": "div"
   },
   "contexts": []
 }
@@ -6123,6 +6387,52 @@ export default class LegacyBindComponentSelected extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "template-tag-multiple/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> {
+  key: DataTableKey<Row>;
+  value: Header;
+}
+
+export type TemplateTagMultipleProps<
+  Row extends DataTableRow = DataTableRow,
+  Header extends DataTableRow = DataTableRow,
+> = {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row, Header>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (
+    this: void,
+    ...args: [{ headers: ReadonlyArray<DataTableHeader<Row, Header>>; rows: ReadonlyArray<Row> }]
+  ) => void;
+};
+
+export default class TemplateTagMultiple<
+  Row extends DataTableRow = DataTableRow,
+  Header extends DataTableRow = DataTableRow,
+> extends SvelteComponentTyped<
+  TemplateTagMultipleProps<Row, Header>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<DataTableHeader<Row, Header>>; rows: ReadonlyArray<Row> } }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-props-intersection/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -6938,6 +7248,46 @@ export default class SlotPropDottedAccess extends SvelteComponentTyped<
       i: number;
     };
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "template-tag/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
+  value: string;
+}
+
+export type TemplateTagProps<Row extends DataTableRow = DataTableRow> = {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (
+    this: void,
+    ...args: [{ headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> }]
+  ) => void;
+};
+
+export default class TemplateTag<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  TemplateTagProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> } }
 > {}
 "
 `;
@@ -8591,6 +8941,46 @@ export default class BindThisMultiple extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "context-template-tag/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: any;
+  [key: string]: any;
+}
+
+export type DataTableRowId = any;
+
+export type DataTableContext<Row extends DataTableRow = DataTableRow> = {
+  batchSelectedIds: import("svelte/store").Writable<ReadonlyArray<DataTableRowId>>;
+  tableRows: import("svelte/store").Writable<ReadonlyArray<Row>>;
+  /** Reset selected row ids */
+  resetSelectedRowIds: () => void;
+  /** Filter rows by search value */
+  filterRows: (
+    searchValue: string,
+    customFilter?: (row: Row, value: string) => boolean,
+  ) => ReadonlyArray<DataTableRowId>;
+};
+
+export type ContextTemplateTagProps<Row extends DataTableRow = DataTableRow> = {
+  /**
+   * Specify the rows the data table should render.
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextTemplateTag<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  ContextTemplateTagProps<Row>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-whole-props-imported/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 import type { Props } from "./types";
@@ -9115,6 +9505,57 @@ export default class ExtendProps extends SvelteComponentTyped<
   ExtendPropsProps,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "template-tag-with-rest-props/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
+  value: string;
+}
+
+type $RestProps = SvelteHTMLElements["div"];
+
+type $Props<Row extends DataTableRow = DataTableRow> = {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (
+    this: void,
+    ...args: [{ headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> }]
+  ) => void;
+
+  [key: \`data-\${string}\`]: unknown;
+};
+
+export type TemplateTagWithRestPropsProps<Row extends DataTableRow = DataTableRow> = Omit<
+  $RestProps,
+  keyof $Props<Row>
+> &
+  $Props<Row>;
+
+export default class TemplateTagWithRestProps<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  TemplateTagWithRestPropsProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> } }
 > {}
 "
 `;

--- a/tests/e2e/carbon/src/DataTable/DataTable.svelte
+++ b/tests/e2e/carbon/src/DataTable/DataTable.svelte
@@ -1,7 +1,6 @@
 <script>
   /**
  * @generics {Row extends DataTableRow = DataTableRow} Row
- * @template {DataTableRow} Row
  * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
  * @typedef {any} DataTableValue
  * @typedef {{ key: DataTableKey<Row>; empty: boolean; display?: (item: Value, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableEmptyHeader<Row>

--- a/tests/fixtures/context-template-tag/input.svelte
+++ b/tests/fixtures/context-template-tag/input.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  /**
+   * @typedef {{ id: any; [key: string]: any; }} DataTableRow
+   * @typedef {any} DataTableRowId
+   * @template {DataTableRow} [Row=DataTableRow]
+   */
+
+  /**
+   * Specify the rows the data table should render.
+   * @type {ReadonlyArray<Row>}
+   */
+  export let rows = [];
+
+  /**
+   * @type {import("svelte/store").Writable<ReadonlyArray<DataTableRowId>>}
+   */
+  const batchSelectedIds = writable([]);
+
+  /**
+   * @type {import("svelte/store").Writable<ReadonlyArray<Row>>}
+   */
+  const tableRows = writable(rows);
+
+  /**
+   * Reset selected row ids
+   * @type {() => void}
+   */
+  const resetSelectedRowIds = () => {};
+
+  /**
+   * Filter rows by search value
+   * @type {(searchValue: string, customFilter?: (row: Row, value: string) => boolean) => ReadonlyArray<DataTableRowId>}
+   */
+  const filterRows = (searchValue, customFilter) => [];
+
+  setContext("DataTable", {
+    batchSelectedIds,
+    tableRows,
+    resetSelectedRowIds,
+    filterRows,
+  });
+</script>
+
+<div><slot /></div>

--- a/tests/fixtures/context-template-tag/output.d.ts
+++ b/tests/fixtures/context-template-tag/output.d.ts
@@ -1,0 +1,36 @@
+import { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: any;
+  [key: string]: any;
+}
+
+export type DataTableRowId = any;
+
+export type DataTableContext<Row extends DataTableRow = DataTableRow> = {
+  batchSelectedIds: import("svelte/store").Writable<ReadonlyArray<DataTableRowId>>;
+  tableRows: import("svelte/store").Writable<ReadonlyArray<Row>>;
+  /** Reset selected row ids */
+  resetSelectedRowIds: () => void;
+  /** Filter rows by search value */
+  filterRows: (
+    searchValue: string,
+    customFilter?: (row: Row, value: string) => boolean,
+  ) => ReadonlyArray<DataTableRowId>;
+};
+
+export type ContextTemplateTagProps<Row extends DataTableRow = DataTableRow> = {
+  /**
+   * Specify the rows the data table should render.
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextTemplateTag<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  ContextTemplateTagProps<Row>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-template-tag/output.json
+++ b/tests/fixtures/context-template-tag/output.json
@@ -1,0 +1,73 @@
+{
+  "props": [
+    {
+      "name": "rows",
+      "kind": "let",
+      "description": "Specify the rows the data table should render.",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: any; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: any; [key: string]: any; }"
+    },
+    {
+      "type": "any",
+      "name": "DataTableRowId",
+      "ts": "type DataTableRowId = any"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [
+    {
+      "key": "DataTable",
+      "typeName": "DataTableContext",
+      "properties": [
+        {
+          "name": "batchSelectedIds",
+          "type": "import(\"svelte/store\").Writable<ReadonlyArray<DataTableRowId>>",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "tableRows",
+          "type": "import(\"svelte/store\").Writable<ReadonlyArray<Row>>",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "resetSelectedRowIds",
+          "type": "() => void",
+          "description": "Reset selected row ids",
+          "optional": false
+        },
+        {
+          "name": "filterRows",
+          "type": "(searchValue: string, customFilter?: (row: Row, value: string) => boolean) => ReadonlyArray<DataTableRowId>",
+          "description": "Filter rows by search value",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/generics-multiple/input.svelte
+++ b/tests/fixtures/generics-multiple/input.svelte
@@ -3,7 +3,6 @@
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: Header; }} DataTableHeader<Row=DataTableRow,Header=DataTableRow>
-   * @template {DataTableRow} <Row extends DataTableRow = DataTableRow>
    * @generics {Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow} Row,Header
    */
 

--- a/tests/fixtures/template-tag-multiple/Test.svelte
+++ b/tests/fixtures/template-tag-multiple/Test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import Generics from "./output";
+
+  const rows = [
+    { id: 1, name: "Name 1", port: 3000 },
+    { id: 2, name: "Name 2", port: 3001 },
+    { id: 3, name: "Name 3", port: 3000 },
+  ] as const;
+</script>
+
+<Generics
+  headers={[
+    {
+      key: "name",
+      value: {
+        id: 0,
+        name: "Name",
+        port: 3000,
+      },
+    },
+    {
+      key: "port",
+      value: {
+        id: 1,
+        name: "Name",
+        port: 3001,
+      },
+    },
+  ]}
+  {rows}
+  let:headers
+  let:rows
+>
+  {#each rows as row}
+    {row.name}
+  {/each}
+  {#each headers as header}
+    {header.value.name}
+  {/each}
+</Generics>

--- a/tests/fixtures/template-tag-multiple/input.svelte
+++ b/tests/fixtures/template-tag-multiple/input.svelte
@@ -2,11 +2,12 @@
   /**
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
-   * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @typedef {{ key: DataTableKey<Row>; value: Header; }} DataTableHeader<Row=DataTableRow,Header=DataTableRow>
+   * @template {DataTableRow} [Row=DataTableRow]
+   * @template {DataTableRow} [Header=DataTableRow]
    */
 
-  /** @type {ReadonlyArray<DataTableHeader<Row>>} */
+  /** @type {ReadonlyArray<DataTableHeader<Row, Header>>} */
   export let headers = [];
 
   /** @type {ReadonlyArray<Row>} */

--- a/tests/fixtures/template-tag-multiple/output.d.ts
+++ b/tests/fixtures/template-tag-multiple/output.d.ts
@@ -1,0 +1,42 @@
+import { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> {
+  key: DataTableKey<Row>;
+  value: Header;
+}
+
+export type TemplateTagMultipleProps<
+  Row extends DataTableRow = DataTableRow,
+  Header extends DataTableRow = DataTableRow,
+> = {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row, Header>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (
+    this: void,
+    ...args: [{ headers: ReadonlyArray<DataTableHeader<Row, Header>>; rows: ReadonlyArray<Row> }]
+  ) => void;
+};
+
+export default class TemplateTagMultiple<
+  Row extends DataTableRow = DataTableRow,
+  Header extends DataTableRow = DataTableRow,
+> extends SvelteComponentTyped<
+  TemplateTagMultipleProps<Row, Header>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<DataTableHeader<Row, Header>>; rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/template-tag-multiple/output.json
+++ b/tests/fixtures/template-tag-multiple/output.json
@@ -1,0 +1,57 @@
+{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row, Header>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row, Header>>, rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \"id\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: Header; }",
+      "name": "DataTableHeader<Row=DataTableRow,Header=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow,Header=DataTableRow> { key: DataTableKey<Row>; value: Header; }"
+    }
+  ],
+  "generics": [
+    "Row,Header",
+    "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
+  ],
+  "contexts": []
+}

--- a/tests/fixtures/template-tag-with-rest-props/Test.svelte
+++ b/tests/fixtures/template-tag-with-rest-props/Test.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import Generics, { type DataTableHeader } from "./output";
+
+  const headers: DataTableHeader<{ name: string; port: number }>[] = [
+    {
+      key: "name",
+      value: "Name",
+    },
+    {
+      key: "port",
+      value: "Port",
+    },
+  ];
+
+  const rows = [
+    { id: 1, name: "Name 1", port: 3000 },
+    { id: 2, name: "Name 2", port: 3000 },
+    { id: 3, name: "Name 3", port: 3000 },
+  ] as const;
+</script>
+
+<Generics
+  {headers}
+  {rows}
+  let:rows
+>
+  {#each rows as row}
+    {row.name}
+    {row.port}
+  {/each}
+</Generics>
+
+<Generics
+  headers={[
+    {
+      key: "name",
+      value: "Name",
+    },
+    {
+      key: "port",
+      value: "Port",
+    },
+  ]}
+  rows={[
+    { id: 1, name: "Name 1", port: 3000 },
+    { id: 2, name: "Name 2", port: 3000 },
+    { id: 3, name: "Name 3", port: 3000 },
+  ]}
+  let:rows
+>
+  {#each rows as row}
+    {row.name}
+  {/each}
+</Generics>

--- a/tests/fixtures/template-tag-with-rest-props/input.svelte
+++ b/tests/fixtures/template-tag-with-rest-props/input.svelte
@@ -3,7 +3,7 @@
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
    */
 
   /** @type {ReadonlyArray<DataTableHeader<Row>>} */

--- a/tests/fixtures/template-tag-with-rest-props/output.d.ts
+++ b/tests/fixtures/template-tag-with-rest-props/output.d.ts
@@ -1,0 +1,47 @@
+import { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
+  value: string;
+}
+
+type $RestProps = SvelteHTMLElements["div"];
+
+type $Props<Row extends DataTableRow = DataTableRow> = {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (
+    this: void,
+    ...args: [{ headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> }]
+  ) => void;
+
+  [key: `data-${string}`]: unknown;
+};
+
+export type TemplateTagWithRestPropsProps<Row extends DataTableRow = DataTableRow> = Omit<
+  $RestProps,
+  keyof $Props<Row>
+> &
+  $Props<Row>;
+
+export default class TemplateTagWithRestProps<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  TemplateTagWithRestPropsProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/template-tag-with-rest-props/output.json
+++ b/tests/fixtures/template-tag-with-rest-props/output.json
@@ -1,0 +1,61 @@
+{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \"id\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: string; }",
+      "name": "DataTableHeader<Row=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow> { key: DataTableKey<Row>; value: string; }"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "rest_props": {
+    "type": "Element",
+    "name": "div"
+  },
+  "contexts": []
+}

--- a/tests/fixtures/template-tag/Test.svelte
+++ b/tests/fixtures/template-tag/Test.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import Generics, { type DataTableHeader } from "./output";
+
+  const headers: DataTableHeader<{ name: string; port: number }>[] = [
+    {
+      key: "name",
+      value: "Name",
+    },
+    {
+      key: "port",
+      value: "Port",
+    },
+  ];
+
+  const rows = [
+    { id: 1, name: "Name 1", port: 3000 },
+    { id: 2, name: "Name 2", port: 3000 },
+    { id: 3, name: "Name 3", port: 3000 },
+  ] as const;
+</script>
+
+<Generics
+  {headers}
+  {rows}
+  let:rows
+>
+  {#each rows as row}
+    {row.name}
+    {row.port}
+  {/each}
+</Generics>
+
+<Generics
+  headers={[
+    {
+      key: "name",
+      value: "Name",
+    },
+    {
+      key: "port",
+      value: "Port",
+    },
+  ]}
+  rows={[
+    { id: 1, name: "Name 1", port: 3000 },
+    { id: 2, name: "Name 2", port: 3000 },
+    { id: 3, name: "Name 3", port: 3000 },
+  ]}
+  let:rows
+>
+  {#each rows as row}
+    {row.name}
+  {/each}
+</Generics>

--- a/tests/fixtures/template-tag/input.svelte
+++ b/tests/fixtures/template-tag/input.svelte
@@ -3,7 +3,7 @@
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
    */
 
   /** @type {ReadonlyArray<DataTableHeader<Row>>} */
@@ -13,9 +13,7 @@
   export let rows = [];
 </script>
 
-<div {...$$restProps}>
-  <slot
-    {headers}
-    {rows}
-  />
-</div>
+<slot
+  {headers}
+  {rows}
+/>

--- a/tests/fixtures/template-tag/output.d.ts
+++ b/tests/fixtures/template-tag/output.d.ts
@@ -1,0 +1,36 @@
+import { SvelteComponentTyped } from "svelte";
+
+export interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+export type DataTableKey<Row> = Exclude<keyof Row, "id">;
+
+export interface DataTableHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
+  value: string;
+}
+
+export type TemplateTagProps<Row extends DataTableRow = DataTableRow> = {
+  /**
+   * @default []
+   */
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
+
+  /**
+   * @default []
+   */
+  rows?: ReadonlyArray<Row>;
+
+  children?: (
+    this: void,
+    ...args: [{ headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> }]
+  ) => void;
+};
+
+export default class TemplateTag<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  TemplateTagProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/template-tag/output.json
+++ b/tests/fixtures/template-tag/output.json
@@ -1,0 +1,57 @@
+{
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<DataTableHeader<Row>>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "value": "[]",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<DataTableHeader<Row>>, rows: ReadonlyArray<Row> }"
+    }
+  ],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string | number; [key: string]: any; }",
+      "name": "DataTableRow",
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+    },
+    {
+      "type": "Exclude<keyof Row, \"id\">",
+      "name": "DataTableKey<Row>",
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">"
+    },
+    {
+      "type": "{ key: DataTableKey<Row>; value: string; }",
+      "name": "DataTableHeader<Row=DataTableRow>",
+      "ts": "interface DataTableHeader<Row=DataTableRow> { key: DataTableKey<Row>; value: string; }"
+    }
+  ],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": []
+}


### PR DESCRIPTION
`@template` is the official JSDoc tag for generics. This supports it; `@generics` will continue to work.

---

### Migrating `@generics` → `@template`

`@template` is the standard [JSDoc tag](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template) for generic type parameters. Prefer it over `@generics`: it's recognized by TypeScript and editors, so hovers, "go to definition", and constraint checking all work. `@generics` still works as a sveld-specific alternative, but `@template` is the recommended syntax going forward.

#### Syntax mapping

| `@generics` | `@template` |
|---|---|
| `@generics {Icon = any} Icon` | `@template [Icon=any]` |
| `@generics {T extends string} T` | `@template {string} T` |
| `@generics {Row extends DataTableRow = DataTableRow} Row` | `@template {DataTableRow} [Row=DataTableRow]` |
| `@generics {R extends Foo, H extends Bar} R,H` | `@template {Foo} R`<br>`@template {Bar} H` |

Three rules:

1. `{type}` is the **constraint** (the `extends` upper bound), not the full expression.
2. Defaults use `[Name=Default]` bracket syntax in the name position.
3. Multiple generics use **separate** `@template` tags; no commas.

#### Example

```diff
  <script>
    /**
     * @typedef {{ id: string | number }} DataTableRow
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
     */

    /** @type {ReadonlyArray<Row>} */
    export let rows = [];
  </script>
```

The generated `.d.ts` output is identical.

#### Notes

- `@generics` is not deprecated and continues to work.
- If both tags appear in the same JSDoc block, `@generics` takes precedence.