### PR TITLE
fix(component-parser): preserve union `@type` and fix free-text attribution in `@event`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,41 @@ export default class Component extends SvelteComponentTyped<
 > {}
 ```
 
+#### Discriminated unions in event details
+
+When the event detail is a union (or any non-object shape), use `@type` to declare it directly. An explicit `@type` takes precedence over `@property` tags, so the union is preserved verbatim in the emitted `.d.ts` rather than being flattened into independent property unions. The special form `@type {object}` is the only exception — it signals that the shape should be built from the `@property` tags (as shown above).
+
+**Example:**
+
+```svelte
+<script>
+  /**
+   * @event sort
+   * @type {{ key: null; direction: "none" } | { key: string; direction: "ascending" | "descending" }}
+   * Dispatched when a sortable column header would change the active sort.
+   */
+
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+</script>
+```
+
+Output:
+
+```ts
+export default class Component extends SvelteComponentTyped<
+  ComponentProps,
+  {
+    /** Dispatched when a sortable column header would change the active sort. */
+    sort: CustomEvent<{ key: null; direction: "none" } | { key: string; direction: "ascending" | "descending" }>;
+  },
+  Record<string, never>
+> {}
+```
+
+Any free-text prose after the tags is attached to the event description, not to a property doc.
+
 ### Context API
 
 `sveld` automatically generates TypeScript definitions for Svelte's `setContext`/`getContext` API by extracting types from JSDoc annotations on the context values.

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -124,6 +124,17 @@ function cleanDescription(description: string | undefined): string | undefined {
 }
 
 /**
+ * Returns the description text that appears on the same line as the tag itself,
+ * ignoring continuation lines that `comment-parser` aggregated into the tag's
+ * `description` field. Continuation lines belong to the next tag (or the
+ * enclosing event/typedef) and must not pollute the tag's own JSDoc.
+ */
+function getInlineTagDescription(tagSource: { tokens: { description?: string } }[] | undefined): string | undefined {
+  if (!tagSource || tagSource.length === 0) return undefined;
+  return tagSource[0].tokens.description;
+}
+
+/**
  * Maps ESTree `VariableDeclaration.kind` to `ComponentProp.kind`.
  * `var` becomes `let` for Svelte-oriented output; `using` / `await using`
  * map to `const` (single binding, not a valid Svelte prop keyword).
@@ -3337,6 +3348,7 @@ export default class ComponentParser {
       let currentEventType: string | undefined;
       let currentEventDescription: string | undefined;
       let currentEventSource: SourceRange | undefined;
+      let currentEventTagLine: number | undefined;
       const eventProperties: Array<{
         name: string;
         type: string;
@@ -3384,6 +3396,12 @@ export default class ComponentParser {
        * description lines and tag lines when looking backwards.
        */
       const tagLineNumbers = new Set<number>();
+      /**
+       * Track description line numbers already claimed as preceding-description
+       * for some tag, so trailing-text scans (e.g. `finalizeEvent`) don't
+       * re-attribute them to the wrong owner.
+       */
+      const consumedDescriptionLines = new Set<number>();
       for (const tagInfo of tags) {
         if (tagInfo.source && tagInfo.source.length > 0) {
           tagLineNumbers.add(tagInfo.source[0].number);
@@ -3432,6 +3450,7 @@ export default class ComponentParser {
          * non-blank non-description line.
          */
         const descLines: string[] = [];
+        const claimedLineNums: number[] = [];
         let foundDescriptionBlock = false;
 
         for (let lineNum = tagLineNumber - 1; lineNum >= 1; lineNum--) {
@@ -3449,6 +3468,7 @@ export default class ComponentParser {
           const desc = lineDescriptions.get(lineNum);
           if (desc) {
             descLines.unshift(desc);
+            claimedLineNums.unshift(lineNum);
             foundDescriptionBlock = true;
           } else if (foundDescriptionBlock) {
             /**
@@ -3478,7 +3498,9 @@ export default class ComponentParser {
            * to find the description block.
            */
         }
-        return descLines.length > 0 ? descLines.join("\n").trim() : undefined;
+        if (descLines.length === 0) return undefined;
+        for (const n of claimedLineNums) consumedDescriptionLines.add(n);
+        return descLines.join("\n").trim();
       };
 
       /**
@@ -3520,11 +3542,63 @@ export default class ComponentParser {
        */
       const finalizeEvent = () => {
         if (currentEventName !== undefined) {
+          /**
+           * Prefer an explicit `@type` shape over a property-derived object so
+           * unions and other non-object shapes survive intact. `@type {object}`
+           * (the documentation-only sentinel) falls through to property-derived
+           * construction so existing `@type {object} + @property` fixtures
+           * continue to work.
+           */
+          const explicitType =
+            currentEventType && currentEventType !== "object" && currentEventType !== "Object"
+              ? currentEventType
+              : undefined;
           let detailType: string;
-          if (eventProperties.length > 0) {
+          if (explicitType) {
+            detailType = explicitType;
+          } else if (eventProperties.length > 0) {
             detailType = this.buildEventDetailFromProperties(eventProperties, currentEventName, true);
           } else {
             detailType = currentEventType || "";
+          }
+
+          /**
+           * Capture trailing free-text paragraphs inside the event's scope and
+           * append them to the event description. The scope extends from the
+           * `@event` tag line to the next non-event-internal tag (next `@event`,
+           * `@typedef`, `@callback`, `@slot`, `@snippet`, `@restProps`) or to
+           * the end of the comment block. Lines already claimed as
+           * preceding-description for another tag are skipped.
+           */
+          if (currentEventTagLine !== undefined) {
+            let scopeBoundaryLine: number | undefined;
+            for (const t of tags) {
+              const tLine = t.source?.[0]?.number;
+              if (typeof tLine !== "number") continue;
+              if (tLine <= currentEventTagLine) continue;
+              if (t.tag === "property" || t.tag === "type") continue;
+              scopeBoundaryLine = tLine;
+              break;
+            }
+            const trailing: string[] = [];
+            const sortedLineNums = Array.from(lineDescriptions.keys()).sort((a, b) => a - b);
+            for (const lineNum of sortedLineNums) {
+              if (lineNum <= currentEventTagLine) continue;
+              if (scopeBoundaryLine !== undefined && lineNum >= scopeBoundaryLine) continue;
+              if (consumedDescriptionLines.has(lineNum)) continue;
+              const desc = lineDescriptions.get(lineNum);
+              const trimmed = desc?.trim();
+              if (trimmed) {
+                trailing.push(trimmed);
+                consumedDescriptionLines.add(lineNum);
+              }
+            }
+            if (trailing.length > 0) {
+              const trailingText = trailing.join("\n");
+              currentEventDescription = currentEventDescription
+                ? `${currentEventDescription}\n${trailingText}`
+                : trailingText;
+            }
           }
 
           this.addDispatchedEvent({
@@ -3540,6 +3614,7 @@ export default class ComponentParser {
           currentEventType = undefined;
           currentEventDescription = undefined;
           currentEventSource = undefined;
+          currentEventTagLine = undefined;
         }
       };
 
@@ -3718,7 +3793,7 @@ export default class ComponentParser {
              * only when no passthrough tags precede `@slot` (avoids treating `@example` fenced code
              * as the slot description).
              */
-            const inlineSlotDesc = cleanDescription(description);
+            const inlineSlotDesc = cleanDescription(getInlineTagDescription(tagSource));
             let slotDesc = inlineSlotDesc;
             if (!slotDesc && isFirstTag && !commentDescriptionUsed && commentDescription) {
               slotDesc = commentDescription;
@@ -3752,7 +3827,8 @@ export default class ComponentParser {
              */
             currentEventName = name;
             currentEventType = type;
-            const inlineEventDesc = cleanDescription(description);
+            currentEventTagLine = tagSource && tagSource.length > 0 ? tagSource[0].number : undefined;
+            const inlineEventDesc = cleanDescription(getInlineTagDescription(tagSource));
             currentEventDescription = inlineEventDesc || precedingDescription;
             if (!currentEventDescription && isFirstTag && !commentDescriptionUsed && commentDescription) {
               currentEventDescription = commentDescription;
@@ -3796,7 +3872,7 @@ export default class ComponentParser {
             const propertyData = {
               name,
               type,
-              description: cleanDescription(description),
+              description: cleanDescription(getInlineTagDescription(tagSource)),
               optional: optional || false,
               default: defaultValue,
             };
@@ -3821,7 +3897,7 @@ export default class ComponentParser {
              */
             currentTypedefName = name;
             currentTypedefType = type;
-            const inlineTypedefDesc = cleanDescription(description);
+            const inlineTypedefDesc = cleanDescription(getInlineTagDescription(tagSource));
             currentTypedefDescription = inlineTypedefDesc || precedingDescription;
             if (!currentTypedefDescription && isFirstTag && !commentDescriptionUsed && commentDescription) {
               currentTypedefDescription = commentDescription;
@@ -3841,7 +3917,7 @@ export default class ComponentParser {
              * Subsequent @param and @returns tags will be accumulated for this callback.
              */
             currentCallbackName = name;
-            const inlineCallbackDesc = cleanDescription(description);
+            const inlineCallbackDesc = cleanDescription(getInlineTagDescription(tagSource));
             currentCallbackDescription = inlineCallbackDesc || precedingDescription;
             if (!currentCallbackDescription && isFirstTag && !commentDescriptionUsed && commentDescription) {
               currentCallbackDescription = commentDescription;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -3113,7 +3113,7 @@ exports[`fixtures (JSON) "typedef-event-shared-block/input.svelte" 1`] = `
       "type": "dispatched",
       "name": "dequeue",
       "detail": "null",
