### PR TITLE
feat: add `createSveld` documenter interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ If no `input` is specified, `sveld` will infer the entry point based on the `pac
 import { sveld } from "sveld";
 import pkg from "./package.json" with { type: "json" };
 
-sveld({
+await sveld({
   input: "./src/index.js",
   glob: true,
   markdown: true,
@@ -276,6 +276,38 @@ sveld({
 });
 ```
 
+For advanced usage, `createSveld` exposes the same pipeline as a documenter with separate `inspect` and `write` methods.
+
+Use `inspect` when you need component metadata without writing files:
+
+```js
+import { createSveld } from "sveld";
+
+const documenter = createSveld();
+
+const document = await documenter.inspect({
+  input: "./src/index.js",
+  glob: true,
+});
+
+console.log([...document.components.keys()]);
+```
+
+Use `write` when you want the same generated files as `sveld(...)` and a result describing what was written:
+
+```js
+const result = await documenter.write({
+  input: "./src/index.js",
+  glob: true,
+  json: true,
+  markdown: true,
+});
+
+console.log(result.written); // ["types", "json", "markdown"]
+```
+
+`inspect` returns `undefined` when no entry point can be resolved. Otherwise, its document includes `components` for exported components and `allComponentsForTypes` for exported plus glob-discovered Svelte files used by TypeScript definition generation.
+
 #### `jsonOptions.outDir`
 
 If `json` is `true`, a `COMPONENT_API.json` file will be generated at the root of your project. This file contains documentation for all components.
