### PR TITLE
feat(component-parser): support `@bindable` notation for readonly/writable reactive props

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,38 @@ Local variables or parameters that shadow a prop name do not count as writes to 
 
 `reactive: false` means `sveld` found no such evidence. It does not imply that parent-side `bind:` usage is impossible.
 
+### `binding`
+
+The optional `binding` field in generated JSON is explicit documentation metadata for a prop's intended `bind:` contract. It is separate from `reactive`, and it is never inferred from internal writes or `$bindable()`.
+
+Use `@bindable readonly` for component-owned or output-style bindings where the consumer binds to the current value emitted by the component:
+
+```svelte
+<script>
+  /**
+   * Bind to the current value emitted by the component.
+   * @bindable readonly
+   */
+  export let size = undefined;
+</script>
+```
+
+Use `@bindable writable` for two-way or shared state bindings where either the consumer or component may control the value:
+
+```svelte
+<script>
+  /**
+   * Bind to state controlled by either the consumer or component.
+   * @bindable writable
+   */
+  export let open = false;
+</script>
+```
+
+Generated JSON includes `"binding": "readonly"` or `"binding": "writable"` for annotated props. Unannotated props omit the field.
+
+This is documentation metadata only. Generated `.svelte.d.ts` prop types are unchanged because TypeScript cannot reliably express Svelte component binding direction.
+
 For stable output, generated `events` arrays are emitted in deterministic sorted order.
 
 ### `@type`

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -230,6 +230,7 @@ interface ComponentParserOptions {
 }
 
 type ComponentPropName = string;
+type ComponentPropBinding = "readonly" | "writable";
 
 /**
  * Parameter information for function props.
@@ -279,6 +280,8 @@ interface ComponentProp {
   isRequired: boolean;
   /** Whether this prop is reactive (can change and trigger reactivity) */
   reactive: boolean;