-      "description": "Slot for rendering breakpoint sizes",
+      "description": "Event fired when item is dequeued from the queue",
       "source": {
         "start": {
           "line": 31,
@@ -3129,7 +3129,7 @@ exports[`fixtures (JSON) "typedef-event-shared-block/input.svelte" 1`] = `
       "type": "dispatched",
       "name": "queue",
       "detail": "null",
-      "description": "Event fired when item is dequeued from the queue",
+      "description": "Event fired when queue is updated",
       "source": {
         "start": {
           "line": 31,
@@ -3184,6 +3184,68 @@ exports[`fixtures (JSON) "typedef-event-shared-block/input.svelte" 1`] = `
       "type": "320 | 672 | 1056 | 1312 | 1584",
       "name": "BreakpointValue",
       "ts": "type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "typedef-discriminated-union-recursive/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "tree",
+      "kind": "let",
+      "type": "Tree",
+      "typeSource": "jsdoc",
+      "value": "{ kind: \\"leaf\\", value: 0 }",
+      "defaultValue": {
+        "raw": "{ kind: \\"leaf\\", value: 0 }",
+        "kind": "object",
+        "value": {
+          "kind": "leaf",
+          "value": 0
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 47
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ kind: \\"leaf\\"; value: number } | { kind: \\"node\\"; children: Tree[] }",
+      "name": "Tree",
+      "ts": "type Tree = { kind: \\"leaf\\"; value: number } | { kind: \\"node\\"; children: Tree[] }"
     }
   ],
   "generics": null,
@@ -6477,6 +6539,100 @@ exports[`fixtures (JSON) "bind-this/input.svelte" 1`] = `
   ],
   "events": [],
   "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "typedef-discriminated-union/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "result",
+      "kind": "let",
+      "type": "Result",
+      "typeSource": "jsdoc",
+      "value": "{ kind: \\"success\\", value: \\"ok\\" }",
+      "defaultValue": {
+        "raw": "{ kind: \\"success\\", value: \\"ok\\" }",
+        "kind": "object",
+        "value": {
+          "kind": "success",
+          "value": "ok"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 8,
+          "column": 55
+        }
+      }
+    },
+    {
+      "name": "status",
+      "kind": "let",
+      "type": "Status",
+      "typeSource": "jsdoc",
+      "value": "\\"pending\\"",
+      "defaultValue": {
+        "raw": "\\"pending\\"",
+        "kind": "literal",
+        "value": "pending"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 32
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ kind: \\"success\\"; value: string } | { kind: \\"error\\"; error: Error }",
+      "name": "Result",
+      "ts": "type Result = { kind: \\"success\\"; value: string } | { kind: \\"error\\"; error: Error }"
+    },
+    {
+      "type": "{ ok: true; data: number } | { ok: false; reason: string } | \\"pending\\"",
+      "name": "Status",
+      "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \\"pending\\""
+    }
+  ],
   "generics": null,
   "contexts": []
 }
@@ -10095,6 +10251,48 @@ exports[`fixtures (JSON) "event-explicit-null/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "dispatched-events-jsdoc-union-type/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "sort",
+      "detail": "{ key: null; direction: \\"none\\" } | { key: string; direction: \\"ascending\\" | \\"descending\\" }",
+      "description": "Dispatched when a sortable column header would change the active sort.",
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 4
+        },
+        "end": {
+          "line": 15,
+          "column": 54
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "context-generics/input.svelte" 1`] = `
 "{
   "source": {
@@ -11802,6 +12000,85 @@ exports[`fixtures (JSON) "element-tag-map-text-elements/input.svelte" 1`] = `
     "type": "Element",
     "name": "abbr | code | em | strong | mark | kbd | samp | var"
   },
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "typedef-discriminated-union-intersection/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "entity",
+      "kind": "let",
+      "type": "Entity",
+      "typeSource": "jsdoc",
+      "value": "{ id: \\"1\\", createdAt: 0, kind: \\"user\\", name: \\"Ada\\" }",
+      "defaultValue": {
+        "raw": "{ id: \\"1\\", createdAt: 0, kind: \\"user\\", name: \\"Ada\\" }",
+        "kind": "object",
+        "value": {
+          "id": "1",
+          "createdAt": 0,
+          "kind": "user",
+          "name": "Ada"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 75
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ id: string; createdAt: number }",
+      "name": "Base",
+      "ts": "interface Base { id: string; createdAt: number }"
+    },
+    {
+      "type": "Base & { kind: \\"user\\"; name: string }",
+      "name": "User",
+      "ts": "type User = Base & { kind: \\"user\\"; name: string }"
+    },
+    {
+      "type": "Base & { kind: \\"post\\"; title: string; body: string }",
+      "name": "Post",
+      "ts": "type Post = Base & { kind: \\"post\\"; title: string; body: string }"
+    },
+    {
+      "type": "User | Post",
+      "name": "Entity",
+      "ts": "type Entity = User | Post"
+    }
+  ],
+  "generics": null,
   "contexts": []
 }
 "
@@ -13889,9 +14166,9 @@ export default class TypedefEventSharedBlock extends SvelteComponentTyped<
       size: BreakpointSize;
       breakpointValue: BreakpointValue;
     }>;
-    /** Slot for rendering breakpoint sizes */
-    dequeue: CustomEvent<null>;
     /** Event fired when item is dequeued from the queue */
+    dequeue: CustomEvent<null>;
+    /** Event fired when queue is updated */
     queue: CustomEvent<null>;
     /** Event fired when size changes */
     resize: CustomEvent<null>;
@@ -13905,6 +14182,26 @@ export default class TypedefEventSharedBlock extends SvelteComponentTyped<
     /** description */
     "inline-slot": { a: 4 };
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "typedef-discriminated-union-recursive/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type Tree = { kind: "leaf"; value: number } | { kind: "node"; children: Tree[] };
+
+export type TypedefDiscriminatedUnionRecursiveProps = {
+  /**
+   * @default { kind: "leaf", value: 0 }
+   */
+  tree?: Tree;
+};
+
+export default class TypedefDiscriminatedUnionRecursive extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionRecursiveProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;
@@ -14907,6 +15204,33 @@ export default class BindThis extends SvelteComponentTyped<
   BindThisProps,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "typedef-discriminated-union/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type Result = { kind: "success"; value: string } | { kind: "error"; error: Error };
+
+export type Status = { ok: true; data: number } | { ok: false; reason: string } | "pending";
+
+export type TypedefDiscriminatedUnionProps = {
+  /**
+   * @default { kind: "success", value: "ok" }
+   */
+  result?: Result;
+
+  /**
+   * @default "pending"
+   */
+  status?: Status;
+};
+
+export default class TypedefDiscriminatedUnion extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;
@@ -15953,6 +16277,22 @@ export default class EventExplicitNull extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "dispatched-events-jsdoc-union-type/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsJsdocUnionTypeProps = Record<string, never>;
+
+export default class DispatchedEventsJsdocUnionType extends SvelteComponentTyped<
+  DispatchedEventsJsdocUnionTypeProps,
+  {
+    /** Dispatched when a sortable column header would change the active sort. */
+    sort: CustomEvent<{ key: null; direction: "none" } | { key: string; direction: "ascending" | "descending" }>;
+  },
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "context-generics/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -16592,6 +16932,35 @@ export default class ElementTagMapTextElements extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "typedef-discriminated-union-intersection/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export interface Base {
+  id: string;
+  createdAt: number;
+}
+
+export type User = Base & { kind: "user"; name: string };
+
+export type Post = Base & { kind: "post"; title: string; body: string };
+
+export type Entity = User | Post;
+
+export type TypedefDiscriminatedUnionIntersectionProps = {
+  /**
+   * @default { id: "1", createdAt: 0, kind: "user", name: "Ada" }
+   */
+  entity?: Entity;
+};
+
+export default class TypedefDiscriminatedUnionIntersection extends SvelteComponentTyped<
+  TypedefDiscriminatedUnionIntersectionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "slots-spread/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -17003,317 +17372,6 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
     /** Row id maps to server-side UUID v4 (not v1-v3). */
     item: { id: string };
   }
-> {}
-"
-`;
-
-exports[`fixtures (JSON) "typedef-discriminated-union/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 13,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [
-    {
-      "name": "result",
-      "kind": "let",
-      "type": "Result",
-      "typeSource": "jsdoc",
-      "value": "{ kind: \\"success\\", value: \\"ok\\" }",
-      "defaultValue": {
-        "raw": "{ kind: \\"success\\", value: \\"ok\\" }",
-        "kind": "object",
-        "value": {
-          "kind": "success",
-          "value": "ok"
-        }
-      },
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 8,
-          "column": 2
-        },
-        "end": {
-          "line": 8,
-          "column": 55
-        }
-      }
-    },
-    {
-      "name": "status",
-      "kind": "let",
-      "type": "Status",
-      "typeSource": "jsdoc",
-      "value": "\\"pending\\"",
-      "defaultValue": {
-        "raw": "\\"pending\\"",
-        "kind": "literal",
-        "value": "pending"
-      },
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 11,
-          "column": 2
-        },
-        "end": {
-          "line": 11,
-          "column": 32
-        }
-      }
-    }
-  ],
-  "moduleExports": [],
-  "slots": [],
-  "events": [],
-  "typedefs": [
-    {
-      "type": "{ kind: \\"success\\"; value: string } | { kind: \\"error\\"; error: Error }",
-      "name": "Result",
-      "ts": "type Result = { kind: \\"success\\"; value: string } | { kind: \\"error\\"; error: Error }"
-    },
-    {
-      "type": "{ ok: true; data: number } | { ok: false; reason: string } | \\"pending\\"",
-      "name": "Status",
-      "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \\"pending\\""
-    }
-  ],
-  "generics": null,
-  "contexts": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "typedef-discriminated-union/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type Result = { kind: "success"; value: string } | { kind: "error"; error: Error };
-
-export type Status = { ok: true; data: number } | { ok: false; reason: string } | "pending";
-
-export type TypedefDiscriminatedUnionProps = {
-  /**
-   * @default { kind: "success", value: "ok" }
-   */
-  result?: Result;
-
-  /**
-   * @default "pending"
-   */
-  status?: Status;
-};
-
-export default class TypedefDiscriminatedUnion extends SvelteComponentTyped<
-  TypedefDiscriminatedUnionProps,
-  Record<string, any>,
-  Record<string, never>
-> {}
-"
-`;
-
-exports[`fixtures (JSON) "typedef-discriminated-union-recursive/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 9,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [
-    {
-      "name": "tree",
-      "kind": "let",
-      "type": "Tree",
-      "typeSource": "jsdoc",
-      "value": "{ kind: \\"leaf\\", value: 0 }",
-      "defaultValue": {
-        "raw": "{ kind: \\"leaf\\", value: 0 }",
-        "kind": "object",
-        "value": {
-          "kind": "leaf",
-          "value": 0
-        }
-      },
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 7,
-          "column": 2
-        },
-        "end": {
-          "line": 7,
-          "column": 47
-        }
-      }
-    }
-  ],
-  "moduleExports": [],
-  "slots": [],
-  "events": [],
-  "typedefs": [
-    {
-      "type": "{ kind: \\"leaf\\"; value: number } | { kind: \\"node\\"; children: Tree[] }",
-      "name": "Tree",
-      "ts": "type Tree = { kind: \\"leaf\\"; value: number } | { kind: \\"node\\"; children: Tree[] }"
-    }
-  ],
-  "generics": null,
-  "contexts": []
-}
-"
-`;
-
-exports[`fixtures (JSON) "typedef-discriminated-union-intersection/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 12,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [
-    {
-      "name": "entity",
-      "kind": "let",
-      "type": "Entity",
-      "typeSource": "jsdoc",
-      "value": "{ id: \\"1\\", createdAt: 0, kind: \\"user\\", name: \\"Ada\\" }",
-      "defaultValue": {
-        "raw": "{ id: \\"1\\", createdAt: 0, kind: \\"user\\", name: \\"Ada\\" }",
-        "kind": "object",
-        "value": {
-          "id": "1",
-          "createdAt": 0,
-          "kind": "user",
-          "name": "Ada"
-        }
-      },
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 10,
-          "column": 2
-        },
-        "end": {
-          "line": 10,
-          "column": 75
-        }
-      }
-    }
-  ],
-  "moduleExports": [],
-  "slots": [],
-  "events": [],
-  "typedefs": [
-    {
-      "type": "{ id: string; createdAt: number }",
-      "name": "Base",
-      "ts": "interface Base { id: string; createdAt: number }"
-    },
-    {
-      "type": "Base & { kind: \\"user\\"; name: string }",
-      "name": "User",
-      "ts": "type User = Base & { kind: \\"user\\"; name: string }"
-    },
-    {
-      "type": "Base & { kind: \\"post\\"; title: string; body: string }",
-      "name": "Post",
-      "ts": "type Post = Base & { kind: \\"post\\"; title: string; body: string }"
-    },
-    {
-      "type": "User | Post",
-      "name": "Entity",
-      "ts": "type Entity = User | Post"
-    }
-  ],
-  "generics": null,
-  "contexts": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "typedef-discriminated-union-recursive/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type Tree = { kind: "leaf"; value: number } | { kind: "node"; children: Tree[] };
-
-export type TypedefDiscriminatedUnionRecursiveProps = {
-  /**
-   * @default { kind: "leaf", value: 0 }
-   */
-  tree?: Tree;
-};
-
-export default class TypedefDiscriminatedUnionRecursive extends SvelteComponentTyped<
-  TypedefDiscriminatedUnionRecursiveProps,
-  Record<string, any>,
-  Record<string, never>
-> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "typedef-discriminated-union-intersection/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export interface Base {
-  id: string;
-  createdAt: number;
-}
-
-export type User = Base & { kind: "user"; name: string };
-
-export type Post = Base & { kind: "post"; title: string; body: string };
-
-export type Entity = User | Post;
-
-export type TypedefDiscriminatedUnionIntersectionProps = {
-  /**
-   * @default { id: "1", createdAt: 0, kind: "user", name: "Ada" }
-   */
-  entity?: Entity;
-};
-
-export default class TypedefDiscriminatedUnionIntersection extends SvelteComponentTyped<
-  TypedefDiscriminatedUnionIntersectionProps,
-  Record<string, any>,
-  Record<string, never>
 > {}
 "
 `;

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 156,
   "components": [

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 4,
   "components": [

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 4,
   "components": [

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 5,
   "components": [

--- a/tests/e2e/path-aliases/COMPONENT_API.json
+++ b/tests/e2e/path-aliases/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 2,
   "components": [

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/svelte5-legacy/COMPONENT_API.json
+++ b/tests/e2e/svelte5-legacy/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/svelte5-runes/COMPONENT_API.json
+++ b/tests/e2e/svelte5-runes/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/sveltekit/COMPONENT_API.json
+++ b/tests/e2e/sveltekit/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.31.0",
-    "svelteVersion": "5.55.0"
+    "version": "0.32.2",
+    "svelteVersion": "5.55.9"
   },
   "total": 1,
   "components": [

--- a/tests/fixtures/dispatched-events-jsdoc-union-type/input.svelte
+++ b/tests/fixtures/dispatched-events-jsdoc-union-type/input.svelte
@@ -1,0 +1,19 @@
+<script>
+  /**
+   * @event sort
+   * @type {{ key: null; direction: "none" } | { key: string; direction: "ascending" | "descending" }}
+   * @property {string | null} key - Proposed sort column, or `null` when direction is `none`.
+   * @property {"ascending" | "descending" | "none"} direction - Proposed sort direction.
+   * Dispatched when a sortable column header would change the active sort.
+   */
+
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  function handleSort() {
+    dispatch("sort", { key: null, direction: "none" });
+  }
+</script>
+
+<button on:click={handleSort}>Sort</button>

--- a/tests/fixtures/dispatched-events-jsdoc-union-type/output.d.ts
+++ b/tests/fixtures/dispatched-events-jsdoc-union-type/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsJsdocUnionTypeProps = Record<string, never>;
+
+export default class DispatchedEventsJsdocUnionType extends SvelteComponentTyped<
+  DispatchedEventsJsdocUnionTypeProps,
+  {
+    /** Dispatched when a sortable column header would change the active sort. */
+    sort: CustomEvent<{ key: null; direction: "none" } | { key: string; direction: "ascending" | "descending" }>;
+  },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-events-jsdoc-union-type/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-union-type/output.json
@@ -1,0 +1,38 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "sort",
+      "detail": "{ key: null; direction: \"none\" } | { key: string; direction: \"ascending\" | \"descending\" }",
+      "description": "Dispatched when a sortable column header would change the active sort.",
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 4
+        },
+        "end": {
+          "line": 15,
+          "column": 54
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/typedef-event-shared-block/output.d.ts
+++ b/tests/fixtures/typedef-event-shared-block/output.d.ts
@@ -38,9 +38,9 @@ export default class TypedefEventSharedBlock extends SvelteComponentTyped<
       size: BreakpointSize;
       breakpointValue: BreakpointValue;
     }>;
-    /** Slot for rendering breakpoint sizes */
-    dequeue: CustomEvent<null>;
     /** Event fired when item is dequeued from the queue */
+    dequeue: CustomEvent<null>;
+    /** Event fired when queue is updated */
     queue: CustomEvent<null>;
     /** Event fired when size changes */
     resize: CustomEvent<null>;

--- a/tests/fixtures/typedef-event-shared-block/output.json
+++ b/tests/fixtures/typedef-event-shared-block/output.json
@@ -159,7 +159,7 @@
       "type": "dispatched",
       "name": "dequeue",
       "detail": "null",
-      "description": "Slot for rendering breakpoint sizes",
+      "description": "Event fired when item is dequeued from the queue",
       "source": {
         "start": {
           "line": 31,
@@ -175,7 +175,7 @@
       "type": "dispatched",
       "name": "queue",
       "detail": "null",
-      "description": "Event fired when item is dequeued from the queue",
+      "description": "Event fired when queue is updated",
       "source": {
         "start": {
           "line": 31,


### PR DESCRIPTION
An explicit non-`object` `@type` now takes precedence over `@property`-derived shape, so discriminated unions survive intact instead of flattening into independent property unions. Tag descriptions use same-line text only, routing trailing prose to the event and stopping continuation lines from leaking into the prior tag.