### PR TITLE
feat(writer-json): add JSON schema and generator metadata

### DIFF
--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import { version as svelteVersion } from "svelte/package.json";
+import { name as packageName, version as packageVersion } from "../../package.json";
 import { normalizeSeparators } from "../path";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import { createJsonWriter } from "./Writer";
@@ -17,8 +19,24 @@ export interface WriteJsonOptions {
  * component documentation objects.
  */
 interface JsonOutput {
+  schemaVersion: 1;
+  generator: {
+    name: string;
+    version: string;
+    svelteVersion: string;
+  };
   total: number;
   components: ComponentDocApi[];
+}
+
+const JSON_SCHEMA_VERSION = 1;
+
+function createGeneratorMetadata(): JsonOutput["generator"] {
+  return {
+    name: packageName,
+    version: packageVersion,
+    svelteVersion,
+  };
 }
 
 /**
@@ -94,6 +112,8 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
  */
 async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptions) {
   const output: JsonOutput = {
+    schemaVersion: JSON_SCHEMA_VERSION,
+    generator: createGeneratorMetadata(),
     total: components.size,
     components: transformAndSortComponents(components, options.inputDir),
   };

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 156,
   "components": [
     {

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 1,
   "components": [
     {

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 4,
   "components": [
     {

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 4,
   "components": [
     {

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 5,
   "components": [
     {

--- a/tests/e2e/path-aliases/COMPONENT_API.json
+++ b/tests/e2e/path-aliases/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 2,
   "components": [
     {

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 1,
   "components": [
     {

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 1,
   "components": [
     {

--- a/tests/e2e/svelte5-legacy/COMPONENT_API.json
+++ b/tests/e2e/svelte5-legacy/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 1,
   "components": [
     {

--- a/tests/e2e/svelte5-runes/COMPONENT_API.json
+++ b/tests/e2e/svelte5-runes/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 1,
   "components": [
     {

--- a/tests/e2e/sveltekit/COMPONENT_API.json
+++ b/tests/e2e/sveltekit/COMPONENT_API.json
@@ -1,4 +1,10 @@
 {
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.31.0",
+    "svelteVersion": "5.55.0"
+  },
   "total": 1,
   "components": [
     {

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync, rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
+import { version as svelteVersion } from "svelte/package.json";
+import { name as packageName, version as packageVersion } from "../package.json";
+import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
+import writeJson from "../src/writer/writer-json";
+
+function createComponent(moduleName: string, filePath: string): ComponentDocApi {
+  return {
+    moduleName,
+    filePath,
+    props: [],
+    moduleExports: [],
+    slots: [],
+    events: [],
+    typedefs: [],
+    generics: null,
+    rest_props: undefined,
+  };
+}
+
+describe("writeJson", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("writes schema and generator metadata to combined JSON output", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+    const components: ComponentDocs = new Map([
+      ["Zeta", createComponent("Zeta", "Zeta.svelte")],
+      ["Alpha", createComponent("Alpha", "Alpha.svelte")],
+    ]);
+
+    try {
+      await writeJson(components, {
+        input: "src",
+        inputDir: "src",
+        outFile,
+      });
+
+      const output = JSON.parse(readFileSync(path.join(tempDir, "COMPONENT_API.json"), "utf-8"));
+
+      expect(output).toMatchObject({
+        schemaVersion: 1,
+        generator: {
+          name: packageName,
+          version: packageVersion,
+          svelteVersion,
+        },
+        total: 2,
+      });
+      expect(output.components.map((component: ComponentDocApi) => component.moduleName)).toEqual(["Alpha", "Zeta"]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Add schemaVersion and generator details to the combined JSON output, including the sveld package version and Svelte compiler version.