+  /** Explicit author-documented binding direction from `@bindable` JSDoc */
+  binding?: ComponentPropBinding;
 }
 
 /**
@@ -1564,6 +1567,12 @@ export default class ComponentParser {
     }
   }
 
+  private logParserWarning(message: string) {
+    if (this.options?.verbose) {
+      console.warn(`Warning: ${message}`);
+    }
+  }
+
   private static formatComment(comment: string) {
     let formatted_comment = comment;
 
@@ -1617,11 +1626,13 @@ export default class ComponentParser {
       "event",
       "typedef",
       "callback",
+      "bindable",
     ]);
 
     let typeTag: (typeof tags)[number] | undefined;
     const paramTags: typeof tags = [];
     let returnsTag: (typeof tags)[number] | undefined;
+    let binding: ComponentPropBinding | undefined;
     const additionalTags: typeof tags = [];
 
     for (const tag of tags) {
@@ -1631,6 +1642,18 @@ export default class ComponentParser {
         paramTags.push(tag);
       } else if (tag.tag === "returns" || tag.tag === "return") {
         returnsTag = tag;
+      } else if (tag.tag === "bindable") {
+        if (tag.type) {
+          this.logParserWarning(`Ignoring invalid @bindable value "${tag.type} ${tag.name}".`);
+          continue;
+        }
+
+        const value = `${tag.name}${tag.description ? ` ${tag.description}` : ""}`.trim();
+        if (value === "readonly" || value === "writable") {
+          binding ??= value;
+        } else {
+          this.logParserWarning(`Ignoring invalid @bindable value "${value}".`);
+        }
       } else if (!excludedTags.has(tag.tag)) {
         additionalTags.push(tag);
       }
@@ -1640,6 +1663,7 @@ export default class ComponentParser {
       type: typeTag,
       param: paramTags,
       returns: returnsTag,
+      binding,
       additional: additionalTags,
       description: parsed[0]?.description,
     };
@@ -1758,6 +1782,7 @@ export default class ComponentParser {
         params?: ComponentPropParam[];
         returnType?: string;
         description?: string;
+        binding?: ComponentPropBinding;
       }
     | undefined {
     if (!leadingComments) return undefined;
@@ -1773,6 +1798,7 @@ export default class ComponentParser {
       type: typeTag,
       param: paramTags,
       returns: returnsTag,
+      binding,
       additional: additionalTags,
       description: commentDescription,
     } = this.getCommentTags(comment);
@@ -1821,7 +1847,7 @@ export default class ComponentParser {
       description = descriptionParts.join("\n");
     }
 
-    return { type, params, returnType, description };
+    return { type, params, returnType, description, binding };
   }
 
   private buildRunesPropTypeMetadata() {
@@ -2386,6 +2412,7 @@ export default class ComponentParser {
           name: propName,
           kind: "let",
           description: propertyJSDoc?.description,
+          binding: propertyJSDoc?.binding,
           type,
           value,
           params: propertyJSDoc?.params,
@@ -4562,6 +4589,7 @@ export default class ComponentParser {
             name: prop_name,
             kind,
             description,
+            binding: jsdocInfo?.binding,
             type,
             value,
             params,

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -6,7 +6,7 @@ export const WHITESPACE_REGEX = /\s+/g;
 export const MD_TYPE_UNDEFINED = "--";
 
 export const PROP_TABLE_HEADER =
-  "| Prop name | Required | Kind | Reactive | Type | Default value | Description |\n| :- | :- | :- | :- |\n";
+  "| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |\n| :- | :- | :- | :- | :- | :- | :- | :- |\n";
 export const SLOT_TABLE_HEADER = "| Slot name | Default | Props | Fallback |\n| :- | :- | :- | :- |\n";
 export const EVENT_TABLE_HEADER = "| Event name | Type | Detail | Description |\n| :- | :- | :- | :- |\n";
 

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -96,7 +96,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
         "raw",
         `| ${prop.name} | ${prop.isRequired ? "Yes" : "No"} | ${`<code>${prop.kind}</code>`} | ${
           prop.reactive ? "Yes" : "No"
-        } | ${formatPropType(prop.type)} | ${formatPropValue(prop.value)} | ${formatPropDescription(
+        } | ${prop.binding ?? "--"} | ${formatPropType(prop.type)} | ${formatPropValue(prop.value)} | ${formatPropDescription(
           prop.description,
         )} |\n`,
       );

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -66,6 +66,37 @@ describe("ComponentParser", () => {
     expect(disabledProp?.description).toBe("Controls the disabled state");
   });
 
+  test("parses @bindable JSDoc metadata and ignores invalid values", () => {
+    const log = jest.spyOn(console, "log").mockImplementation(() => undefined);
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const parser = new ComponentParser({ verbose: true });
+    const source = `
+      <script>
+        /**
+         * Current value.
+         * @bindable readonly
+         */
+        export let size = undefined;
+
+        /**
+         * Invalid binding documentation.
+         * @bindable sideways
+         */
+        export let invalid = false;
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+
+    expect(result.props.find((p) => p.name === "size")?.binding).toBe("readonly");
+    expect(result.props.find((p) => p.name === "size")?.description).toBe("Current value.");
+    expect(result.props.find((p) => p.name === "invalid")?.binding).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith('Warning: Ignoring invalid @bindable value "sideways".');
+
+    warn.mockRestore();
+    log.mockRestore();
+  });
+
   test("preserves JSDoc when @ts-ignore is present", () => {
     const parser = new ComponentParser();
     const source = `

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -1,5 +1,6 @@
 import type { AppendType } from "../src/writer/WriterMarkdown";
 import WriterMarkdown from "../src/writer/WriterMarkdown";
+import { writeMarkdownCore } from "../src/writer/writer-markdown-core";
 
 describe("WriterMarkdown", () => {
   test("basic functionality", () => {
@@ -71,5 +72,68 @@ describe("WriterMarkdown", () => {
 
     expect(lastType).toBe("h1");
     expect(lastDocument).toBe(document);
+  });
+
+  test("props table includes binding metadata", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: "Example.svelte",
+            moduleName: "Example",
+            props: [
+              {
+                name: "size",
+                kind: "let",
+                constant: false,
+                description: "Current value.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+                binding: "readonly",
+              },
+              {
+                name: "open",
+                kind: "let",
+                constant: false,
+                description: "Shared state.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: true,
+                binding: "writable",
+              },
+              {
+                name: "label",
+                kind: "let",
+                constant: false,
+                description: "Label text.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toMatchSnapshot();
+    expect(output).toContain(
+      "| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |",
+    );
+    expect(output).toContain("| open | No | <code>let</code> | Yes | writable | -- | -- | Shared state. |");
+    expect(output).toContain("| size | No | <code>let</code> | No | readonly | -- | -- | Current value. |");
+    expect(output).toContain("| label | No | <code>let</code> | No | -- | -- | -- | Label text. |");
   });
 });

--- a/tests/__snapshots__/WriterMarkdown.test.ts.snap
+++ b/tests/__snapshots__/WriterMarkdown.test.ts.snap
@@ -1,0 +1,30 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`WriterMarkdown props table includes binding metadata 1`] = `
+"# Component Index
+
+## Components
+
+  - [\`Example\`](#example)
+
+---
+
+## \`Example\`
+
+### Props
+
+| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
+| :- | :- | :- | :- | :- | :- | :- | :- |
+| open | No | <code>let</code> | Yes | writable | -- | -- | Shared state. |
+| size | No | <code>let</code> | No | readonly | -- | -- | Current value. |
+| label | No | <code>let</code> | No | -- | -- | -- | Label text. |
+### Slots
+
+None.
+
+### Events
+
+None.
+
+"
+`;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -3524,6 +3524,57 @@ exports[`fixtures (JSON) "async-function-props/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "bindable-direction-legacy/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Bind to the current value emitted by the component.",
+      "binding": "readonly",
+      "value": "undefined",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "open",
+      "kind": "let",
+      "description": "Bind to state controlled by either the consumer or component.",
+      "binding": "writable",
+      "type": "boolean",
+      "value": "false",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": true
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Regular unannotated prop.",
+      "type": "string",
+      "value": "\\"Toggle\\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-whole-props-typed/input.svelte" 1`] = `
 "{
   "props": [
@@ -4766,6 +4817,57 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
       "slot_props": "Record<string, never>"
     }
   ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "bindable-direction-runes/input.svelte" 1`] = `
+"{
+  "props": [
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Bind to the current value emitted by the component.",
+      "binding": "readonly",
+      "value": "undefined",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "open",
+      "kind": "let",
+      "description": "Bind to state controlled by either the consumer or component.",
+      "binding": "writable",
+      "type": "boolean",
+      "value": "false",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": true
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Regular unannotated prop.",
+      "type": "string",
+      "value": "\\"Toggle\\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
   "events": [],
   "typedefs": [],
   "generics": null,
@@ -8163,6 +8265,37 @@ export default class AsyncFunctionProps extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "bindable-direction-legacy/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type BindableDirectionLegacyProps = {
+  /**
+   * Bind to the current value emitted by the component.
+   * @default undefined
+   */
+  size?: undefined;
+
+  /**
+   * Bind to state controlled by either the consumer or component.
+   * @default false
+   */
+  open?: boolean;
+
+  /**
+   * Regular unannotated prop.
+   * @default "Toggle"
+   */
+  label?: string;
+};
+
+export default class BindableDirectionLegacy extends SvelteComponentTyped<
+  BindableDirectionLegacyProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-whole-props-typed/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -8937,6 +9070,37 @@ export default class BindThisMultiple extends SvelteComponentTyped<
   BindThisMultipleProps,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "bindable-direction-runes/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type BindableDirectionRunesProps = {
+  /**
+   * Bind to the current value emitted by the component.
+   * @default undefined
+   */
+  size?: undefined;
+
+  /**
+   * Bind to state controlled by either the consumer or component.
+   * @default false
+   */
+  open?: boolean;
+
+  /**
+   * Regular unannotated prop.
+   * @default "Toggle"
+   */
+  label?: string;
+};
+
+export default class BindableDirectionRunes extends SvelteComponentTyped<
+  BindableDirectionRunesProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;

--- a/tests/e2e/carbon/COMPONENT_INDEX.md
+++ b/tests/e2e/carbon/COMPONENT_INDEX.md
@@ -167,12 +167,12 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                              | Default value          | Description                                      |
-| :-------- | :------- | :--------------- | :------- | --------------------------------- | ---------------------- | ------------------------------------------------ |
-| align     | No       | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
-| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
-| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
+| Prop name | Required | Kind             | Reactive | Binding | Type                              | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | :------ | :-------------------------------- | :--------------------- | :----------------------------------------------- |
+| align     | No       | <code>let</code> | No       | --      | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
+| skeleton  | No       | <code>let</code> | No       | --      | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
 
 ### Slots
 
@@ -193,12 +193,12 @@
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                 | Default value                  | Description                                                                                                                              |
-| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| disabled        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to disable the accordion item                                                                                              |
-| open            | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to open the first accordion item                                                                                           |
-| title           | No       | <code>let</code> | No       | <code>string</code>  | <code>"title"</code>           | Specify the title of the accordion item heading<br />Alternatively, use the "title" slot (e.g., &lt;div slot="title"&gt;...&lt;/div&gt;) |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>  | <code>"Expand/Collapse"</code> | Specify the ARIA label for the accordion item chevron icon                                                                               |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                 | Default value                  | Description                                                                                                                              |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| disabled        | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>             | Set to `true` to disable the accordion item                                                                                              |
+| open            | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>             | Set to `true` to open the first accordion item                                                                                           |
+| title           | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"title"</code>           | Specify the title of the accordion item heading<br />Alternatively, use the "title" slot (e.g., &lt;div slot="title"&gt;...&lt;/div&gt;) |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Expand/Collapse"</code> | Specify the ARIA label for the accordion item chevron icon                                                                               |
 
 ### Slots
 
@@ -222,12 +222,12 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                              | Default value          | Description                                      |
-| :-------- | :------- | :--------------- | :------- | --------------------------------- | ---------------------- | ------------------------------------------------ |
-| count     | No       | <code>let</code> | No       | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
-| align     | No       | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
-| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
-| open      | No       | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
+| Prop name | Required | Kind             | Reactive | Binding | Type                              | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | :------ | :-------------------------------- | :--------------------- | :----------------------------------------------- |
+| count     | No       | <code>let</code> | No       | --      | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
+| align     | No       | <code>let</code> | No       | --      | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| open      | No       | <code>let</code> | No       | --      | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
 
 ### Slots
 
@@ -246,9 +246,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                                                               | Default value      | Description              |
-| :-------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ |
-| ratio     | No       | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "9x16" &#124; "1x2"</code> | <code>"2x1"</code> | Specify the aspect ratio |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                                                               | Default value      | Description              |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------- | :----------------- | :----------------------- |
+| ratio     | No       | <code>let</code> | No       | --      | <code>"2x1" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "9x16" &#124; "1x2"</code> | <code>"2x1"</code> | Specify the aspect ratio |
 
 ### Slots
 
@@ -264,10 +264,10 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                 | Default value      | Description                                         |
-| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------------- |
-| noTrailingSlash | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
-| skeleton        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to display skeleton state             |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                         |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------------------- |
+| noTrailingSlash | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
+| skeleton        | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to display skeleton state             |
 
 ### Slots
 
@@ -288,10 +288,10 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                 | Default value          | Description                                                      |
-| :------------ | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------------------------- |
-| href          | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
-| isCurrentPage | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                 | Default value          | Description                                                      |
+| :------------ | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------- | :--------------------------------------------------------------- |
+| href          | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
+| isCurrentPage | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
 
 ### Slots
 
@@ -312,10 +312,10 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                 | Default value      | Description                                         |
-| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------------- |
-| noTrailingSlash | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
-| count           | No       | <code>let</code> | No       | <code>number</code>  | <code>3</code>     | Specify the number of breadcrumb items to render    |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                         |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------------------- |
+| noTrailingSlash | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
+| count           | No       | <code>let</code> | No       | --      | <code>number</code>  | <code>3</code>     | Specify the number of breadcrumb items to render    |
 
 ### Slots
 
@@ -334,24 +334,24 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                                                                              |
-| :--------------- | :------- | :--------------- | :------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref              | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                                                                                   |
-| kind             | No       | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button.                                                                                                                                                                                                                              |
-| size             | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code>                                                              | <code>"default"</code> | Specify the size of button.                                                                                                                                                                                                                              |
-| expressive       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to use Carbon's expressive typesetting                                                                                                                                                                                                     |
-| isSelected       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to enable the selected state for an icon-only, ghost button.                                                                                                                                                                               |
-| icon             | No       | <code>let</code> | No       | <code>any</code>                                                                                                                          | <code>undefined</code> | Specify the icon to render.<br />Alternatively, use the named slot "icon".<br />@example <br />`svelte<br />&lt;Button&gt;<br />  &lt;Icon slot="icon" size={20} /&gt;<br />&lt;/Button&gt;<br />`                                                       |
-| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon.                                                                                                                                                                                                              |
-| tooltipAlignment | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon.<br />Only applies to icon-only buttons.                                                                                                                                                           |
-| tooltipPosition  | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon.                                                                                                                                                                                                    |
-| hideTooltip      | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to hide the tooltip while maintaining accessibility.<br />Only applies to icon-only buttons.<br />When `true`, the tooltip is visually hidden but the `iconDescription` remains accessible to screen readers.                              |
-| as               | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element.<br />Props are destructured as `props` in the default slot.<br />@example <br />`svelte<br />&lt;Button let:props&gt;<br />  &lt;div {...props}&gt;Custom Element&lt;/div&gt;<br />&lt;/Button&gt;<br />` |
-| skeleton         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                                                                              |
-| disabled         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                                                                                      |
-| href             | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link.                                                                                                                                                                                                                    |
-| tabindex         | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                                                                                     |
-| type             | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                                                                                      |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                                                                              |
+| :--------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------- | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref              | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                                                                                   |
+| kind             | No       | <code>let</code> | No       | --      | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button.                                                                                                                                                                                                                              |
+| size             | No       | <code>let</code> | No       | --      | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code>                                                              | <code>"default"</code> | Specify the size of button.                                                                                                                                                                                                                              |
+| expressive       | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to use Carbon's expressive typesetting                                                                                                                                                                                                     |
+| isSelected       | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to enable the selected state for an icon-only, ghost button.                                                                                                                                                                               |
+| icon             | No       | <code>let</code> | No       | --      | <code>any</code>                                                                                                                          | <code>undefined</code> | Specify the icon to render.<br />Alternatively, use the named slot "icon".<br />@example <br />`svelte<br />&lt;Button&gt;<br />  &lt;Icon slot="icon" size={20} /&gt;<br />&lt;/Button&gt;<br />`                                                       |
+| iconDescription  | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon.                                                                                                                                                                                                              |
+| tooltipAlignment | No       | <code>let</code> | No       | --      | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon.<br />Only applies to icon-only buttons.                                                                                                                                                           |
+| tooltipPosition  | No       | <code>let</code> | No       | --      | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon.                                                                                                                                                                                                    |
+| hideTooltip      | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to hide the tooltip while maintaining accessibility.<br />Only applies to icon-only buttons.<br />When `true`, the tooltip is visually hidden but the `iconDescription` remains accessible to screen readers.                              |
+| as               | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element.<br />Props are destructured as `props` in the default slot.<br />@example <br />`svelte<br />&lt;Button let:props&gt;<br />  &lt;div {...props}&gt;Custom Element&lt;/div&gt;<br />&lt;/Button&gt;<br />` |
+| skeleton         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                                                                              |
+| disabled         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                                                                                      |
+| href             | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link.                                                                                                                                                                                                                    |
+| tabindex         | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                                                                                     |
+| type             | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                                                                                      |
 
 ### Slots
 
@@ -375,9 +375,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
-| stacked   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to stack the buttons vertically |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                   |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------------- |
+| stacked   | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to stack the buttons vertically |
 
 ### Slots
 
@@ -393,11 +393,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                   |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
-| href      | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link                                                          |
-| size      | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton                                                           |
-| small     | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | @deprecated this prop will be removed in the next major release<br />Use size="small" instead |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                 | Default value          | Description                                                                                   |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------- | :--------------------- | :-------------------------------------------------------------------------------------------- |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>undefined</code> | Set the `href` to use an anchor link                                                          |
+| size      | No       | <code>let</code> | No       | --      | <code>"default" &#124; "field" &#124; "small"</code> | <code>"default"</code> | Specify the size of button skeleton                                                           |
+| small     | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>     | @deprecated this prop will be removed in the next major release<br />Use size="small" instead |
 
 ### Slots
 
@@ -416,19 +416,19 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                       |
-| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | ------------------------------------------------- |
-| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element      |
-| checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                                 | Specify whether the checkbox is checked           |
-| indeterminate | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Specify whether the checkbox is indeterminate     |
-| skeleton      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to display the skeleton state       |
-| readonly      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` for the checkbox to be read-only    |
-| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the checkbox             |
-| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the label text                            |
-| hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text     |
-| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Set a name for the input element                  |
-| title         | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                             | Specify the title attribute for the label element |
-| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input label                     |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                       |
+| :------------ | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :------------------------------------------------ |
+| ref           | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element      |
+| checked       | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code>                                 | Specify whether the checkbox is checked           |
+| indeterminate | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Specify whether the checkbox is indeterminate     |
+| skeleton      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to display the skeleton state       |
+| readonly      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` for the checkbox to be read-only    |
+| disabled      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the checkbox             |
+| labelText     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the label text                            |
+| hideLabel     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text     |
+| name          | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Set a name for the input element                  |
+| title         | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                             | Specify the title attribute for the label element |
+| id            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input label                     |
 
 ### Slots
 
@@ -469,11 +469,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                               |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ----------------------------------------- |
-| clicked   | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
-| light     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
-| href      | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value          | Description                               |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------- | :---------------------------------------- |
+| clicked   | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
+| light     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
 
 ### Slots
 
@@ -495,25 +495,25 @@ None.
 
 ### Props
 
-| Prop name             | Required | Kind             | Reactive | Type                                                 | Default value                                      | Description                                                                                                                |
-| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| ref                   | No       | <code>let</code> | Yes      | <code>null &#124; HTMLPreElement</code>              | <code>null</code>                                  | Obtain a reference to the pre HTML element                                                                                 |
-| showMoreLess          | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to enable the show more/less button                                                                          |
-| expanded              | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to expand a multi-line code snippet (type="multi")                                                           |
-| type                  | No       | <code>let</code> | No       | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                              | Set the type of code snippet                                                                                               |
-| code                  | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                             | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;) |
-| hideCopyButton        | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to hide the copy button                                                                                      |
-| disabled              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                    |
-| wrapText              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                       |
-| light                 | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to enable the light variant                                                                                  |
-| skeleton              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to display the skeleton state                                                                                |
-| copyButtonDescription | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                             | Specify the ARIA label for the copy button icon                                                                            |
-| copyLabel             | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                             | Specify the ARIA label of the copy button                                                                                  |
-| feedback              | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Copied!"</code>                             | Specify the feedback text displayed when clicking the snippet                                                              |
-| feedbackTimeout       | No       | <code>let</code> | No       | <code>number</code>                                  | <code>2000</code>                                  | Set the timeout duration (ms) to display feedback text                                                                     |
-| showLessText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Show less"</code>                           | Specify the show less text<br />`type` must be "multi"                                                                     |
-| showMoreText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Show more"</code>                           | Specify the show more text<br />`type` must be "multi"                                                                     |
-| id                    | No       | <code>let</code> | No       | <code>string</code>                                  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the code element                                                                                             |
+| Prop name             | Required | Kind             | Reactive | Binding | Type                                                 | Default value                                      | Description                                                                                                                |
+| :-------------------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------- | :------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| ref                   | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLPreElement</code>              | <code>null</code>                                  | Obtain a reference to the pre HTML element                                                                                 |
+| showMoreLess          | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to enable the show more/less button                                                                          |
+| expanded              | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to expand a multi-line code snippet (type="multi")                                                           |
+| type                  | No       | <code>let</code> | No       | --      | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                              | Set the type of code snippet                                                                                               |
+| code                  | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>undefined</code>                             | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;) |
+| hideCopyButton        | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to hide the copy button                                                                                      |
+| disabled              | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                    |
+| wrapText              | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                       |
+| light                 | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to enable the light variant                                                                                  |
+| skeleton              | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to display the skeleton state                                                                                |
+| copyButtonDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>undefined</code>                             | Specify the ARIA label for the copy button icon                                                                            |
+| copyLabel             | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>undefined</code>                             | Specify the ARIA label of the copy button                                                                                  |
+| feedback              | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>"Copied!"</code>                             | Specify the feedback text displayed when clicking the snippet                                                              |
+| feedbackTimeout       | No       | <code>let</code> | No       | --      | <code>number</code>                                  | <code>2000</code>                                  | Set the timeout duration (ms) to display feedback text                                                                     |
+| showLessText          | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>"Show less"</code>                           | Specify the show less text<br />`type` must be "multi"                                                                     |
+| showMoreText          | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>"Show more"</code>                           | Specify the show more text<br />`type` must be "multi"                                                                     |
+| id                    | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the code element                                                                                             |
 
 ### Slots
 
@@ -535,9 +535,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                 | Default value         | Description                  |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------ | --------------------- | ---------------------------- |
-| type      | No       | <code>let</code> | No       | <code>"single" &#124; "multi"</code> | <code>"single"</code> | Set the type of code snippet |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                 | Default value         | Description                  |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------- | :-------------------- | :--------------------------- |
+| type      | No       | <code>let</code> | No       | --      | <code>"single" &#124; "multi"</code> | <code>"single"</code> | Set the type of code snippet |
 
 ### Slots
 
@@ -569,19 +569,19 @@ export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
-| :------------ | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
-| noGutter      | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
-| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
-| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
-| padding       | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
-| aspectRatio   | No       | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
-| sm            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
-| md            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
-| lg            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
-| xlg           | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
-| max           | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
+| :------------ | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------- | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
+| noGutter      | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
+| noGutterLeft  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
+| noGutterRight | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
+| padding       | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
+| aspectRatio   | No       | <code>let</code> | No       | --      | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
+| sm            | No       | <code>let</code> | No       | --      | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
+| md            | No       | <code>let</code> | No       | --      | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
+| lg            | No       | <code>let</code> | No       | --      | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
+| xlg           | No       | <code>let</code> | No       | --      | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
+| max           | No       | <code>let</code> | No       | --      | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
 
 ### Slots
 
@@ -606,27 +606,27 @@ export interface ComboBoxItem {
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                                        | Default value                                      | Description                                                              |
-| :--------------- | :------- | :--------------- | :------- | ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------ |
-| listRef          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                     | <code>null</code>                                  | Obtain a reference to the list HTML element                              |
-| ref              | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                   | <code>null</code>                                  | Obtain a reference to the input HTML element                             |
-| open             | No       | <code>let</code> | Yes      | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to open the combobox menu dropdown                         |
-| value            | No       | <code>let</code> | Yes      | <code>string</code>                                         | <code>""</code>                                    | Specify the selected combobox value                                      |
-| selectedIndex    | No       | <code>let</code> | Yes      | <code>number</code>                                         | <code>-1</code>                                    | Set the selected item by value index                                     |
-| items            | No       | <code>let</code> | No       | <code>ComboBoxItem[]</code>                                 | <code>[]</code>                                    | Set the combobox items                                                   |
-| itemToString     | No       | <code>let</code> | No       | <code>(item: ComboBoxItem) => string</code>                 | --                                                 | Override the display of a combobox item                                  |
-| size             | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                               | <code>undefined</code>                             | Set the size of the combobox                                             |
-| disabled         | No       | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to disable the combobox                                    |
-| titleText        | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                    | Specify the title text of the combobox                                   |
-| placeholder      | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                    | Specify the placeholder text                                             |
-| helperText       | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                    | Specify the helper text                                                  |
-| invalidText      | No       | <code>let</code> | No       | <code>string</code>                                         | <code>""</code>                                    | Specify the invalid state text                                           |
-| invalid          | No       | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to indicate an invalid state                               |
-| light            | No       | <code>let</code> | No       | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to enable the light variant                                |
-| shouldFilterItem | No       | <code>let</code> | No       | <code>(item: ComboBoxItem, value: string) => boolean</code> | --                                                 | Determine if an item should be filtered given the current combobox value |
-| translateWithId  | No       | <code>let</code> | No       | <code>(id: any) => string</code>                            | <code>undefined</code>                             | Override the default translation ids                                     |
-| id               | No       | <code>let</code> | No       | <code>string</code>                                         | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component                                     |
-| name             | No       | <code>let</code> | No       | <code>string</code>                                         | <code>undefined</code>                             | Specify a name attribute for the input                                   |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                                        | Default value                                      | Description                                                              |
+| :--------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------------------------------- |
+| listRef          | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code>                     | <code>null</code>                                  | Obtain a reference to the list HTML element                              |
+| ref              | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code>                   | <code>null</code>                                  | Obtain a reference to the input HTML element                             |
+| open             | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to open the combobox menu dropdown                         |
+| value            | No       | <code>let</code> | Yes      | --      | <code>string</code>                                         | <code>""</code>                                    | Specify the selected combobox value                                      |
+| selectedIndex    | No       | <code>let</code> | Yes      | --      | <code>number</code>                                         | <code>-1</code>                                    | Set the selected item by value index                                     |
+| items            | No       | <code>let</code> | No       | --      | <code>ComboBoxItem[]</code>                                 | <code>[]</code>                                    | Set the combobox items                                                   |
+| itemToString     | No       | <code>let</code> | No       | --      | <code>(item: ComboBoxItem) => string</code>                 | --                                                 | Override the display of a combobox item                                  |
+| size             | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>                               | <code>undefined</code>                             | Set the size of the combobox                                             |
+| disabled         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to disable the combobox                                    |
+| titleText        | No       | <code>let</code> | No       | --      | <code>string</code>                                         | <code>""</code>                                    | Specify the title text of the combobox                                   |
+| placeholder      | No       | <code>let</code> | No       | --      | <code>string</code>                                         | <code>""</code>                                    | Specify the placeholder text                                             |
+| helperText       | No       | <code>let</code> | No       | --      | <code>string</code>                                         | <code>""</code>                                    | Specify the helper text                                                  |
+| invalidText      | No       | <code>let</code> | No       | --      | <code>string</code>                                         | <code>""</code>                                    | Specify the invalid state text                                           |
+| invalid          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to indicate an invalid state                               |
+| light            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                        | <code>false</code>                                 | Set to `true` to enable the light variant                                |
+| shouldFilterItem | No       | <code>let</code> | No       | --      | <code>(item: ComboBoxItem, value: string) => boolean</code> | --                                                 | Determine if an item should be filtered given the current combobox value |
+| translateWithId  | No       | <code>let</code> | No       | --      | <code>(id: any) => string</code>                            | <code>undefined</code>                             | Override the default translation ids                                     |
+| id               | No       | <code>let</code> | No       | --      | <code>string</code>                                         | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component                                     |
+| name             | No       | <code>let</code> | No       | --      | <code>string</code>                                         | <code>undefined</code>                             | Specify a name attribute for the input                                   |
 
 ### Slots
 
@@ -647,15 +647,15 @@ None.
 
 ### Props
 
-| Prop name                  | Required | Kind             | Reactive | Type                                      | Default value                             | Description                                                           |
-| :------------------------- | :------- | :--------------- | :------- | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
-| ref                        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
-| open                       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
-| size                       | No       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
-| danger                     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
-| preventCloseOnClickOutside | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
-| containerClass             | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
-| selectorPrimaryFocus       | No       | <code>let</code> | No       | <code>null &#124; string</code>           | <code>"[data-modal-primary-focus]"</code> | Specify a selector to be focused when opening the modal               |
+| Prop name                  | Required | Kind             | Reactive | Binding | Type                                      | Default value                             | Description                                                           |
+| :------------------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :---------------------------------------- | :-------------------------------------------------------------------- |
+| ref                        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
+| open                       | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
+| size                       | No       | <code>let</code> | No       | --      | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
+| danger                     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
+| preventCloseOnClickOutside | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
+| containerClass             | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
+| selectorPrimaryFocus       | No       | <code>let</code> | No       | --      | <code>null &#124; string</code>           | <code>"[data-modal-primary-focus]"</code> | Specify a selector to be focused when opening the modal               |
 
 ### Slots
 
@@ -680,9 +680,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value               | Description                         |
-| :-------- | :------- | :--------------- | :------- | ------------------- | --------------------------- | ----------------------------------- |
-| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"main-content"</code> | Specify the id for the main element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value               | Description                         |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :-------------------------- | :---------------------------------- |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"main-content"</code> | Specify the id for the main element |
 
 ### Slots
 
@@ -698,11 +698,11 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                          | Default value          | Description                               |
-| :------------ | :------- | :--------------- | :------- | ----------------------------- | ---------------------- | ----------------------------------------- |
-| selectedIndex | No       | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
-| light         | No       | <code>let</code> | No       | <code>boolean</code>          | <code>false</code>     | Set to `true` to enable the light variant |
-| size          | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                          | Default value          | Description                               |
+| :------------ | :------- | :--------------- | :------- | :------ | :---------------------------- | :--------------------- | :---------------------------------------- |
+| selectedIndex | No       | <code>let</code> | Yes      | --      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
+| light         | No       | <code>let</code> | No       | --      | <code>boolean</code>          | <code>false</code>     | Set to `true` to enable the light variant |
+| size          | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
 
 ### Slots
 
@@ -724,11 +724,11 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                       | Default value          | Description                                            |
-| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | ------------------------------------------------------ |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>      | Obtain a reference to the button HTML element          |
-| feedback        | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Copied!"</code> | Set the feedback text shown after clicking the button  |
-| feedbackTimeout | No       | <code>let</code> | No       | <code>number</code>                        | <code>2000</code>      | Set the timeout duration (ms) to display feedback text |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                       | Default value          | Description                                            |
+| :-------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :--------------------- | :----------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>      | Obtain a reference to the button HTML element          |
+| feedback        | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Copied!"</code> | Set the feedback text shown after clicking the button  |
+| feedbackTimeout | No       | <code>let</code> | No       | --      | <code>number</code>                        | <code>2000</code>      | Set the timeout duration (ms) to display feedback text |
 
 ### Slots
 
@@ -747,9 +747,9 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                | Default value                    | Description                                      |
-| :-------------- | :------- | :--------------- | :------- | ------------------- | -------------------------------- | ------------------------------------------------ |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code> | <code>"Copy to clipboard"</code> | Set the title and ARIA label for the copy button |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                | Default value                    | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------------------------- | :----------------------------------------------- |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"Copy to clipboard"</code> | Set the title and ARIA label for the copy button |
 
 ### Slots
 
@@ -811,30 +811,30 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                                                                | Default value          | Description                                                                                                         |
-| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| selectedRowIds      | No       | <code>let</code> | Yes      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
-| selectable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
-| expandedRowIds      | No       | <code>let</code> | Yes      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
-| expandable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
-| sortDirection       | No       | <code>let</code> | Yes      | <code>"none" &#124; "ascending" &#124; "descending"</code>          | <code>"none"</code>    | Specify the sort direction                                                                                          |
-| sortKey             | No       | <code>let</code> | Yes      | <code>DataTableKey</code>                                           | <code>null</code>      | Specify the header key to sort by                                                                                   |
-| headers             | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableHeader<Row>></code>                    | <code>[]</code>        | Specify the data table headers                                                                                      |
-| rows                | No       | <code>let</code> | No       | <code>ReadonlyArray<Row></code>                                     | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
-| size                | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
-| title               | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
-| description         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the description of the data table                                                                           |
-| zebra               | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
-| sortable            | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
-| batchExpansion      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
-| nonExpandableRowIds | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the ids for rows that should not be expandable                                                              |
-| radio               | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
-| batchSelection      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
-| nonSelectableRowIds | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the ids of rows that should not be selectable                                                               |
-| stickyHeader        | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
-| useStaticWidth      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width                                                                                   |
-| pageSize            | No       | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Specify the number of items to display in a page                                                                    |
-| page                | No       | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Set to `number` to set current page                                                                                 |
+| Prop name           | Required | Kind             | Reactive | Binding | Type                                                                | Default value          | Description                                                                                                         |
+| :------------------ | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------ | :--------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| selectedRowIds      | No       | <code>let</code> | Yes      | --      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
+| selectable          | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
+| expandedRowIds      | No       | <code>let</code> | Yes      | --      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
+| expandable          | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
+| sortDirection       | No       | <code>let</code> | Yes      | --      | <code>"none" &#124; "ascending" &#124; "descending"</code>          | <code>"none"</code>    | Specify the sort direction                                                                                          |
+| sortKey             | No       | <code>let</code> | Yes      | --      | <code>DataTableKey</code>                                           | <code>null</code>      | Specify the header key to sort by                                                                                   |
+| headers             | No       | <code>let</code> | No       | --      | <code>ReadonlyArray<DataTableHeader<Row>></code>                    | <code>[]</code>        | Specify the data table headers                                                                                      |
+| rows                | No       | <code>let</code> | No       | --      | <code>ReadonlyArray<Row></code>                                     | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
+| size                | No       | <code>let</code> | No       | --      | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
+| title               | No       | <code>let</code> | No       | --      | <code>string</code>                                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
+| description         | No       | <code>let</code> | No       | --      | <code>string</code>                                                 | <code>""</code>        | Specify the description of the data table                                                                           |
+| zebra               | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
+| sortable            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
+| batchExpansion      | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
+| nonExpandableRowIds | No       | <code>let</code> | No       | --      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the ids for rows that should not be expandable                                                              |
+| radio               | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
+| batchSelection      | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
+| nonSelectableRowIds | No       | <code>let</code> | No       | --      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the ids of rows that should not be selectable                                                               |
+| stickyHeader        | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
+| useStaticWidth      | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width                                                                                   |
+| pageSize            | No       | <code>let</code> | No       | --      | <code>number</code>                                                 | <code>0</code>         | Specify the number of items to display in a page                                                                    |
+| page                | No       | <code>let</code> | No       | --      | <code>number</code>                                                 | <code>0</code>         | Set to `number` to set current page                                                                                 |
 
 ### Slots
 
@@ -866,15 +866,15 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                                    | Default value          | Description                                                                                  |
-| :---------- | :------- | :--------------- | :------- | ------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------- |
-| columns     | No       | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
-| rows        | No       | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
-| size        | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
-| zebra       | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
-| showHeader  | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
-| headers     | No       | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
-| showToolbar | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                                    | Default value          | Description                                                                                  |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------ | :--------------------- | :------------------------------------------------------------------------------------------- |
+| columns     | No       | <code>let</code> | No       | --      | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
+| rows        | No       | <code>let</code> | No       | --      | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
+| size        | No       | <code>let</code> | No       | --      | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
+| zebra       | No       | <code>let</code> | No       | --      | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
+| showHeader  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
+| headers     | No       | <code>let</code> | No       | --      | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
+| showToolbar | No       | <code>let</code> | No       | --      | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
 
 ### Slots
 
@@ -893,18 +893,18 @@ None.
 
 ### Props
 
-| Prop name      | Required | Kind             | Reactive | Type                                                 | Default value                                      | Description                                   |
-| :------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | -------------------------------------------------- | --------------------------------------------- |
-| value          | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                    | Specify the date picker input value           |
-| datePickerType | No       | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                              | Specify the date picker type                  |
-| appendTo       | No       | <code>let</code> | No       | <code>HTMLElement</code>                             | <code>document.body</code>                         | Specify the element to append the calendar to |
-| dateFormat     | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                               | Specify the date format                       |
-| maxDate        | No       | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                  | Specify the maximum date                      |
-| minDate        | No       | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                  | Specify the minimum date                      |
-| locale         | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                  | Specify the locale                            |
-| short          | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to use the short variant        |
-| light          | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to enable the light variant     |
-| id             | No       | <code>let</code> | No       | <code>string</code>                                  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the date picker element         |
+| Prop name      | Required | Kind             | Reactive | Binding | Type                                                 | Default value                                      | Description                                   |
+| :------------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------- | :------------------------------------------------- | :-------------------------------------------- |
+| value          | No       | <code>let</code> | Yes      | --      | <code>number &#124; string</code>                    | <code>""</code>                                    | Specify the date picker input value           |
+| datePickerType | No       | <code>let</code> | No       | --      | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                              | Specify the date picker type                  |
+| appendTo       | No       | <code>let</code> | No       | --      | <code>HTMLElement</code>                             | <code>document.body</code>                         | Specify the element to append the calendar to |
+| dateFormat     | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>"m/d/Y"</code>                               | Specify the date format                       |
+| maxDate        | No       | <code>let</code> | No       | --      | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                  | Specify the maximum date                      |
+| minDate        | No       | <code>let</code> | No       | --      | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                  | Specify the minimum date                      |
+| locale         | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>"en"</code>                                  | Specify the locale                            |
+| short          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to use the short variant        |
+| light          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>                                 | Set to `true` to enable the light variant     |
+| id             | No       | <code>let</code> | No       | --      | <code>string</code>                                  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the date picker element         |
 
 ### Slots
 
@@ -926,21 +926,21 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                        |
-| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | -------------------------------------------------- |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element       |
-| size            | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                             | Set the size of the input                          |
-| type            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                | Specify the input type                             |
-| placeholder     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the input placeholder text                 |
-| pattern         | No       | <code>let</code> | No       | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>        | Specify the Regular Expression for the input value |
-| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the input                 |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the ARIA label for the calendar icon       |
-| id              | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                    |
-| labelText       | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the label text                             |
-| hideLabel       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text      |
-| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to indicate an invalid state         |
-| invalidText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the invalid state text                     |
-| name            | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                             | Set a name for the input element                   |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                        |
+| :-------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element       |
+| size            | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                             | Set the size of the input                          |
+| type            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"text"</code>                                | Specify the input type                             |
+| placeholder     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the input placeholder text                 |
+| pattern         | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>        | Specify the Regular Expression for the input value |
+| disabled        | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the input                 |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the ARIA label for the calendar icon       |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                    |
+| labelText       | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the label text                             |
+| hideLabel       | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text      |
+| invalid         | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to indicate an invalid state         |
+| invalidText     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the invalid state text                     |
+| name            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                             | Set a name for the input element                   |
 
 ### Slots
 
@@ -958,10 +958,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value                                      | Description                               |
-| :-------- | :------- | :--------------- | :------- | -------------------- | -------------------------------------------------- | ----------------------------------------- |
-| range     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                                 | Set to `true` to use the range variant    |
-| id        | No       | <code>let</code> | No       | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id to be used by the label element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value                                      | Description                               |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :------------------------------------------------- | :---------------------------------------- |
+| range     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to use the range variant    |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id to be used by the label element |
 
 ### Slots
 
@@ -993,28 +993,28 @@ export interface DropdownItem {
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                        | Default value                                      | Description                                            |
-| :-------------- | :------- | :--------------- | :------- | ------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------ |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>  | <code>null</code>                                  | Obtain a reference to the button HTML element          |
-| inline          | No       | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to use the inline variant                |
-| open            | No       | <code>let</code> | Yes      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to open the dropdown                     |
-| selectedIndex   | No       | <code>let</code> | Yes      | <code>number</code>                         | <code>-1</code>                                    | Specify the selected item index                        |
-| items           | No       | <code>let</code> | No       | <code>DropdownItem[]</code>                 | <code>[]</code>                                    | Set the dropdown items                                 |
-| itemToString    | No       | <code>let</code> | No       | <code>(item: DropdownItem) => string</code> | --                                                 | Override the display of a dropdown item<br />@required |
-| type            | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>      | <code>"default"</code>                             | Specify the type of dropdown                           |
-| size            | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>   | <code>undefined</code>                             | Specify the size of the dropdown field                 |
-| light           | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to enable the light variant              |
-| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to disable the dropdown                  |
-| titleText       | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                    | Specify the title text                                 |
-| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to indicate an invalid state             |
-| invalidText     | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                    | Specify the invalid state text                         |
-| warn            | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to indicate an warning state             |
-| warnText        | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                    | Specify the warning state text                         |
-| helperText      | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>                                    | Specify the helper text                                |
-| label           | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                             | Specify the list box label                             |
-| translateWithId | No       | <code>let</code> | No       | <code>(id: any) => string</code>            | <code>undefined</code>                             | Override the default translation ids                   |
-| id              | No       | <code>let</code> | No       | <code>string</code>                         | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component                   |
-| name            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>                             | Specify a name attribute for the list box              |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                        | Default value                                      | Description                                            |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------------------------------ | :------------------------------------------------- | :----------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>  | <code>null</code>                                  | Obtain a reference to the button HTML element          |
+| inline          | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to use the inline variant                |
+| open            | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to open the dropdown                     |
+| selectedIndex   | No       | <code>let</code> | Yes      | --      | <code>number</code>                         | <code>-1</code>                                    | Specify the selected item index                        |
+| items           | No       | <code>let</code> | No       | --      | <code>DropdownItem[]</code>                 | <code>[]</code>                                    | Set the dropdown items                                 |
+| itemToString    | No       | <code>let</code> | No       | --      | <code>(item: DropdownItem) => string</code> | --                                                 | Override the display of a dropdown item<br />@required |
+| type            | No       | <code>let</code> | No       | --      | <code>"default" &#124; "inline"</code>      | <code>"default"</code>                             | Specify the type of dropdown                           |
+| size            | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "lg" &#124; "xl"</code>   | <code>undefined</code>                             | Specify the size of the dropdown field                 |
+| light           | No       | <code>let</code> | No       | --      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to enable the light variant              |
+| disabled        | No       | <code>let</code> | No       | --      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to disable the dropdown                  |
+| titleText       | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>""</code>                                    | Specify the title text                                 |
+| invalid         | No       | <code>let</code> | No       | --      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to indicate an invalid state             |
+| invalidText     | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>""</code>                                    | Specify the invalid state text                         |
+| warn            | No       | <code>let</code> | No       | --      | <code>boolean</code>                        | <code>false</code>                                 | Set to `true` to indicate an warning state             |
+| warnText        | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>""</code>                                    | Specify the warning state text                         |
+| helperText      | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>""</code>                                    | Specify the helper text                                |
+| label           | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>undefined</code>                             | Specify the list box label                             |
+| translateWithId | No       | <code>let</code> | No       | --      | <code>(id: any) => string</code>            | <code>undefined</code>                             | Override the default translation ids                   |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component                   |
+| name            | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>undefined</code>                             | Specify a name attribute for the list box              |
 
 ### Slots
 
@@ -1030,9 +1030,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
-| inline    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the inline variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------- |
+| inline    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the inline variant |
 
 ### Slots
 
@@ -1051,19 +1051,19 @@ None.
 
 ### Props
 
-| Prop name             | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                           |
-| :-------------------- | :------- | :--------------- | :------- | ------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------- |
-| ref                   | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                  | Obtain a reference to the top-level element           |
-| tilePadding           | No       | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                     | Specify the padding of the tile (number of pixels)    |
-| tileMaxHeight         | No       | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                     | Specify the max height of the tile (number of pixels) |
-| expanded              | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to expand the tile                      |
-| light                 | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to enable the light variant             |
-| tileCollapsedIconText | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to expand Tile"</code>             | Specify the icon text of the collapsed tile           |
-| tileExpandedIconText  | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to collapse Tile"</code>           | Specify the icon text of the expanded tile            |
-| tileExpandedLabel     | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the icon label of the expanded tile           |
-| tileCollapsedLabel    | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the icon label of the collapsed tile          |
-| tabindex              | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                   | Specify the tabindex                                  |
-| id                    | No       | <code>let</code> | No       | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level div element               |
+| Prop name             | Required | Kind             | Reactive | Binding | Type                                       | Default value                                      | Description                                           |
+| :-------------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :------------------------------------------------- | :---------------------------------------------------- |
+| ref                   | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                  | Obtain a reference to the top-level element           |
+| tilePadding           | No       | <code>let</code> | Yes      | --      | <code>number</code>                        | <code>0</code>                                     | Specify the padding of the tile (number of pixels)    |
+| tileMaxHeight         | No       | <code>let</code> | Yes      | --      | <code>number</code>                        | <code>0</code>                                     | Specify the max height of the tile (number of pixels) |
+| expanded              | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to expand the tile                      |
+| light                 | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to enable the light variant             |
+| tileCollapsedIconText | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Interact to expand Tile"</code>             | Specify the icon text of the collapsed tile           |
+| tileExpandedIconText  | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Interact to collapse Tile"</code>           | Specify the icon text of the expanded tile            |
+| tileExpandedLabel     | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the icon label of the expanded tile           |
+| tileCollapsedLabel    | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the icon label of the collapsed tile          |
+| tabindex              | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"0"</code>                                   | Specify the tabindex                                  |
+| id                    | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level div element               |
 
 ### Slots
 
@@ -1086,19 +1086,19 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind               | Reactive | Type                                                                                       | Default value                           | Description                                                           |
-| :--------------- | :------- | :----------------- | :------- | ------------------------------------------------------------------------------------------ | --------------------------------------- | --------------------------------------------------------------------- |
-| files            | No       | <code>let</code>   | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                         | Obtain the uploaded file names                                        |
-| status           | No       | <code>let</code>   | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code>                                   | <code>"uploading"</code>                | Specify the file uploader status                                      |
-| accept           | No       | <code>let</code>   | No       | <code>string[]</code>                                                                      | <code>[]</code>                         | Specify the accepted file types                                       |
-| multiple         | No       | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to allow multiple files                                 |
-| clearFiles       | No       | <code>const</code> | No       | <code>() => void</code>                                                                    | --                                      | Override the default behavior of clearing the array of uploaded files |
-| labelDescription | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label description                                         |
-| labelTitle       | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label title                                               |
-| kind             | No       | <code>let</code>   | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                  | Specify the kind of file uploader button                              |
-| buttonLabel      | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the button label                                              |
-| iconDescription  | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>"Provide icon description"</code> | Specify the ARIA label used for the status icons                      |
-| name             | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify a name attribute for the file button uploader input           |
+| Prop name        | Required | Kind               | Reactive | Binding | Type                                                                                       | Default value                           | Description                                                           |
+| :--------------- | :------- | :----------------- | :------- | :------ | :----------------------------------------------------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------- |
+| files            | No       | <code>let</code>   | Yes      | --      | <code>File[]</code>                                                                        | <code>[]</code>                         | Obtain the uploaded file names                                        |
+| status           | No       | <code>let</code>   | No       | --      | <code>"uploading" &#124; "edit" &#124; "complete"</code>                                   | <code>"uploading"</code>                | Specify the file uploader status                                      |
+| accept           | No       | <code>let</code>   | No       | --      | <code>string[]</code>                                                                      | <code>[]</code>                         | Specify the accepted file types                                       |
+| multiple         | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to allow multiple files                                 |
+| clearFiles       | No       | <code>const</code> | No       | --      | <code>() => void</code>                                                                    | --                                      | Override the default behavior of clearing the array of uploaded files |
+| labelDescription | No       | <code>let</code>   | No       | --      | <code>string</code>                                                                        | <code>""</code>                         | Specify the label description                                         |
+| labelTitle       | No       | <code>let</code>   | No       | --      | <code>string</code>                                                                        | <code>""</code>                         | Specify the label title                                               |
+| kind             | No       | <code>let</code>   | No       | --      | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                  | Specify the kind of file uploader button                              |
+| buttonLabel      | No       | <code>let</code>   | No       | --      | <code>string</code>                                                                        | <code>""</code>                         | Specify the button label                                              |
+| iconDescription  | No       | <code>let</code>   | No       | --      | <code>string</code>                                                                        | <code>"Provide icon description"</code> | Specify the ARIA label used for the status icons                      |
+| name             | No       | <code>let</code>   | No       | --      | <code>string</code>                                                                        | <code>""</code>                         | Specify a name attribute for the file button uploader input           |
 
 ### Slots
 
@@ -1121,19 +1121,19 @@ None.
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                                                                                       | Default value                                      | Description                                  |
-| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------- | -------------------------------------------- |
-| ref                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                  | <code>null</code>                                  | Obtain a reference to the input HTML element |
-| labelText           | No       | <code>let</code> | Yes      | <code>string</code>                                                                        | <code>"Add file"</code>                            | Specify the label text                       |
-| accept              | No       | <code>let</code> | No       | <code>string[]</code>                                                                      | <code>[]</code>                                    | Specify the accepted file types              |
-| multiple            | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                                 | Set to `true` to allow multiple files        |
-| disabled            | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                                 | Set to `true` to disable the input           |
-| disableLabelChanges | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                                 | Set to `true` to disable label changes       |
-| kind                | No       | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                             | Specify the kind of file uploader button     |
-| role                | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"button"</code>                              | Specify the label role                       |
-| tabindex            | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"0"</code>                                   | Specify `tabindex` attribute                 |
-| id                  | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element              |
-| name                | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>""</code>                                    | Specify a name attribute for the input       |
+| Prop name           | Required | Kind             | Reactive | Binding | Type                                                                                       | Default value                                      | Description                                  |
+| :------------------ | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------------------------------------- | :------------------------------------------------- | :------------------------------------------- |
+| ref                 | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code>                                                  | <code>null</code>                                  | Obtain a reference to the input HTML element |
+| labelText           | No       | <code>let</code> | Yes      | --      | <code>string</code>                                                                        | <code>"Add file"</code>                            | Specify the label text                       |
+| accept              | No       | <code>let</code> | No       | --      | <code>string[]</code>                                                                      | <code>[]</code>                                    | Specify the accepted file types              |
+| multiple            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                       | <code>false</code>                                 | Set to `true` to allow multiple files        |
+| disabled            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                       | <code>false</code>                                 | Set to `true` to disable the input           |
+| disableLabelChanges | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                       | <code>false</code>                                 | Set to `true` to disable label changes       |
+| kind                | No       | <code>let</code> | No       | --      | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                             | Specify the kind of file uploader button     |
+| role                | No       | <code>let</code> | No       | --      | <code>string</code>                                                                        | <code>"button"</code>                              | Specify the label role                       |
+| tabindex            | No       | <code>let</code> | No       | --      | <code>string</code>                                                                        | <code>"0"</code>                                   | Specify `tabindex` attribute                 |
+| id                  | No       | <code>let</code> | No       | --      | <code>string</code>                                                                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element              |
+| name                | No       | <code>let</code> | No       | --      | <code>string</code>                                                                        | <code>""</code>                                    | Specify a name attribute for the input       |
 
 ### Slots
 
@@ -1151,18 +1151,18 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                                                                                  |
-| :------------ | :------- | :--------------- | :------- | ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>  | <code>null</code>                                  | Obtain a reference to the input HTML element                                                                 |
-| accept        | No       | <code>let</code> | No       | <code>string[]</code>                      | <code>[]</code>                                    | Specify the accepted file types                                                                              |
-| multiple      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to allow multiple files                                                                        |
-| validateFiles | No       | <code>let</code> | No       | <code>(files: FileList) => FileList</code> | --                                                 | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
-| labelText     | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Add file"</code>                            | Specify the label text                                                                                       |
-| role          | No       | <code>let</code> | No       | <code>string</code>                        | <code>"button"</code>                              | Specify the `role` attribute of the drop container                                                           |
-| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the input                                                                           |
-| tabindex      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                   | Specify `tabindex` attribute                                                                                 |
-| id            | No       | <code>let</code> | No       | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                                                                              |
-| name          | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify a name attribute for the input                                                                       |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                                       | Default value                                      | Description                                                                                                  |
+| :------------ | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- |
+| ref           | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code>  | <code>null</code>                                  | Obtain a reference to the input HTML element                                                                 |
+| accept        | No       | <code>let</code> | No       | --      | <code>string[]</code>                      | <code>[]</code>                                    | Specify the accepted file types                                                                              |
+| multiple      | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to allow multiple files                                                                        |
+| validateFiles | No       | <code>let</code> | No       | --      | <code>(files: FileList) => FileList</code> | --                                                 | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
+| labelText     | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Add file"</code>                            | Specify the label text                                                                                       |
+| role          | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"button"</code>                              | Specify the `role` attribute of the drop container                                                           |
+| disabled      | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the input                                                                           |
+| tabindex      | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"0"</code>                                   | Specify `tabindex` attribute                                                                                 |
+| id            | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                                                                              |
+| name          | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify a name attribute for the input                                                                       |
 
 ### Slots
 
@@ -1184,15 +1184,15 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                                     | Default value                                      | Description                                      |
-| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| status          | No       | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code>                           | Specify the file uploader status                 |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                    | Specify the ARIA label used for the status icons |
-| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                                 | Set to `true` to indicate an invalid state       |
-| errorSubject    | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                    | Specify the error subject text                   |
-| errorBody       | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                    | Specify the error body text                      |
-| id              | No       | <code>let</code> | No       | <code>string</code>                                      | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element              |
-| name            | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                    | Specify the file uploader name                   |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                                     | Default value                                      | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------- |
+| status          | No       | <code>let</code> | No       | --      | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code>                           | Specify the file uploader status                 |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                      | <code>""</code>                                    | Specify the ARIA label used for the status icons |
+| invalid         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                     | <code>false</code>                                 | Set to `true` to indicate an invalid state       |
+| errorSubject    | No       | <code>let</code> | No       | --      | <code>string</code>                                      | <code>""</code>                                    | Specify the error subject text                   |
+| errorBody       | No       | <code>let</code> | No       | --      | <code>string</code>                                      | <code>""</code>                                    | Specify the error body text                      |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>                                      | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element              |
+| name            | No       | <code>let</code> | No       | --      | <code>string</code>                                      | <code>""</code>                                    | Specify the file uploader name                   |
 
 ### Slots
 
@@ -1230,11 +1230,11 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                                     | Default value            | Description                                      |
-| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
-| status          | No       | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code> | Specify the file name status                     |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>          | Specify the ARIA label used for the status icons |
-| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>       | Set to `true` to indicate an invalid state       |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                                     | Default value            | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------- | :----------------------- | :----------------------------------------------- |
+| status          | No       | <code>let</code> | No       | --      | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code> | Specify the file name status                     |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                      | <code>""</code>          | Specify the ARIA label used for the status icons |
+| invalid         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                     | <code>false</code>       | Set to `true` to indicate an invalid state       |
 
 ### Slots
 
@@ -1291,12 +1291,12 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                 | Default value      | Description                                |
-| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------------ |
-| invalid     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state |
-| message     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a form requirement |
-| messageText | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the message text                   |
-| legendText  | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the legend text                    |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------------------- |
+| invalid     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state |
+| message     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to render a form requirement |
+| messageText | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>    | Specify the message text                   |
+| legendText  | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>    | Specify the legend text                    |
 
 ### Slots
 
@@ -1338,9 +1338,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value                                      | Description                               |
-| :-------- | :------- | :--------------- | :------- | ------------------- | -------------------------------------------------- | ----------------------------------------- |
-| id        | No       | <code>let</code> | No       | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id to be used by the label element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value                                      | Description                               |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------------------------------------------- | :---------------------------------------- |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id to be used by the label element |
 
 ### Slots
 
@@ -1361,16 +1361,16 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
-| :------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Grid let:props&gt;&lt;header {...props}&gt;...&lt;/header&gt;&lt;/Grid&gt;) |
-| condensed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
-| narrow        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
-| fullWidth     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fullWidth variant                                                                                                                                                      |
-| noGutter      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
-| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
-| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
-| padding       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                                                                                                                                                                     |
+| :------------ | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Grid let:props&gt;&lt;header {...props}&gt;...&lt;/header&gt;&lt;/Grid&gt;) |
+| condensed     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
+| narrow        | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
+| fullWidth     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the fullWidth variant                                                                                                                                                      |
+| noGutter      | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
+| noGutterLeft  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
+| noGutterRight | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
+| padding       | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
 
 ### Slots
 
@@ -1386,16 +1386,16 @@ None.
 
 ### Props
 
-| Prop name               | Required | Kind             | Reactive | Type                                       | Default value          | Description                                                                                                                      |
-| :---------------------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| ref                     | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                    |
-| isSideNavOpen           | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to open the side nav                                                                                               |
-| expandedByDefault       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                   |
-| uiShellAriaLabel        | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the ARIA label for the header                                                                                            |
-| href                    | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                                                                                                     |
-| company                 | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the company name                                                                                                         |
-| platformName            | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;) |
-| persistentHamburgerMenu | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                      |
+| Prop name               | Required | Kind             | Reactive | Binding | Type                                       | Default value          | Description                                                                                                                      |
+| :---------------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| ref                     | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                    |
+| isSideNavOpen           | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to open the side nav                                                                                               |
+| expandedByDefault       | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                   |
+| uiShellAriaLabel        | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the ARIA label for the header                                                                                            |
+| href                    | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                                                                                                     |
+| company                 | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the company name                                                                                                         |
+| platformName            | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;) |
+| persistentHamburgerMenu | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                      |
 
 ### Slots
 
@@ -1425,13 +1425,13 @@ export interface HeaderActionSlideTransition {
 
 ### Props
 
-| Prop name  | Required | Kind             | Reactive | Type                                                         | Default value                  | Description                                                                                                   |
-| :--------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
-| isOpen     | No       | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>             | Set to `true` to open the panel                                                                               |
-| icon       | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>         | Specify the icon from `carbon-icons-svelte` to render                                                         |
-| text       | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
-| transition | No       | <code>let</code> | No       | <code>false &#124; HeaderActionSlideTransition</code>        | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`)<br />Set to `false` to disable the transition       |
+| Prop name  | Required | Kind             | Reactive | Binding | Type                                                         | Default value                  | Description                                                                                                   |
+| :--------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :----------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| ref        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
+| isOpen     | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                         | <code>false</code>             | Set to `true` to open the panel                                                                               |
+| icon       | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code>         | Specify the icon from `carbon-icons-svelte` to render                                                         |
+| text       | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
+| transition | No       | <code>let</code> | No       | --      | <code>false &#124; HeaderActionSlideTransition</code>        | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`)<br />Set to `false` to disable the transition       |
 
 ### Slots
 
@@ -1451,12 +1451,12 @@ export interface HeaderActionSlideTransition {
 
 ### Props
 
-| Prop name    | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :----------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
-| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
-| linkIsActive | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active state                 |
-| href         | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
-| icon         | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name    | Required | Kind             | Reactive | Binding | Type                                                         | Default value          | Description                                           |
+| :----------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :--------------------- | :---------------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
+| linkIsActive | No       | <code>let</code> | No       | --      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active state                 |
+| href         | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
+| icon         | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -1470,9 +1470,9 @@ None.
 
 ### Props
 
-| Prop name      | Required | Kind             | Reactive | Type                 | Default value      | Description                       |
-| :------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------- |
-| searchIsActive | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code> | Set to `true` to focus the search |
+| Prop name      | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                       |
+| :------------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------- |
+| searchIsActive | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code> | Set to `true` to focus the search |
 
 ### Slots
 
@@ -1490,11 +1490,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                   |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | --------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element |
-| isActive  | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active variant       |
-| icon      | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon to render                    |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                         | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :--------------------- | :-------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element |
+| isActive  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to use the active variant       |
+| icon      | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -1512,9 +1512,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value          | Description                                                                  |
-| :-------- | :------- | :--------------- | :------- | ------------------- | ---------------------- | ---------------------------------------------------------------------------- |
-| ariaLabel | No       | <code>let</code> | No       | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav<br />@deprecated use "aria-label" instead |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value          | Description                                                                  |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :--------------------- | :--------------------------------------------------------------------------- |
+| ariaLabel | No       | <code>let</code> | No       | --      | <code>string</code> | <code>undefined</code> | Specify the ARIA label for the nav<br />@deprecated use "aria-label" instead |
 
 ### Slots
 
@@ -1530,11 +1530,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
-| text      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                       | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :--------------------- | :-------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text      | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
 
 ### Slots
 
@@ -1557,13 +1557,13 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                       | Default value                  | Description                                   |
-| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------ | --------------------------------------------- |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>              | Obtain a reference to the HTML anchor element |
-| expanded        | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>             | Set to `true` to toggle the expanded state    |
-| href            | No       | <code>let</code> | No       | <code>string</code>                        | <code>"/"</code>               | Specify the `href` attribute                  |
-| text            | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>         | Specify the text                              |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Expand/Collapse"</code> | Specify the ARIA label for the chevron icon   |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                       | Default value                  | Description                                   |
+| :-------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :----------------------------- | :-------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>              | Obtain a reference to the HTML anchor element |
+| expanded        | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                       | <code>false</code>             | Set to `true` to toggle the expanded state    |
+| href            | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"/"</code>               | Specify the `href` attribute                  |
+| text            | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code>         | Specify the text                              |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Expand/Collapse"</code> | Specify the ARIA label for the chevron icon   |
 
 ### Slots
 
@@ -1604,10 +1604,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                       | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :--------------------- | :-------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
 
 ### Slots
 
@@ -1651,13 +1651,13 @@ export interface HeaderSearchResult {
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                                      | Default value      | Description                                        |
-| :------------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | -------------------------------------------------- |
-| selectedResultIndex | No       | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
-| ref                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
-| active              | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
-| value               | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
-| results             | No       | <code>let</code> | No       | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
+| Prop name           | Required | Kind             | Reactive | Binding | Type                                      | Default value      | Description                                        |
+| :------------------ | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :----------------- | :------------------------------------------------- |
+| selectedResultIndex | No       | <code>let</code> | Yes      | --      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
+| ref                 | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
+| active              | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
+| value               | No       | <code>let</code> | Yes      | --      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
+| results             | No       | <code>let</code> | No       | --      | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
 
 ### Slots
 
@@ -1699,10 +1699,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
-| render    | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
-| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to display the skeleton state           |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                         | Default value          | Description                                           |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :--------------------- | :---------------------------------------------------- |
+| render    | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| skeleton  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to display the skeleton state           |
 
 ### Slots
 
@@ -1721,9 +1721,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description              |
-| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ------------------------ |
-| size      | No       | <code>let</code> | No       | <code>number</code> | <code>16</code> | Set the size of the icon |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value   | Description              |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :-------------- | :----------------------- |
+| size      | No       | <code>let</code> | No       | --      | <code>number</code> | <code>16</code> | Set the size of the icon |
 
 ### Slots
 
@@ -1742,12 +1742,12 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                                                     | Default value          | Description                                                       |
-| :-------------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------- |
-| status          | No       | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
-| description     | No       | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
-| successDelay    | No       | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                                                     | Default value          | Description                                                       |
+| :-------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------------------- | :--------------------- | :---------------------------------------------------------------- |
+| status          | No       | <code>let</code> | No       | --      | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
+| description     | No       | <code>let</code> | No       | --      | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
+| successDelay    | No       | <code>let</code> | No       | --      | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
 
 ### Slots
 
@@ -1767,16 +1767,16 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
-| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| kind            | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
-| lowContrast     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
-| timeout         | No       | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
-| role            | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
-| title           | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
-| subtitle        | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
-| hideCloseButton | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                                                                                           | Default value                      | Description                                                             |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------------------- | :--------------------------------- | :---------------------------------------------------------------------- |
+| kind            | No       | <code>let</code> | No       | --      | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
+| lowContrast     | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
+| timeout         | No       | <code>let</code> | No       | --      | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
+| role            | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
+| title           | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
+| subtitle        | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
+| hideCloseButton | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
 
 ### Slots
 
@@ -1799,14 +1799,14 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                                   | Default value          | Description                                      |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------- | ---------------------- | ------------------------------------------------ |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element |
-| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                     |
-| href      | No       | <code>let</code> | No       | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                           |
-| inline    | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant          |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox            |
-| visited   | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles            |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                                   | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------------------------- | :--------------------- | :----------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element |
+| size      | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                     |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                           |
+| inline    | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant          |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox            |
+| visited   | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles            |
 
 ### Slots
 
@@ -1827,17 +1827,17 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                   | Default value          | Description                                |
-| :---------- | :------- | :--------------- | :------- | -------------------------------------- | ---------------------- | ------------------------------------------ |
-| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
-| type        | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
-| open        | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
-| light       | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
-| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to disable the list box      |
-| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an invalid state |
-| invalidText | No       | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the invalid state text             |
-| warn        | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an warning state |
-| warnText    | No       | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the warning state text             |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                   | Default value          | Description                                |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------------------------- | :--------------------- | :----------------------------------------- |
+| size        | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
+| type        | No       | <code>let</code> | No       | --      | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
+| open        | No       | <code>let</code> | No       | --      | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
+| light       | No       | <code>let</code> | No       | --      | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
+| disabled    | No       | <code>let</code> | No       | --      | <code>boolean</code>                   | <code>false</code>     | Set to `true` to disable the list box      |
+| invalid     | No       | <code>let</code> | No       | --      | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an invalid state |
+| invalidText | No       | <code>let</code> | No       | --      | <code>string</code>                    | <code>""</code>        | Specify the invalid state text             |
+| warn        | No       | <code>let</code> | No       | --      | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an warning state |
+| warnText    | No       | <code>let</code> | No       | --      | <code>string</code>                    | <code>""</code>        | Specify the warning state text             |
 
 ### Slots
 
@@ -1862,15 +1862,15 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name       | Required | Kind               | Reactive | Type                                                   | Default value                                      | Description                                      |
-| :-------------- | :------- | :----------------- | :------- | ------------------------------------------------------ | -------------------------------------------------- | ------------------------------------------------ |
-| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                | <code>null</code>                                  | Obtain a reference to the top-level HTML element |
-| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                   | <code>false</code>                                 | Set to `true` to disable the list box field      |
-| role            | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"combobox"</code>                            | Specify the role attribute                       |
-| tabindex        | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"-1"</code>                                  | Specify the tabindex                             |
-| translationIds  | No       | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>          | <code>{ close: "close", open: "open" }</code>      | Default translation ids                          |
-| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxFieldTranslationId) => string</code> | --                                                 | Override the default translation ids             |
-| id              | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element              |
+| Prop name       | Required | Kind               | Reactive | Binding | Type                                                   | Default value                                      | Description                                      |
+| :-------------- | :------- | :----------------- | :------- | :------ | :----------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------- |
+| ref             | No       | <code>let</code>   | Yes      | --      | <code>null &#124; HTMLDivElement</code>                | <code>null</code>                                  | Obtain a reference to the top-level HTML element |
+| disabled        | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                   | <code>false</code>                                 | Set to `true` to disable the list box field      |
+| role            | No       | <code>let</code>   | No       | --      | <code>string</code>                                    | <code>"combobox"</code>                            | Specify the role attribute                       |
+| tabindex        | No       | <code>let</code>   | No       | --      | <code>string</code>                                    | <code>"-1"</code>                                  | Specify the tabindex                             |
+| translationIds  | No       | <code>const</code> | No       | --      | <code>{ close: "close", open: "open" }</code>          | <code>{ close: "close", open: "open" }</code>      | Default translation ids                          |
+| translateWithId | No       | <code>let</code>   | No       | --      | <code>(id: ListBoxFieldTranslationId) => string</code> | --                                                 | Override the default translation ids             |
+| id              | No       | <code>let</code>   | No       | --      | <code>string</code>                                    | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element              |
 
 ### Slots
 
@@ -1893,10 +1893,10 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                    | Default value                                      | Description                            |
-| :-------- | :------- | :--------------- | :------- | --------------------------------------- | -------------------------------------------------- | -------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                  | Obtain a reference to the HTML element |
-| id        | No       | <code>let</code> | No       | <code>string</code>                     | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element    |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                    | Default value                                      | Description                            |
+| :-------- | :------- | :--------------- | :------- | :------ | :-------------------------------------- | :------------------------------------------------- | :------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                  | Obtain a reference to the HTML element |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element    |
 
 ### Slots
 
@@ -1920,11 +1920,11 @@ export type ListBoxMenuIconTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name       | Required | Kind               | Reactive | Type                                                      | Default value                                 | Description                                  |
-| :-------------- | :------- | :----------------- | :------- | --------------------------------------------------------- | --------------------------------------------- | -------------------------------------------- |
-| open            | No       | <code>let</code>   | No       | <code>boolean</code>                                      | <code>false</code>                            | Set to `true` to open the list box menu icon |
-| translationIds  | No       | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>             | <code>{ close: "close", open: "open" }</code> | Default translation ids                      |
-| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxMenuIconTranslationId) => string</code> | --                                            | Override the default translation ids         |
+| Prop name       | Required | Kind               | Reactive | Binding | Type                                                      | Default value                                 | Description                                  |
+| :-------------- | :------- | :----------------- | :------- | :------ | :-------------------------------------------------------- | :-------------------------------------------- | :------------------------------------------- |
+| open            | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                      | <code>false</code>                            | Set to `true` to open the list box menu icon |
+| translationIds  | No       | <code>const</code> | No       | --      | <code>{ close: "close", open: "open" }</code>             | <code>{ close: "close", open: "open" }</code> | Default translation ids                      |
+| translateWithId | No       | <code>let</code>   | No       | --      | <code>(id: ListBoxMenuIconTranslationId) => string</code> | --                                            | Override the default translation ids         |
 
 ### Slots
 
@@ -1940,10 +1940,10 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
-| active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
-| highlighted | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                   |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------------- |
+| active      | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
+| highlighted | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
 
 ### Slots
 
@@ -1969,13 +1969,13 @@ export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
 ### Props
 
-| Prop name       | Required | Kind               | Reactive | Type                                                                     | Default value                                                            | Description                                      |
-| :-------------- | :------- | :----------------- | :------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------ |
-| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
-| selectionCount  | No       | <code>let</code>   | No       | <code>any</code>                                                         | <code>undefined</code>                                                   | Specify the number of selected items             |
-| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
-| translationIds  | No       | <code>const</code> | No       | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
-| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxSelectionTranslationId) => string</code>               | --                                                                       | Override the default translation ids             |
+| Prop name       | Required | Kind               | Reactive | Binding | Type                                                                     | Default value                                                            | Description                                      |
+| :-------------- | :------- | :----------------- | :------- | :------ | :----------------------------------------------------------------------- | :----------------------------------------------------------------------- | :----------------------------------------------- |
+| ref             | No       | <code>let</code>   | Yes      | --      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
+| selectionCount  | No       | <code>let</code>   | No       | --      | <code>any</code>                                                         | <code>undefined</code>                                                   | Specify the number of selected items             |
+| disabled        | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
+| translationIds  | No       | <code>const</code> | No       | --      | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
+| translateWithId | No       | <code>let</code>   | No       | --      | <code>(id: ListBoxSelectionTranslationId) => string</code>               | --                                                                       | Override the default translation ids             |
 
 ### Slots
 
