### PR TITLE
docs: add guide on branded types

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,59 @@ In `<script lang="ts">` components, write the type alias directly — `sveld` pr
 </script>
 ```
 
+#### Branded types
+
+A branded type is a primitive intersected with a unique marker so that otherwise interchangeable values (a `UserId` vs. any other `string`) become distinct domain types. At runtime the value is still the underlying primitive, but TypeScript treats the brand as a separate type. Declare the brand inline with `@type` — `sveld` preserves the intersection verbatim in the emitted prop type, so the brand participates fully in IntelliSense, autocomplete, and hover tooltips on the consumer side.
+
+**Example:**
+
+```svelte
+<script>
+  /**
+   * A branded string. At runtime it is a plain `string`, but the brand makes it
+   * a distinct domain type that other strings cannot be assigned to.
+   *
+   * @type {string & { readonly __brand: "UserId" }}
+   */
+  export let userId;
+
+  /**
+   * A branded number representing a monetary amount in cents.
+   *
+   * @type {number & { readonly __brand: "Cents" }}
+   */
+  export let amount;
+</script>
+```
+
+Output:
+
+```ts
+export type ComponentProps = {
+  /**
+   * A branded string. At runtime it is a plain `string`, but the brand makes it
+   * a distinct domain type that other strings cannot be assigned to.
+   * @default undefined
+   */
+  userId: string & { readonly __brand: "UserId" };
+
+  /**
+   * A branded number representing a monetary amount in cents.
+   * @default undefined
+   */
+  amount: number & { readonly __brand: "Cents" };
+};
+```
+
+Consumers construct branded values with a narrowing cast and then enjoy compile-time protection against mixing them up:
+
+```ts
+const userId = "user_123" as ComponentProps["userId"];
+
+// Error: a plain string is not assignable to the branded userId
+component.$set({ userId: "user_123" });
+```
+
 ### `@callback`
 
 The `@callback` tag defines a function type using `@param` and `@returns` tags, following the [TypeScript JSDoc `@callback` specification](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#callback). Like `@typedef`, callbacks are exported from the generated TypeScript definition file.

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -17375,3 +17375,123 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "typedef-branded-types/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "userId",
+      "kind": "let",
+      "description": "A branded string. At runtime it is a plain \`string\`, but the brand makes it\\na distinct domain type that other strings cannot be assigned to.",
+      "type": "UserId",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 20
+        }
+      }
+    },
+    {
+      "name": "amount",
+      "kind": "let",
+      "description": "A branded number representing a monetary amount in cents.",
+      "type": "Cents",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 2
+        },
+        "end": {
+          "line": 19,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "string & { readonly __brand: \\"UserId\\" }",
+      "name": "UserId",
+      "description": "A branded string. At runtime it is a plain \`string\`, but the brand makes it\\na distinct domain type that other strings cannot be assigned to.",
+      "ts": "type UserId = string & { readonly __brand: \\"UserId\\" }"
+    },
+    {
+      "type": "number & { readonly __brand: \\"Cents\\" }",
+      "name": "Cents",
+      "description": "A branded number representing a monetary amount in cents.",
+      "ts": "type Cents = number & { readonly __brand: \\"Cents\\" }"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "typedef-branded-types/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+/**
+ * A branded string. At runtime it is a plain \`string\`, but the brand makes it
+ * a distinct domain type that other strings cannot be assigned to.
+ */
+export type UserId = string & { readonly __brand: "UserId" };
+
+/**
+ * A branded number representing a monetary amount in cents.
+ */
+export type Cents = number & { readonly __brand: "Cents" };
+
+export type TypedefBrandedTypesProps = {
+  /**
+   * A branded string. At runtime it is a plain \`string\`, but the brand makes it
+   * a distinct domain type that other strings cannot be assigned to.
+   * @default undefined
+   */
+  userId: UserId;
+
+  /**
+   * A branded number representing a monetary amount in cents.
+   * @default undefined
+   */
+  amount: Cents;
+};
+
+export default class TypedefBrandedTypes extends SvelteComponentTyped<
+  TypedefBrandedTypesProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;

--- a/tests/fixtures/typedef-branded-types/input.svelte
+++ b/tests/fixtures/typedef-branded-types/input.svelte
@@ -1,0 +1,22 @@
+<script>
+  /**
+   * A branded string. At runtime it is a plain `string`, but the brand makes it
+   * a distinct domain type that other strings cannot be assigned to.
+   *
+   * @typedef {string & { readonly __brand: "UserId" }} UserId
+   */
+
+  /**
+   * A branded number representing a monetary amount in cents.
+   *
+   * @typedef {number & { readonly __brand: "Cents" }} Cents
+   */
+
+  /** @type {UserId} */
+  export let userId;
+
+  /** @type {Cents} */
+  export let amount;
+</script>
+
+<div data-user={userId}>{amount}</div>

--- a/tests/fixtures/typedef-branded-types/output.d.ts
+++ b/tests/fixtures/typedef-branded-types/output.d.ts
@@ -1,0 +1,33 @@
+import { SvelteComponentTyped } from "svelte";
+
+/**
+ * A branded string. At runtime it is a plain `string`, but the brand makes it
+ * a distinct domain type that other strings cannot be assigned to.
+ */
+export type UserId = string & { readonly __brand: "UserId" };
+
+/**
+ * A branded number representing a monetary amount in cents.
+ */
+export type Cents = number & { readonly __brand: "Cents" };
+
+export type TypedefBrandedTypesProps = {
+  /**
+   * A branded string. At runtime it is a plain `string`, but the brand makes it
+   * a distinct domain type that other strings cannot be assigned to.
+   * @default undefined
+   */
+  userId: UserId;
+
+  /**
+   * A branded number representing a monetary amount in cents.
+   * @default undefined
+   */
+  amount: Cents;
+};
+
+export default class TypedefBrandedTypes extends SvelteComponentTyped<
+  TypedefBrandedTypesProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/typedef-branded-types/output.json
+++ b/tests/fixtures/typedef-branded-types/output.json
@@ -1,0 +1,79 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "userId",
+      "kind": "let",
+      "description": "A branded string. At runtime it is a plain `string`, but the brand makes it\na distinct domain type that other strings cannot be assigned to.",
+      "type": "UserId",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 20
+        }
+      }
+    },
+    {
+      "name": "amount",
+      "kind": "let",
+      "description": "A branded number representing a monetary amount in cents.",
+      "type": "Cents",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 2
+        },
+        "end": {
+          "line": 19,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "string & { readonly __brand: \"UserId\" }",
+      "name": "UserId",
+      "description": "A branded string. At runtime it is a plain `string`, but the brand makes it\na distinct domain type that other strings cannot be assigned to.",
+      "ts": "type UserId = string & { readonly __brand: \"UserId\" }"
+    },
+    {
+      "type": "number & { readonly __brand: \"Cents\" }",
+      "name": "Cents",
+      "description": "A branded number representing a monetary amount in cents.",
+      "ts": "type Cents = number & { readonly __brand: \"Cents\" }"
+    }
+  ],
+  "generics": null,
+  "contexts": []
+}


### PR DESCRIPTION
By nature, branded types are supported; this adds a fixture/docs for scannability.