### PR TITLE
fix(types): specify `rootDir` for build generation

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "lib",
+    "rootDir": "src",
     "target": "ESNext",
     "module": "CommonJS"
   },


### PR DESCRIPTION
Regression from #279

Types are now generated in `lib/src`, breaking type definitions for consumers.