@@ -2012,13 +2012,13 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                 | Default value                                      | Description                                |
-| :---------- | :------- | :--------------- | :------- | -------------------- | -------------------------------------------------- | ------------------------------------------ |
-| small       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                                 | Set to `true` to use the small variant     |
-| active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                  | Set to `false` to disable the active state |
-| withOverlay | No       | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                  | Set to `false` to disable the overlay      |
-| description | No       | <code>let</code> | No       | <code>string</code>  | <code>"Active loading indicator"</code>            | Specify the label description              |
-| id          | No       | <code>let</code> | No       | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the label element            |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                 | Default value                                      | Description                                |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------- | :------------------------------------------------- | :----------------------------------------- |
+| small       | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to use the small variant     |
+| active      | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>true</code>                                  | Set to `false` to disable the active state |
+| withOverlay | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>true</code>                                  | Set to `false` to disable the overlay      |
+| description | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Active loading indicator"</code>            | Specify the label description              |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the label element            |
 
 ### Slots
 
@@ -2032,27 +2032,27 @@ None.
 
 ### Props
 
-| Prop name                  | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                                                |
-| :------------------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------- |
-| ref                        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                                  | Obtain a reference to the top-level HTML element                           |
-| open                       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to open the modal                                            |
-| size                       | No       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                             | Set the size of the modal                                                  |
-| danger                     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to use the danger variant                                    |
-| alert                      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable alert mode                                         |
-| passiveModal               | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to use the passive variant                                   |
-| modalHeading               | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                             | Specify the modal heading                                                  |
-| modalLabel                 | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                             | Specify the modal label                                                    |
-| modalAriaLabel             | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                             | Specify the ARIA label for the modal                                       |
-| iconDescription            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Close the modal"</code>                     | Specify the ARIA label for the close icon                                  |
-| hasForm                    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` if the modal contains form elements                          |
-| hasScrollingContent        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` if the modal contains scrolling content                      |
-| primaryButtonText          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the primary button text                                            |
-| primaryButtonDisabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the primary button                                |
-| shouldSubmitOnEnter        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>true</code>                                  | Set to `true` for the primary button to be triggered when pressing "Enter" |
-| secondaryButtonText        | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the secondary button text                                          |
-| selectorPrimaryFocus       | No       | <code>let</code> | No       | <code>string</code>                       | <code>"[data-modal-primary-focus]"</code>          | Specify a selector to be focused when opening the modal                    |
-| preventCloseOnClickOutside | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to prevent the modal from closing when clicking outside      |
-| id                         | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element                                        |
+| Prop name                  | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                                                |
+| :------------------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :------------------------------------------------------------------------- |
+| ref                        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                                  | Obtain a reference to the top-level HTML element                           |
+| open                       | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to open the modal                                            |
+| size                       | No       | <code>let</code> | No       | --      | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                             | Set the size of the modal                                                  |
+| danger                     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to use the danger variant                                    |
+| alert                      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable alert mode                                         |
+| passiveModal               | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to use the passive variant                                   |
+| modalHeading               | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                             | Specify the modal heading                                                  |
+| modalLabel                 | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                             | Specify the modal label                                                    |
+| modalAriaLabel             | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                             | Specify the ARIA label for the modal                                       |
+| iconDescription            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"Close the modal"</code>                     | Specify the ARIA label for the close icon                                  |
+| hasForm                    | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` if the modal contains form elements                          |
+| hasScrollingContent        | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` if the modal contains scrolling content                      |
+| primaryButtonText          | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the primary button text                                            |
+| primaryButtonDisabled      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the primary button                                |
+| shouldSubmitOnEnter        | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>true</code>                                  | Set to `true` for the primary button to be triggered when pressing "Enter" |
+| secondaryButtonText        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the secondary button text                                          |
+| selectorPrimaryFocus       | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"[data-modal-primary-focus]"</code>          | Specify a selector to be focused when opening the modal                    |
+| preventCloseOnClickOutside | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to prevent the modal from closing when clicking outside      |
+| id                         | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element                                        |
 
 ### Slots
 
