### PR TITLE
feat(writer-json): add `syntaxMode` and `scriptLanguage` metadata

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -204,9 +204,19 @@ export function getParsedComponentTypeScriptMetadata(component: {
 }
 
 type SyntaxMode = "legacy" | "runes";
+type ScriptLanguage = "js" | "ts";
 type ScopeBindingKind = "prop" | "local";
 type ScopeBinding = { kind: ScopeBindingKind; publicPropName?: string };
 type LexicalScope = Map<string, ScopeBinding>;
+
+type ModernScriptAttribute = {
+  name?: string;
+  value?: Array<{ data?: string; raw?: string }> | boolean;
+};
+
+type ModernScriptNode = {
+  attributes?: ModernScriptAttribute[];
+};
 
 /**
  * Diagnostic information for component parsing.
@@ -614,6 +624,10 @@ interface ComponentContext {
  * ```
  */
 export interface ParsedComponent {
+  /** Whether the component uses legacy or runes syntax according to compiler metadata */
+  syntaxMode: SyntaxMode;
+  /** Language used by the instance or module script when it can be determined */
+  scriptLanguage?: ScriptLanguage;
   /** Component props that can be passed to the component */
   props: ComponentProp[];
   /** Exports from `<script context="module">` block */
@@ -644,6 +658,9 @@ export default class ComponentParser {
 
   /** Whether the component uses legacy or runes syntax according to compiler metadata */
   private syntaxMode: SyntaxMode = "legacy";
+
+  /** Language used by the component's instance or module script, when supported */
+  private scriptLanguage?: ScriptLanguage;
 
   /** Raw source code of the Svelte component being parsed */
   private source?: string;
@@ -748,6 +765,40 @@ export default class ComponentParser {
 
   private static mapToArray<T>(map: Map<string, T> | Map<ComponentSlotName, T>) {
     return Array.from(map, ([_key, value]) => value);
+  }
+
+  private static getStaticAttributeValue(attribute: ModernScriptAttribute) {
+    if (!Array.isArray(attribute.value)) return undefined;
+
+    return attribute.value
+      .map((value) => value.data ?? value.raw ?? "")
+      .join("")
+      .trim();
+  }
+
+  private static resolveScriptLanguage(parsed: {
+    instance?: ModernScriptNode;
+    module?: ModernScriptNode;
+  }): ScriptLanguage | undefined {
+    const scripts = [parsed.instance, parsed.module].filter(
+      (script): script is ModernScriptNode => script !== undefined,
+    );
+    let hasPlainScript = false;
+
+    for (const script of scripts) {
+      const langAttribute = script.attributes?.find((attribute) => attribute.name === "lang");
+      if (!langAttribute) {
+        hasPlainScript = true;
+        continue;
+      }
+
+      const language = ComponentParser.getStaticAttributeValue(langAttribute)?.toLowerCase();
+      if (language === "ts") {
+        return "ts";
+      }
+    }
+
+    return hasPlainScript ? "js" : undefined;
   }
 
   private static assignValue(value?: "" | string) {
@@ -1859,7 +1910,7 @@ export default class ComponentParser {
     if (!this.source) return;
 
     const modernParsed = parse(this.source, { modern: true }) as {
-      instance?: {
+      instance?: ModernScriptNode & {
         content?: {
           body?: Array<{
             type?: string;
@@ -1904,8 +1955,10 @@ export default class ComponentParser {
           }>;
         };
       };
+      module?: ModernScriptNode;
     };
 
+    this.scriptLanguage = ComponentParser.resolveScriptLanguage(modernParsed);
     const body = modernParsed.instance?.content?.body ?? [];
 
     for (const statement of body) {
@@ -4079,6 +4132,7 @@ export default class ComponentParser {
    */
   public cleanup() {
     this.syntaxMode = "legacy";
+    this.scriptLanguage = undefined;
     this.source = undefined;
     this.compiled = undefined;
     this.parsed = undefined;
@@ -5036,6 +5090,8 @@ export default class ComponentParser {
     const contextsArray = ComponentParser.mapToArray(this.contexts);
 
     const parsedComponent: ParsedComponent = {
+      syntaxMode: this.syntaxMode,
+      ...(this.scriptLanguage ? { scriptLanguage: this.scriptLanguage } : {}),
       props: processedProps,
       moduleExports: moduleExportsArray,
       slots: processedSlots,

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -6,6 +6,64 @@ describe("ComponentParser", () => {
     filePath: "/test/TestComponent.svelte",
   };
 
+  test("detects legacy syntax with plain JavaScript script", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        export let label;
+      </script>
+
+      <button>{label}</button>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+
+    expect(result.syntaxMode).toBe("legacy");
+    expect(result.scriptLanguage).toBe("js");
+  });
+
+  test("detects legacy syntax with TypeScript script", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script lang="ts">
+        export let label: string;
+      </script>
+
+      <button>{label}</button>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+
+    expect(result.syntaxMode).toBe("legacy");
+    expect(result.scriptLanguage).toBe("ts");
+  });
+
+  test("detects runes syntax metadata", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script lang="ts">
+        let { label }: { label: string } = $props();
+      </script>
+
+      <button>{label}</button>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+
+    expect(result.syntaxMode).toBe("runes");
+    expect(result.scriptLanguage).toBe("ts");
+  });
+
+  test("omits script language for markup-only components", () => {
+    const parser = new ComponentParser();
+    const source = "<button>Label</button>";
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+
+    expect(result.syntaxMode).toBe("legacy");
+    expect(result).not.toHaveProperty("scriptLanguage");
+  });
+
   test("parses basic component exports", () => {
     const parser = new ComponentParser();
     const source = `  

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -82,6 +82,7 @@ describe("WriterMarkdown", () => {
           {
             filePath: "Example.svelte",
             moduleName: "Example",
+            syntaxMode: "legacy",
             props: [
               {
                 name: "size",

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`fixtures (JSON) "runes-callback-annotated/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "onsnowball",
@@ -49,6 +51,7 @@ exports[`fixtures (JSON) "runes-callback-annotated/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -66,6 +69,8 @@ exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "text",
@@ -116,6 +121,8 @@ exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "module-reexport-mixed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "name",
@@ -186,6 +193,8 @@ exports[`fixtures (JSON) "module-reexport-mixed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "generics-multiple/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -247,6 +256,8 @@ exports[`fixtures (JSON) "generics-multiple/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-empty/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -266,6 +277,8 @@ exports[`fixtures (JSON) "context-empty/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-example/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -292,6 +305,8 @@ exports[`fixtures (JSON) "slot-jsdoc-example/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-dispatched-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",
@@ -324,6 +339,8 @@ exports[`fixtures (JSON) "runes-dispatched-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "module-reexport/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "data",
@@ -367,6 +384,8 @@ exports[`fixtures (JSON) "module-reexport/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "resolve-default-chained/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "chained",
@@ -416,6 +435,8 @@ exports[`fixtures (JSON) "resolve-default-chained/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "accessor-param-returns/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "add",
@@ -565,6 +586,8 @@ exports[`fixtures (JSON) "accessor-param-returns/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "typedef-description/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "gap",
@@ -609,6 +632,8 @@ exports[`fixtures (JSON) "typedef-description/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "typedef-jsdoc-properties/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "user",
@@ -678,6 +703,8 @@ exports[`fixtures (JSON) "typedef-jsdoc-properties/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "legacy-bind-component-selected/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "pageSize",
@@ -703,6 +730,8 @@ exports[`fixtures (JSON) "legacy-bind-component-selected/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "template-tag-multiple/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -764,6 +793,8 @@ exports[`fixtures (JSON) "template-tag-multiple/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-props-intersection/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "label",
@@ -798,6 +829,8 @@ exports[`fixtures (JSON) "runes-props-intersection/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "mixed-event-types/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -835,6 +868,8 @@ exports[`fixtures (JSON) "mixed-event-types/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "legacy-bind-component-ref-forward/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "listRef",
@@ -859,6 +894,8 @@ exports[`fixtures (JSON) "legacy-bind-component-ref-forward/input.svelte" 1`] = 
 
 exports[`fixtures (JSON) "dispatched-events-dynamic/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -878,6 +915,8 @@ exports[`fixtures (JSON) "dispatched-events-dynamic/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "legacy-export-typed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "title",
@@ -913,6 +952,8 @@ exports[`fixtures (JSON) "legacy-export-typed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-issue-103/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -945,6 +986,8 @@ exports[`fixtures (JSON) "context-issue-103/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-mixed-separators/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -977,6 +1020,8 @@ exports[`fixtures (JSON) "context-mixed-separators/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "jsdoc-type-params/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "showNode",
@@ -1022,6 +1067,8 @@ exports[`fixtures (JSON) "jsdoc-type-params/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "reactive-shadowed-local-reassignment/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",
@@ -1047,6 +1094,8 @@ exports[`fixtures (JSON) "reactive-shadowed-local-reassignment/input.svelte" 1`]
 
 exports[`fixtures (JSON) "empty-collection-defaults/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "items",
@@ -1116,6 +1165,8 @@ exports[`fixtures (JSON) "empty-collection-defaults/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "function-declaration/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "fnA",
@@ -1171,6 +1222,7 @@ exports[`fixtures (JSON) "function-declaration/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -1211,6 +1263,8 @@ exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "binary-expression-numeric/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "sum",
@@ -1302,6 +1356,8 @@ exports[`fixtures (JSON) "binary-expression-numeric/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "reactive-shadowed-callback-param/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",
@@ -1327,6 +1383,8 @@ exports[`fixtures (JSON) "reactive-shadowed-callback-param/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "typedef-event-shared-block/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "size",
@@ -1429,6 +1487,8 @@ exports[`fixtures (JSON) "typedef-event-shared-block/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "theme-component/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "theme",
@@ -1521,6 +1581,8 @@ exports[`fixtures (JSON) "theme-component/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "callback/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "onChange",
@@ -1585,6 +1647,8 @@ exports[`fixtures (JSON) "callback/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-description-with-dash/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -1605,6 +1669,8 @@ exports[`fixtures (JSON) "slot-description-with-dash/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-bindable/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",
@@ -1630,6 +1696,8 @@ exports[`fixtures (JSON) "runes-bindable/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "events-stable-order/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -1664,6 +1732,8 @@ exports[`fixtures (JSON) "events-stable-order/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "mixed-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -1688,6 +1758,8 @@ exports[`fixtures (JSON) "mixed-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",
@@ -1782,6 +1854,8 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-underscore/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -1814,6 +1888,8 @@ exports[`fixtures (JSON) "context-underscore/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "rest-props-description-multiline/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "variant",
@@ -1844,6 +1920,8 @@ exports[`fixtures (JSON) "rest-props-description-multiline/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-props-basic/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "title",
@@ -1878,6 +1956,8 @@ exports[`fixtures (JSON) "runes-props-basic/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-inheritdoc-before-slot/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -1904,6 +1984,8 @@ exports[`fixtures (JSON) "slot-jsdoc-inheritdoc-before-slot/input.svelte" 1`] = 
 
 exports[`fixtures (JSON) "unary-expression-defaults/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "offset",
@@ -1977,6 +2059,8 @@ exports[`fixtures (JSON) "unary-expression-defaults/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "empty-export/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -1990,6 +2074,8 @@ exports[`fixtures (JSON) "empty-export/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "module-reexport-direct/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "config",
@@ -2037,6 +2123,8 @@ exports[`fixtures (JSON) "module-reexport-direct/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-prop-dotted-access/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "point",
@@ -2068,6 +2156,8 @@ exports[`fixtures (JSON) "slot-prop-dotted-access/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "template-tag/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -2129,6 +2219,8 @@ exports[`fixtures (JSON) "template-tag/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-snippets-named/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "item",
@@ -2158,6 +2250,8 @@ exports[`fixtures (JSON) "runes-snippets-named/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "typed-slots/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",
@@ -2195,6 +2289,8 @@ exports[`fixtures (JSON) "typed-slots/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "constructor-expression-defaults/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "cache",
@@ -2341,6 +2437,8 @@ exports[`fixtures (JSON) "constructor-expression-defaults/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "default-slot-with-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "items",
@@ -2373,6 +2471,8 @@ exports[`fixtures (JSON) "default-slot-with-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-snippets-annotated/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",
@@ -2415,6 +2515,8 @@ exports[`fixtures (JSON) "runes-snippets-annotated/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-snippet-description-hyphens/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "row",
@@ -2454,6 +2556,8 @@ exports[`fixtures (JSON) "runes-snippet-description-hyphens/input.svelte" 1`] = 
 
 exports[`fixtures (JSON) "element-tag-map-table-cells/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "cellType",
@@ -2483,6 +2587,8 @@ exports[`fixtures (JSON) "element-tag-map-table-cells/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-typedef/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -2527,6 +2633,8 @@ exports[`fixtures (JSON) "context-typedef/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-colon/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -2559,6 +2667,8 @@ exports[`fixtures (JSON) "context-colon/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-events-typed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -2592,6 +2702,8 @@ exports[`fixtures (JSON) "forwarded-events-typed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -2631,6 +2743,8 @@ exports[`fixtures (JSON) "dispatched-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-two-slots-one-block-order/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -2662,6 +2776,8 @@ exports[`fixtures (JSON) "slot-jsdoc-two-slots-one-block-order/input.svelte" 1`]
 
 exports[`fixtures (JSON) "slot-jsdoc-orphan-type-before-slot/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -2682,6 +2798,8 @@ exports[`fixtures (JSON) "slot-jsdoc-orphan-type-before-slot/input.svelte" 1`] =
 
 exports[`fixtures (JSON) "module-reexport-renamed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "visible",
@@ -2726,6 +2844,8 @@ exports[`fixtures (JSON) "module-reexport-renamed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "typedefs/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop1",
@@ -2779,6 +2899,8 @@ exports[`fixtures (JSON) "typedefs/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "generics-with-rest-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -2844,6 +2966,8 @@ exports[`fixtures (JSON) "generics-with-rest-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",
@@ -2874,6 +2998,8 @@ exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "instance-reexport/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "data",
@@ -2912,6 +3038,8 @@ exports[`fixtures (JSON) "instance-reexport/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "explicit-default-no-duplicate/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "shouldFilter",
@@ -3032,6 +3160,8 @@ exports[`fixtures (JSON) "explicit-default-no-duplicate/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "dispatched-events-typed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -3063,6 +3193,7 @@ exports[`fixtures (JSON) "dispatched-events-typed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "input-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -3092,6 +3223,8 @@ exports[`fixtures (JSON) "input-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "required/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",
@@ -3155,6 +3288,8 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-imported-type/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -3193,6 +3328,8 @@ exports[`fixtures (JSON) "context-imported-type/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "reactive-shadowed-each-binding/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",
@@ -3218,6 +3355,8 @@ exports[`fixtures (JSON) "reactive-shadowed-each-binding/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "legacy-bind-component-value/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",
@@ -3243,6 +3382,8 @@ exports[`fixtures (JSON) "legacy-bind-component-value/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "callback-typedef/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "direction",
@@ -3289,6 +3430,8 @@ exports[`fixtures (JSON) "callback-typedef/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "legacy-pass-through-nonreactive/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",
@@ -3314,6 +3457,8 @@ exports[`fixtures (JSON) "legacy-pass-through-nonreactive/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "prop-comments/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",
@@ -3370,6 +3515,8 @@ exports[`fixtures (JSON) "prop-comments/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-events-native-with-jsdoc/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -3411,6 +3558,8 @@ exports[`fixtures (JSON) "forwarded-events-native-with-jsdoc/input.svelte" 1`] =
 
 exports[`fixtures (JSON) "runes-generics/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -3472,6 +3621,8 @@ exports[`fixtures (JSON) "runes-generics/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "async-function-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "initialize",
@@ -3526,6 +3677,8 @@ exports[`fixtures (JSON) "async-function-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "bindable-direction-legacy/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "size",
@@ -3577,6 +3730,8 @@ exports[`fixtures (JSON) "bindable-direction-legacy/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-whole-props-typed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "item",
@@ -3617,6 +3772,8 @@ exports[`fixtures (JSON) "runes-whole-props-typed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-simple/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -3655,6 +3812,8 @@ exports[`fixtures (JSON) "context-simple/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "renamed-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "class",
@@ -3681,6 +3840,8 @@ exports[`fixtures (JSON) "renamed-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "infer-with-types/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "propBool",
@@ -3766,6 +3927,8 @@ exports[`fixtures (JSON) "infer-with-types/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-callback-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "onclick",
@@ -3789,6 +3952,8 @@ exports[`fixtures (JSON) "runes-callback-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "arrow-function-with-jsdoc/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "transform",
@@ -3833,6 +3998,8 @@ exports[`fixtures (JSON) "arrow-function-with-jsdoc/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-description-named-pair/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -3859,6 +4026,8 @@ exports[`fixtures (JSON) "slot-description-named-pair/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "non-literal-defaults/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "position",
@@ -4022,6 +4191,8 @@ exports[`fixtures (JSON) "non-literal-defaults/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-native-with-detail/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4043,6 +4214,8 @@ exports[`fixtures (JSON) "forwarded-native-with-detail/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-props-renamed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "class",
@@ -4066,6 +4239,8 @@ exports[`fixtures (JSON) "runes-props-renamed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "multiple-typedef-same-property/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "user",
@@ -4113,6 +4288,8 @@ exports[`fixtures (JSON) "multiple-typedef-same-property/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-snippets-default/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "item",
@@ -4142,6 +4319,8 @@ exports[`fixtures (JSON) "runes-snippets-default/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-module/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "a",
@@ -4243,6 +4422,8 @@ exports[`fixtures (JSON) "context-module/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "element-tag-map-new/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "semanticTag",
@@ -4272,6 +4453,8 @@ exports[`fixtures (JSON) "element-tag-map-new/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "html-in-template-string/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "message",
@@ -4297,6 +4480,8 @@ exports[`fixtures (JSON) "html-in-template-string/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "type",
@@ -4326,6 +4511,8 @@ exports[`fixtures (JSON) "rest-props-multiple/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-multiple-tags/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -4356,6 +4543,8 @@ exports[`fixtures (JSON) "slot-jsdoc-multiple-tags/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-from-component-to-native/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4400,6 +4589,8 @@ exports[`fixtures (JSON) "forwarded-from-component-to-native/input.svelte" 1`] =
 
 exports[`fixtures (JSON) "call-expression-defaults/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "id",
@@ -4458,6 +4649,8 @@ exports[`fixtures (JSON) "call-expression-defaults/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-enum-not-passthrough/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -4478,6 +4671,8 @@ exports[`fixtures (JSON) "slot-jsdoc-enum-not-passthrough/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "template-literal-default/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "id",
@@ -4539,6 +4734,7 @@ exports[`fixtures (JSON) "template-literal-default/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "no-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4552,6 +4748,8 @@ exports[`fixtures (JSON) "no-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "event-explicit-null/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4585,6 +4783,8 @@ exports[`fixtures (JSON) "event-explicit-null/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-generics/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "rows",
@@ -4662,6 +4862,7 @@ exports[`fixtures (JSON) "context-generics/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "svelte-element-hardcoded-button/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4680,6 +4881,8 @@ exports[`fixtures (JSON) "svelte-element-hardcoded-button/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-standard-event-custom-detail/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "files",
@@ -4722,6 +4925,8 @@ exports[`fixtures (JSON) "forwarded-standard-event-custom-detail/input.svelte" 1
 
 exports[`fixtures (JSON) "runes-props-interface/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "foo",
@@ -4756,6 +4961,7 @@ exports[`fixtures (JSON) "runes-props-interface/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "component-comment-single/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -4776,6 +4982,8 @@ exports[`fixtures (JSON) "component-comment-single/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",
@@ -4827,6 +5035,8 @@ exports[`fixtures (JSON) "bind-this-multiple/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "bindable-direction-runes/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "size",
@@ -4878,6 +5088,8 @@ exports[`fixtures (JSON) "bindable-direction-runes/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-template-tag/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "rows",
@@ -4955,6 +5167,8 @@ exports[`fixtures (JSON) "context-template-tag/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-whole-props-imported/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4968,6 +5182,8 @@ exports[`fixtures (JSON) "runes-whole-props-imported/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-custom-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -4994,6 +5210,8 @@ exports[`fixtures (JSON) "forwarded-custom-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "reactive-direct-mutation-still-true/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",
@@ -5019,6 +5237,8 @@ exports[`fixtures (JSON) "reactive-direct-mutation-still-true/input.svelte" 1`] 
 
 exports[`fixtures (JSON) "typedef/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "id",
@@ -5067,6 +5287,7 @@ exports[`fixtures (JSON) "typedef/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "rest-props-simple/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5084,6 +5305,7 @@ exports[`fixtures (JSON) "rest-props-simple/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5107,6 +5329,7 @@ exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5127,6 +5350,8 @@ exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-rest-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "variant",
@@ -5154,6 +5379,8 @@ exports[`fixtures (JSON) "runes-rest-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-custom-event-null/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5182,6 +5409,8 @@ exports[`fixtures (JSON) "forwarded-custom-event-null/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5214,6 +5443,8 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
 
 exports[`fixtures (JSON) "slot-props-union-types/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "items",
@@ -5251,6 +5482,7 @@ exports[`fixtures (JSON) "slot-props-union-types/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "svelte-element-hardcoded-div/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5269,6 +5501,8 @@ exports[`fixtures (JSON) "svelte-element-hardcoded-div/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "runes-snippet-positional/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "row",
@@ -5293,6 +5527,8 @@ exports[`fixtures (JSON) "runes-snippet-positional/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "legacy-bind-component-ref/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",
@@ -5317,6 +5553,8 @@ exports[`fixtures (JSON) "legacy-bind-component-ref/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5337,6 +5575,8 @@ exports[`fixtures (JSON) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] 
 
 exports[`fixtures (JSON) "svelte-element-dynamic/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "tag",
@@ -5366,6 +5606,8 @@ exports[`fixtures (JSON) "svelte-element-dynamic/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "prop-comment-complex/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "text",
@@ -5410,6 +5652,8 @@ exports[`fixtures (JSON) "prop-comment-complex/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "element-tag-map-text-elements/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "textElement",
@@ -5439,6 +5683,8 @@ exports[`fixtures (JSON) "element-tag-map-text-elements/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5464,6 +5710,8 @@ exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "rest-props-description/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "variant",
@@ -5494,6 +5742,8 @@ exports[`fixtures (JSON) "rest-props-description/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-description-hyphens-prose/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5514,6 +5764,8 @@ exports[`fixtures (JSON) "slot-description-hyphens-prose/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-space/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5540,6 +5792,8 @@ exports[`fixtures (JSON) "context-space/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "extend-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "secondary",
@@ -5579,6 +5833,8 @@ exports[`fixtures (JSON) "extend-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "template-tag-with-rest-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -5644,6 +5900,8 @@ exports[`fixtures (JSON) "template-tag-with-rest-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "forwarded-and-dispatched-events/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5663,6 +5921,8 @@ exports[`fixtures (JSON) "forwarded-and-dispatched-events/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slots-spread-typed/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5688,6 +5948,8 @@ exports[`fixtures (JSON) "slots-spread-typed/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-inline-functions/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5724,6 +5986,8 @@ exports[`fixtures (JSON) "context-inline-functions/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [
@@ -5762,6 +6026,8 @@ exports[`fixtures (JSON) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "typed-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop1",
@@ -5820,6 +6086,8 @@ exports[`fixtures (JSON) "typed-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "reactive-shadowed-local-assignment/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",
@@ -5845,6 +6113,8 @@ exports[`fixtures (JSON) "reactive-shadowed-local-assignment/input.svelte" 1`] =
 
 exports[`fixtures (JSON) "runes-typed-props/input.svelte" 1`] = `
 "{
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",
@@ -5894,6 +6164,8 @@ exports[`fixtures (JSON) "runes-typed-props/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",
@@ -5955,6 +6227,8 @@ exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "context-dot-notation/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],
@@ -5987,6 +6261,8 @@ exports[`fixtures (JSON) "context-dot-notation/input.svelte" 1`] = `
 
 exports[`fixtures (JSON) "slot-description-hyphens-inline/input.svelte" 1`] = `
 "{
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Accordion",
       "filePath": "src/Accordion/Accordion.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "align",
@@ -107,6 +109,8 @@
     {
       "moduleName": "AccordionItem",
       "filePath": "src/Accordion/AccordionItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "title",
@@ -188,6 +192,8 @@
     {
       "moduleName": "AccordionSkeleton",
       "filePath": "src/Accordion/AccordionSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "count",
@@ -254,6 +260,8 @@
     {
       "moduleName": "AspectRatio",
       "filePath": "src/AspectRatio/AspectRatio.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "ratio",
@@ -281,6 +289,8 @@
     {
       "moduleName": "Breadcrumb",
       "filePath": "src/Breadcrumb/Breadcrumb.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "noTrailingSlash",
@@ -345,6 +355,8 @@
     {
       "moduleName": "BreadcrumbItem",
       "filePath": "src/Breadcrumb/BreadcrumbItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "href",
@@ -393,6 +405,8 @@
     {
       "moduleName": "BreadcrumbSkeleton",
       "filePath": "src/Breadcrumb/BreadcrumbSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "noTrailingSlash",
@@ -435,6 +449,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/Button/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "kind",
@@ -674,6 +690,8 @@
     {
       "moduleName": "ButtonSet",
       "filePath": "src/Button/ButtonSet.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "stacked",
@@ -701,6 +719,8 @@
     {
       "moduleName": "ButtonSkeleton",
       "filePath": "src/Button/ButtonSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "href",
@@ -755,6 +775,8 @@
     {
       "moduleName": "Checkbox",
       "filePath": "src/Checkbox/Checkbox.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "checked",
@@ -930,6 +952,7 @@
     {
       "moduleName": "CheckboxSkeleton",
       "filePath": "src/Checkbox/CheckboxSkeleton.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [],
@@ -947,6 +970,8 @@
     {
       "moduleName": "ClickableTile",
       "filePath": "src/Tile/ClickableTile.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "clicked",
@@ -1004,6 +1029,8 @@
     {
       "moduleName": "CodeSnippet",
       "filePath": "src/CodeSnippet/CodeSnippet.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",
@@ -1257,6 +1284,8 @@
     {
       "moduleName": "CodeSnippetSkeleton",
       "filePath": "src/CodeSnippet/CodeSnippetSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",
@@ -1287,6 +1316,8 @@
     {
       "moduleName": "Column",
       "filePath": "src/Grid/Column.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "as",
@@ -1454,6 +1485,8 @@
     {
       "moduleName": "ComboBox",
       "filePath": "src/ComboBox/ComboBox.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "items",
@@ -1710,6 +1743,8 @@
     {
       "moduleName": "ComposedModal",
       "filePath": "src/ComposedModal/ComposedModal.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -1832,6 +1867,8 @@
     {
       "moduleName": "Content",
       "filePath": "src/UIShell/Content.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "id",
@@ -1859,6 +1896,8 @@
     {
       "moduleName": "ContentSwitcher",
       "filePath": "src/ContentSwitcher/ContentSwitcher.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selectedIndex",
@@ -1936,6 +1975,8 @@
     {
       "moduleName": "Copy",
       "filePath": "src/Copy/Copy.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "feedback",
@@ -1995,6 +2036,8 @@
     {
       "moduleName": "CopyButton",
       "filePath": "src/CopyButton/CopyButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "iconDescription",
@@ -2027,6 +2070,8 @@
     {
       "moduleName": "DataTable",
       "filePath": "src/DataTable/DataTable.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "headers",
@@ -2433,6 +2478,8 @@
     {
       "moduleName": "DataTableSkeleton",
       "filePath": "src/DataTable/DataTableSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "columns",
@@ -2539,6 +2586,8 @@
     {
       "moduleName": "DatePicker",
       "filePath": "src/DatePicker/DatePicker.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "datePickerType",
@@ -2708,6 +2757,8 @@
     {
       "moduleName": "DatePickerInput",
       "filePath": "src/DatePicker/DatePickerInput.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -2881,6 +2932,8 @@
     {
       "moduleName": "DatePickerSkeleton",
       "filePath": "src/DatePicker/DatePickerSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "range",
@@ -2923,6 +2976,8 @@
     {
       "moduleName": "Dropdown",
       "filePath": "src/Dropdown/Dropdown.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "items",
@@ -3197,6 +3252,8 @@
     {
       "moduleName": "DropdownSkeleton",
       "filePath": "src/Dropdown/DropdownSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "inline",
@@ -3227,6 +3284,8 @@
     {
       "moduleName": "ExpandableTile",
       "filePath": "src/Tile/ExpandableTile.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "expanded",
@@ -3389,6 +3448,8 @@
     {
       "moduleName": "Filename",
       "filePath": "src/FileUploader/Filename.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "status",
@@ -3441,6 +3502,8 @@
     {
       "moduleName": "FileUploader",
       "filePath": "src/FileUploader/FileUploader.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "status",
@@ -3598,6 +3661,8 @@
     {
       "moduleName": "FileUploaderButton",
       "filePath": "src/FileUploader/FileUploaderButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "accept",
@@ -3747,6 +3812,8 @@
     {
       "moduleName": "FileUploaderDropContainer",
       "filePath": "src/FileUploader/FileUploaderDropContainer.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "accept",
@@ -3887,6 +3954,8 @@
     {
       "moduleName": "FileUploaderItem",
       "filePath": "src/FileUploader/FileUploaderItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "status",
@@ -3989,6 +4058,8 @@
     {
       "moduleName": "FileUploaderSkeleton",
       "filePath": "src/FileUploader/FileUploaderSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [],
@@ -4006,6 +4077,8 @@
     {
       "moduleName": "FluidForm",
       "filePath": "src/FluidForm/FluidForm.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -4028,6 +4101,7 @@
     {
       "moduleName": "Form",
       "filePath": "src/Form/Form.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -4048,6 +4122,8 @@
     {
       "moduleName": "FormGroup",
       "filePath": "src/FormGroup/FormGroup.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "invalid",
@@ -4116,6 +4192,7 @@
     {
       "moduleName": "FormItem",
       "filePath": "src/FormItem/FormItem.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -4135,6 +4212,8 @@
     {
       "moduleName": "FormLabel",
       "filePath": "src/FormLabel/FormLabel.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "id",
@@ -4167,6 +4246,8 @@
     {
       "moduleName": "Grid",
       "filePath": "src/Grid/Grid.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "as",
@@ -4282,6 +4363,8 @@
     {
       "moduleName": "Header",
       "filePath": "src/UIShell/GlobalHeader/Header.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "expandedByDefault",
@@ -4408,6 +4491,8 @@
     {
       "moduleName": "HeaderAction",
       "filePath": "src/UIShell/GlobalHeader/HeaderAction.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "isOpen",
@@ -4502,6 +4587,8 @@
     {
       "moduleName": "HeaderActionLink",
       "filePath": "src/UIShell/GlobalHeader/HeaderActionLink.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "linkIsActive",
@@ -4563,6 +4650,8 @@
     {
       "moduleName": "HeaderActionSearch",
       "filePath": "src/UIShell/GlobalHeader/HeaderActionSearch.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "searchIsActive",
@@ -4599,6 +4688,8 @@
     {
       "moduleName": "HeaderGlobalAction",
       "filePath": "src/UIShell/HeaderGlobalAction.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "isActive",
@@ -4655,6 +4746,8 @@
     {
       "moduleName": "HeaderNav",
       "filePath": "src/UIShell/GlobalHeader/HeaderNav.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "ariaLabel",
@@ -4682,6 +4775,8 @@
     {
       "moduleName": "HeaderNavItem",
       "filePath": "src/UIShell/GlobalHeader/HeaderNavItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "href",
@@ -4740,6 +4835,8 @@
     {
       "moduleName": "HeaderNavMenu",
       "filePath": "src/UIShell/GlobalHeader/HeaderNavMenu.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "expanded",
@@ -4824,6 +4921,7 @@
     {
       "moduleName": "HeaderPanelDivider",
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelDivider.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -4837,6 +4935,8 @@
     {
       "moduleName": "HeaderPanelLink",
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelLink.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "href",
@@ -4876,6 +4976,7 @@
     {
       "moduleName": "HeaderPanelLinks",
       "filePath": "src/UIShell/GlobalHeader/HeaderPanelLinks.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -4889,6 +4990,8 @@
     {
       "moduleName": "HeaderSearch",
       "filePath": "src/UIShell/HeaderSearch.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -4989,6 +5092,7 @@
     {
       "moduleName": "HeaderUtilities",
       "filePath": "src/UIShell/GlobalHeader/HeaderUtilities.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -5002,6 +5106,8 @@
     {
       "moduleName": "Icon",
       "filePath": "src/Icon/Icon.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "render",
@@ -5056,6 +5162,8 @@
     {
       "moduleName": "IconSkeleton",
       "filePath": "src/Icon/IconSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -5086,6 +5194,8 @@
     {
       "moduleName": "InlineLoading",
       "filePath": "src/InlineLoading/InlineLoading.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "status",
@@ -5153,6 +5263,8 @@
     {
       "moduleName": "InlineNotification",
       "filePath": "src/Notification/InlineNotification.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "kind",
@@ -5283,6 +5395,8 @@
     {
       "moduleName": "Link",
       "filePath": "src/Link/Link.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -5375,6 +5489,8 @@
     {
       "moduleName": "ListBox",
       "filePath": "src/ListBox/ListBox.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -5501,6 +5617,8 @@
     {
       "moduleName": "ListBoxField",
       "filePath": "src/ListBox/ListBoxField.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "disabled",
@@ -5612,6 +5730,8 @@
     {
       "moduleName": "ListBoxMenu",
       "filePath": "src/ListBox/ListBoxMenu.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "id",
@@ -5651,6 +5771,8 @@
     {
       "moduleName": "ListBoxMenuIcon",
       "filePath": "src/ListBox/ListBoxMenuIcon.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "open",
@@ -5705,6 +5827,8 @@
     {
       "moduleName": "ListBoxMenuItem",
       "filePath": "src/ListBox/ListBoxMenuItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "active",
@@ -5748,6 +5872,8 @@
     {
       "moduleName": "ListBoxSelection",
       "filePath": "src/ListBox/ListBoxSelection.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selectionCount",
@@ -5826,6 +5952,7 @@
     {
       "moduleName": "ListItem",
       "filePath": "src/ListItem/ListItem.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -5845,6 +5972,8 @@
     {
       "moduleName": "Loading",
       "filePath": "src/Loading/Loading.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "small",
@@ -5918,6 +6047,8 @@
     {
       "moduleName": "Modal",
       "filePath": "src/Modal/Modal.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -6191,6 +6322,8 @@
     {
       "moduleName": "ModalBody",
       "filePath": "src/ComposedModal/ModalBody.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "hasForm",
@@ -6230,6 +6363,8 @@
     {
       "moduleName": "ModalFooter",
       "filePath": "src/ComposedModal/ModalFooter.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "primaryButtonText",
@@ -6317,6 +6452,8 @@
     {
       "moduleName": "ModalHeader",
       "filePath": "src/ComposedModal/ModalHeader.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "title",
@@ -6416,6 +6553,8 @@
     {
       "moduleName": "MultiSelect",
       "filePath": "src/MultiSelect/MultiSelect.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "items",
@@ -6772,6 +6911,8 @@
     {
       "moduleName": "NotificationActionButton",
       "filePath": "src/Notification/NotificationActionButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -6791,6 +6932,8 @@
     {
       "moduleName": "NotificationButton",
       "filePath": "src/Notification/NotificationButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "notificationType",
@@ -6857,6 +7000,8 @@
     {
       "moduleName": "NotificationIcon",
       "filePath": "src/Notification/NotificationIcon.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "kind",
@@ -6905,6 +7050,8 @@
     {
       "moduleName": "NotificationTextDetails",
       "filePath": "src/Notification/NotificationTextDetails.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "notificationType",
@@ -6967,6 +7114,8 @@
     {
       "moduleName": "NumberInput",
       "filePath": "src/NumberInput/NumberInput.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -7275,6 +7424,8 @@
     {
       "moduleName": "NumberInputSkeleton",
       "filePath": "src/NumberInput/NumberInputSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "hideLabel",
@@ -7305,6 +7456,8 @@
     {
       "moduleName": "OrderedList",
       "filePath": "src/OrderedList/OrderedList.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "nested",
@@ -7349,6 +7502,8 @@
     {
       "moduleName": "OutboundLink",
       "filePath": "src/Link/OutboundLink.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -7369,6 +7524,8 @@
     {
       "moduleName": "OverflowMenu",
       "filePath": "src/OverflowMenu/OverflowMenu.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -7564,6 +7721,8 @@
     {
       "moduleName": "OverflowMenuItem",
       "filePath": "src/OverflowMenu/OverflowMenuItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "text",
@@ -7695,6 +7854,8 @@
     {
       "moduleName": "Pagination",
       "filePath": "src/Pagination/Pagination.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "page",
@@ -7902,6 +8063,8 @@
     {
       "moduleName": "PaginationNav",
       "filePath": "src/PaginationNav/PaginationNav.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "page",
@@ -8003,6 +8166,8 @@
     {
       "moduleName": "PaginationSkeleton",
       "filePath": "src/Pagination/PaginationSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [],
@@ -8020,6 +8185,8 @@
     {
       "moduleName": "PasswordInput",
       "filePath": "src/TextInput/PasswordInput.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -8259,6 +8426,8 @@
     {
       "moduleName": "ProgressIndicator",
       "filePath": "src/ProgressIndicator/ProgressIndicator.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "currentIndex",
@@ -8343,6 +8512,8 @@
     {
       "moduleName": "ProgressIndicatorSkeleton",
       "filePath": "src/ProgressIndicator/ProgressIndicatorSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "vertical",
@@ -8385,6 +8556,8 @@
     {
       "moduleName": "ProgressStep",
       "filePath": "src/ProgressIndicator/ProgressStep.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "complete",
@@ -8507,6 +8680,8 @@
     {
       "moduleName": "RadioButton",
       "filePath": "src/RadioButton/RadioButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -8628,6 +8803,8 @@
     {
       "moduleName": "RadioButtonGroup",
       "filePath": "src/RadioButtonGroup/RadioButtonGroup.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selected",
@@ -8723,6 +8900,7 @@
     {
       "moduleName": "RadioButtonSkeleton",
       "filePath": "src/RadioButton/RadioButtonSkeleton.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [],
@@ -8740,6 +8918,8 @@
     {
       "moduleName": "RadioTile",
       "filePath": "src/Tile/RadioTile.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "checked",
@@ -8846,6 +9026,8 @@
     {
       "moduleName": "Row",
       "filePath": "src/Grid/Row.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "as",
@@ -8949,6 +9131,8 @@
     {
       "moduleName": "Search",
       "filePath": "src/Search/Search.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "small",
@@ -9153,6 +9337,8 @@
     {
       "moduleName": "SearchSkeleton",
       "filePath": "src/Search/SearchSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "small",
@@ -9195,6 +9381,8 @@
     {
       "moduleName": "Select",
       "filePath": "src/Select/Select.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selected",
@@ -9389,6 +9577,8 @@
     {
       "moduleName": "SelectableTile",
       "filePath": "src/Tile/SelectableTile.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selected",
@@ -9518,6 +9708,8 @@
     {
       "moduleName": "SelectItem",
       "filePath": "src/Select/SelectItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -9578,6 +9770,8 @@
     {
       "moduleName": "SelectItemGroup",
       "filePath": "src/Select/SelectItemGroup.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "disabled",
@@ -9617,6 +9811,8 @@
     {
       "moduleName": "SelectSkeleton",
       "filePath": "src/Select/SelectSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "hideLabel",
@@ -9647,6 +9843,8 @@
     {
       "moduleName": "SideNav",
       "filePath": "src/UIShell/SideNav/SideNav.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "fixed",
@@ -9698,6 +9896,7 @@
     {
       "moduleName": "SideNavItems",
       "filePath": "src/UIShell/SideNav/SideNavItems.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -9711,6 +9910,8 @@
     {
       "moduleName": "SideNavLink",
       "filePath": "src/UIShell/SideNav/SideNavLink.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "isSelected",
@@ -9784,6 +9985,8 @@
     {
       "moduleName": "SideNavMenu",
       "filePath": "src/UIShell/SideNav/SideNavMenu.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "expanded",
@@ -9847,6 +10050,8 @@
     {
       "moduleName": "SideNavMenuItem",
       "filePath": "src/UIShell/SideNav/SideNavMenuItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "isSelected",
@@ -9908,6 +10113,7 @@
     {
       "moduleName": "SkeletonPlaceholder",
       "filePath": "src/SkeletonPlaceholder/SkeletonPlaceholder.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [],
@@ -9925,6 +10131,8 @@
     {
       "moduleName": "SkeletonText",
       "filePath": "src/SkeletonText/SkeletonText.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "lines",
@@ -9991,6 +10199,8 @@
     {
       "moduleName": "SkipToContent",
       "filePath": "src/UIShell/SkipToContent.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "href",
@@ -10035,6 +10245,8 @@
     {
       "moduleName": "Slider",
       "filePath": "src/Slider/Slider.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -10258,6 +10470,8 @@
     {
       "moduleName": "SliderSkeleton",
       "filePath": "src/Slider/SliderSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "hideLabel",
@@ -10288,6 +10502,8 @@
     {
       "moduleName": "StructuredList",
       "filePath": "src/StructuredList/StructuredList.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selected",
@@ -10358,6 +10574,7 @@
     {
       "moduleName": "StructuredListBody",
       "filePath": "src/StructuredList/StructuredListBody.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -10377,6 +10594,8 @@
     {
       "moduleName": "StructuredListCell",
       "filePath": "src/StructuredList/StructuredListCell.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "head",
@@ -10421,6 +10640,7 @@
     {
       "moduleName": "StructuredListHead",
       "filePath": "src/StructuredList/StructuredListHead.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -10440,6 +10660,8 @@
     {
       "moduleName": "StructuredListInput",
       "filePath": "src/StructuredList/StructuredListInput.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "checked",
@@ -10525,6 +10747,8 @@
     {
       "moduleName": "StructuredListRow",
       "filePath": "src/StructuredList/StructuredListRow.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "head",
@@ -10582,6 +10806,8 @@
     {
       "moduleName": "StructuredListSkeleton",
       "filePath": "src/StructuredList/StructuredListSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "rows",
@@ -10624,6 +10850,8 @@
     {
       "moduleName": "Switch",
       "filePath": "src/ContentSwitcher/Switch.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "text",
@@ -10710,6 +10938,8 @@
     {
       "moduleName": "Tab",
       "filePath": "src/Tabs/Tab.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "label",
@@ -10807,6 +11037,8 @@
     {
       "moduleName": "TabContent",
       "filePath": "src/Tabs/TabContent.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "id",
@@ -10834,6 +11066,8 @@
     {
       "moduleName": "Table",
       "filePath": "src/DataTable/Table.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -10921,6 +11155,7 @@
     {
       "moduleName": "TableBody",
       "filePath": "src/DataTable/TableBody.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -10935,6 +11170,7 @@
     {
       "moduleName": "TableCell",
       "filePath": "src/DataTable/TableCell.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -10954,6 +11190,8 @@
     {
       "moduleName": "TableContainer",
       "filePath": "src/DataTable/TableContainer.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "title",
@@ -11005,6 +11243,7 @@
     {
       "moduleName": "TableHead",
       "filePath": "src/DataTable/TableHead.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -11024,6 +11263,8 @@
     {
       "moduleName": "TableHeader",
       "filePath": "src/DataTable/TableHeader.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "scope",
@@ -11079,6 +11320,7 @@
     {
       "moduleName": "TableRow",
       "filePath": "src/DataTable/TableRow.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -11098,6 +11340,8 @@
     {
       "moduleName": "Tabs",
       "filePath": "src/Tabs/Tabs.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selected",
@@ -11197,6 +11441,8 @@
     {
       "moduleName": "TabsSkeleton",
       "filePath": "src/Tabs/TabsSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "count",
@@ -11227,6 +11473,8 @@
     {
       "moduleName": "Tag",
       "filePath": "src/Tag/Tag.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",
@@ -11336,6 +11584,7 @@
     {
       "moduleName": "TagSkeleton",
       "filePath": "src/Tag/TagSkeleton.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [],
@@ -11353,6 +11602,8 @@
     {
       "moduleName": "TextArea",
       "filePath": "src/TextArea/TextArea.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -11543,6 +11794,8 @@
     {
       "moduleName": "TextAreaSkeleton",
       "filePath": "src/TextArea/TextAreaSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "hideLabel",
@@ -11573,6 +11826,8 @@
     {
       "moduleName": "TextInput",
       "filePath": "src/TextInput/TextInput.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -11812,6 +12067,8 @@
     {
       "moduleName": "TextInputSkeleton",
       "filePath": "src/TextInput/TextInputSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "hideLabel",
@@ -11842,6 +12099,8 @@
     {
       "moduleName": "Tile",
       "filePath": "src/Tile/Tile.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "light",
@@ -11874,6 +12133,8 @@
     {
       "moduleName": "TileGroup",
       "filePath": "src/Tile/TileGroup.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "selected",
@@ -11939,6 +12200,8 @@
     {
       "moduleName": "TimePicker",
       "filePath": "src/TimePicker/TimePicker.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -12143,6 +12406,8 @@
     {
       "moduleName": "TimePickerSelect",
       "filePath": "src/TimePicker/TimePickerSelect.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -12267,6 +12532,8 @@
     {
       "moduleName": "ToastNotification",
       "filePath": "src/Notification/ToastNotification.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "kind",
@@ -12400,6 +12667,8 @@
     {
       "moduleName": "Toggle",
       "filePath": "src/Toggle/Toggle.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -12523,6 +12792,8 @@
     {
       "moduleName": "ToggleSkeleton",
       "filePath": "src/Toggle/ToggleSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -12577,6 +12848,8 @@
     {
       "moduleName": "ToggleSmall",
       "filePath": "src/ToggleSmall/ToggleSmall.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "toggled",
@@ -12683,6 +12956,8 @@
     {
       "moduleName": "ToggleSmallSkeleton",
       "filePath": "src/ToggleSmall/ToggleSmallSkeleton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "labelText",
@@ -12725,6 +13000,8 @@
     {
       "moduleName": "Toolbar",
       "filePath": "src/DataTable/Toolbar.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "size",
@@ -12765,6 +13042,8 @@
     {
       "moduleName": "ToolbarBatchActions",
       "filePath": "src/DataTable/ToolbarBatchActions.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "formatTotalSelected",
@@ -12791,6 +13070,7 @@
     {
       "moduleName": "ToolbarContent",
       "filePath": "src/DataTable/ToolbarContent.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -12804,6 +13084,8 @@
     {
       "moduleName": "ToolbarMenu",
       "filePath": "src/DataTable/ToolbarMenu.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -12822,6 +13104,8 @@
     {
       "moduleName": "ToolbarMenuItem",
       "filePath": "src/DataTable/ToolbarMenuItem.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -12847,6 +13131,8 @@
     {
       "moduleName": "ToolbarSearch",
       "filePath": "src/DataTable/ToolbarSearch.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "value",
@@ -12925,6 +13211,8 @@
     {
       "moduleName": "Tooltip",
       "filePath": "src/Tooltip/Tooltip.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "align",
@@ -13127,6 +13415,8 @@
     {
       "moduleName": "TooltipDefinition",
       "filePath": "src/TooltipDefinition/TooltipDefinition.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "tooltipText",
@@ -13218,6 +13508,8 @@
     {
       "moduleName": "TooltipIcon",
       "filePath": "src/TooltipIcon/TooltipIcon.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "tooltipText",
@@ -13309,6 +13601,8 @@
     {
       "moduleName": "UnorderedList",
       "filePath": "src/UnorderedList/UnorderedList.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "nested",

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/button/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "ts",
       "props": [
         {
           "name": "type",

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",
@@ -53,6 +55,7 @@
     {
       "moduleName": "Link",
       "filePath": "src/Link.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -72,6 +75,8 @@
     {
       "moduleName": "Quote",
       "filePath": "src/Quote.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "quote",
@@ -114,6 +119,8 @@
     {
       "moduleName": "SecondaryButton",
       "filePath": "src/SecondaryButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "secondary",

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",
@@ -62,6 +64,7 @@
     {
       "moduleName": "Header",
       "filePath": "src/nested/Header.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -75,6 +78,7 @@
     {
       "moduleName": "Link",
       "filePath": "src/Link.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -94,6 +98,8 @@
     {
       "moduleName": "Quote",
       "filePath": "src/Quote.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "quote",

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/components/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",
@@ -53,6 +55,7 @@
     {
       "moduleName": "Card",
       "filePath": "src/components/Card.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -66,6 +69,7 @@
     {
       "moduleName": "Header",
       "filePath": "src/nested/Header.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -79,6 +83,7 @@
     {
       "moduleName": "Link",
       "filePath": "src/Link.svelte",
+      "syntaxMode": "legacy",
       "props": [],
       "moduleExports": [],
       "slots": [
@@ -98,6 +103,8 @@
     {
       "moduleName": "Quote",
       "filePath": "src/Quote.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "quote",

--- a/tests/e2e/path-aliases/COMPONENT_API.json
+++ b/tests/e2e/path-aliases/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/lib/components/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "text",
@@ -46,6 +48,8 @@
     {
       "moduleName": "Input",
       "filePath": "src/lib/components/Input.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "placeholder",

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "component/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "component/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",

--- a/tests/e2e/svelte5-legacy/COMPONENT_API.json
+++ b/tests/e2e/svelte5-legacy/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "LegacyButton",
       "filePath": "src/LegacyButton.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "label",

--- a/tests/e2e/svelte5-runes/COMPONENT_API.json
+++ b/tests/e2e/svelte5-runes/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "RunesButton",
       "filePath": "src/RunesButton.svelte",
+      "syntaxMode": "runes",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "label",

--- a/tests/e2e/sveltekit/COMPONENT_API.json
+++ b/tests/e2e/sveltekit/COMPONENT_API.json
@@ -10,6 +10,8 @@
     {
       "moduleName": "Button",
       "filePath": "src/lib/Button.svelte",
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
       "props": [
         {
           "name": "type",

--- a/tests/fixtures/accessor-param-returns/output.json
+++ b/tests/fixtures/accessor-param-returns/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "add",

--- a/tests/fixtures/anchor-props/output.json
+++ b/tests/fixtures/anchor-props/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/arrow-function-with-jsdoc/output.json
+++ b/tests/fixtures/arrow-function-with-jsdoc/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "transform",

--- a/tests/fixtures/async-function-props/output.json
+++ b/tests/fixtures/async-function-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "initialize",

--- a/tests/fixtures/binary-expression-numeric/output.json
+++ b/tests/fixtures/binary-expression-numeric/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "sum",

--- a/tests/fixtures/bind-this-multiple/output.json
+++ b/tests/fixtures/bind-this-multiple/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",

--- a/tests/fixtures/bind-this/output.json
+++ b/tests/fixtures/bind-this/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",

--- a/tests/fixtures/bindable-direction-legacy/output.json
+++ b/tests/fixtures/bindable-direction-legacy/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "size",

--- a/tests/fixtures/bindable-direction-runes/output.json
+++ b/tests/fixtures/bindable-direction-runes/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "size",

--- a/tests/fixtures/call-expression-defaults/output.json
+++ b/tests/fixtures/call-expression-defaults/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "id",

--- a/tests/fixtures/callback-typedef/output.json
+++ b/tests/fixtures/callback-typedef/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "direction",

--- a/tests/fixtures/callback/output.json
+++ b/tests/fixtures/callback/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "onChange",

--- a/tests/fixtures/component-comment-multi/output.json
+++ b/tests/fixtures/component-comment-multi/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/component-comment-single/output.json
+++ b/tests/fixtures/component-comment-single/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/constructor-expression-defaults/output.json
+++ b/tests/fixtures/constructor-expression-defaults/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "cache",

--- a/tests/fixtures/context-colon/output.json
+++ b/tests/fixtures/context-colon/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/context-dot-notation/output.json
+++ b/tests/fixtures/context-dot-notation/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/context-empty/output.json
+++ b/tests/fixtures/context-empty/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/context-generics/output.json
+++ b/tests/fixtures/context-generics/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "rows",

--- a/tests/fixtures/context-imported-type/output.json
+++ b/tests/fixtures/context-imported-type/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/context-inline-functions/output.json
+++ b/tests/fixtures/context-inline-functions/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/context-issue-103/output.json
+++ b/tests/fixtures/context-issue-103/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/context-mixed-separators/output.json
+++ b/tests/fixtures/context-mixed-separators/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/context-module/output.json
+++ b/tests/fixtures/context-module/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "a",

--- a/tests/fixtures/context-simple/output.json
+++ b/tests/fixtures/context-simple/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/context-space/output.json
+++ b/tests/fixtures/context-space/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/context-template-tag/output.json
+++ b/tests/fixtures/context-template-tag/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "rows",

--- a/tests/fixtures/context-typedef/output.json
+++ b/tests/fixtures/context-typedef/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/context-underscore/output.json
+++ b/tests/fixtures/context-underscore/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/default-slot-with-props/output.json
+++ b/tests/fixtures/default-slot-with-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "items",

--- a/tests/fixtures/dispatched-events-dynamic/output.json
+++ b/tests/fixtures/dispatched-events-dynamic/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/dispatched-events-typed/output.json
+++ b/tests/fixtures/dispatched-events-typed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/element-tag-map-new/output.json
+++ b/tests/fixtures/element-tag-map-new/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "semanticTag",

--- a/tests/fixtures/element-tag-map-table-cells/output.json
+++ b/tests/fixtures/element-tag-map-table-cells/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "cellType",

--- a/tests/fixtures/element-tag-map-text-elements/output.json
+++ b/tests/fixtures/element-tag-map-text-elements/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "textElement",

--- a/tests/fixtures/empty-collection-defaults/output.json
+++ b/tests/fixtures/empty-collection-defaults/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "items",

--- a/tests/fixtures/empty-export/output.json
+++ b/tests/fixtures/empty-export/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/event-explicit-null/output.json
+++ b/tests/fixtures/event-explicit-null/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/events-stable-order/output.json
+++ b/tests/fixtures/events-stable-order/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/explicit-default-no-duplicate/output.json
+++ b/tests/fixtures/explicit-default-no-duplicate/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "shouldFilter",

--- a/tests/fixtures/extend-props/output.json
+++ b/tests/fixtures/extend-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "secondary",

--- a/tests/fixtures/forwarded-and-dispatched-events/output.json
+++ b/tests/fixtures/forwarded-and-dispatched-events/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/forwarded-custom-event-null/output.json
+++ b/tests/fixtures/forwarded-custom-event-null/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/forwarded-custom-events/output.json
+++ b/tests/fixtures/forwarded-custom-events/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
+++ b/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/forwarded-events-typed/output.json
+++ b/tests/fixtures/forwarded-events-typed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/forwarded-events/output.json
+++ b/tests/fixtures/forwarded-events/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/forwarded-from-component-to-native/output.json
+++ b/tests/fixtures/forwarded-from-component-to-native/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/forwarded-native-with-detail/output.json
+++ b/tests/fixtures/forwarded-native-with-detail/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/forwarded-standard-event-custom-detail/output.json
+++ b/tests/fixtures/forwarded-standard-event-custom-detail/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "files",

--- a/tests/fixtures/function-declaration/output.json
+++ b/tests/fixtures/function-declaration/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "fnA",

--- a/tests/fixtures/generics-multiple/output.json
+++ b/tests/fixtures/generics-multiple/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/generics-with-rest-props/output.json
+++ b/tests/fixtures/generics-with-rest-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/generics/output.json
+++ b/tests/fixtures/generics/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/html-in-template-string/output.json
+++ b/tests/fixtures/html-in-template-string/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "message",

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",

--- a/tests/fixtures/infer-with-types/output.json
+++ b/tests/fixtures/infer-with-types/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "propBool",

--- a/tests/fixtures/input-events/output.json
+++ b/tests/fixtures/input-events/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/instance-reexport/output.json
+++ b/tests/fixtures/instance-reexport/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "data",

--- a/tests/fixtures/jsdoc-type-params/output.json
+++ b/tests/fixtures/jsdoc-type-params/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "showNode",

--- a/tests/fixtures/legacy-bind-component-ref-forward/output.json
+++ b/tests/fixtures/legacy-bind-component-ref-forward/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "listRef",

--- a/tests/fixtures/legacy-bind-component-ref/output.json
+++ b/tests/fixtures/legacy-bind-component-ref/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "ref",

--- a/tests/fixtures/legacy-bind-component-selected/output.json
+++ b/tests/fixtures/legacy-bind-component-selected/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "pageSize",

--- a/tests/fixtures/legacy-bind-component-value/output.json
+++ b/tests/fixtures/legacy-bind-component-value/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",

--- a/tests/fixtures/legacy-export-typed/output.json
+++ b/tests/fixtures/legacy-export-typed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "title",

--- a/tests/fixtures/legacy-pass-through-nonreactive/output.json
+++ b/tests/fixtures/legacy-pass-through-nonreactive/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",

--- a/tests/fixtures/mixed-event-types/output.json
+++ b/tests/fixtures/mixed-event-types/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/mixed-events/output.json
+++ b/tests/fixtures/mixed-events/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/module-reexport-direct/output.json
+++ b/tests/fixtures/module-reexport-direct/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "config",

--- a/tests/fixtures/module-reexport-mixed/output.json
+++ b/tests/fixtures/module-reexport-mixed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "name",

--- a/tests/fixtures/module-reexport-renamed/output.json
+++ b/tests/fixtures/module-reexport-renamed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "visible",

--- a/tests/fixtures/module-reexport/output.json
+++ b/tests/fixtures/module-reexport/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "data",

--- a/tests/fixtures/multiple-typedef-same-property/output.json
+++ b/tests/fixtures/multiple-typedef-same-property/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "user",

--- a/tests/fixtures/no-props/output.json
+++ b/tests/fixtures/no-props/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/non-literal-defaults/output.json
+++ b/tests/fixtures/non-literal-defaults/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "position",

--- a/tests/fixtures/prop-comment-complex/output.json
+++ b/tests/fixtures/prop-comment-complex/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "text",

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",

--- a/tests/fixtures/reactive-direct-mutation-still-true/output.json
+++ b/tests/fixtures/reactive-direct-mutation-still-true/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",

--- a/tests/fixtures/reactive-shadowed-callback-param/output.json
+++ b/tests/fixtures/reactive-shadowed-callback-param/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",

--- a/tests/fixtures/reactive-shadowed-each-binding/output.json
+++ b/tests/fixtures/reactive-shadowed-each-binding/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",

--- a/tests/fixtures/reactive-shadowed-local-assignment/output.json
+++ b/tests/fixtures/reactive-shadowed-local-assignment/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",

--- a/tests/fixtures/reactive-shadowed-local-reassignment/output.json
+++ b/tests/fixtures/reactive-shadowed-local-reassignment/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "disabled",

--- a/tests/fixtures/renamed-props/output.json
+++ b/tests/fixtures/renamed-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "class",

--- a/tests/fixtures/required/output.json
+++ b/tests/fixtures/required/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",

--- a/tests/fixtures/resolve-default-chained/output.json
+++ b/tests/fixtures/resolve-default-chained/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "chained",

--- a/tests/fixtures/rest-props-description-multiline/output.json
+++ b/tests/fixtures/rest-props-description-multiline/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "variant",

--- a/tests/fixtures/rest-props-description/output.json
+++ b/tests/fixtures/rest-props-description/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "variant",

--- a/tests/fixtures/rest-props-multiple/output.json
+++ b/tests/fixtures/rest-props-multiple/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "type",

--- a/tests/fixtures/rest-props-simple/output.json
+++ b/tests/fixtures/rest-props-simple/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/runes-bindable/output.json
+++ b/tests/fixtures/runes-bindable/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",

--- a/tests/fixtures/runes-callback-annotated/output.json
+++ b/tests/fixtures/runes-callback-annotated/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "onsnowball",

--- a/tests/fixtures/runes-callback-props/output.json
+++ b/tests/fixtures/runes-callback-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "onclick",

--- a/tests/fixtures/runes-dispatched-events/output.json
+++ b/tests/fixtures/runes-dispatched-events/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "value",

--- a/tests/fixtures/runes-generics/output.json
+++ b/tests/fixtures/runes-generics/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/runes-props-basic/output.json
+++ b/tests/fixtures/runes-props-basic/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "title",

--- a/tests/fixtures/runes-props-interface/output.json
+++ b/tests/fixtures/runes-props-interface/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "foo",

--- a/tests/fixtures/runes-props-intersection/output.json
+++ b/tests/fixtures/runes-props-intersection/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "label",

--- a/tests/fixtures/runes-props-renamed/output.json
+++ b/tests/fixtures/runes-props-renamed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "class",

--- a/tests/fixtures/runes-rest-props/output.json
+++ b/tests/fixtures/runes-rest-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "variant",

--- a/tests/fixtures/runes-snippet-description-hyphens/output.json
+++ b/tests/fixtures/runes-snippet-description-hyphens/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "row",

--- a/tests/fixtures/runes-snippet-positional/output.json
+++ b/tests/fixtures/runes-snippet-positional/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "row",

--- a/tests/fixtures/runes-snippets-annotated/output.json
+++ b/tests/fixtures/runes-snippets-annotated/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",

--- a/tests/fixtures/runes-snippets-default/output.json
+++ b/tests/fixtures/runes-snippets-default/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "item",

--- a/tests/fixtures/runes-snippets-named/output.json
+++ b/tests/fixtures/runes-snippets-named/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "item",

--- a/tests/fixtures/runes-typed-props/output.json
+++ b/tests/fixtures/runes-typed-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",

--- a/tests/fixtures/runes-whole-props-imported/output.json
+++ b/tests/fixtures/runes-whole-props-imported/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/runes-whole-props-typed/output.json
+++ b/tests/fixtures/runes-whole-props-typed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
   "props": [
     {
       "name": "item",

--- a/tests/fixtures/slot-description-hyphens-inline/output.json
+++ b/tests/fixtures/slot-description-hyphens-inline/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-description-hyphens-prose/output.json
+++ b/tests/fixtures/slot-description-hyphens-prose/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-description-named-pair/output.json
+++ b/tests/fixtures/slot-description-named-pair/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-description-with-dash/output.json
+++ b/tests/fixtures/slot-description-with-dash/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.json
+++ b/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-example/output.json
+++ b/tests/fixtures/slot-jsdoc-example/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-multiple-tags/output.json
+++ b/tests/fixtures/slot-jsdoc-multiple-tags/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-template-not-passthrough/output.json
+++ b/tests/fixtures/slot-jsdoc-template-not-passthrough/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.json
+++ b/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slot-prop-dotted-access/output.json
+++ b/tests/fixtures/slot-prop-dotted-access/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "point",

--- a/tests/fixtures/slot-props-union-types/output.json
+++ b/tests/fixtures/slot-props-union-types/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "items",

--- a/tests/fixtures/slots-named/output.json
+++ b/tests/fixtures/slots-named/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "text",

--- a/tests/fixtures/slots-spread-typed/output.json
+++ b/tests/fixtures/slots-spread-typed/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/slots-spread/output.json
+++ b/tests/fixtures/slots-spread/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
   "slots": [

--- a/tests/fixtures/svelte-element-dynamic/output.json
+++ b/tests/fixtures/svelte-element-dynamic/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "tag",

--- a/tests/fixtures/svelte-element-hardcoded-button/output.json
+++ b/tests/fixtures/svelte-element-hardcoded-button/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/svelte-element-hardcoded-div/output.json
+++ b/tests/fixtures/svelte-element-hardcoded-div/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/svg-props/output.json
+++ b/tests/fixtures/svg-props/output.json
@@ -1,4 +1,5 @@
 {
+  "syntaxMode": "legacy",
   "props": [],
   "moduleExports": [],
   "slots": [],

--- a/tests/fixtures/template-literal-default/output.json
+++ b/tests/fixtures/template-literal-default/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "id",

--- a/tests/fixtures/template-tag-multiple/output.json
+++ b/tests/fixtures/template-tag-multiple/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/template-tag-with-rest-props/output.json
+++ b/tests/fixtures/template-tag-with-rest-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/template-tag/output.json
+++ b/tests/fixtures/template-tag/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "headers",

--- a/tests/fixtures/theme-component/output.json
+++ b/tests/fixtures/theme-component/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "theme",

--- a/tests/fixtures/typed-props/output.json
+++ b/tests/fixtures/typed-props/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop1",

--- a/tests/fixtures/typed-slots/output.json
+++ b/tests/fixtures/typed-slots/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop",

--- a/tests/fixtures/typedef-description/output.json
+++ b/tests/fixtures/typedef-description/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "gap",

--- a/tests/fixtures/typedef-event-shared-block/output.json
+++ b/tests/fixtures/typedef-event-shared-block/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "size",

--- a/tests/fixtures/typedef-jsdoc-properties/output.json
+++ b/tests/fixtures/typedef-jsdoc-properties/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "user",

--- a/tests/fixtures/typedef/output.json
+++ b/tests/fixtures/typedef/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "id",

--- a/tests/fixtures/typedefs/output.json
+++ b/tests/fixtures/typedefs/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "prop1",

--- a/tests/fixtures/unary-expression-defaults/output.json
+++ b/tests/fixtures/unary-expression-defaults/output.json
@@ -1,4 +1,6 @@
 {
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
   "props": [
     {
       "name": "offset",

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -10,6 +10,7 @@ function createComponent(moduleName: string, filePath: string): ComponentDocApi 
   return {
     moduleName,
     filePath,
+    syntaxMode: "legacy",
     props: [],
     moduleExports: [],
     slots: [],

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -23,6 +23,7 @@ describe("writerTsDefinition", () => {
     ).toEqual("export interface MyTypedef { [key: string]: boolean; }");
 
     const parsed_output: ParsedComponent = {
+      syntaxMode: "legacy",
       props: [
         {
           name: "propBool",
@@ -118,6 +119,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "default",
       filePath: "./src/ModuleName.svelte",
+      syntaxMode: "legacy",
       props: [],
       moduleExports: [],
       slots: [],
@@ -241,6 +243,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "TestComponent",
       filePath: "./src/TestComponent.svelte",
+      syntaxMode: "legacy",
       props: [
         {
           name: "add",
@@ -375,6 +378,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "TestComponent",
       filePath: "./src/TestComponent.svelte",
+      syntaxMode: "legacy",
       props: [],
       moduleExports: [
         {
@@ -421,6 +425,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "CardComponent",
       filePath: "./src/CardComponent.svelte",
+      syntaxMode: "legacy",
       props: [
         {
           name: "title",
@@ -504,6 +509,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "SlotOnlyComponent",
       filePath: "./src/SlotOnlyComponent.svelte",
+      syntaxMode: "legacy",
       props: [],
       moduleExports: [],
       slots: [
@@ -531,6 +537,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "RunesTable",
       filePath: "./src/RunesTable.svelte",
+      syntaxMode: "legacy",
       props: [
         {
           name: "row",
@@ -560,6 +567,7 @@ describe("writerTsDefinition", () => {
     const component_api: ComponentDocApi = {
       moduleName: "TypedButton",
       filePath: "./src/TypedButton.svelte",
+      syntaxMode: "legacy",
       props: [
         {
           name: "disabled",


### PR DESCRIPTION
Builds on #279

Expose per-component syntaxMode and scriptLanguage metadata from the parser, using compiler runes metadata and Svelte script AST attributes.