### PR TITLE
fix(component-parser): support discriminated unions in `@typedef`

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,80 @@ export type ComponentProps = {
 
 > **Note:** The inline syntax `@typedef {{ name: string }} User` continues to work for backwards compatibility.
 
+#### Discriminated unions
+
+A `@typedef` can be a union of object literals, optionally mixed with primitive members. `sveld` emits these as `export type X = ...` aliases (not `interface`), so the discriminant narrows correctly on the consumer side.
+
+**Signature:**
+
+```js
+/**
+ * @typedef {A | B | C} TypeName
+ */
+```
+
+**Example:**
+
+```svelte
+<script>
+  /**
+   * @typedef {{ kind: "success"; value: string } | { kind: "error"; error: Error }} Result
+   * @typedef {{ ok: true; data: number } | { ok: false; reason: string } | "pending"} Status
+   */
+
+  /** @type {Result} */
+  export let result = { kind: "success", value: "ok" };
+
+  /** @type {Status} */
+  export let status = "pending";
+</script>
+```
+
+Output:
+
+```ts
+export type Result = { kind: "success"; value: string } | { kind: "error"; error: Error };
+
+export type Status = { ok: true; data: number } | { ok: false; reason: string } | "pending";
+
+export type ComponentProps = {
+  /** @default { kind: "success", value: "ok" } */
+  result?: Result;
+  /** @default "pending" */
+  status?: Status;
+};
+```
+
+Consumers can then narrow on the discriminant:
+
+```ts
+function describe(r: Result) {
+  switch (r.kind) {
+    case "success":
+      return r.value;
+    case "error":
+      return r.error.message;
+  }
+}
+```
+
+The same pattern works inline via `@type`, which is useful when the union is only used for a single prop:
+
+```js
+/** @type {{ kind: "success"; value: string } | { kind: "error"; error: Error }} */
+export let result = { kind: "success", value: "ok" };
+```
+
+In `<script lang="ts">` components, write the type alias directly — `sveld` preserves it in the emitted `.d.ts`:
+
+```svelte
+<script lang="ts">
+  type Result = { kind: "success"; value: string } | { kind: "error"; error: Error };
+
+  let { result = { kind: "success", value: "ok" } }: { result?: Result } = $props();
+</script>
+```
+
 ### `@callback`
 
 The `@callback` tag defines a function type using `@param` and `@returns` tags, following the [TypeScript JSDoc `@callback` specification](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#callback). Like `@typedef`, callbacks are exported from the generated TypeScript definition file.

--- a/playground/src/data.ts
+++ b/playground/src/data.ts
@@ -151,6 +151,42 @@ const dispatchedEventsAnnotatedRunes: Example = {
 </form>`,
 };
 
+const discriminatedUnionRunes: Example = {
+  name: "Discriminated unions",
+  moduleName: "DiscriminatedUnionRunes",
+  code: `<script>
+  /**
+   * @typedef {{ kind: "success"; value: string } | { kind: "error"; error: Error }} Result
+   * @typedef {{ ok: true; data: number } | { ok: false; reason: string } | "pending"} Status
+   */
+
+  let {
+    /** @type {Result} */
+    result = { kind: "success", value: "ok" },
+    /** @type {Status} */
+    status = "pending",
+  } = $props();
+
+  function describe(r) {
+    switch (r.kind) {
+      case "success":
+        return r.value;
+      case "error":
+        return r.error.message;
+    }
+  }
+</script>
+
+<p>{describe(result)}</p>
+{#if typeof status === "string"}
+  <p>Status: {status}</p>
+{:else if status.ok}
+  <p>Data: {status.data}</p>
+{:else}
+  <p>Failed: {status.reason}</p>
+{/if}`,
+};
+
 const forwardedEventsRunes: Example = {
   name: "Forwarded events",
   moduleName: "ForwardedEventsRunes",
@@ -714,6 +750,7 @@ export default [
   typeScriptPropsRunes,
   dispatchedEventsRunes,
   dispatchedEventsAnnotatedRunes,
+  discriminatedUnionRunes,
   forwardedEventsRunes,
   genericsRunes,
   aliasedPropsRunes,

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -63,6 +63,9 @@ const WORD_CHAR_REGEX = /\w/;
 /** True when a slice between an AST comment end and a node start is only whitespace. */
 const ONLY_WHITESPACE_REGEX = /^\s*$/;
 
+/** Trailing semicolon on a typedef source slice before brace matching. */
+const TRAILING_SEMICOLON_REGEX = /;$/;
+
 /**
  * Extracts description text after the last dash from JSDoc comments.
  *
@@ -345,21 +348,46 @@ const DEFAULT_SLOT_NAME = null;
 type ComponentSlotName = typeof DEFAULT_SLOT_NAME | string;
 
 /**
- * Regular expression for detecting type definition endings.
+ * Returns true when `source` is a single balanced object literal — that is,
+ * its leading `{` matches its trailing `}` (optionally followed by `;`) with
+ * no top-level content before or after.
  *
- * Matches closing braces that indicate the end of a type definition
- * (e.g., `}` or `};`). Used to determine if a typedef should be
- * formatted as an interface or type alias.
- *
- * @example
- * ```ts
- * // Matches:
- * // "{ x: number }"     -> interface
- * // "{ x: number };"    -> interface
- * // "string | number"   -> type alias
- * ```
+ * Used to decide whether a `@typedef` body can be emitted as a TypeScript
+ * `interface X {...}` (single object literal) or must be emitted as a
+ * `type X = ...` alias (anything else: unions, intersections, primitives,
+ * generics, tuples, etc.). Without this check, a discriminated union like
+ * `{...} | {...}` would slip through and produce invalid TS.
  */
-const TYPEDEF_END_REGEX = /(\}|\};)$/;
+function isSingleObjectLiteral(source: string): boolean {
+  const s = source.trim().replace(TRAILING_SEMICOLON_REGEX, "").trimEnd();
+  if (!s.startsWith("{") || !s.endsWith("}")) return false;
+
+  let depth = 0;
+  let stringDelimiter: '"' | "'" | "`" | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (stringDelimiter !== null) {
+      if (ch === "\\") {
+        i++;
+        continue;
+      }
+      if (ch === stringDelimiter) stringDelimiter = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      stringDelimiter = ch;
+      continue;
+    }
+    if (ch === "{" || ch === "[" || ch === "(") depth++;
+    else if (ch === "}" || ch === "]" || ch === ")") {
+      depth--;
+      // The opening `{` closed before the end of the string, so there must
+      // be additional top-level content (e.g. `{...} | {...}`).
+      if (depth === 0 && i < s.length - 1) return false;
+    }
+  }
+  return depth === 0;
+}
 
 /**
  * Regular expression for splitting context keys into parts.
@@ -3555,11 +3583,13 @@ export default class ComponentParser {
           } else if (currentTypedefType) {
             /**
              * Use inline type definition (existing behavior).
-             * If the type ends with `}` or `};`, treat it as an interface body,
-             * otherwise treat it as a type alias.
+             * Only emit `interface X {...}` when the body is a single balanced
+             * object literal. Unions/intersections (e.g. `{...} | {...}`) and
+             * other shapes are emitted as `type X = ...` aliases so they remain
+             * valid TypeScript.
              */
             typedefType = currentTypedefType;