@@ -2080,10 +2080,10 @@ None.
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                 | Default value      | Description                                           |
-| :------------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------- |
-| hasForm             | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains form elements     |
-| hasScrollingContent | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains scrolling content |
+| Prop name           | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                           |
+| :------------------ | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------------------- |
+| hasForm             | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains form elements     |
+| hasScrollingContent | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains scrolling content |
 
 ### Slots
 
@@ -2099,14 +2099,14 @@ None.
 
 ### Props
 
-| Prop name             | Required | Kind             | Reactive | Type                 | Default value          | Description                                 |
-| :-------------------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ------------------------------------------- |
-| primaryButtonText     | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the primary button text             |
-| primaryButtonDisabled | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the primary button |
-| primaryClass          | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the primary button      |
-| secondaryButtonText   | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the secondary button text           |
-| secondaryClass        | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a class for the secondary button    |
-| danger                | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the danger variant     |
+| Prop name             | Required | Kind             | Reactive | Binding | Type                 | Default value          | Description                                 |
+| :-------------------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------- | :------------------------------------------ |
+| primaryButtonText     | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>        | Specify the primary button text             |
+| primaryButtonDisabled | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the primary button |
+| primaryClass          | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>undefined</code> | Specify a class for the primary button      |
+| secondaryButtonText   | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>        | Specify the secondary button text           |
+| secondaryClass        | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>undefined</code> | Specify a class for the secondary button    |
+| danger                | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to use the danger variant     |
 
 ### Slots
 
@@ -2122,15 +2122,15 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                | Default value        | Description                               |
-| :-------------- | :------- | :--------------- | :------- | ------------------- | -------------------- | ----------------------------------------- |
-| title           | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal title                   |
-| label           | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal label                   |
-| labelClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the label class                   |
-| titleClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the title class                   |
-| closeClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close class                   |
-| closeIconClass  | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close icon class              |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code> | <code>"Close"</code> | Specify the ARIA label for the close icon |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                | Default value        | Description                               |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------------- | :---------------------------------------- |
+| title           | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>      | Specify the modal title                   |
+| label           | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>      | Specify the modal label                   |
+| labelClass      | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>      | Specify the label class                   |
+| titleClass      | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>      | Specify the title class                   |
+| closeClass      | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>      | Specify the close class                   |
+| closeIconClass  | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>      | Specify the close icon class              |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"Close"</code> | Specify the ARIA label for the close icon |
 
 ### Slots
 