@@ -283,7 +315,7 @@ If `json` is `true`, a `COMPONENT_API.json` file will be generated at the root o
 Use the `jsonOptions.outDir` option to specify the folder for individual JSON files to be emitted.
 
 ```js
-sveld({
+await sveld({
   json: true,
   jsonOptions: {
     // an individual JSON file will be generated for each component API

--- a/src/SveldDocumenter.ts
+++ b/src/SveldDocumenter.ts
@@ -1,0 +1,312 @@
+import { lstatSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
+import { parse as parseSvelte } from "svelte/compiler";
+import { globSync } from "tinyglobby";
+import ComponentParser, { type ParsedComponent } from "./ComponentParser";
+import { getSvelteEntry } from "./get-svelte-entry";
+import { type ParsedExports, parseExports } from "./parse-exports";
+import { normalizeSeparators } from "./path";
+import writeJson, { type WriteJsonOptions } from "./writer/writer-json";
+import writeMarkdown, { type WriteMarkdownOptions } from "./writer/writer-markdown";
+import writeTsDefinitions, { type WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
+
+export interface SveldOptions {
+  /**
+   * Specify the input to the uncompiled Svelte source.
+   * Programmatic callers historically use `input`; plugin callers use `entry`.
+   */
+  input?: string;
+  /**
+   * Specify the entry point to uncompiled Svelte source.
+   * If not provided, sveld will use the "svelte" field from package.json.
+   */
+  entry?: string;
+  glob?: boolean;
+  types?: boolean;
+  typesOptions?: Partial<Omit<WriteTsDefinitionsOptions, "inputDir">>;
+  json?: boolean;
+  jsonOptions?: Partial<Omit<WriteJsonOptions, "inputDir">>;
+  markdown?: boolean;
+  markdownOptions?: Partial<WriteMarkdownOptions>;
+}
+
+type ComponentModuleName = string;
+
+export interface ComponentDocApi extends ParsedComponent {
+  filePath: string;
+  moduleName: string;
+}
+
+export type ComponentDocs = Map<ComponentModuleName, ComponentDocApi>;
+
+export interface GenerateBundleResult {
+  exports: ParsedExports;
+  components: ComponentDocs;
+  allComponentsForTypes: ComponentDocs;
+}
+
+export interface SveldDocument extends GenerateBundleResult {
+  input: string;
+  inputDir: string;
+}
+
+export type SveldOutputKind = "types" | "json" | "markdown";
+
+export interface SveldWriteResult {
+  document: SveldDocument;
+  written: SveldOutputKind[];
+}
+
+export interface SveldDocumenter {
+  inspect(opts?: SveldOptions): Promise<SveldDocument | undefined>;
+  write(opts?: SveldOptions): Promise<SveldWriteResult | undefined>;
+}
+
+export interface SveldAdapters {
+  resolveInput(opts?: SveldOptions): string | null;
+  generateBundle(input: string, glob: boolean): Promise<GenerateBundleResult>;
+  writeOutput(
+    result: GenerateBundleResult,
+    opts: Omit<SveldOptions, "input">,
+    input: string,
+  ): Promise<SveldOutputKind[]>;
+}
+
+const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
+const HYPHEN_REGEX = /-/g;
+
+function stripTopLevelStyleBlock(source: string) {
+  try {
+    const parsed = parseSvelte(source, { modern: false }) as { css?: { start?: number; end?: number } };
+    const start = parsed.css?.start;
+    const end = parsed.css?.end;
+
+    if (start === undefined || end === undefined) {
+      return source;
+    }
+
+    return `${source.slice(0, start)}${source.slice(end)}`;
+  } catch {
+    // Fall back to the previous regex behavior if the source cannot be parsed.
+    return source.replace(STYLE_TAG_REGEX, "");
+  }
+}
+
+function resolveSveldInput(opts?: SveldOptions) {
+  return getSvelteEntry(opts?.input ?? opts?.entry);
+}
+
+export function createSveld(adapters: Partial<SveldAdapters> = {}): SveldDocumenter {
+  const resolveInput = adapters.resolveInput ?? resolveSveldInput;
+  const generate = adapters.generateBundle ?? generateBundle;
+  const writeOutputs = adapters.writeOutput ?? writeOutput;
+
+  const inspect: SveldDocumenter["inspect"] = async (opts?: SveldOptions) => {
+    const input = resolveInput(opts);
+    if (input === null) return undefined;
+
+    return {
+      input,
+      inputDir: dirname(input),
+      ...(await generate(input, opts?.glob === true)),
+    };
+  };
+
+  return {
+    inspect,
+    async write(opts?: SveldOptions) {
+      const document = await inspect(opts);
+      if (document === undefined) return undefined;
+
+      const written = await writeOutputs(document, opts || {}, document.input);
+
+      return {
+        document,
+        written,
+      };
+    },
+  };
+}
+
+/**
+ * Generates component documentation bundle from Svelte source files.
+ *
+ * Parses exports, discovers components (optionally via glob), and processes
+ * all Svelte files to extract component metadata. Returns both exported
+ * components (for JSON/Markdown) and all components (for TypeScript definitions).
+ */
+export async function generateBundle(input: string, glob: boolean): Promise<GenerateBundleResult> {
+  const isFile = lstatSync(input).isFile();
+  const dir = isFile ? dirname(input) : input;
+  const rootDir = resolve(dir);
+  const resolveComponentFilePath = (filePath: string) =>
+    isAbsolute(filePath) ? resolve(filePath) : resolve(rootDir, filePath);
+
+  let exports: ParsedExports = {};
+  if (isFile) {
+    const entry = readFileSync(input, "utf-8");
+    exports = parseExports(entry, rootDir);
+  }
+
+  const allComponents: ParsedExports = { ...exports };
+
+  if (glob) {
+    for (const matchedFile of globSync(["**/*.svelte"], { cwd: rootDir, absolute: true })) {
+      const file = resolve(matchedFile);
+      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
+      const source = normalizeSeparators(`./${relative(rootDir, file)}`);
+
+      if (exports[moduleName]) {
+        exports[moduleName].source = source;
+      }
+
+      if (allComponents[moduleName]) {
+        allComponents[moduleName].source = source;
+      } else {
+        allComponents[moduleName] = { source, default: false };
+      }
+    }
+  }
+
+  const components: ComponentDocs = new Map();
+  const allComponentsForTypes: ComponentDocs = new Map();
+  const exportEntries = Object.entries(exports);
+  const allComponentEntries = Object.entries(allComponents);
+
+  const uniqueFilePaths = new Set<string>();
+  for (const [, entry] of exportEntries) {
+    const filePath = entry.source;
+    const { ext } = parse(filePath);
+    if (ext === ".svelte") {
+      uniqueFilePaths.add(resolveComponentFilePath(filePath));
+    }
+  }
+  for (const [, entry] of allComponentEntries) {
+    const filePath = entry.source;
+    const { ext } = parse(filePath);
+    if (ext === ".svelte") {
+      uniqueFilePaths.add(resolveComponentFilePath(filePath));
+    }
+  }
+
+  const fileContents = await Promise.all(
+    Array.from(uniqueFilePaths).map(async (filePath) => {
+      try {
+        const content = await readFile(filePath, "utf-8");
+        return { path: filePath, content };
+      } catch (error) {
+        console.warn(`Warning: Failed to read file ${filePath}:`, error);
+        return { path: filePath, content: null };
+      }
+    }),
+  );
+
+  const fileMap = new Map<string, string | null>(fileContents.map(({ path, content }) => [path, content]));
+
+  const processComponent = async (
+    [exportName, entry]: [string, ParsedExports[string]],
+    entries: Array<[string, ParsedExports[string]]>,
+    fileMap: Map<string, string | null>,
+  ) => {
+    const filePath = entry.source;
+    const { ext, name } = parse(filePath);
+
+    let moduleName = exportName;
+
+    if (entries.length === 1 && exportName === "default") {
+      moduleName = name;
+    }
+
+    if (ext === ".svelte") {
+      const resolvedPath = resolveComponentFilePath(filePath);
+      const source = fileMap.get(resolvedPath);
+
+      if (source === null || source === undefined) {
+        return null;
+      }
+
+      const parser = new ComponentParser();
+      const parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
+        moduleName,
+        filePath,
+      });
+
+      return {
+        moduleName,
+        filePath,
+        ...parsed,
+      };
+    }
+
+    return null;
+  };
+
+  const componentPromises = exportEntries.map((entry) => processComponent(entry, exportEntries, fileMap));
+  const allComponentPromises = allComponentEntries.map((entry) =>
+    processComponent(entry, allComponentEntries, fileMap),
+  );
+
+  const [results, allResults] = await Promise.all([Promise.all(componentPromises), Promise.all(allComponentPromises)]);
+
+  for (const result of results) {
+    if (result) {
+      components.set(result.moduleName, result);
+    }
+  }
+
+  for (const result of allResults) {
+    if (result) {
+      allComponentsForTypes.set(result.moduleName, result);
+    }
+  }
+
+  return {
+    exports,
+    components,
+    allComponentsForTypes,
+  };
+}
+
+/**
+ * Writes output files based on sveld options.
+ */
+export async function writeOutput(
+  result: GenerateBundleResult,
+  opts: Omit<SveldOptions, "input">,
+  input: string,
+): Promise<SveldOutputKind[]> {
+  const inputDir = dirname(input);
+  const written: SveldOutputKind[] = [];
+
+  if (opts?.types !== false) {
+    await writeTsDefinitions(result.allComponentsForTypes, {
+      outDir: "types",
+      preamble: "",
+      ...opts?.typesOptions,
+      exports: result.exports,
+      inputDir,
+    });
+    written.push("types");
+  }
+
+  if (opts?.json) {
+    await writeJson(result.components, {
+      outFile: "COMPONENT_API.json",
+      ...opts?.jsonOptions,
+      input,
+      inputDir,
+    });
+    written.push("json");
+  }
+
+  if (opts?.markdown) {
+    await writeMarkdown(result.components, {
+      outFile: "COMPONENT_INDEX.md",
+      ...opts?.markdownOptions,
+    });
+    written.push("markdown");
+  }
+
+  return written;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,8 @@ import resolve from "@rollup/plugin-node-resolve";
 import { rollup } from "rollup";
 import svelte from "rollup-plugin-svelte";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { generateBundle, type PluginSveldOptions, writeOutput } from "./plugin";
+import type { PluginSveldOptions } from "./plugin";
+import { createSveld } from "./SveldDocumenter";
 
 /**
  * Command-line interface for sveld.
@@ -44,7 +45,8 @@ export async function cli(process: NodeJS.Process) {
 
   await rollup_bundle.generate({});
 
-  const result = await generateBundle(input, options?.glob === true);
-
-  writeOutput(result, options, input);
+  await createSveld().write({
+    ...options,
+    entry: input,
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as ComponentParser } from "./ComponentParser";
 export { cli } from "./cli";
 export { default } from "./plugin";
+export { createSveld } from "./SveldDocumenter";
 export { sveld } from "./sveld";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,59 +1,15 @@
-import { lstatSync, readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
-import { parse as parseSvelte } from "svelte/compiler";
-import { globSync } from "tinyglobby";
-import ComponentParser, { type ParsedComponent } from "./ComponentParser";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { type ParsedExports, parseExports } from "./parse-exports";
-import { normalizeSeparators } from "./path";
-import writeJson, { type WriteJsonOptions } from "./writer/writer-json";
-import writeMarkdown, { type WriteMarkdownOptions } from "./writer/writer-markdown";
-import writeTsDefinitions, { type WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
+import { createSveld, type SveldOptions } from "./SveldDocumenter";
 
-export interface PluginSveldOptions {
-  /**
-   * Specify the entry point to uncompiled Svelte source.
-   * If not provided, sveld will use the "svelte" field from package.json.
-   */
-  entry?: string;
-  glob?: boolean;
-  types?: boolean;
-  typesOptions?: Partial<Omit<WriteTsDefinitionsOptions, "inputDir">>;
-  json?: boolean;
-  jsonOptions?: Partial<Omit<WriteJsonOptions, "inputDir">>;
-  markdown?: boolean;
-  markdownOptions?: Partial<WriteMarkdownOptions>;
-}
+export {
+  type ComponentDocApi,
+  type ComponentDocs,
+  type GenerateBundleResult,
+  generateBundle,
+  writeOutput,
+} from "./SveldDocumenter";
 
-type ComponentModuleName = string;
-
-export interface ComponentDocApi extends ParsedComponent {
-  filePath: string;
-  moduleName: string;
-}
-
-export type ComponentDocs = Map<ComponentModuleName, ComponentDocApi>;
-
-const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
-const HYPHEN_REGEX = /-/g;
-
-function stripTopLevelStyleBlock(source: string) {
-  try {
-    const parsed = parseSvelte(source, { modern: false }) as { css?: { start?: number; end?: number } };
-    const start = parsed.css?.start;
-    const end = parsed.css?.end;
-
-    if (start === undefined || end === undefined) {
-      return source;
-    }
-
-    return `${source.slice(0, start)}${source.slice(end)}`;
-  } catch {
-    // Fall back to the previous regex behavior if the source cannot be parsed.
-    return source.replace(STYLE_TAG_REGEX, "");
-  }
-}
+export interface PluginSveldOptions extends Omit<SveldOptions, "input"> {}
 
 interface SveldPlugin {
   name: string;
@@ -61,11 +17,11 @@ interface SveldPlugin {
   enforce?: "pre" | "post";
   buildStart(): void;
   generateBundle(): Promise<void>;
-  writeBundle(): void;
+  writeBundle(): Promise<void>;
 }
 
 export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
-  let result: GenerateBundleResult;
+  const documenter = createSveld();
   let input: string | null;
 
   return {
@@ -76,278 +32,16 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
       input = getSvelteEntry(opts?.entry);
     },
     async generateBundle() {
+      // Generation is handled in writeBundle so output completion can be awaited
+      // through one deep module interface.
+    },
+    async writeBundle() {
       if (input != null) {
-        result = await generateBundle(input, opts?.glob === true);
+        await documenter.write({
+          ...opts,
+          entry: input,
+        });
       }
     },
-    writeBundle() {
-      if (input != null) writeOutput(result, opts || {}, input);
-    },
   };
-}
-
-interface GenerateBundleResult {
-  exports: ParsedExports;
-  components: ComponentDocs;
-  allComponentsForTypes: ComponentDocs;
-}
-
-/**
- * Generates component documentation bundle from Svelte source files.
- *
- * Parses exports, discovers components (optionally via glob), and processes
- * all Svelte files to extract component metadata. Returns both exported
- * components (for JSON/Markdown) and all components (for TypeScript definitions).
- *
- * @param input - Entry point file or directory containing Svelte components
- * @param glob - Whether to glob for all .svelte files in the directory
- * @returns Bundle result containing exports, components, and allComponentsForTypes
- *
- * @example
- * ```ts
- * // Generate from single file:
- * const result = await generateBundle("./src/App.svelte", false);
- *
- * // Generate from directory with glob:
- * const result = await generateBundle("./src", true);
- * ```
- */
-export async function generateBundle(input: string, glob: boolean) {
-  const isFile = lstatSync(input).isFile();
-  const dir = isFile ? dirname(input) : input;
-  const rootDir = resolve(dir);
-  const resolveComponentFilePath = (filePath: string) =>
-    isAbsolute(filePath) ? resolve(filePath) : resolve(rootDir, filePath);
-
-  /**
-   * Only parse exports if input is a file.
-   * Directory inputs don't have a single entry point to parse exports from.
-   */
-  let exports: ParsedExports = {};
-  if (isFile) {
-    const entry = readFileSync(input, "utf-8");
-    exports = parseExports(entry, rootDir);
-  }
-
-  const allComponents: ParsedExports = { ...exports };
-
-  if (glob) {
-    for (const matchedFile of globSync(["**/*.svelte"], { cwd: rootDir, absolute: true })) {
-      const file = resolve(matchedFile);
-      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
-      const source = normalizeSeparators(`./${relative(rootDir, file)}`);
-
-      if (exports[moduleName]) {
-        exports[moduleName].source = source;
-      }
-
-      if (allComponents[moduleName]) {
-        allComponents[moduleName].source = source;
-      } else {
-        allComponents[moduleName] = { source, default: false };
-      }
-    }
-  }
-
-  const components: ComponentDocs = new Map();
-  const allComponentsForTypes: ComponentDocs = new Map();
-  const exportEntries = Object.entries(exports);
-  const allComponentEntries = Object.entries(allComponents);
-
-  const uniqueFilePaths = new Set<string>();
-  for (const [, entry] of exportEntries) {
-    const filePath = entry.source;
-    const { ext } = parse(filePath);
-    if (ext === ".svelte") {
-      uniqueFilePaths.add(resolveComponentFilePath(filePath));
-    }
-  }
-  for (const [, entry] of allComponentEntries) {
-    const filePath = entry.source;
-    const { ext } = parse(filePath);
-    if (ext === ".svelte") {
-      uniqueFilePaths.add(resolveComponentFilePath(filePath));
-    }
-  }
-
-  const fileContents = await Promise.all(
-    Array.from(uniqueFilePaths).map(async (filePath) => {
-      try {
-        const content = await readFile(filePath, "utf-8");
-        return { path: filePath, content };
-      } catch (error) {
-        console.warn(`Warning: Failed to read file ${filePath}:`, error);
-        return { path: filePath, content: null };
-      }
-    }),
-  );
-
-  const fileMap = new Map<string, string | null>(fileContents.map(({ path, content }) => [path, content]));
-
-  /**
-   * Helper function to process a single component.
-   *
-   * Reads the component file, removes top-level styles for metadata parsing,
-   * and parses it to extract component metadata. Handles file read errors gracefully.
-   *
-   * @param entry - Export entry tuple [exportName, exportInfo]
-   * @param entries - All export entries for context
-   * @param fileMap - Map of file paths to their contents
-   * @returns Component documentation or null if processing failed
-   *
-   * @example
-   * ```ts
-   * const result = await processComponent(
-   *   ["Button", { source: "./Button.svelte", default: true }],
-   *   allEntries,
-   *   fileMap
-   * );
-   * // Returns: { moduleName: "Button", filePath: "./Button.svelte", props: [...], ... }
-   * ```
-   */
-  const processComponent = async (
-    [exportName, entry]: [string, ParsedExports[string]],
-    entries: Array<[string, ParsedExports[string]]>,
-    fileMap: Map<string, string | null>,
-  ) => {
-    const filePath = entry.source;
-    const { ext, name } = parse(filePath);
-
-    let moduleName = exportName;
-
-    if (entries.length === 1 && exportName === "default") {
-      moduleName = name;
-    }
-
-    if (ext === ".svelte") {
-      const resolvedPath = resolveComponentFilePath(filePath);
-      const source = fileMap.get(resolvedPath);
-
-      if (source === null || source === undefined) {
-        /**
-         * File was not found or failed to read, skip this component.
-         * This can happen if the file doesn't exist or if there was an error
-         * reading it (already logged as a warning).
-         */
-        return null;
-      }
-
-      const parser = new ComponentParser();
-      const parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
-        moduleName,
-        filePath,
-      });
-
-      return {
-        moduleName,
-        filePath,
-        ...parsed,
-      };
-    }
-
-    return null;
-  };
-
-  /**
-   * Process exported components (for metadata/JSON/Markdown).
-   * Only components that are explicitly exported are included in the
-   * components map for JSON and Markdown output.
-   */
-  const componentPromises = exportEntries.map((entry) => processComponent(entry, exportEntries, fileMap));
-
-  /**
-   * Process all components (for .d.ts generation).
-   * All discovered components are included in allComponentsForTypes
-   * to ensure TypeScript definitions are generated for all components,
-   * even if they're not explicitly exported.
-   */
-  const allComponentPromises = allComponentEntries.map((entry) =>
-    processComponent(entry, allComponentEntries, fileMap),
-  );
-
-  const [results, allResults] = await Promise.all([Promise.all(componentPromises), Promise.all(allComponentPromises)]);
-
-  for (const result of results) {
-    if (result) {
-      components.set(result.moduleName, result);
-    }
-  }
-
-  for (const result of allResults) {
-    if (result) {
-      allComponentsForTypes.set(result.moduleName, result);
-    }
-  }
-
-  return {
-    exports,
-    components,
-    allComponentsForTypes,
-  };
-}
-
-/**
- * Writes output files based on plugin options.
- *
- * Generates TypeScript definitions, JSON metadata, and/or Markdown documentation
- * based on the options provided. Uses different component sets for different
- * output types to match expected behavior.
- *
- * @param result - Bundle result containing exports and component documentation
- * @param opts - Plugin options determining what outputs to generate
- * @param input - Input file path for determining input directory
- *
- * @example
- * ```ts
- * writeOutput(result, {
- *   types: true,
- *   json: true,
- *   markdown: true
- * }, "./src/App.svelte");
- * // Generates: types/*.d.ts, COMPONENT_API.json, COMPONENT_INDEX.md
- * ```
- */
-export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptions, input: string) {
-  const inputDir = dirname(input);
-
-  if (opts?.types !== false) {
-    /**
-     * Use allComponentsForTypes to generate .d.ts for all discovered components.
-     * This ensures TypeScript definitions are available for all components,
-     * not just exported ones, which is useful for type checking.
-     */
-    writeTsDefinitions(result.allComponentsForTypes, {
-      outDir: "types",
-      preamble: "",
-      ...opts?.typesOptions,
-      exports: result.exports,
-      inputDir,
-    });
-  }
-
-  if (opts?.json) {
-    /**
-     * Use components (exported only) for JSON metadata.
-     * JSON output should only include components that are actually exported,
-     * matching the public API surface.
-     */
-    writeJson(result.components, {
-      outFile: "COMPONENT_API.json",
-      ...opts?.jsonOptions,
-      input,
-      inputDir,
-    });
-  }
-
-  if (opts?.markdown) {
-    /**
-     * Use components (exported only) for Markdown documentation.
-     * Documentation should only include exported components that are
-     * part of the public API.
-     */
-    writeMarkdown(result.components, {
-      outFile: "COMPONENT_INDEX.md",
-      ...opts?.markdownOptions,
-    });
-  }
 }

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,7 +1,6 @@
-import { getSvelteEntry } from "./get-svelte-entry";
-import { generateBundle, type PluginSveldOptions, writeOutput } from "./plugin";
+import { type SveldOptions as BaseSveldOptions, createSveld } from "./SveldDocumenter";
 
-interface SveldOptions extends PluginSveldOptions {
+interface SveldOptions extends BaseSveldOptions {
   /**
    * Specify the input to the uncompiled Svelte source.
    * If no value is provided, `sveld` will attempt to infer
@@ -32,8 +31,5 @@ interface SveldOptions extends PluginSveldOptions {
  * ```
  */
 export async function sveld(opts?: SveldOptions) {
-  const input = getSvelteEntry(opts?.input);
-  if (input === null) return;
-  const result = await generateBundle(input, opts?.glob === true);
-  writeOutput(result, opts || {}, input);
+  return createSveld().write(opts);
 }

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -1,4 +1,4 @@
-import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import type { ComponentDocApi, ComponentDocs } from "../SveldDocumenter";
 import type { AppendType } from "./MarkdownWriterBase";
 import {
   EVENT_TABLE_HEADER,

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { version as svelteVersion } from "svelte/package.json";
 import { name as packageName, version as packageVersion } from "../../package.json";
 import { normalizeSeparators } from "../path";
-import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import type { ComponentDocApi, ComponentDocs } from "../SveldDocumenter";
 import { createJsonWriter } from "./Writer";
 
 export interface WriteJsonOptions {

--- a/src/writer/writer-markdown-core.ts
+++ b/src/writer/writer-markdown-core.ts
@@ -1,4 +1,4 @@
-import type { ComponentDocs } from "../plugin";
+import type { ComponentDocs } from "../SveldDocumenter";
 import { type AppendType, MarkdownWriterBaseImpl } from "./MarkdownWriterBase";
 import { renderComponentsToMarkdown } from "./markdown-render-utils";
 

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import type { ComponentDocs } from "../plugin";
+import type { ComponentDocs } from "../SveldDocumenter";
 import { renderComponentsToMarkdown } from "./markdown-render-utils";
 import WriterMarkdown, { type AppendType } from "./WriterMarkdown";
 

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -1,5 +1,5 @@
 import { getParsedComponentTypeScriptMetadata } from "../ComponentParser";
-import type { ComponentDocApi } from "../plugin";
+import type { ComponentDocApi } from "../SveldDocumenter";
 
 const ANY_TYPE = "any";
 const EMPTY_STR = "";

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { convertSvelteExt, createExports } from "../create-exports";
 import type { ParsedExports } from "../parse-exports";
-import type { ComponentDocs } from "../plugin";
+import type { ComponentDocs } from "../SveldDocumenter";
 import { createTypeScriptWriter } from "./Writer";
 import { writeTsDefinition } from "./writer-ts-definitions-core";
 

--- a/tests/SveldDocumenter.test.ts
+++ b/tests/SveldDocumenter.test.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createSveld } from "../src/SveldDocumenter";
+
+function createFixture() {
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "sveld-documenter-"));
+  const srcDir = path.join(fixtureDir, "src");
+
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(path.join(srcDir, "index.js"), `export { default as Button } from "./Button.svelte";`);
+  writeFileSync(
+    path.join(srcDir, "Button.svelte"),
+    `<script lang="ts">
+  /** Button label */
+  export let label: string;
+</script>
+
+<button>{label}</button>
+`,
+  );
+  writeFileSync(
+    path.join(srcDir, "Internal.svelte"),
+    `<script lang="ts">
+  export let hidden: boolean;
+</script>
+`,
+  );
+
+  return fixtureDir;
+}
+
+describe("SveldDocumenter", () => {
+  const originalCwd = process.cwd();
+
+  function removeFixtureDir(fixtureDir: string) {
+    process.chdir(originalCwd);
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  test("inspect builds the document without writing outputs", async () => {
+    const fixtureDir = createFixture();
+
+    try {
+      process.chdir(fixtureDir);
+
+      const document = await createSveld().inspect({
+        input: "src/index.js",
+        glob: true,
+      });
+
+      expect(document?.components.has("Button")).toBe(true);
+      expect(document?.components.has("Internal")).toBe(false);
+      expect(document?.allComponentsForTypes.has("Internal")).toBe(true);
+      expect(existsSync(path.join(fixtureDir, "types"))).toBe(false);
+      expect(existsSync(path.join(fixtureDir, "COMPONENT_API.json"))).toBe(false);
+      expect(existsSync(path.join(fixtureDir, "COMPONENT_INDEX.md"))).toBe(false);
+    } finally {
+      removeFixtureDir(fixtureDir);
+    }
+  });
+
+  test("write awaits all selected output files", async () => {
+    const fixtureDir = createFixture();
+
+    try {
+      process.chdir(fixtureDir);
+
+      const result = await createSveld().write({
+        input: "src/index.js",
+        glob: true,
+        types: true,
+        json: true,
+        markdown: true,
+      });
+
+      const typesIndexPath = path.join(fixtureDir, "types", "index.d.ts");
+      const internalTypesPath = path.join(fixtureDir, "types", "Internal.svelte.d.ts");
+      const jsonPath = path.join(fixtureDir, "COMPONENT_API.json");
+      const markdownPath = path.join(fixtureDir, "COMPONENT_INDEX.md");
+
+      expect(result?.written).toEqual(["types", "json", "markdown"]);
+      expect(existsSync(typesIndexPath)).toBe(true);
+      expect(existsSync(internalTypesPath)).toBe(true);
+      expect(existsSync(jsonPath)).toBe(true);
+      expect(existsSync(markdownPath)).toBe(true);
+
+      const json = JSON.parse(readFileSync(jsonPath, "utf-8"));
+      expect(json.components.map((component: { moduleName: string }) => component.moduleName)).toEqual(["Button"]);
+      expect(readFileSync(markdownPath, "utf-8")).toContain("`Button`");
+      expect(readFileSync(markdownPath, "utf-8")).not.toContain("`Internal`");
+    } finally {
+      removeFixtureDir(fixtureDir);
+    }
+  });
+
+  test("createSveld accepts adapters at the documenter seam", async () => {
+    const bundle = {
+      exports: {},
+      components: new Map(),
+      allComponentsForTypes: new Map(),
+    };
+    const generateBundle = jest.fn(async () => bundle);
+    const writeOutput = jest.fn(async () => ["types" as const]);
+
+    const result = await createSveld({
+      resolveInput: () => "src/index.js",
+      generateBundle,
+      writeOutput,
+    }).write({
+      types: true,
+    });
+
+    expect(generateBundle).toHaveBeenCalledWith("src/index.js", false);
+    expect(writeOutput).toHaveBeenCalledWith(expect.objectContaining(bundle), { types: true }, "src/index.js");
+    expect(result?.written).toEqual(["types"]);
+  });
+});


### PR DESCRIPTION
Adds `createSveld()` with `inspect()` and `write()` for advanced programmatic usage, while preserving existing `sveld()`, plugin, `generateBundle()`, and `writeOutput()` compatibility. This centralizes the docs pipeline, makes output writing awaitable, documents the new API, and adds coverage for inspect-only usage, write completion, component selection, and adapter injection.

Callers can now inspect component metadata without writing files, await reliable output completion, and use a deeper module interface that hides pipeline ordering while preserving existing JSON, Markdown, and TypeScript generation behavior.

```js
import { createSveld } from "sveld";

const documenter = createSveld();

const document = await documenter.inspect({
  input: "./src/index.js",
  glob: true,
});

console.log([...document.components.keys()]);
```