-            typedefTs = TYPEDEF_END_REGEX.test(typedefType)
+            typedefTs = isSingleObjectLiteral(typedefType)
               ? `interface ${currentTypedefName} ${typedefType}`
               : `type ${currentTypedefName} = ${typedefType}`;
           } else {

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -17006,3 +17006,314 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "typedef-discriminated-union/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "result",
+      "kind": "let",
+      "type": "Result",
+      "typeSource": "jsdoc",
+      "value": "{ kind: \\"success\\", value: \\"ok\\" }",
+      "defaultValue": {
+        "raw": "{ kind: \\"success\\", value: \\"ok\\" }",
+        "kind": "object",
+        "value": {
+          "kind": "success",
+          "value": "ok"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 8,
+          "column": 55
+        }
+      }
+    },
+    {
+      "name": "status",
+      "kind": "let",
+      "type": "Status",
+      "typeSource": "jsdoc",
+      "value": "\\"pending\\"",
+      "defaultValue": {
+        "raw": "\\"pending\\"",
+        "kind": "literal",
+        "value": "pending"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 32
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ kind: \\"success\\"; value: string } | { kind: \\"error\\"; error: Error }",
+      "name": "Result",
+      "ts": "type Result = { kind: \\"success\\"; value: string } | { kind: \\"error\\"; error: Error }"
+    },
+    {
+      "type": "{ ok: true; data: number } | { ok: false; reason: string } | \\"pending\\"",
+      "name": "Status",
+      "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \\"pending\\""
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "typedef-discriminated-union/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type Result = { kind: "success"; value: string } | { kind: "error"; error: Error };
+
+export type Status = { ok: true; data: number } | { ok: false; reason: string } | "pending";
+
+export type TypedefDiscriminatedUnionProps = {
+  /**
+   * @default { kind: "success", value: "ok" }
+   */
+  result?: Result;
+
+  /**
+   * @default "pending"
+   */
+  status?: Status;
+};
+
+export default class TypedefDiscriminatedUnion extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (JSON) "typedef-discriminated-union-recursive/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "tree",
+      "kind": "let",
+      "type": "Tree",
+      "typeSource": "jsdoc",
+      "value": "{ kind: \\"leaf\\", value: 0 }",
+      "defaultValue": {
+        "raw": "{ kind: \\"leaf\\", value: 0 }",
+        "kind": "object",
+        "value": {
+          "kind": "leaf",
+          "value": 0
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 47
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ kind: \\"leaf\\"; value: number } | { kind: \\"node\\"; children: Tree[] }",
+      "name": "Tree",
+      "ts": "type Tree = { kind: \\"leaf\\"; value: number } | { kind: \\"node\\"; children: Tree[] }"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "typedef-discriminated-union-intersection/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "entity",
+      "kind": "let",
+      "type": "Entity",
+      "typeSource": "jsdoc",
+      "value": "{ id: \\"1\\", createdAt: 0, kind: \\"user\\", name: \\"Ada\\" }",
+      "defaultValue": {
+        "raw": "{ id: \\"1\\", createdAt: 0, kind: \\"user\\", name: \\"Ada\\" }",
+        "kind": "object",
+        "value": {
+          "id": "1",
+          "createdAt": 0,
+          "kind": "user",
+          "name": "Ada"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 75
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string; createdAt: number }",
+      "name": "Base",
+      "ts": "interface Base { id: string; createdAt: number }"
+    },
+    {
+      "type": "Base & { kind: \\"user\\"; name: string }",
+      "name": "User",
+      "ts": "type User = Base & { kind: \\"user\\"; name: string }"
+    },
+    {
+      "type": "Base & { kind: \\"post\\"; title: string; body: string }",
+      "name": "Post",
+      "ts": "type Post = Base & { kind: \\"post\\"; title: string; body: string }"
+    },
+    {
+      "type": "User | Post",
+      "name": "Entity",
+      "ts": "type Entity = User | Post"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "typedef-discriminated-union-recursive/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type Tree = { kind: "leaf"; value: number } | { kind: "node"; children: Tree[] };
+
+export type TypedefDiscriminatedUnionRecursiveProps = {
+  /**
+   * @default { kind: "leaf", value: 0 }
+   */
+  tree?: Tree;
+};
+
+export default class TypedefDiscriminatedUnionRecursive extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionRecursiveProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "typedef-discriminated-union-intersection/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export interface Base {
+  id: string;
+  createdAt: number;
+}
+
+export type User = Base & { kind: "user"; name: string };
+
+export type Post = Base & { kind: "post"; title: string; body: string };
+
+export type Entity = User | Post;
+
+export type TypedefDiscriminatedUnionIntersectionProps = {
+  /**
+   * @default { id: "1", createdAt: 0, kind: "user", name: "Ada" }
+   */
+  entity?: Entity;
+};
+
+export default class TypedefDiscriminatedUnionIntersection extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionIntersectionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;

--- a/tests/fixtures/typedef-discriminated-union-intersection/Test.svelte
+++ b/tests/fixtures/typedef-discriminated-union-intersection/Test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import TypedefDiscriminatedUnionIntersection, { type Base, type Entity, type Post, type User } from "./output";
+
+  const user: User = { id: "1", createdAt: 0, kind: "user", name: "Ada" };
+  const post: Post = {
+    id: "2",
+    createdAt: 1,
+    kind: "post",
+    title: "Hello",
+    body: "world",
+  };
+
+  function describe(e: Entity): string {
+    // The shared base is available before narrowing.
+    const _shared: Base = { id: e.id, createdAt: e.createdAt };
+    void _shared;
+
+    switch (e.kind) {
+      case "user":
+        return e.name;
+      case "post":
+        return e.title + ": " + e.body;
+      default: {
+        const _exhaustive: never = e;
+        return _exhaustive;
+      }
+    }
+  }
+</script>
+
+<TypedefDiscriminatedUnionIntersection entity={user} />
+<TypedefDiscriminatedUnionIntersection entity={post} />
+<TypedefDiscriminatedUnionIntersection
+  entity={{
+    id: "3",
+    createdAt: 2,
+    kind: "user",
+    name: describe(post),
+  }}
+/>

--- a/tests/fixtures/typedef-discriminated-union-intersection/input.svelte
+++ b/tests/fixtures/typedef-discriminated-union-intersection/input.svelte
@@ -1,0 +1,11 @@
+<script>
+  /**
+   * @typedef {{ id: string; createdAt: number }} Base
+   * @typedef {Base & { kind: "user"; name: string }} User
+   * @typedef {Base & { kind: "post"; title: string; body: string }} Post
+   * @typedef {User | Post} Entity
+   */
+
+  /** @type {Entity} */
+  export let entity = { id: "1", createdAt: 0, kind: "user", name: "Ada" };
+</script>

--- a/tests/fixtures/typedef-discriminated-union-intersection/output.d.ts
+++ b/tests/fixtures/typedef-discriminated-union-intersection/output.d.ts
@@ -1,0 +1,25 @@
+import { SvelteComponentTyped } from "svelte";
+
+export interface Base {
+  id: string;
+  createdAt: number;
+}
+
+export type User = Base & { kind: "user"; name: string };
+
+export type Post = Base & { kind: "post"; title: string; body: string };
+
+export type Entity = User | Post;
+
+export type TypedefDiscriminatedUnionIntersectionProps = {
+  /**
+   * @default { id: "1", createdAt: 0, kind: "user", name: "Ada" }
+   */
+  entity?: Entity;
+};
+
+export default class TypedefDiscriminatedUnionIntersection extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionIntersectionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/typedef-discriminated-union-intersection/output.json
+++ b/tests/fixtures/typedef-discriminated-union-intersection/output.json
@@ -1,0 +1,75 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "entity",
+      "kind": "let",
+      "type": "Entity",
+      "typeSource": "jsdoc",
+      "value": "{ id: \"1\", createdAt: 0, kind: \"user\", name: \"Ada\" }",
+      "defaultValue": {
+        "raw": "{ id: \"1\", createdAt: 0, kind: \"user\", name: \"Ada\" }",
+        "kind": "object",
+        "value": {
+          "id": "1",
+          "createdAt": 0,
+          "kind": "user",
+          "name": "Ada"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 75
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string; createdAt: number }",
+      "name": "Base",
+      "ts": "interface Base { id: string; createdAt: number }"
+    },
+    {
+      "type": "Base & { kind: \"user\"; name: string }",
+      "name": "User",
+      "ts": "type User = Base & { kind: \"user\"; name: string }"
+    },
+    {
+      "type": "Base & { kind: \"post\"; title: string; body: string }",
+      "name": "Post",
+      "ts": "type Post = Base & { kind: \"post\"; title: string; body: string }"
+    },
+    {
+      "type": "User | Post",
+      "name": "Entity",
+      "ts": "type Entity = User | Post"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/typedef-discriminated-union-recursive/Test.svelte
+++ b/tests/fixtures/typedef-discriminated-union-recursive/Test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import TypedefDiscriminatedUnionRecursive, { type Tree } from "./output";
+
+  const leaf: Tree = { kind: "leaf", value: 1 };
+  const nested: Tree = {
+    kind: "node",
+    children: [
+      { kind: "leaf", value: 2 },
+      {
+        kind: "node",
+        children: [{ kind: "leaf", value: 3 }],
+      },
+    ],
+  };
+
+  function sum(t: Tree): number {
+    switch (t.kind) {
+      case "leaf":
+        return t.value;
+      case "node":
+        return t.children.reduce((acc, child) => acc + sum(child), 0);
+      default: {
+        const _exhaustive: never = t;
+        return _exhaustive;
+      }
+    }
+  }
+</script>
+
+<TypedefDiscriminatedUnionRecursive tree={leaf} />
+<TypedefDiscriminatedUnionRecursive tree={nested} />
+<TypedefDiscriminatedUnionRecursive tree={{ kind: "leaf", value: sum(nested) }} />

--- a/tests/fixtures/typedef-discriminated-union-recursive/input.svelte
+++ b/tests/fixtures/typedef-discriminated-union-recursive/input.svelte
@@ -1,0 +1,8 @@
+<script>
+  /**
+   * @typedef {{ kind: "leaf"; value: number } | { kind: "node"; children: Tree[] }} Tree
+   */
+
+  /** @type {Tree} */
+  export let tree = { kind: "leaf", value: 0 };
+</script>

--- a/tests/fixtures/typedef-discriminated-union-recursive/output.d.ts
+++ b/tests/fixtures/typedef-discriminated-union-recursive/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type Tree = { kind: "leaf"; value: number } | { kind: "node"; children: Tree[] };
+
+export type TypedefDiscriminatedUnionRecursiveProps = {
+  /**
+   * @default { kind: "leaf", value: 0 }
+   */
+  tree?: Tree;
+};
+
+export default class TypedefDiscriminatedUnionRecursive extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionRecursiveProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/typedef-discriminated-union-recursive/output.json
+++ b/tests/fixtures/typedef-discriminated-union-recursive/output.json
@@ -1,0 +1,58 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "tree",
+      "kind": "let",
+      "type": "Tree",
+      "typeSource": "jsdoc",
+      "value": "{ kind: \"leaf\", value: 0 }",
+      "defaultValue": {
+        "raw": "{ kind: \"leaf\", value: 0 }",
+        "kind": "object",
+        "value": {
+          "kind": "leaf",
+          "value": 0
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 47
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ kind: \"leaf\"; value: number } | { kind: \"node\"; children: Tree[] }",
+      "name": "Tree",
+      "ts": "type Tree = { kind: \"leaf\"; value: number } | { kind: \"node\"; children: Tree[] }"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/typedef-discriminated-union/Test.svelte
+++ b/tests/fixtures/typedef-discriminated-union/Test.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import TypedefDiscriminatedUnion, { type Result, type Status } from "./output";
+
+  const success: Result = { kind: "success", value: "ok" };
+  const failure: Result = { kind: "error", error: new Error("boom") };
+
+  const pending: Status = "pending";
+  const okStatus: Status = { ok: true, data: 42 };
+  const failStatus: Status = { ok: false, reason: "nope" };
+
+  function describe(r: Result): string {
+    switch (r.kind) {
+      case "success":
+        return r.value;
+      case "error":
+        return r.error.message;
+      default: {
+        const _exhaustive: never = r;
+        return _exhaustive;
+      }
+    }
+  }
+</script>
+
+<TypedefDiscriminatedUnion
+  result={success}
+  status={pending}
+/>
+
+<TypedefDiscriminatedUnion
+  result={failure}
+  status={okStatus}
+/>
+
+<TypedefDiscriminatedUnion
+  result={{ kind: "success", value: describe(success) }}
+  status={failStatus}
+/>

--- a/tests/fixtures/typedef-discriminated-union/input.svelte
+++ b/tests/fixtures/typedef-discriminated-union/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  /**
+   * @typedef {{ kind: "success"; value: string } | { kind: "error"; error: Error }} Result
+   * @typedef {{ ok: true; data: number } | { ok: false; reason: string } | "pending"} Status
+   */
+
+  /** @type {Result} */
+  export let result = { kind: "success", value: "ok" };
+
+  /** @type {Status} */
+  export let status = "pending";
+</script>

--- a/tests/fixtures/typedef-discriminated-union/output.d.ts
+++ b/tests/fixtures/typedef-discriminated-union/output.d.ts
@@ -1,0 +1,23 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type Result = { kind: "success"; value: string } | { kind: "error"; error: Error };
+
+export type Status = { ok: true; data: number } | { ok: false; reason: string } | "pending";
+
+export type TypedefDiscriminatedUnionProps = {
+  /**
+   * @default { kind: "success", value: "ok" }
+   */
+  result?: Result;
+
+  /**
+   * @default "pending"
+   */
+  status?: Status;
+};
+
+export default class TypedefDiscriminatedUnion extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/typedef-discriminated-union/output.json
+++ b/tests/fixtures/typedef-discriminated-union/output.json
@@ -1,0 +1,90 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "result",
+      "kind": "let",
+      "type": "Result",
+      "typeSource": "jsdoc",
+      "value": "{ kind: \"success\", value: \"ok\" }",
+      "defaultValue": {
+        "raw": "{ kind: \"success\", value: \"ok\" }",
+        "kind": "object",
+        "value": {
+          "kind": "success",
+          "value": "ok"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 8,
+          "column": 55
+        }
+      }
+    },
+    {
+      "name": "status",
+      "kind": "let",
+      "type": "Status",
+      "typeSource": "jsdoc",
+      "value": "\"pending\"",
+      "defaultValue": {
+        "raw": "\"pending\"",
+        "kind": "literal",
+        "value": "pending"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 32
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ kind: \"success\"; value: string } | { kind: \"error\"; error: Error }",
+      "name": "Result",
+      "ts": "type Result = { kind: \"success\"; value: string } | { kind: \"error\"; error: Error }"
+    },
+    {
+      "type": "{ ok: true; data: number } | { ok: false; reason: string } | \"pending\"",
+      "name": "Status",
+      "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \"pending\""
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}


### PR DESCRIPTION
Previously, any typedef body ending in `}` was emitted as `interface`, breaking unions whose last member is an object literal. Now emit `type X = ...` unless the body is a single balanced `{}`.