@@ -2161,34 +2161,34 @@ export interface MultiSelectItem {
 
 ### Props
 
-| Prop name         | Required | Kind             | Reactive | Type                                                                                           | Default value                                      | Description                                                                           |
-| :---------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| open              | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to open the dropdown                                                    |
-| value             | No       | <code>let</code> | Yes      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the multiselect value                                                         |
-| selectedIds       | No       | <code>let</code> | Yes      | <code>MultiSelectItemId[]</code>                                                               | <code>[]</code>                                    | Set the selected ids                                                                  |
-| items             | No       | <code>let</code> | Yes      | <code>MultiSelectItem[]</code>                                                                 | <code>[]</code>                                    | Set the multiselect items                                                             |
-| itemToString      | No       | <code>let</code> | No       | <code>(item: MultiSelectItem) => string</code>                                                 | --                                                 | Override the display of a multiselect item                                            |
-| size              | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                      | <code>undefined</code>                             | Set the size of the combobox                                                          |
-| type              | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                         | <code>"default"</code>                             | Specify the type of multiselect                                                       |
-| selectionFeedback | No       | <code>let</code> | No       | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                    | <code>"top-after-reopen"</code>                    | Specify the selection feedback after selecting items                                  |
-| disabled          | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to disable the dropdown                                                 |
-| filterable        | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to filter items                                                         |
-| filterItem        | No       | <code>let</code> | No       | <code>(item: MultiSelectItem, value: string) => string</code>                                  | --                                                 | Override the filtering logic<br />The default filtering is an exact string comparison |
-| light             | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to enable the light variant                                             |
-| locale            | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>"en"</code>                                  | Specify the locale                                                                    |
-| placeholder       | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                    | Specify the placeholder text                                                          |
-| sortItem          | No       | <code>let</code> | No       | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | --                                                 | Override the sorting logic<br />The default sorting compare the item text value       |
-| translateWithId   | No       | <code>let</code> | No       | <code>(id: any) => string</code>                                                               | <code>undefined</code>                             | Override the default translation ids                                                  |
-| titleText         | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                    | Specify the title text                                                                |
-| useTitleInItem    | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to pass the item to `itemToString` in the checkbox                      |
-| invalid           | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to indicate an invalid state                                            |
-| invalidText       | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                    | Specify the invalid state text                                                        |
-| warn              | No       | <code>let</code> | No       | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to indicate an warning state                                            |
-| warnText          | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                    | Specify the warning state text                                                        |
-| helperText        | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                    | Specify the helper text                                                               |
-| label             | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>""</code>                                    | Specify the list box label                                                            |
-| id                | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component                                                  |
-| name              | No       | <code>let</code> | No       | <code>string</code>                                                                            | <code>undefined</code>                             | Specify a name attribute for the select                                               |
+| Prop name         | Required | Kind             | Reactive | Binding | Type                                                                                           | Default value                                      | Description                                                                           |
+| :---------------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------------------------------------------------- | :------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| open              | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to open the dropdown                                                    |
+| value             | No       | <code>let</code> | Yes      | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the multiselect value                                                         |
+| selectedIds       | No       | <code>let</code> | Yes      | --      | <code>MultiSelectItemId[]</code>                                                               | <code>[]</code>                                    | Set the selected ids                                                                  |
+| items             | No       | <code>let</code> | Yes      | --      | <code>MultiSelectItem[]</code>                                                                 | <code>[]</code>                                    | Set the multiselect items                                                             |
+| itemToString      | No       | <code>let</code> | No       | --      | <code>(item: MultiSelectItem) => string</code>                                                 | --                                                 | Override the display of a multiselect item                                            |
+| size              | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                      | <code>undefined</code>                             | Set the size of the combobox                                                          |
+| type              | No       | <code>let</code> | No       | --      | <code>"default" &#124; "inline"</code>                                                         | <code>"default"</code>                             | Specify the type of multiselect                                                       |
+| selectionFeedback | No       | <code>let</code> | No       | --      | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                    | <code>"top-after-reopen"</code>                    | Specify the selection feedback after selecting items                                  |
+| disabled          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to disable the dropdown                                                 |
+| filterable        | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to filter items                                                         |
+| filterItem        | No       | <code>let</code> | No       | --      | <code>(item: MultiSelectItem, value: string) => string</code>                                  | --                                                 | Override the filtering logic<br />The default filtering is an exact string comparison |
+| light             | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to enable the light variant                                             |
+| locale            | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>"en"</code>                                  | Specify the locale                                                                    |
+| placeholder       | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the placeholder text                                                          |
+| sortItem          | No       | <code>let</code> | No       | --      | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | --                                                 | Override the sorting logic<br />The default sorting compare the item text value       |
+| translateWithId   | No       | <code>let</code> | No       | --      | <code>(id: any) => string</code>                                                               | <code>undefined</code>                             | Override the default translation ids                                                  |
+| titleText         | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the title text                                                                |
+| useTitleInItem    | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to pass the item to `itemToString` in the checkbox                      |
+| invalid           | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to indicate an invalid state                                            |
+| invalidText       | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the invalid state text                                                        |
+| warn              | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                           | <code>false</code>                                 | Set to `true` to indicate an warning state                                            |
+| warnText          | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the warning state text                                                        |
+| helperText        | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the helper text                                                               |
+| label             | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>""</code>                                    | Specify the list box label                                                            |
+| id                | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component                                                  |
+| name              | No       | <code>let</code> | No       | --      | <code>string</code>                                                                            | <code>undefined</code>                             | Specify a name attribute for the select                                               |
 
 ### Slots
 
@@ -2229,12 +2229,12 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                                         | Default value             | Description                                           |
-| :--------------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ------------------------- | ----------------------------------------------------- |
-| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                         | <code>"toast"</code>      | Set the type of notification                          |
-| icon             | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>Close20</code>      | Specify the icon from `carbon-icons-svelte` to render |
-| title            | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>    | Specify the title of the icon                         |
-| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                          | <code>"Close icon"</code> | Specify the ARIA label for the icon                   |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                                         | Default value             | Description                                           |
+| :--------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :------------------------ | :---------------------------------------------------- |
+| notificationType | No       | <code>let</code> | No       | --      | <code>"toast" &#124; "inline"</code>                         | <code>"toast"</code>      | Set the type of notification                          |
+| icon             | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>Close20</code>      | Specify the icon from `carbon-icons-svelte` to render |
+| title            | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code>    | Specify the title of the icon                         |
+| iconDescription  | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>"Close icon"</code> | Specify the ARIA label for the icon                   |
 
 ### Slots
 
@@ -2253,11 +2253,11 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                           |
-| :--------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------- |
-| kind             | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification icon |
-| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                                                                           | <code>"toast"</code>               | Set the type of notification          |
-| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon   |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                                                                                           | Default value                      | Description                           |
+| :--------------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------------------- | :--------------------------------- | :------------------------------------ |
+| kind             | No       | <code>let</code> | No       | --      | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification icon |
+| notificationType | No       | <code>let</code> | No       | --      | <code>"toast" &#124; "inline"</code>                                                                           | <code>"toast"</code>               | Set the type of notification          |
+| iconDescription  | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon   |
 
 ### Slots
 
@@ -2271,12 +2271,12 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                 | Default value          | Description                  |
-| :--------------- | :------- | :--------------- | :------- | ------------------------------------ | ---------------------- | ---------------------------- |
-| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code> | <code>"toast"</code>   | Set the type of notification |
-| title            | No       | <code>let</code> | No       | <code>string</code>                  | <code>"Title"</code>   | Specify the title text       |
-| subtitle         | No       | <code>let</code> | No       | <code>string</code>                  | <code>""</code>        | Specify the subtitle text    |
-| caption          | No       | <code>let</code> | No       | <code>string</code>                  | <code>"Caption"</code> | Specify the caption text     |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                 | Default value          | Description                  |
+| :--------------- | :------- | :--------------- | :------- | :------ | :----------------------------------- | :--------------------- | :--------------------------- |
+| notificationType | No       | <code>let</code> | No       | --      | <code>"toast" &#124; "inline"</code> | <code>"toast"</code>   | Set the type of notification |
+| title            | No       | <code>let</code> | No       | --      | <code>string</code>                  | <code>"Title"</code>   | Specify the title text       |
+| subtitle         | No       | <code>let</code> | No       | --      | <code>string</code>                  | <code>""</code>        | Specify the subtitle text    |
+| caption          | No       | <code>let</code> | No       | --      | <code>string</code>                  | <code>"Caption"</code> | Specify the caption text     |
 
 ### Slots
 
@@ -2298,31 +2298,31 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Props
 
-| Prop name       | Required | Kind               | Reactive | Type                                                            | Default value                                                    | Description                                    |
-| :-------------- | :------- | :----------------- | :------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
-| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element   |
-| value           | No       | <code>let</code>   | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                                  | Specify the input value                        |
-| size            | No       | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                      |
-| step            | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                     |
-| max             | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                      |
-| min             | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                      |
-| light           | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant      |
-| readonly        | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only    |
-| mobile          | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the mobile variant     |
-| allowEmpty      | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to allow for an empty value      |
-| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to disable the input             |
-| iconDescription | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the ARIA label for the increment icons |
-| invalid         | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an invalid state     |
-| invalidText     | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the invalid state text                 |
-| warn            | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an warning state     |
-| warnText        | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the warning state text                 |
-| helperText      | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the helper text                        |
-| label           | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the label text                         |
-| hideLabel       | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to visually hide the label text  |
-| translateWithId | No       | <code>let</code>   | No       | <code>(id: NumberInputTranslationId) => string</code>           | --                                                               | Override the default translation ids           |
-| translationIds  | No       | <code>const</code> | No       | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                        |
-| id              | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code>               | Set an id for the input element                |
-| name            | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input         |
+| Prop name       | Required | Kind               | Reactive | Binding | Type                                                            | Default value                                                    | Description                                    |
+| :-------------- | :------- | :----------------- | :------- | :------ | :-------------------------------------------------------------- | :--------------------------------------------------------------- | :--------------------------------------------- |
+| ref             | No       | <code>let</code>   | Yes      | --      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element   |
+| value           | No       | <code>let</code>   | Yes      | --      | <code>number &#124; string</code>                               | <code>""</code>                                                  | Specify the input value                        |
+| size            | No       | <code>let</code>   | No       | --      | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                      |
+| step            | No       | <code>let</code>   | No       | --      | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                     |
+| max             | No       | <code>let</code>   | No       | --      | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                      |
+| min             | No       | <code>let</code>   | No       | --      | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                      |
+| light           | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant      |
+| readonly        | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only    |
+| mobile          | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the mobile variant     |
+| allowEmpty      | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to allow for an empty value      |
+| disabled        | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to disable the input             |
+| iconDescription | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>""</code>                                                  | Specify the ARIA label for the increment icons |
+| invalid         | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an invalid state     |
+| invalidText     | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>""</code>                                                  | Specify the invalid state text                 |
+| warn            | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an warning state     |
+| warnText        | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>""</code>                                                  | Specify the warning state text                 |
+| helperText      | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>""</code>                                                  | Specify the helper text                        |
+| label           | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>""</code>                                                  | Specify the label text                         |
+| hideLabel       | No       | <code>let</code>   | No       | --      | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to visually hide the label text  |
+| translateWithId | No       | <code>let</code>   | No       | --      | <code>(id: NumberInputTranslationId) => string</code>           | --                                                               | Override the default translation ids           |
+| translationIds  | No       | <code>const</code> | No       | --      | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                        |
+| id              | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code>               | Set an id for the input element                |
+| name            | No       | <code>let</code>   | No       | --      | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input         |
 
 ### Slots
 
@@ -2345,9 +2345,9 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
-| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -2366,10 +2366,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
-| nested    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
-| native    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use native list styles |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------- |
+| nested    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
+| native    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use native list styles |
 
 ### Slots
 
@@ -2411,20 +2411,20 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                                         | Default value                                      | Description                                                       |
-| :--------------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------- |
-| menuRef          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>                    | <code>null</code>                                  | Obtain a reference to the overflow menu element                   |
-| buttonRef        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>                                  | Obtain a reference to the trigger button element                  |
-| open             | No       | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>                                 | Set to `true` to open the menu                                    |
-| size             | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                | <code>undefined</code>                             | Specify the size of the overflow menu                             |
-| direction        | No       | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                           | <code>"bottom"</code>                              | Specify the direction of the overflow menu relative to the button |
-| light            | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                                 | Set to `true` to enable the light variant                         |
-| flipped          | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>                                 | Set to `true` to flip the menu relative to the button             |
-| menuOptionsClass | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                             | Specify the menu options class                                    |
-| icon             | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>OverflowMenuVertical16</code>                | Specify the icon from `carbon-icons-svelte` to render             |
-| iconClass        | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code>                             | Specify the icon class                                            |
-| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                          | <code>"Open and close list of options"</code>      | Specify the ARIA label for the icon                               |
-| id               | No       | <code>let</code> | No       | <code>string</code>                                          | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the button element                                  |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                                         | Default value                                      | Description                                                       |
+| :--------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :------------------------------------------------- | :---------------------------------------------------------------- |
+| menuRef          | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLUListElement</code>                    | <code>null</code>                                  | Obtain a reference to the overflow menu element                   |
+| buttonRef        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>                                  | Obtain a reference to the trigger button element                  |
+| open             | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                         | <code>false</code>                                 | Set to `true` to open the menu                                    |
+| size             | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>                                | <code>undefined</code>                             | Specify the size of the overflow menu                             |
+| direction        | No       | <code>let</code> | No       | --      | <code>"top" &#124; "bottom"</code>                           | <code>"bottom"</code>                              | Specify the direction of the overflow menu relative to the button |
+| light            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                         | <code>false</code>                                 | Set to `true` to enable the light variant                         |
+| flipped          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                         | <code>false</code>                                 | Set to `true` to flip the menu relative to the button             |
+| menuOptionsClass | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code>                             | Specify the menu options class                                    |
+| icon             | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>OverflowMenuVertical16</code>                | Specify the icon from `carbon-icons-svelte` to render             |
+| iconClass        | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code>                             | Specify the icon class                                            |
+| iconDescription  | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>"Open and close list of options"</code>      | Specify the ARIA label for the icon                               |
+| id               | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the button element                                  |
 
 ### Slots
 
@@ -2448,17 +2448,17 @@ None.
 
 ### Props
 
-| Prop name    | Required | Kind             | Reactive | Type                                                                | Default value                                      | Description                                                                         |
-| :----------- | :------- | :--------------- | :------- | ------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code> | <code>null</code>                                  | Obtain a reference to the HTML element                                              |
-| primaryFocus | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` if the item should be focused when opening the menu                   |
-| text         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>"Provide text"</code>                        | Specify the item text<br />Alternatively, use the default slot for a custom element |
-| href         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>                                    | Specify the `href` attribute if the item is a link                                  |
-| disabled     | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` to disable the item                                                   |
-| hasDivider   | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` to include a divider                                                  |
-| danger       | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` to use the danger variant                                             |
-| requireTitle | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>true</code>                                  | Set to `false` to omit the button `title` attribute                                 |
-| id           | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element                                                 |
+| Prop name    | Required | Kind             | Reactive | Binding | Type                                                                | Default value                                      | Description                                                                         |
+| :----------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------ | :------------------------------------------------- | :---------------------------------------------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code> | <code>null</code>                                  | Obtain a reference to the HTML element                                              |
+| primaryFocus | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` if the item should be focused when opening the menu                   |
+| text         | No       | <code>let</code> | No       | --      | <code>string</code>                                                 | <code>"Provide text"</code>                        | Specify the item text<br />Alternatively, use the default slot for a custom element |
+| href         | No       | <code>let</code> | No       | --      | <code>string</code>                                                 | <code>""</code>                                    | Specify the `href` attribute if the item is a link                                  |
+| disabled     | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` to disable the item                                                   |
+| hasDivider   | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` to include a divider                                                  |
+| danger       | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>false</code>                                 | Set to `true` to use the danger variant                                             |
+| requireTitle | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                | <code>true</code>                                  | Set to `false` to omit the button `title` attribute                                 |
+| id           | No       | <code>let</code> | No       | --      | <code>string</code>                                                 | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element                                                 |
 
 ### Slots
 
@@ -2477,24 +2477,24 @@ None.
 
 ### Props
 
-| Prop name             | Required | Kind             | Reactive | Type                                                             | Default value                                      | Description                                      |
-| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| pageSize              | No       | <code>let</code> | Yes      | <code>number</code>                                              | <code>10</code>                                    | Specify the number of items to display in a page |
-| page                  | No       | <code>let</code> | Yes      | <code>number</code>                                              | <code>1</code>                                     | Specify the current page index                   |
-| totalItems            | No       | <code>let</code> | No       | <code>number</code>                                              | <code>0</code>                                     | Specify the total number of items                |
-| disabled              | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` to disable the pagination          |
-| forwardText           | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Next page"</code>                           | Specify the forward button text                  |
-| backwardText          | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Previous page"</code>                       | Specify the backward button text                 |
-| itemsPerPageText      | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Items per page:"</code>                     | Specify the items per page text                  |
-| itemText              | No       | <code>let</code> | No       | <code>(min: number, max: number) => string</code>                | --                                                 | Override the item text                           |
-| itemRangeText         | No       | <code>let</code> | No       | <code>(min: number, max: number, total: number) => string</code> | --                                                 | Override the item range text                     |
-| pageInputDisabled     | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` to disable the page input          |
-| pageSizeInputDisabled | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` to disable the page size input     |
-| pageSizes             | No       | <code>let</code> | No       | <code>number[]</code>                                            | <code>[10]</code>                                  | Specify the available page sizes                 |
-| pagesUnknown          | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` if the number of pages is unknown  |
-| pageText              | No       | <code>let</code> | No       | <code>(page: number) => string</code>                            | --                                                 | Override the page text                           |
-| pageRangeText         | No       | <code>let</code> | No       | <code>(current: number, total: number) => string</code>          | --                                                 | Override the page range text                     |
-| id                    | No       | <code>let</code> | No       | <code>string</code>                                              | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element              |
+| Prop name             | Required | Kind             | Reactive | Binding | Type                                                             | Default value                                      | Description                                      |
+| :-------------------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------- |
+| pageSize              | No       | <code>let</code> | Yes      | --      | <code>number</code>                                              | <code>10</code>                                    | Specify the number of items to display in a page |
+| page                  | No       | <code>let</code> | Yes      | --      | <code>number</code>                                              | <code>1</code>                                     | Specify the current page index                   |
+| totalItems            | No       | <code>let</code> | No       | --      | <code>number</code>                                              | <code>0</code>                                     | Specify the total number of items                |
+| disabled              | No       | <code>let</code> | No       | --      | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` to disable the pagination          |
+| forwardText           | No       | <code>let</code> | No       | --      | <code>string</code>                                              | <code>"Next page"</code>                           | Specify the forward button text                  |
+| backwardText          | No       | <code>let</code> | No       | --      | <code>string</code>                                              | <code>"Previous page"</code>                       | Specify the backward button text                 |
+| itemsPerPageText      | No       | <code>let</code> | No       | --      | <code>string</code>                                              | <code>"Items per page:"</code>                     | Specify the items per page text                  |
+| itemText              | No       | <code>let</code> | No       | --      | <code>(min: number, max: number) => string</code>                | --                                                 | Override the item text                           |
+| itemRangeText         | No       | <code>let</code> | No       | --      | <code>(min: number, max: number, total: number) => string</code> | --                                                 | Override the item range text                     |
+| pageInputDisabled     | No       | <code>let</code> | No       | --      | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` to disable the page input          |
+| pageSizeInputDisabled | No       | <code>let</code> | No       | --      | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` to disable the page size input     |
+| pageSizes             | No       | <code>let</code> | No       | --      | <code>number[]</code>                                            | <code>[10]</code>                                  | Specify the available page sizes                 |
+| pagesUnknown          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                             | <code>false</code>                                 | Set to `true` if the number of pages is unknown  |
+| pageText              | No       | <code>let</code> | No       | --      | <code>(page: number) => string</code>                            | --                                                 | Override the page text                           |
+| pageRangeText         | No       | <code>let</code> | No       | --      | <code>(current: number, total: number) => string</code>          | --                                                 | Override the page range text                     |
+| id                    | No       | <code>let</code> | No       | --      | <code>string</code>                                              | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element              |
 
 ### Slots
 
@@ -2510,14 +2510,14 @@ None.
 
 ### Props
 
-| Prop name    | Required | Kind             | Reactive | Type                 | Default value                | Description                               |
-| :----------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | ----------------------------------------- |
-| page         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
-| total        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
-| shown        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
-| loop         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |
-| forwardText  | No       | <code>let</code> | No       | <code>string</code>  | <code>"Next page"</code>     | Specify the forward button text           |
-| backwardText | No       | <code>let</code> | No       | <code>string</code>  | <code>"Previous page"</code> | Specify the backward button text          |
+| Prop name    | Required | Kind             | Reactive | Binding | Type                 | Default value                | Description                               |
+| :----------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------------- | :---------------------------------------- |
+| page         | No       | <code>let</code> | Yes      | --      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
+| total        | No       | <code>let</code> | No       | --      | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
+| shown        | No       | <code>let</code> | No       | --      | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
+| loop         | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |
+| forwardText  | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Next page"</code>     | Specify the forward button text           |
+| backwardText | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Previous page"</code> | Specify the backward button text          |
 
 ### Slots
 
@@ -2554,26 +2554,26 @@ None.
 
 ### Props
 
-| Prop name         | Required | Kind             | Reactive | Type                                                            | Default value                                      | Description                                           |
-| :---------------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------- |
-| ref               | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                  | Obtain a reference to the input HTML element          |
-| type              | No       | <code>let</code> | Yes      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                            | Set to `"text"` to toggle the password visibility     |
-| value             | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                    | Specify the input value                               |
-| size              | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                             | Set the size of the input                             |
-| placeholder       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the placeholder text                          |
-| hidePasswordLabel | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"Hide password"</code>                       | Specify the hide password label text                  |
-| showPasswordLabel | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"Show password"</code>                       | Specify the show password label text                  |
-| tooltipAlignment  | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon |
-| tooltipPosition   | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                              | Set the position of the tooltip relative to the icon  |
-| light             | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to enable the light variant             |
-| disabled          | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to disable the input                    |
-| helperText        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the helper text                               |
-| labelText         | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the label text                                |
-| hideLabel         | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to visually hide the label text         |
-| invalid           | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to indicate an invalid state            |
-| invalidText       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the text for the invalid state                |
-| id                | No       | <code>let</code> | No       | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                       |
-| name              | No       | <code>let</code> | No       | <code>string</code>                                             | <code>undefined</code>                             | Specify a name attribute for the input                |
+| Prop name         | Required | Kind             | Reactive | Binding | Type                                                            | Default value                                      | Description                                           |
+| :---------------- | :------- | :--------------- | :------- | :------ | :-------------------------------------------------------------- | :------------------------------------------------- | :---------------------------------------------------- |
+| ref               | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                  | Obtain a reference to the input HTML element          |
+| type              | No       | <code>let</code> | Yes      | --      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                            | Set to `"text"` to toggle the password visibility     |
+| value             | No       | <code>let</code> | Yes      | --      | <code>number &#124; string</code>                               | <code>""</code>                                    | Specify the input value                               |
+| size              | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                             | Set the size of the input                             |
+| placeholder       | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the placeholder text                          |
+| hidePasswordLabel | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>"Hide password"</code>                       | Specify the hide password label text                  |
+| showPasswordLabel | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>"Show password"</code>                       | Specify the show password label text                  |
+| tooltipAlignment  | No       | <code>let</code> | No       | --      | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon |
+| tooltipPosition   | No       | <code>let</code> | No       | --      | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                              | Set the position of the tooltip relative to the icon  |
+| light             | No       | <code>let</code> | No       | --      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to enable the light variant             |
+| disabled          | No       | <code>let</code> | No       | --      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to disable the input                    |
+| helperText        | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the helper text                               |
+| labelText         | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the label text                                |
+| hideLabel         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to visually hide the label text         |
+| invalid           | No       | <code>let</code> | No       | --      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to indicate an invalid state            |
+| invalidText       | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the text for the invalid state                |
+| id                | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                       |
+| name              | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>undefined</code>                             | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -2597,12 +2597,12 @@ None.
 
 ### Props
 
-| Prop name            | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                    |
-| :------------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| currentIndex         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>     | Specify the current step index                                                                 |
-| vertical             | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant                                                      |
-| spaceEqually         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to specify whether the progress steps should be split equally in size in the div |
-| preventChangeOnClick | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent `currentIndex` from updating                                          |
+| Prop name            | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                                                                    |
+| :------------------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :--------------------------------------------------------------------------------------------- |
+| currentIndex         | No       | <code>let</code> | Yes      | --      | <code>number</code>  | <code>0</code>     | Specify the current step index                                                                 |
+| vertical             | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant                                                      |
+| spaceEqually         | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to specify whether the progress steps should be split equally in size in the div |
+| preventChangeOnClick | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to prevent `currentIndex` from updating                                          |
 
 ### Slots
 
@@ -2624,10 +2624,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
-| vertical  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant |
-| count     | No       | <code>let</code> | No       | <code>number</code>  | <code>4</code>     | Specify the number of steps to render     |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------- |
+| vertical  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant |
+| count     | No       | <code>let</code> | No       | --      | <code>number</code>  | <code>4</code>     | Specify the number of steps to render     |
 
 ### Slots
 
@@ -2646,16 +2646,16 @@ None.
 
 ### Props
 
-| Prop name      | Required | Kind             | Reactive | Type                 | Default value                                      | Description                                |
-| :------------- | :------- | :--------------- | :------- | -------------------- | -------------------------------------------------- | ------------------------------------------ |
-| current        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to use the current variant   |
-| complete       | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                                 | Set to `true` for the complete variant     |
-| disabled       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                                 | Set to `true` to disable the progress step |
-| invalid        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                                 | Set to `true` to indicate an invalid state |
-| description    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                    | Specify the step description               |
-| label          | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                    | Specify the step label                     |
-| secondaryLabel | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                    | Specify the step secondary label           |
-| id             | No       | <code>let</code> | No       | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element        |
+| Prop name      | Required | Kind             | Reactive | Binding | Type                 | Default value                                      | Description                                |
+| :------------- | :------- | :--------------- | :------- | :------ | :------------------- | :------------------------------------------------- | :----------------------------------------- |
+| current        | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to use the current variant   |
+| complete       | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` for the complete variant     |
+| disabled       | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to disable the progress step |
+| invalid        | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to indicate an invalid state |
+| description    | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>                                    | Specify the step description               |
+| label          | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>                                    | Specify the step label                     |
+| secondaryLabel | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>                                    | Specify the step secondary label           |
+| id             | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element        |
 
 ### Slots
 
@@ -2677,17 +2677,17 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                     |
-| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | ----------------------------------------------- |
-| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element    |
-| checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to check the radio button         |
-| value         | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the value of the radio button           |
-| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | et to `true` to disable the radio button        |
-| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>        | <code>"right"</code>                               | Specify the label position                      |
-| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the label text                          |
-| hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text   |
-| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                 |
-| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify a name attribute for the checkbox input |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                     |
+| :------------ | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :---------------------------------------------- |
+| ref           | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element    |
+| checked       | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to check the radio button         |
+| value         | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the value of the radio button           |
+| disabled      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | et to `true` to disable the radio button        |
+| labelPosition | No       | <code>let</code> | No       | --      | <code>"right" &#124; "left"</code>        | <code>"right"</code>                               | Specify the label position                      |
+| labelText     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the label text                          |
+| hideLabel     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text   |
+| id            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                 |
+| name          | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -2703,13 +2703,13 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                                        | Default value             | Description                                  |
-| :------------ | :------- | :--------------- | :------- | ------------------------------------------- | ------------------------- | -------------------------------------------- |
-| selected      | No       | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
-| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
-| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
-| orientation   | No       | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
-| id            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                                        | Default value             | Description                                  |
+| :------------ | :------- | :--------------- | :------- | :------ | :------------------------------------------ | :------------------------ | :------------------------------------------- |
+| selected      | No       | <code>let</code> | Yes      | --      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
+| disabled      | No       | <code>let</code> | No       | --      | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
+| labelPosition | No       | <code>let</code> | No       | --      | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
+| orientation   | No       | <code>let</code> | No       | --      | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
+| id            | No       | <code>let</code> | No       | --      | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
 
 ### Slots
 
@@ -2750,15 +2750,15 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                 | Default value                                      | Description                                              |
-| :-------------- | :------- | :--------------- | :------- | -------------------- | -------------------------------------------------- | -------------------------------------------------------- |
-| checked         | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to check the tile                          |
-| light           | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                                 | Set to `true` to enable the light variant                |
-| value           | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                    | Specify the value of the radio input                     |
-| tabindex        | No       | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>                                   | Specify the tabindex                                     |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>  | <code>"Tile checkmark"</code>                      | Specify the ARIA label for the radio tile checkmark icon |
-| id              | No       | <code>let</code> | No       | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                          |
-| name            | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                    | Specify a name attribute for the input                   |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                 | Default value                                      | Description                                              |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------- | :------------------------------------------------- | :------------------------------------------------------- |
+| checked         | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to check the tile                          |
+| light           | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to enable the light variant                |
+| value           | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>                                    | Specify the value of the radio input                     |
+| tabindex        | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"0"</code>                                   | Specify the tabindex                                     |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Tile checkmark"</code>                      | Specify the ARIA label for the radio tile checkmark icon |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                          |
+| name            | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>                                    | Specify a name attribute for the input                   |
 
 ### Slots
 
@@ -2781,15 +2781,15 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
-| :------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Row let:props&gt;&lt;section {...props}&gt;...&lt;/section&gt;&lt;/Row&gt;) |
-| condensed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
-| narrow        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
-| noGutter      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
-| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
-| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
-| padding       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
+| Prop name     | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                                                                                                                                                                     |
+| :------------ | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Row let:props&gt;&lt;section {...props}&gt;...&lt;/section&gt;&lt;/Row&gt;) |
+| condensed     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
+| narrow        | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
+| noGutter      | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
+| noGutterLeft  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
+| noGutterRight | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
+| padding       | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
 
 ### Slots
 
@@ -2805,22 +2805,22 @@ None.
 
 ### Props
 
-| Prop name            | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                                                                |
-| :------------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| ref                  | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element                                               |
-| value                | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                    | Specify the value of the search input                                                      |
-| small                | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | @deprecated this prop will be removed in the next major release<br />Use size="sm" instead |
-| size                 | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>                                  | Specify the size of the search input                                                       |
-| skeleton             | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to display the skeleton state                                                |
-| light                | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable the light variant                                                  |
-| disabled             | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the search input                                                  |
-| type                 | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                | Specify the `type` attribute of the search input                                           |
-| placeholder          | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Search..."</code>                           | Specify the `placeholder` attribute of the search input                                    |
-| autocomplete         | No       | <code>let</code> | No       | <code>"on" &#124; "off"</code>            | <code>"off"</code>                                 | Specify the `autocomplete` attribute                                                       |
-| autofocus            | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to auto focus the search element                                             |
-| closeButtonLabelText | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Clear search input"</code>                  | Specify the close button label text                                                        |
-| labelText            | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the label text                                                                     |
-| id                   | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                                                            |
+| Prop name            | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                                                                |
+| :------------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| ref                  | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element                                               |
+| value                | No       | <code>let</code> | Yes      | --      | <code>string</code>                       | <code>""</code>                                    | Specify the value of the search input                                                      |
+| small                | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | @deprecated this prop will be removed in the next major release<br />Use size="sm" instead |
+| size                 | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>                                  | Specify the size of the search input                                                       |
+| skeleton             | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to display the skeleton state                                                |
+| light                | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable the light variant                                                  |
+| disabled             | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the search input                                                  |
+| type                 | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"text"</code>                                | Specify the `type` attribute of the search input                                           |
+| placeholder          | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"Search..."</code>                           | Specify the `placeholder` attribute of the search input                                    |
+| autocomplete         | No       | <code>let</code> | No       | --      | <code>"on" &#124; "off"</code>            | <code>"off"</code>                                 | Specify the `autocomplete` attribute                                                       |
+| autofocus            | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to auto focus the search element                                             |
+| closeButtonLabelText | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"Clear search input"</code>                  | Specify the close button label text                                                        |
+| labelText            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the label text                                                                     |
+| id                   | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                                                            |
 
 ### Slots
 
@@ -2845,10 +2845,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                      | Default value      | Description                                                                                                 |
-| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
-| small     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | @deprecated this prop will be removed in the next major release<br />Set to `true` to use the small variant |
-| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>  | Specify the size of the search input                                                                        |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                      | Default value      | Description                                                                                                 |
+| :-------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------- |
+| small     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code> | @deprecated this prop will be removed in the next major release<br />Set to `true` to use the small variant |
+| size      | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code>  | Specify the size of the search input                                                                        |
 
 ### Slots
 
@@ -2867,22 +2867,22 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                     |
-| :---------- | :------- | :--------------- | :------- | ------------------------------------------ | -------------------------------------------------- | ----------------------------------------------- |
-| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                  | Obtain a reference to the select HTML element   |
-| selected    | No       | <code>let</code> | Yes      | <code>string</code>                        | <code>undefined</code>                             | Specify the selected item value                 |
-| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                             | Set the size of the select input                |
-| inline      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to use the inline variant         |
-| light       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to enable the light variant       |
-| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the select element     |
-| id          | No       | <code>let</code> | No       | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the select element                |
-| name        | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                             | Specify a name attribute for the select element |
-| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to indicate an invalid state      |
-| invalidText | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the invalid state text                  |
-| helperText  | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the helper text                         |
-| noLabel     | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to not render a label             |
-| labelText   | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the label text                          |
-| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to visually hide the label text   |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                       | Default value                                      | Description                                     |
+| :---------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :------------------------------------------------- | :---------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                  | Obtain a reference to the select HTML element   |
+| selected    | No       | <code>let</code> | Yes      | --      | <code>string</code>                        | <code>undefined</code>                             | Specify the selected item value                 |
+| size        | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                             | Set the size of the select input                |
+| inline      | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to use the inline variant         |
+| light       | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to enable the light variant       |
+| disabled    | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the select element     |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the select element                |
+| name        | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code>                             | Specify a name attribute for the select element |
+| invalid     | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to indicate an invalid state      |
+| invalidText | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the invalid state text                  |
+| helperText  | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the helper text                         |
+| noLabel     | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to not render a label             |
+| labelText   | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the label text                          |
+| hideLabel   | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to visually hide the label text   |
 
 ### Slots
 
@@ -2901,12 +2901,12 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                         |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------- |
-| value     | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option value            |
-| text      | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option text             |
-| hidden    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the option    |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the option |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                         |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------- |
+| value     | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>    | Specify the option value            |
+| text      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>    | Specify the option text             |
+| hidden    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the option    |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to disable the option |
 
 ### Slots
 
@@ -2920,10 +2920,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value                | Description                                         |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | --------------------------------------------------- |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to disable the optgroup element       |
-| label     | No       | <code>let</code> | No       | <code>string</code>  | <code>"Provide label"</code> | Specify the label attribute of the optgroup element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value                | Description                                         |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------------- | :-------------------------------------------------- |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>           | Set to `true` to disable the optgroup element       |
+| label     | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Provide label"</code> | Specify the label attribute of the optgroup element |
 
 ### Slots
 
@@ -2939,9 +2939,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
-| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -2960,17 +2960,17 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                                   |
-| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------- |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element                  |
-| selected        | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to select the tile                              |
-| light           | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable the light variant                     |
-| title           | No       | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                               | Specify the title of the selectable tile                      |
-| value           | No       | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                               | Specify the value of the selectable tile                      |
-| tabindex        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                   | Specify the tabindex                                          |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Tile checkmark"</code>                      | Specify the ARIA label for the selectable tile checkmark icon |
-| id              | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                               |
-| name            | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify a name attribute for the input                        |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                                   |
+| :-------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :------------------------------------------------------------ |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element                  |
+| selected        | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to select the tile                              |
+| light           | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable the light variant                     |
+| title           | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"title"</code>                               | Specify the title of the selectable tile                      |
+| value           | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"value"</code>                               | Specify the value of the selectable tile                      |
+| tabindex        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"0"</code>                                   | Specify the tabindex                                          |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"Tile checkmark"</code>                      | Specify the ARIA label for the selectable tile checkmark icon |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                               |
+| name            | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify a name attribute for the input                        |
 
 ### Slots
 
@@ -2992,11 +2992,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                                |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ------------------------------------------ |
-| isOpen    | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state |
-| fixed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant     |
-| ariaLabel | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav         |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value          | Description                                |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------- | :----------------------------------------- |
+| isOpen    | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state |
+| fixed     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant     |
+| ariaLabel | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav         |
 
 ### Slots
 
@@ -3028,13 +3028,13 @@ None.
 
 ### Props
 
-| Prop name  | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :--------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
-| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
-| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to select the current link              |
-| href       | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
-| text       | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
-| icon       | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name  | Required | Kind             | Reactive | Binding | Type                                                         | Default value          | Description                                           |
+| :--------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :--------------------- | :---------------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code>                   | <code>null</code>      | Obtain a reference to the HTML anchor element         |
+| isSelected | No       | <code>let</code> | No       | --      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to select the current link              |
+| href       | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code> | Specify the `href` attribute                          |
+| text       | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
+| icon       | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -3050,12 +3050,12 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                         | Default value          | Description                                           |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element         |
-| expanded  | No       | <code>let</code> | Yes      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to toggle the expanded state            |
-| text      | No       | <code>let</code> | No       | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
-| icon      | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                         | Default value          | Description                                           |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------------------------- | :--------------------- | :---------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>                   | <code>null</code>      | Obtain a reference to the HTML button element         |
+| expanded  | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                         | <code>false</code>     | Set to `true` to toggle the expanded state            |
+| text      | No       | <code>let</code> | No       | --      | <code>string</code>                                          | <code>undefined</code> | Specify the text                                      |
+| icon      | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code> | <code>undefined</code> | Specify the icon from `carbon-icons-svelte` to render |
 
 ### Slots
 
@@ -3073,12 +3073,12 @@ None.
 
 ### Props
 
-| Prop name  | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :--------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
-| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>undefined</code> | Set to `true` to select the item              |
-| href       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
-| text       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
+| Prop name  | Required | Kind             | Reactive | Binding | Type                                       | Default value          | Description                                   |
+| :--------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :--------------------- | :-------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| isSelected | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>undefined</code> | Set to `true` to select the item              |
+| href       | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text       | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
 
 ### Slots
 
@@ -3113,12 +3113,12 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value       | Description                                     |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------- | ----------------------------------------------- |
-| lines     | No       | <code>let</code> | No       | <code>number</code>  | <code>3</code>      | Specify the number of lines to render           |
-| heading   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the heading size variant   |
-| paragraph | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the paragraph size variant |
-| width     | No       | <code>let</code> | No       | <code>string</code>  | <code>"100%"</code> | Specify the width of the text (% or px)         |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value       | Description                                     |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :------------------ | :---------------------------------------------- |
+| lines     | No       | <code>let</code> | No       | --      | <code>number</code>  | <code>3</code>      | Specify the number of lines to render           |
+| heading   | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>  | Set to `true` to use the heading size variant   |
+| paragraph | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>  | Set to `true` to use the paragraph size variant |
+| width     | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"100%"</code> | Specify the width of the text (% or px)         |
 
 ### Slots
 
@@ -3137,10 +3137,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value                | Description                  |
-| :-------- | :------- | :--------------- | :------- | ------------------- | ---------------------------- | ---------------------------- |
-| href      | No       | <code>let</code> | No       | <code>string</code> | <code>"#main-content"</code> | Specify the `href` attribute |
-| tabindex  | No       | <code>let</code> | No       | <code>string</code> | <code>"0"</code>             | Specify the tabindex         |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value                | Description                  |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :--------------------------- | :--------------------------- |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"#main-content"</code> | Specify the `href` attribute |
+| tabindex  | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"0"</code>             | Specify the tabindex         |
 
 ### Slots
 
@@ -3158,25 +3158,25 @@ None.
 
 ### Props
 
-| Prop name      | Required | Kind             | Reactive | Type                                    | Default value                                      | Description                                |
-| :------------- | :------- | :--------------- | :------- | --------------------------------------- | -------------------------------------------------- | ------------------------------------------ |
-| ref            | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                  | Obtain a reference to the HTML element     |
-| value          | No       | <code>let</code> | Yes      | <code>number</code>                     | <code>0</code>                                     | Specify the value of the slider            |
-| max            | No       | <code>let</code> | No       | <code>number</code>                     | <code>100</code>                                   | Set the maximum slider value               |
-| maxLabel       | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                    | Specify the label for the max value        |
-| min            | No       | <code>let</code> | No       | <code>number</code>                     | <code>0</code>                                     | Set the minimum slider value               |
-| minLabel       | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                    | Specify the label for the min value        |
-| step           | No       | <code>let</code> | No       | <code>number</code>                     | <code>1</code>                                     | Set the step value                         |
-| stepMultiplier | No       | <code>let</code> | No       | <code>number</code>                     | <code>4</code>                                     | Set the step multiplier value              |
-| required       | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to require a value           |
-| inputType      | No       | <code>let</code> | No       | <code>string</code>                     | <code>"number"</code>                              | Specify the input type                     |
-| disabled       | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to disable the slider        |
-| light          | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to enable the light variant  |
-| hideTextInput  | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to hide the text input       |
-| id             | No       | <code>let</code> | No       | <code>string</code>                     | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the slider div element       |
-| invalid        | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to indicate an invalid state |
-| labelText      | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                    | Specify the label text                     |
-| name           | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                    | Set a name for the slider element          |
+| Prop name      | Required | Kind             | Reactive | Binding | Type                                    | Default value                                      | Description                                |
+| :------------- | :------- | :--------------- | :------- | :------ | :-------------------------------------- | :------------------------------------------------- | :----------------------------------------- |
+| ref            | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                  | Obtain a reference to the HTML element     |
+| value          | No       | <code>let</code> | Yes      | --      | <code>number</code>                     | <code>0</code>                                     | Specify the value of the slider            |
+| max            | No       | <code>let</code> | No       | --      | <code>number</code>                     | <code>100</code>                                   | Set the maximum slider value               |
+| maxLabel       | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>""</code>                                    | Specify the label for the max value        |
+| min            | No       | <code>let</code> | No       | --      | <code>number</code>                     | <code>0</code>                                     | Set the minimum slider value               |
+| minLabel       | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>""</code>                                    | Specify the label for the min value        |
+| step           | No       | <code>let</code> | No       | --      | <code>number</code>                     | <code>1</code>                                     | Set the step value                         |
+| stepMultiplier | No       | <code>let</code> | No       | --      | <code>number</code>                     | <code>4</code>                                     | Set the step multiplier value              |
+| required       | No       | <code>let</code> | No       | --      | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to require a value           |
+| inputType      | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>"number"</code>                              | Specify the input type                     |
+| disabled       | No       | <code>let</code> | No       | --      | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to disable the slider        |
+| light          | No       | <code>let</code> | No       | --      | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to enable the light variant  |
+| hideTextInput  | No       | <code>let</code> | No       | --      | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to hide the text input       |
+| id             | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the slider div element       |
+| invalid        | No       | <code>let</code> | No       | --      | <code>boolean</code>                    | <code>false</code>                                 | Set to `true` to indicate an invalid state |
+| labelText      | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>""</code>                                    | Specify the label text                     |
+| name           | No       | <code>let</code> | No       | --      | <code>string</code>                     | <code>""</code>                                    | Set a name for the slider element          |
 
 ### Slots
 
@@ -3196,9 +3196,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
-| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -3217,11 +3217,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                                    |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------- |
-| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
-| border    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the bordered variant      |
-| selection | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value          | Description                                    |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------- | :--------------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | --      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
+| border    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to use the bordered variant      |
+| selection | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
 
 ### Slots
 
@@ -3264,10 +3264,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                       |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------- |
-| head      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header  |
-| noWrap    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent wrapping |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                       |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------- |
+| head      | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header  |
+| noWrap    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to prevent wrapping |
 
 ### Slots
 
@@ -3309,14 +3309,14 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                  |
-| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | -------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element |
-| checked   | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to check the input             |
-| title     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                               | Specify the title of the input               |
-| value     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                               | Specify the value of the input               |
-| id        | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element              |
-| name      | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify a name attribute for the input       |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                  |
+| :-------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element |
+| checked   | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to check the input             |
+| title     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"title"</code>                               | Specify the title of the input               |
+| value     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"value"</code>                               | Specify the value of the input               |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element              |
+| name      | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify a name attribute for the input       |
 
 ### Slots
 
@@ -3330,11 +3330,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
-| head      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header     |
-| label     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a label slot |
-| tabindex  | No       | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>   | Specify the tabindex                 |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------------- |
+| head      | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header     |
+| label     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to render a label slot |
+| tabindex  | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"0"</code>   | Specify the tabindex                 |
 
 ### Slots
 
@@ -3356,10 +3356,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
-| rows      | No       | <code>let</code> | No       | <code>number</code>  | <code>5</code>     | Specify the number of rows                |
-| border    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the bordered variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------- |
+| rows      | No       | <code>let</code> | No       | --      | <code>number</code>  | <code>5</code>     | Specify the number of rows                |
+| border    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the bordered variant |
 
 ### Slots
 
@@ -3378,13 +3378,13 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                                                                                      |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                  | Obtain a reference to the button HTML element                                                                    |
-| selected  | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` for the switch to be selected                                                                      |
-| text      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Provide text"</code>                        | Specify the switch text<br />Alternatively, use the "text" slot (e.g., &lt;span slot="text"&gt;...&lt;/span&gt;) |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the switch                                                                              |
-| id        | No       | <code>let</code> | No       | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the button element                                                                                 |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                       | Default value                                      | Description                                                                                                      |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                  | Obtain a reference to the button HTML element                                                                    |
+| selected  | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` for the switch to be selected                                                                      |
+| text      | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Provide text"</code>                        | Specify the switch text<br />Alternatively, use the "text" slot (e.g., &lt;span slot="text"&gt;...&lt;/span&gt;) |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the switch                                                                              |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the button element                                                                                 |
 
 ### Slots
 
@@ -3406,14 +3406,14 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                                                                                                  |
-| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>                                  | Obtain a reference to the anchor HTML element                                                                                |
-| label     | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the tab label<br />Alternatively, use the default slot (e.g., &lt;Tab&gt;&lt;span&gt;Label&lt;/span&gt;&lt;/Tab&gt;) |
-| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"#"</code>                                   | Specify the href attribute                                                                                                   |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the tab                                                                                             |
-| tabindex  | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                   | Specify the tabindex                                                                                                         |
-| id        | No       | <code>let</code> | No       | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element                                                                                          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                       | Default value                                      | Description                                                                                                                  |
+| :-------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>                                  | Obtain a reference to the anchor HTML element                                                                                |
+| label     | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the tab label<br />Alternatively, use the default slot (e.g., &lt;Tab&gt;&lt;span&gt;Label&lt;/span&gt;&lt;/Tab&gt;) |
+| href      | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"#"</code>                                   | Specify the href attribute                                                                                                   |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the tab                                                                                             |
+| tabindex  | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"0"</code>                                   | Specify the tabindex                                                                                                         |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element                                                                                          |
 
 ### Slots
 
@@ -3434,9 +3434,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value                                      | Description                         |
-| :-------- | :------- | :--------------- | :------- | ------------------- | -------------------------------------------------- | ----------------------------------- |
-| id        | No       | <code>let</code> | No       | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value                                      | Description                         |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------------------------------------------- | :---------------------------------- |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element |
 
 ### Slots
 
@@ -3452,14 +3452,14 @@ None.
 
 ### Props
 
-| Prop name        | Required | Kind             | Reactive | Type                                                | Default value          | Description                             |
-| :--------------- | :------- | :--------------- | :------- | --------------------------------------------------- | ---------------------- | --------------------------------------- |
-| size             | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table               |
-| zebra            | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles       |
-| useStaticWidth   | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use static width       |
-| shouldShowBorder | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the bordered variant  |
-| sortable         | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant  |
-| stickyHeader     | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header |
+| Prop name        | Required | Kind             | Reactive | Binding | Type                                                | Default value          | Description                             |
+| :--------------- | :------- | :--------------- | :------- | :------ | :-------------------------------------------------- | :--------------------- | :-------------------------------------- |
+| size             | No       | <code>let</code> | No       | --      | <code>"compact" &#124; "short" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table               |
+| zebra            | No       | <code>let</code> | No       | --      | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use zebra styles       |
+| useStaticWidth   | No       | <code>let</code> | No       | --      | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use static width       |
+| shouldShowBorder | No       | <code>let</code> | No       | --      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the bordered variant  |
+| sortable         | No       | <code>let</code> | No       | --      | <code>boolean</code>                                | <code>false</code>     | Set to `true` for the sortable variant  |
+| stickyHeader     | No       | <code>let</code> | No       | --      | <code>boolean</code>                                | <code>false</code>     | Set to `true` to enable a sticky header |
 
 ### Slots
 
@@ -3512,11 +3512,11 @@ None.
 
 ### Props
 
-| Prop name    | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :----------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
-| title        | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the title of the data table       |
-| description  | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the description of the data table |
-| stickyHeader | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable a sticky header   |
+| Prop name    | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                               |
+| :----------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------- |
+| title        | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>    | Specify the title of the data table       |
+| description  | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>    | Specify the description of the data table |
+| stickyHeader | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to enable a sticky header   |
 
 ### Slots
 
@@ -3553,11 +3553,11 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                      | Default value                                      | Description                          |
-| :-------------- | :------- | :--------------- | :------- | ------------------------- | -------------------------------------------------- | ------------------------------------ |
-| scope           | No       | <code>let</code> | No       | <code>string</code>       | <code>"col"</code>                                 | Specify the `scope` attribute        |
-| translateWithId | No       | <code>let</code> | No       | <code>() => string</code> | --                                                 | Override the default id translations |
-| id              | No       | <code>let</code> | No       | <code>string</code>       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element  |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                      | Default value                                      | Description                          |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------------ | :------------------------------------------------- | :----------------------------------- |
+| scope           | No       | <code>let</code> | No       | --      | <code>string</code>       | <code>"col"</code>                                 | Specify the `scope` attribute        |
+| translateWithId | No       | <code>let</code> | No       | --      | <code>() => string</code> | --                                                 | Override the default id translations |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element  |
 
 ### Slots
 
@@ -3599,12 +3599,12 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                    | Description                                 |
-| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------- | ------------------------------------------- |
-| selected        | No       | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>                   | Specify the selected tab index              |
-| type            | No       | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code>           | Specify the type of tabs                    |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Show menu options"</code> | Specify the ARIA label for the chevron icon |
-| triggerHref     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"#"</code>                 | Specify the tab trigger href attribute      |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                      | Default value                    | Description                                 |
+| :-------------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------- | :------------------------------------------ |
+| selected        | No       | <code>let</code> | Yes      | --      | <code>number</code>                       | <code>0</code>                   | Specify the selected tab index              |
+| type            | No       | <code>let</code> | No       | --      | <code>"default" &#124; "container"</code> | <code>"default"</code>           | Specify the type of tabs                    |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"Show menu options"</code> | Specify the ARIA label for the chevron icon |
+| triggerHref     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"#"</code>                 | Specify the tab trigger href attribute      |
 
 ### Slots
 
@@ -3625,9 +3625,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value  | Description                          |
-| :-------- | :------- | :--------------- | :------- | ------------------- | -------------- | ------------------------------------ |
-| count     | No       | <code>let</code> | No       | <code>number</code> | <code>4</code> | Specify the number of tabs to render |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value  | Description                          |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------- | :----------------------------------- |
+| count     | No       | <code>let</code> | No       | --      | <code>number</code> | <code>4</code> | Specify the number of tabs to render |
 
 ### Slots
 
@@ -3646,15 +3646,15 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                                                                                                                                                    | Default value                                      | Description                                            |
-| :-------- | :------- | :--------------- | :------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------ |
-| type      | No       | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast"</code> | <code>undefined</code>                             | Specify the type of tag                                |
-| filter    | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                                 | Set to `true` to use filterable variant                |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                                 | Set to `true` to disable a filterable tag              |
-| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                                 | Set to `true` to display the skeleton state            |
-| title     | No       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>"Clear filter"</code>                        | Set the title for the close button in a filterable tag |
-| icon      | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                                                                            | <code>undefined</code>                             | Specify the icon from `carbon-icons-svelte` to render  |
-| id        | No       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                     | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the filterable tag                       |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                                                                                                                                                    | Default value                                      | Description                                            |
+| :-------- | :------- | :--------------- | :------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------------- |
+| type      | No       | <code>let</code> | No       | --      | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast"</code> | <code>undefined</code>                             | Specify the type of tag                                |
+| filter    | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                                 | Set to `true` to use filterable variant                |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                                 | Set to `true` to disable a filterable tag              |
+| skeleton  | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                                                                                                    | <code>false</code>                                 | Set to `true` to display the skeleton state            |
+| title     | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                                                                                                     | <code>"Clear filter"</code>                        | Set the title for the close button in a filterable tag |
+| icon      | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>                                                                                                                            | <code>undefined</code>                             | Specify the icon from `carbon-icons-svelte` to render  |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                                                                                                     | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the filterable tag                       |
 
 ### Slots
 
@@ -3695,22 +3695,22 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                         | Default value                                      | Description                                     |
-| :---------- | :------- | :--------------- | :------- | -------------------------------------------- | -------------------------------------------------- | ----------------------------------------------- |
-| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                  | Obtain a reference to the textarea HTML element |
-| value       | No       | <code>let</code> | Yes      | <code>string</code>                          | <code>""</code>                                    | Specify the textarea value                      |
-| placeholder | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                    | Specify the placeholder text                    |
-| cols        | No       | <code>let</code> | No       | <code>number</code>                          | <code>50</code>                                    | Specify the number of cols                      |
-| rows        | No       | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                     | Specify the number of rows                      |
-| light       | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to enable the light variant       |
-| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to disable the input              |
-| helperText  | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                    | Specify the helper text                         |
-| labelText   | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                    | Specify the label text                          |
-| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to visually hide the label text   |
-| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to indicate an invalid state      |
-| invalidText | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                    | Specify the text for the invalid state          |
-| id          | No       | <code>let</code> | No       | <code>string</code>                          | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the textarea element              |
-| name        | No       | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                             | Specify a name attribute for the input          |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                         | Default value                                      | Description                                     |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------------------------------- | :------------------------------------------------- | :---------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                  | Obtain a reference to the textarea HTML element |
+| value       | No       | <code>let</code> | Yes      | --      | <code>string</code>                          | <code>""</code>                                    | Specify the textarea value                      |
+| placeholder | No       | <code>let</code> | No       | --      | <code>string</code>                          | <code>""</code>                                    | Specify the placeholder text                    |
+| cols        | No       | <code>let</code> | No       | --      | <code>number</code>                          | <code>50</code>                                    | Specify the number of cols                      |
+| rows        | No       | <code>let</code> | No       | --      | <code>number</code>                          | <code>4</code>                                     | Specify the number of rows                      |
+| light       | No       | <code>let</code> | No       | --      | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to enable the light variant       |
+| disabled    | No       | <code>let</code> | No       | --      | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to disable the input              |
+| helperText  | No       | <code>let</code> | No       | --      | <code>string</code>                          | <code>""</code>                                    | Specify the helper text                         |
+| labelText   | No       | <code>let</code> | No       | --      | <code>string</code>                          | <code>""</code>                                    | Specify the label text                          |
+| hideLabel   | No       | <code>let</code> | No       | --      | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to visually hide the label text   |
+| invalid     | No       | <code>let</code> | No       | --      | <code>boolean</code>                         | <code>false</code>                                 | Set to `true` to indicate an invalid state      |
+| invalidText | No       | <code>let</code> | No       | --      | <code>string</code>                          | <code>""</code>                                    | Specify the text for the invalid state          |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>                          | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the textarea element              |
+| name        | No       | <code>let</code> | No       | --      | <code>string</code>                          | <code>undefined</code>                             | Specify a name attribute for the input          |
 
 ### Slots
 
@@ -3733,9 +3733,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
-| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                                   |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
 
 ### Slots
 
@@ -3754,26 +3754,26 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                      | Default value                                      | Description                                   |
-| :---------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------------------------- | --------------------------------------------- |
-| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element  |
-| value       | No       | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>                                    | Specify the input value                       |
-| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                             | Set the size of the input                     |
-| type        | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the input type                        |
-| placeholder | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the placeholder text                  |
-| light       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable the light variant     |
-| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the input            |
-| helperText  | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the helper text                       |
-| id          | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element               |
-| name        | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                             | Specify a name attribute for the input        |
-| labelText   | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the label text                        |
-| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text |
-| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to indicate an invalid state    |
-| invalidText | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the invalid state text                |
-| warn        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to indicate an warning state    |
-| warnText    | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                    | Specify the warning state text                |
-| required    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to mark the field as required   |
-| inline      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to use inline version           |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                      | Default value                                      | Description                                   |
+| :---------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :------------------------------------------------- | :-------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                  | Obtain a reference to the input HTML element  |
+| value       | No       | <code>let</code> | Yes      | --      | <code>number &#124; string</code>         | <code>""</code>                                    | Specify the input value                       |
+| size        | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                             | Set the size of the input                     |
+| type        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the input type                        |
+| placeholder | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the placeholder text                  |
+| light       | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to enable the light variant     |
+| disabled    | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to disable the input            |
+| helperText  | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the helper text                       |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element               |
+| name        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                             | Specify a name attribute for the input        |
+| labelText   | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the label text                        |
+| hideLabel   | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to visually hide the label text |
+| invalid     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to indicate an invalid state    |
+| invalidText | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the invalid state text                |
+| warn        | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to indicate an warning state    |
+| warnText    | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                    | Specify the warning state text                |
+| required    | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to mark the field as required   |
+| inline      | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                 | Set to `true` to use inline version           |
 
 ### Slots
 
@@ -3797,9 +3797,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
-| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -3818,9 +3818,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
-| light     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :---------------------------------------- |
+| light     | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
 
 ### Slots
 
@@ -3841,11 +3841,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                             |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | --------------------------------------- |
-| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
-| legend    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value          | Description                             |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :--------------------- | :-------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | --      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
+| legend    | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
 
 ### Slots
 
@@ -3863,23 +3863,23 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                      | Default value                                       | Description                                           |
-| :---------- | :------- | :--------------- | :------- | ----------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
-| value       | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
-| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
-| type        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
-| placeholder | No       | <code>let</code> | No       | <code>string</code>                       | <code>"hh=mm"</code>                                | Specify the input placeholder text                    |
-| pattern     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
-| maxlength   | No       | <code>let</code> | No       | <code>number</code>                       | <code>5</code>                                      | Specify the `maxlength` input attribute               |
-| light       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to enable the light variant             |
-| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to disable the input                    |
-| labelText   | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the label text                                |
-| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to visually hide the label text         |
-| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
-| invalidText | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
-| id          | No       | <code>let</code> | No       | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code>  | Set an id for the input element                       |
-| name        | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                      | Default value                                       | Description                                           |
+| :---------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :-------------------------------------------------- | :---------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
+| value       | No       | <code>let</code> | Yes      | --      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
+| size        | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
+| type        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
+| placeholder | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"hh=mm"</code>                                | Specify the input placeholder text                    |
+| pattern     | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
+| maxlength   | No       | <code>let</code> | No       | --      | <code>number</code>                       | <code>5</code>                                      | Specify the `maxlength` input attribute               |
+| light       | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to enable the light variant             |
+| disabled    | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to disable the input                    |
+| labelText   | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                     | Specify the label text                                |
+| hideLabel   | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to visually hide the label text         |
+| invalid     | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
+| invalidText | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>\`ccs-${Math.random().toString(36)}\`</code>  | Set an id for the input element                       |
+| name        | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -3904,16 +3904,16 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                                                                                                                                                                   |
-| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                  | Obtain a reference to the select HTML element                                                                                                                                                 |
-| value           | No       | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                    | Specify the select value                                                                                                                                                                      |
-| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the select                                                                                                                                                           |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>                | Specify the ARIA label for the chevron icon                                                                                                                                                   |
-| labelText       | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                    | Specify the label text                                                                                                                                                                        |
-| hideLabel       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>true</code>                                  | @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.<br />Set to `false` to show the label text |
-| id              | No       | <code>let</code> | No       | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the select element                                                                                                                                                              |
-| name            | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                             | Specify a name attribute for the select element                                                                                                                                               |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                       | Default value                                      | Description                                                                                                                                                                                   |
+| :-------------- | :------- | :--------------- | :------- | :------ | :----------------------------------------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                  | Obtain a reference to the select HTML element                                                                                                                                                 |
+| value           | No       | <code>let</code> | Yes      | --      | <code>number &#124; string</code>          | <code>""</code>                                    | Specify the select value                                                                                                                                                                      |
+| disabled        | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>false</code>                                 | Set to `true` to disable the select                                                                                                                                                           |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>"Open list of options"</code>                | Specify the ARIA label for the chevron icon                                                                                                                                                   |
+| labelText       | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>""</code>                                    | Specify the label text                                                                                                                                                                        |
+| hideLabel       | No       | <code>let</code> | No       | --      | <code>boolean</code>                       | <code>true</code>                                  | @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.<br />Set to `false` to show the label text |
+| id              | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the select element                                                                                                                                                              |
+| name            | No       | <code>let</code> | No       | --      | <code>string</code>                        | <code>undefined</code>                             | Specify a name attribute for the select element                                                                                                                                               |
 
 ### Slots
 
@@ -3934,17 +3934,17 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
-| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| kind            | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
-| lowContrast     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
-| timeout         | No       | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
-| role            | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
-| title           | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
-| subtitle        | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
-| caption         | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Caption"</code>             | Specify the caption text                                                |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
-| hideCloseButton | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                                                                                           | Default value                      | Description                                                             |
+| :-------------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------------------- | :--------------------------------- | :---------------------------------------------------------------------- |
+| kind            | No       | <code>let</code> | No       | --      | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
+| lowContrast     | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
+| timeout         | No       | <code>let</code> | No       | --      | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
+| role            | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
+| title           | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"Title"</code>               | Specify the title text                                                  |
+| subtitle        | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
+| caption         | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"Caption"</code>             | Specify the caption text                                                |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
+| hideCloseButton | No       | <code>let</code> | No       | --      | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
 
 ### Slots
 
@@ -3966,16 +3966,16 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                               | Default value                                      | Description                                     |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------- | -------------------------------------------------- | ----------------------------------------------- |
-| toggled   | No       | <code>let</code> | Yes      | <code>boolean</code>               | <code>false</code>                                 | Set to `true` to toggle the checkbox input      |
-| size      | No       | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                             | Specify the toggle size                         |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                                 | Set to `true` to disable checkbox input         |
-| labelA    | No       | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                                 | Specify the label for the untoggled state       |
-| labelB    | No       | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                  | Specify the label for the toggled state         |
-| labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                    | Specify the label text                          |
-| id        | No       | <code>let</code> | No       | <code>string</code>                | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                 |
-| name      | No       | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                             | Specify a name attribute for the checkbox input |
+| Prop name | Required | Kind             | Reactive | Binding | Type                               | Default value                                      | Description                                     |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------- | :------------------------------------------------- | :---------------------------------------------- |
+| toggled   | No       | <code>let</code> | Yes      | --      | <code>boolean</code>               | <code>false</code>                                 | Set to `true` to toggle the checkbox input      |
+| size      | No       | <code>let</code> | No       | --      | <code>"default" &#124; "sm"</code> | <code>"default"</code>                             | Specify the toggle size                         |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code>               | <code>false</code>                                 | Set to `true` to disable checkbox input         |
+| labelA    | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>"Off"</code>                                 | Specify the label for the untoggled state       |
+| labelB    | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>"On"</code>                                  | Specify the label for the toggled state         |
+| labelText | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>""</code>                                    | Specify the label text                          |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                 |
+| name      | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>undefined</code>                             | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -3999,11 +3999,11 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                               | Default value                                      | Description                     |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------- | -------------------------------------------------- | ------------------------------- |
-| size      | No       | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                             | Specify the toggle size         |
-| labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                    | Specify the label text          |
-| id        | No       | <code>let</code> | No       | <code>string</code>                | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                               | Default value                                      | Description                     |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------- | :------------------------------------------------- | :------------------------------ |
+| size      | No       | <code>let</code> | No       | --      | <code>"default" &#124; "sm"</code> | <code>"default"</code>                             | Specify the toggle size         |
+| labelText | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>""</code>                                    | Specify the label text          |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>                | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element |
 
 ### Slots
 
@@ -4022,15 +4022,15 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value                                      | Description                                     |
-| :-------- | :------- | :--------------- | :------- | -------------------- | -------------------------------------------------- | ----------------------------------------------- |
-| toggled   | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to toggle the checkbox input      |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                                 | Set to `true` to disable checkbox input         |
-| labelA    | No       | <code>let</code> | No       | <code>string</code>  | <code>"Off"</code>                                 | Specify the label for the untoggled state       |
-| labelB    | No       | <code>let</code> | No       | <code>string</code>  | <code>"On"</code>                                  | Specify the label for the toggled state         |
-| labelText | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                    | Specify the label text                          |
-| id        | No       | <code>let</code> | No       | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                 |
-| name      | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code>                             | Specify a name attribute for the checkbox input |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value                                      | Description                                     |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :------------------------------------------------- | :---------------------------------------------- |
+| toggled   | No       | <code>let</code> | Yes      | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to toggle the checkbox input      |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>                                 | Set to `true` to disable checkbox input         |
+| labelA    | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"Off"</code>                                 | Specify the label for the untoggled state       |
+| labelB    | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"On"</code>                                  | Specify the label for the toggled state         |
+| labelText | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>""</code>                                    | Specify the label text                          |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element                 |
+| name      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>undefined</code>                             | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -4053,10 +4053,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value                                      | Description                     |
-| :-------- | :------- | :--------------- | :------- | ------------------- | -------------------------------------------------- | ------------------------------- |
-| labelText | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>                                    | Specify the label text          |
-| id        | No       | <code>let</code> | No       | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value                                      | Description                     |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------------------------------------------- | :------------------------------ |
+| labelText | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code>                                    | Specify the label text          |
+| id        | No       | <code>let</code> | No       | --      | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element |
 
 ### Slots
 
@@ -4075,9 +4075,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                               | Default value          | Description              |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ---------------------- | ------------------------ |
-| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | Specify the toolbar size |
+| Prop name | Required | Kind             | Reactive | Binding | Type                               | Default value          | Description              |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------- | :--------------------- | :----------------------- |
+| size      | No       | <code>let</code> | No       | --      | <code>"sm" &#124; "default"</code> | <code>"default"</code> | Specify the toolbar size |
 
 ### Slots
 
@@ -4093,9 +4093,9 @@ None.
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                                           | Default value | Description                            |
-| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | ------------- | -------------------------------------- |
-| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | --            | Override the total items selected text |
+| Prop name           | Required | Kind             | Reactive | Binding | Type                                           | Default value | Description                            |
+| :------------------ | :------- | :--------------- | :------- | :------ | :--------------------------------------------- | :------------ | :------------------------------------- |
+| formatTotalSelected | No       | <code>let</code> | No       | --      | <code>(totalSelected: number) => string</code> | --            | Override the total items selected text |
 
 ### Slots
 
@@ -4162,13 +4162,13 @@ None.
 
 ### Props
 
-| Prop name  | Required | Kind             | Reactive | Type                                      | Default value      | Description                                   |
-| :--------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | --------------------------------------------- |
-| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element  |
-| expanded   | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to expand the search bar        |
-| value      | No       | <code>let</code> | Yes      | <code>number &#124; string</code>         | <code>""</code>    | Specify the value of the search input         |
-| persistent | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code> | Set to `true` to keep the search bar expanded |
-| tabindex   | No       | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>   | Specify the tabindex                          |
+| Prop name  | Required | Kind             | Reactive | Binding | Type                                      | Default value      | Description                                   |
+| :--------- | :------- | :--------------- | :------- | :------ | :---------------------------------------- | :----------------- | :-------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element  |
+| expanded   | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                      | <code>false</code> | Set to `true` to expand the search bar        |
+| value      | No       | <code>let</code> | Yes      | --      | <code>number &#124; string</code>         | <code>""</code>    | Specify the value of the search input         |
+| persistent | No       | <code>let</code> | No       | --      | <code>boolean</code>                      | <code>false</code> | Set to `true` to keep the search bar expanded |
+| tabindex   | No       | <code>let</code> | No       | --      | <code>string</code>                       | <code>"0"</code>   | Specify the tabindex                          |
 
 ### Slots
 
@@ -4187,22 +4187,22 @@ None.
 
 ### Props
 
-| Prop name       | Required | Kind             | Reactive | Type                                                            | Default value                                      | Description                                                                                                                        |
-| :-------------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| refIcon         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                  | Obtain a reference to the icon HTML element                                                                                        |
-| refTooltip      | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                  | Obtain a reference to the tooltip HTML element                                                                                     |
-| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                  | Obtain a reference to the trigger text HTML element                                                                                |
-| open            | No       | <code>let</code> | Yes      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to open the tooltip                                                                                                  |
-| align           | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon                                                                              |
-| direction       | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                              | Set the direction of the tooltip relative to the button                                                                            |
-| hideIcon        | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to hide the tooltip icon                                                                                             |
-| icon            | No       | <code>let</code> | No       | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>    | <code>Information16</code>                         | Specify the icon from `carbon-icons-svelte` to render for the tooltip button<br />Icon size must be 16px (e.g., `Add16`, `Task16`) |
-| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the ARIA label for the tooltip button                                                                                      |
-| iconName        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the icon name attribute                                                                                                    |
-| tabindex        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"0"</code>                                   | Set the button tabindex                                                                                                            |
-| tooltipId       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the tooltip                                                                                                          |
-| triggerId       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the tooltip button                                                                                                   |
-| triggerText     | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Set the tooltip button text                                                                                                        |
+| Prop name       | Required | Kind             | Reactive | Binding | Type                                                            | Default value                                      | Description                                                                                                                        |
+| :-------------- | :------- | :--------------- | :------- | :------ | :-------------------------------------------------------------- | :------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| refIcon         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                  | Obtain a reference to the icon HTML element                                                                                        |
+| refTooltip      | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                  | Obtain a reference to the tooltip HTML element                                                                                     |
+| ref             | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                  | Obtain a reference to the trigger text HTML element                                                                                |
+| open            | No       | <code>let</code> | Yes      | --      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to open the tooltip                                                                                                  |
+| align           | No       | <code>let</code> | No       | --      | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon                                                                              |
+| direction       | No       | <code>let</code> | No       | --      | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                              | Set the direction of the tooltip relative to the button                                                                            |
+| hideIcon        | No       | <code>let</code> | No       | --      | <code>boolean</code>                                            | <code>false</code>                                 | Set to `true` to hide the tooltip icon                                                                                             |
+| icon            | No       | <code>let</code> | No       | --      | <code>typeof import("carbon-icons-svelte").CarbonIcon</code>    | <code>Information16</code>                         | Specify the icon from `carbon-icons-svelte` to render for the tooltip button<br />Icon size must be 16px (e.g., `Add16`, `Task16`) |
+| iconDescription | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the ARIA label for the tooltip button                                                                                      |
+| iconName        | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the icon name attribute                                                                                                    |
+| tabindex        | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>"0"</code>                                   | Set the button tabindex                                                                                                            |
+| tooltipId       | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the tooltip                                                                                                          |
+| triggerId       | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the tooltip button                                                                                                   |
+| triggerText     | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Set the tooltip button text                                                                                                        |
 
 ### Slots
 
@@ -4223,13 +4223,13 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                              | Default value                                      | Description                                           |
-| :---------- | :------- | :--------------- | :------- | ------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------- |
-| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                  | Obtain a reference to the button HTML element         |
-| tooltipText | No       | <code>let</code> | No       | <code>string</code>                               | <code>""</code>                                    | Specify the tooltip text                              |
-| align       | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon |
-| direction   | No       | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                              | Set the direction of the tooltip relative to the icon |
-| id          | No       | <code>let</code> | No       | <code>string</code>                               | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the tooltip div element                 |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                              | Default value                                      | Description                                           |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------------------------------------ | :------------------------------------------------- | :---------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                  | Obtain a reference to the button HTML element         |
+| tooltipText | No       | <code>let</code> | No       | --      | <code>string</code>                               | <code>""</code>                                    | Specify the tooltip text                              |
+| align       | No       | <code>let</code> | No       | --      | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon |
+| direction   | No       | <code>let</code> | No       | --      | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                              | Set the direction of the tooltip relative to the icon |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>                               | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the tooltip div element                 |
 
 ### Slots
 
@@ -4252,13 +4252,13 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                                                            | Default value                                      | Description                                                       |
-| :---------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------- |
-| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                      | <code>null</code>                                  | Obtain a reference to the button HTML element                     |
-| tooltipText | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                    | Specify the tooltip text.<br />Alternatively, use the "text" slot |
-| align       | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon             |
-| direction   | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                              | Set the direction of the tooltip relative to the icon             |
-| id          | No       | <code>let</code> | No       | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the span element                                    |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                                                            | Default value                                      | Description                                                       |
+| :---------- | :------- | :--------------- | :------- | :------ | :-------------------------------------------------------------- | :------------------------------------------------- | :---------------------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | --      | <code>null &#124; HTMLButtonElement</code>                      | <code>null</code>                                  | Obtain a reference to the button HTML element                     |
+| tooltipText | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>""</code>                                    | Specify the tooltip text.<br />Alternatively, use the "text" slot |
+| align       | No       | <code>let</code> | No       | --      | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                              | Set the alignment of the tooltip relative to the icon             |
+| direction   | No       | <code>let</code> | No       | --      | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                              | Set the direction of the tooltip relative to the icon             |
+| id          | No       | <code>let</code> | No       | --      | <code>string</code>                                             | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the span element                                    |
 
 ### Slots
 
@@ -4281,9 +4281,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
-| nested    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :-------------------------------------- |
+| nested    | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant |
 
 ### Slots
 

--- a/tests/e2e/glob/COMPONENT_INDEX.md
+++ b/tests/e2e/glob/COMPONENT_INDEX.md
@@ -12,10 +12,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value         | Description |
-| :-------- | :------- | :--------------- | :------- | -------------------- | --------------------- | ----------- |
-| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
-| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value         | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :-------------------- | :---------- |
+| type      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"button"</code> | --          |
+| primary   | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>    | --          |
 
 ### Slots
 

--- a/tests/e2e/multi-export-typed/COMPONENT_INDEX.md
+++ b/tests/e2e/multi-export-typed/COMPONENT_INDEX.md
@@ -15,10 +15,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                 | Default value         | Description                              |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | --------------------- | ---------------------------------------- |
-| type      | No       | <code>let</code> | No       | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
-| primary   | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                 | Default value         | Description                              |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------- | :-------------------- | :--------------------------------------- |
+| type      | No       | <code>let</code> | No       | --      | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
+| primary   | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
 
 ### Slots
 
@@ -54,10 +54,10 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description |
-| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------- |
-| quote     | No       | <code>let</code> | No       | <code>string</code> | <code>""</code> | --          |
-| author    | No       | <code>let</code> | No       | <code>string</code> | <code>""</code> | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value   | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :-------------- | :---------- |
+| quote     | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code> | --          |
+| author    | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code> | --          |
 
 ### Slots
 
@@ -73,9 +73,9 @@ None.
 
 ### Props
 
-| Prop name | Required | Kind               | Reactive | Type                 | Default value     | Description |
-| :-------- | :------- | :----------------- | :------- | -------------------- | ----------------- | ----------- |
-| secondary | No       | <code>const</code> | No       | <code>boolean</code> | <code>true</code> | --          |
+| Prop name | Required | Kind               | Reactive | Binding | Type                 | Default value     | Description |
+| :-------- | :------- | :----------------- | :------- | :------ | :------------------- | :---------------- | :---------- |
+| secondary | No       | <code>const</code> | No       | --      | <code>boolean</code> | <code>true</code> | --          |
 
 ### Slots
 

--- a/tests/e2e/multi-export/COMPONENT_INDEX.md
+++ b/tests/e2e/multi-export/COMPONENT_INDEX.md
@@ -15,11 +15,11 @@
 
 ### Props
 
-| Prop name | Required | Kind                  | Reactive | Type                   | Default value         | Description |
-| :-------- | :------- | :-------------------- | :------- | ---------------------- | --------------------- | ----------- |
-| type      | No       | <code>let</code>      | No       | <code>string</code>    | <code>"button"</code> | --          |
-| primary   | No       | <code>let</code>      | No       | <code>boolean</code>   | <code>false</code>    | --          |
-| print     | No       | <code>function</code> | No       | <code>() => any</code> | --                    | --          |
+| Prop name | Required | Kind                  | Reactive | Binding | Type                   | Default value         | Description |
+| :-------- | :------- | :-------------------- | :------- | :------ | :--------------------- | :-------------------- | :---------- |
+| type      | No       | <code>let</code>      | No       | --      | <code>string</code>    | <code>"button"</code> | --          |
+| primary   | No       | <code>let</code>      | No       | --      | <code>boolean</code>   | <code>false</code>    | --          |
+| print     | No       | <code>function</code> | No       | --      | <code>() => any</code> | --                    | --          |
 
 ### Slots
 
@@ -77,10 +77,10 @@ export type Author = string;
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description |
-| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------- |
-| quote     | No       | <code>let</code> | No       | <code>any</code>    | <code>""</code> | --          |
-| author    | No       | <code>let</code> | No       | <code>Author</code> | <code>""</code> | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value   | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :-------------- | :---------- |
+| quote     | No       | <code>let</code> | No       | --      | <code>any</code>    | <code>""</code> | --          |
+| author    | No       | <code>let</code> | No       | --      | <code>Author</code> | <code>""</code> | --          |
 
 ### Slots
 

--- a/tests/e2e/multi-folders/COMPONENT_INDEX.md
+++ b/tests/e2e/multi-folders/COMPONENT_INDEX.md
@@ -16,10 +16,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                 | Default value         | Description                              |
-| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | --------------------- | ---------------------------------------- |
-| type      | No       | <code>let</code> | No       | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
-| primary   | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                                                 | Default value         | Description                              |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------------------------- | :-------------------- | :--------------------------------------- |
+| type      | No       | <code>let</code> | No       | --      | <code>"button" &#124; "submit" &#124; "reset"</code> | <code>"button"</code> | --                                       |
+| primary   | No       | <code>let</code> | No       | --      | <code>boolean</code>                                 | <code>false</code>    | Set to `true` to use the primary variant |
 
 ### Slots
 
@@ -93,10 +93,10 @@ export type Author = string;
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value   | Description |
-| :-------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------- |
-| quote     | No       | <code>let</code> | No       | <code>any</code>    | <code>""</code> | --          |
-| author    | No       | <code>let</code> | No       | <code>Author</code> | <code>""</code> | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value   | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :-------------- | :---------- |
+| quote     | No       | <code>let</code> | No       | --      | <code>any</code>    | <code>""</code> | --          |
+| author    | No       | <code>let</code> | No       | --      | <code>Author</code> | <code>""</code> | --          |
 
 ### Slots
 

--- a/tests/e2e/path-aliases/COMPONENT_INDEX.md
+++ b/tests/e2e/path-aliases/COMPONENT_INDEX.md
@@ -13,10 +13,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value           | Description |
-| :-------- | :------- | :--------------- | :------- | ------------------- | ----------------------- | ----------- |
-| text      | No       | <code>let</code> | No       | <code>string</code> | <code>"Click me"</code> | Button text |
-| size      | No       | <code>let</code> | No       | <code>string</code> | <code>"medium"</code>   | Button size |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value           | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :---------------------- | :---------- |
+| text      | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"Click me"</code> | Button text |
+| size      | No       | <code>let</code> | No       | --      | <code>string</code> | <code>"medium"</code>   | Button size |
 
 ### Slots
 
@@ -30,10 +30,10 @@ None.
 
 ### Props
 
-| Prop name   | Required | Kind             | Reactive | Type                | Default value   | Description       |
-| :---------- | :------- | :--------------- | :------- | ------------------- | --------------- | ----------------- |
-| value       | No       | <code>let</code> | Yes      | <code>string</code> | <code>""</code> | Input value       |
-| placeholder | No       | <code>let</code> | No       | <code>string</code> | <code>""</code> | Input placeholder |
+| Prop name   | Required | Kind             | Reactive | Binding | Type                | Default value   | Description       |
+| :---------- | :------- | :--------------- | :------- | :------ | :------------------ | :-------------- | :---------------- |
+| value       | No       | <code>let</code> | Yes      | --      | <code>string</code> | <code>""</code> | Input value       |
+| placeholder | No       | <code>let</code> | No       | --      | <code>string</code> | <code>""</code> | Input placeholder |
 
 ### Slots
 

--- a/tests/e2e/single-export-default-only/COMPONENT_INDEX.md
+++ b/tests/e2e/single-export-default-only/COMPONENT_INDEX.md
@@ -12,10 +12,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value         | Description |
-| :-------- | :------- | :--------------- | :------- | -------------------- | --------------------- | ----------- |
-| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
-| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value         | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :-------------------- | :---------- |
+| type      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"button"</code> | --          |
+| primary   | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>    | --          |
 
 ### Slots
 

--- a/tests/e2e/single-export/COMPONENT_INDEX.md
+++ b/tests/e2e/single-export/COMPONENT_INDEX.md
@@ -12,10 +12,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value         | Description |
-| :-------- | :------- | :--------------- | :------- | -------------------- | --------------------- | ----------- |
-| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | --          |
-| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value         | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :-------------------- | :---------- |
+| type      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"button"</code> | --          |
+| primary   | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>    | --          |
 
 ### Slots
 

--- a/tests/e2e/svelte5-legacy/COMPONENT_INDEX.md
+++ b/tests/e2e/svelte5-legacy/COMPONENT_INDEX.md
@@ -10,10 +10,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                    |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------ |
-| label     | Yes      | <code>let</code> | No       | --                   | --                 | Label text                     |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Whether the button is disabled |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value      | Description                    |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :----------------- | :----------------------------- |
+| label     | Yes      | <code>let</code> | No       | --      | --                   | --                 | Label text                     |
+| disabled  | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code> | Whether the button is disabled |
 
 ### Slots
 

--- a/tests/e2e/svelte5-runes/COMPONENT_INDEX.md
+++ b/tests/e2e/svelte5-runes/COMPONENT_INDEX.md
@@ -10,12 +10,12 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                | Default value        | Description |
-| :-------- | :------- | :--------------- | :------- | ------------------- | -------------------- | ----------- |
-| value     | No       | <code>let</code> | Yes      | <code>string</code> | <code>"ready"</code> | --          |
-| label     | Yes      | <code>let</code> | No       | --                  | --                   | --          |
-| onclick   | Yes      | <code>let</code> | No       | --                  | --                   | --          |
-| onpress   | Yes      | <code>let</code> | No       | --                  | --                   | --          |
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value        | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------------- | :---------- |
+| value     | No       | <code>let</code> | Yes      | --      | <code>string</code> | <code>"ready"</code> | --          |
+| label     | Yes      | <code>let</code> | No       | --      | --                  | --                   | --          |
+| onclick   | Yes      | <code>let</code> | No       | --      | --                  | --                   | --          |
+| onpress   | Yes      | <code>let</code> | No       | --      | --                  | --                   | --          |
 
 ### Slots
 

--- a/tests/e2e/sveltekit/COMPONENT_INDEX.md
+++ b/tests/e2e/sveltekit/COMPONENT_INDEX.md
@@ -10,10 +10,10 @@
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value         | Description                              |
-| :-------- | :------- | :--------------- | :------- | -------------------- | --------------------- | ---------------------------------------- |
-| type      | No       | <code>let</code> | No       | <code>string</code>  | <code>"button"</code> | Button type attribute                    |
-| primary   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>    | Set to `true` to use the primary variant |
+| Prop name | Required | Kind             | Reactive | Binding | Type                 | Default value         | Description                              |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------- | :-------------------- | :--------------------------------------- |
+| type      | No       | <code>let</code> | No       | --      | <code>string</code>  | <code>"button"</code> | Button type attribute                    |
+| primary   | No       | <code>let</code> | No       | --      | <code>boolean</code> | <code>false</code>    | Set to `true` to use the primary variant |
 
 ### Slots
 

--- a/tests/fixtures/bindable-direction-legacy/input.svelte
+++ b/tests/fixtures/bindable-direction-legacy/input.svelte
@@ -1,0 +1,23 @@
+<script>
+  /**
+   * Bind to the current value emitted by the component.
+   * @bindable readonly
+   */
+  export let size = undefined;
+
+  /**
+   * Bind to state controlled by either the consumer or component.
+   * @bindable writable
+   */
+  export let open = false;
+
+  /** Regular unannotated prop. */
+  export let label = "Toggle";
+
+  function toggle() {
+    open = !open;
+  }
+</script>
+
+<button on:click={toggle}>{label}</button>
+<span>{size}</span>

--- a/tests/fixtures/bindable-direction-legacy/output.d.ts
+++ b/tests/fixtures/bindable-direction-legacy/output.d.ts
@@ -1,0 +1,27 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type BindableDirectionLegacyProps = {
+  /**
+   * Bind to the current value emitted by the component.
+   * @default undefined
+   */
+  size?: undefined;
+
+  /**
+   * Bind to state controlled by either the consumer or component.
+   * @default false
+   */
+  open?: boolean;
+
+  /**
+   * Regular unannotated prop.
+   * @default "Toggle"
+   */
+  label?: string;
+};
+
+export default class BindableDirectionLegacy extends SvelteComponentTyped<
+  BindableDirectionLegacyProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/bindable-direction-legacy/output.json
+++ b/tests/fixtures/bindable-direction-legacy/output.json
@@ -1,0 +1,47 @@
+{
+  "props": [
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Bind to the current value emitted by the component.",
+      "binding": "readonly",
+      "value": "undefined",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "open",
+      "kind": "let",
+      "description": "Bind to state controlled by either the consumer or component.",
+      "binding": "writable",
+      "type": "boolean",
+      "value": "false",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": true
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Regular unannotated prop.",
+      "type": "string",
+      "value": "\"Toggle\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/bindable-direction-runes/input.svelte
+++ b/tests/fixtures/bindable-direction-runes/input.svelte
@@ -1,0 +1,24 @@
+<script>
+  let {
+    /**
+     * Bind to the current value emitted by the component.
+     * @bindable readonly
+     */
+    size = undefined,
+
+    /**
+     * Bind to state controlled by either the consumer or component.
+     * @bindable writable
+     */
+    open = $bindable(false),
+
+    /** Regular unannotated prop. */
+    label = "Toggle",
+  } = $props();
+</script>
+
+<button>{label}</button>
+<span>{size}</span>
+{#if open}
+  <span>Open</span>
+{/if}

--- a/tests/fixtures/bindable-direction-runes/output.d.ts
+++ b/tests/fixtures/bindable-direction-runes/output.d.ts
@@ -1,0 +1,27 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type BindableDirectionRunesProps = {
+  /**
+   * Bind to the current value emitted by the component.
+   * @default undefined
+   */
+  size?: undefined;
+
+  /**
+   * Bind to state controlled by either the consumer or component.
+   * @default false
+   */
+  open?: boolean;
+
+  /**
+   * Regular unannotated prop.
+   * @default "Toggle"
+   */
+  label?: string;
+};
+
+export default class BindableDirectionRunes extends SvelteComponentTyped<
+  BindableDirectionRunesProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/bindable-direction-runes/output.json
+++ b/tests/fixtures/bindable-direction-runes/output.json
@@ -1,0 +1,47 @@
+{
+  "props": [
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Bind to the current value emitted by the component.",
+      "binding": "readonly",
+      "value": "undefined",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    },
+    {
+      "name": "open",
+      "kind": "let",
+      "description": "Bind to state controlled by either the consumer or component.",
+      "binding": "writable",
+      "type": "boolean",
+      "value": "false",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": true
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Regular unannotated prop.",
+      "type": "string",
+      "value": "\"Toggle\"",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}


### PR DESCRIPTION
This library denotes whether a prop is reactive or not in auto-generated JSON/MD. However, it cannot distinguish between one-way vs. two-way reactive variables.

For now, support the consumer's ability to explicitly annotate these reactivity patterns. The intended usage is to express in auto-generated docs whether a variable supports two-way binding.