### PR TITLE
fix(component-parser): inherit JSDoc from identifier default values

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -258,6 +258,11 @@ interface ProcessedInitializer {
   type?: string;
   isFunction: boolean;
   defaultValue?: ComponentPropDefaultValue;
+  /** JSDoc from identifier default when the prop has none. */
+  resolvedType?: string;
+  resolvedDescription?: string;
+  resolvedParams?: ComponentPropParam[];
+  resolvedReturnType?: string;
 }
 
 type ModernScriptAttribute = {
@@ -2553,7 +2558,15 @@ export default class ComponentParser {
       if (depth < 5) {
         const resolvedInit = this.resolveLocalVarInitializer(ident.name);
         if (resolvedInit) {
-          return this.processInitializer(resolvedInit, depth + 1);
+          const inner = this.processInitializer(resolvedInit, depth + 1);
+          const resolvedJSDoc = this.resolveLocalVarJSDoc(ident.name);
+          return {
+            ...inner,
+            resolvedType: resolvedJSDoc?.type ?? inner.resolvedType,
+            resolvedDescription: resolvedJSDoc?.description ?? inner.resolvedDescription,
+            resolvedParams: resolvedJSDoc?.params ?? inner.resolvedParams,
+            resolvedReturnType: resolvedJSDoc?.returnType ?? inner.resolvedReturnType,
+          };
         }
       }
       if ("start" in ident && "end" in ident && typeof ident.start === "number" && typeof ident.end === "number") {
@@ -2611,6 +2624,27 @@ export default class ComponentParser {
         ) {
           return declarator.init;
         }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Look up JSDoc on a local variable declaration by name.
+   */
+  private resolveLocalVarJSDoc(name: string) {
+    for (const decl of this.vars) {
+      const matches = decl.declarations.some(
+        (declarator) =>
+          declarator.id &&
+          typeof declarator.id === "object" &&
+          "type" in declarator.id &&
+          declarator.id.type === "Identifier" &&
+          "name" in declarator.id &&
+          declarator.id.name === name,
+      );
+      if (matches) {
+        return this.processNodeJSDoc(decl as unknown as { leadingComments?: unknown[]; start?: number });
       }
     }
     return undefined;
@@ -2738,17 +2772,21 @@ export default class ComponentParser {
         const { init: unwrappedInit, bindable } = this.unwrapBindableInitializer(init);
         const initResult = unwrappedInit == null ? { isFunction: false } : this.processInitializer(unwrappedInit);
         const { value, type: inferredType, isFunction, defaultValue } = initResult;
+        const inheritedType =
+          typeMetadata?.type === undefined && propertyJSDoc?.type === undefined ? initResult.resolvedType : undefined;
         const isFunctionFromJSDoc =
           !!propertyJSDoc?.params?.length ||
           propertyJSDoc?.returnType !== undefined ||
-          propertyJSDoc?.type?.includes("=>");
-        const type = typeMetadata?.type ?? propertyJSDoc?.type ?? inferredType;
+          propertyJSDoc?.type?.includes("=>") ||
+          !!inheritedType?.includes("=>");
+        const type = typeMetadata?.type ?? propertyJSDoc?.type ?? inheritedType ?? inferredType;
         const typeSource = this.resolveTypeSource({
           hasTypeScriptType: typeMetadata?.type !== undefined,
           hasJSDocType:
             propertyJSDoc?.type !== undefined ||
             propertyJSDoc?.params !== undefined ||
-            propertyJSDoc?.returnType !== undefined,
+            propertyJSDoc?.returnType !== undefined ||
+            inheritedType !== undefined,
           inferredType,
           finalType: type,
         });
@@ -2761,15 +2799,15 @@ export default class ComponentParser {
           name: propName,
           ...(localName === propName ? {} : { localName }),
           kind: "let",
-          description: propertyJSDoc?.description,
+          description: propertyJSDoc?.description ?? initResult.resolvedDescription,
           binding: propertyJSDoc?.binding,
           ...(bindable ? { bindable: true as const } : {}),
           type,
           typeSource,
           value,
           defaultValue,
-          params: propertyJSDoc?.params,
-          returnType: propertyJSDoc?.returnType,
+          params: propertyJSDoc?.params ?? initResult.resolvedParams,
+          returnType: propertyJSDoc?.returnType ?? initResult.resolvedReturnType,
           isFunction: Boolean(isFunction || isFunctionFromJSDoc),
           isFunctionDeclaration: false,
           isRequired: unwrappedInit == null && typeMetadata?.optional !== true,
@@ -4711,6 +4749,12 @@ export default class ComponentParser {
             let returnType: string | undefined;
             let defaultValue: ComponentPropDefaultValue | undefined;
             let inferredType: string | undefined;
+            let resolvedJSDoc:
+              | Pick<
+                  ProcessedInitializer,
+                  "resolvedType" | "resolvedDescription" | "resolvedParams" | "resolvedReturnType"
+                >
+              | undefined;
 
             if (node.declaration.type === "FunctionDeclaration") {
               const funcDecl = node.declaration as { id?: { name?: string } };
@@ -4739,6 +4783,7 @@ export default class ComponentParser {
               kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
               const initResult = init == null ? { isFunction: false } : this.processInitializer(init);
               ({ value, type: inferredType, isFunction, defaultValue } = initResult);
+              resolvedJSDoc = initResult;
               explicitType = this.getExplicitPropType(localPropName);
               type = explicitType ?? inferredType;
             } else {
@@ -4752,6 +4797,16 @@ export default class ComponentParser {
               returnType = jsdocInfo.returnType;
               if (jsdocInfo.description) description = jsdocInfo.description;
             }
+
+            if (explicitType === undefined && jsdocInfo?.type === undefined && resolvedJSDoc?.resolvedType) {
+              type = resolvedJSDoc.resolvedType;
+            }
+            if (description === undefined && resolvedJSDoc?.resolvedDescription) {
+              description = resolvedJSDoc.resolvedDescription;
+            }
+            if (params === undefined && resolvedJSDoc?.resolvedParams) params = resolvedJSDoc.resolvedParams;
+            if (returnType === undefined && resolvedJSDoc?.resolvedReturnType)
+              returnType = resolvedJSDoc.resolvedReturnType;
 
             // Merge returnType into type for function declarations if not overridden by @type
             if (isFunctionDeclaration && type === "() => any" && returnType) {
@@ -4774,7 +4829,10 @@ export default class ComponentParser {
             const typeSource = this.resolveTypeSource({
               hasTypeScriptType: explicitType !== undefined,
               hasJSDocType:
-                jsdocInfo?.type !== undefined || jsdocInfo?.params !== undefined || jsdocInfo?.returnType !== undefined,
+                jsdocInfo?.type !== undefined ||
+                jsdocInfo?.params !== undefined ||
+                jsdocInfo?.returnType !== undefined ||
+                resolvedJSDoc?.resolvedType !== undefined,
               inferredType,
               finalType: type,
             });
@@ -4967,6 +5025,12 @@ export default class ComponentParser {
           let localName: string | undefined;
           let defaultValue: ComponentPropDefaultValue | undefined;
           let inferredType: string | undefined;
+          let resolvedJSDoc:
+            | Pick<
+                ProcessedInitializer,
+                "resolvedType" | "resolvedDescription" | "resolvedParams" | "resolvedReturnType"
+              >
+            | undefined;
 
           if (node.declaration.type === "FunctionDeclaration") {
             const funcDecl = node.declaration as { id?: { name?: string } };
@@ -5001,6 +5065,7 @@ export default class ComponentParser {
             isRequired = kind === "let" && init == null;
             const initResult = init == null ? { isFunction: false } : this.processInitializer(init);
             ({ value, type: inferredType, isFunction, defaultValue } = initResult);
+            resolvedJSDoc = initResult;
             type = explicitType ?? inferredType;
           } else {
             return;
@@ -5013,6 +5078,16 @@ export default class ComponentParser {
             returnType = jsdocInfo.returnType;
             if (jsdocInfo.description) description = jsdocInfo.description;
           }
+
+          if (explicitType === undefined && jsdocInfo?.type === undefined && resolvedJSDoc?.resolvedType) {
+            type = resolvedJSDoc.resolvedType;
+          }
+          if (description === undefined && resolvedJSDoc?.resolvedDescription) {
+            description = resolvedJSDoc.resolvedDescription;
+          }
+          if (params === undefined && resolvedJSDoc?.resolvedParams) params = resolvedJSDoc.resolvedParams;
+          if (returnType === undefined && resolvedJSDoc?.resolvedReturnType)
+            returnType = resolvedJSDoc.resolvedReturnType;
 
           // Merge returnType into type for function declarations if not overridden by @type
           if (isFunctionDeclaration && type === "() => any" && returnType) {
@@ -5035,7 +5110,10 @@ export default class ComponentParser {
           const typeSource = this.resolveTypeSource({
             hasTypeScriptType: explicitType !== undefined,
             hasJSDocType:
-              jsdocInfo?.type !== undefined || jsdocInfo?.params !== undefined || jsdocInfo?.returnType !== undefined,
+              jsdocInfo?.type !== undefined ||
+              jsdocInfo?.params !== undefined ||
+              jsdocInfo?.returnType !== undefined ||
+              resolvedJSDoc?.resolvedType !== undefined,
             inferredType,
             finalType: type,
           });

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -4552,6 +4552,7 @@ export default class ComponentParser {
     this.componentComment = undefined;
     this.componentCommentSource = undefined;
     this.reactive_vars.clear();
+    this.vars.clear();
     this.props.clear();
     this.moduleExports.clear();
     this.slots.clear();

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -18087,3 +18087,390 @@ export default class TypedefBrandedTypes extends SvelteComponentTyped<
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 43,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "copy",
+      "kind": "let",
+      "description": "Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.",
+      "type": "(text: string) => void | Promise<void>",
+      "typeSource": "jsdoc",
+      "defaultValue": {
+        "raw": "async (text) => {     await navigator.clipboard.writeText(text);   }",
+        "kind": "function"
+      },
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 32
+        }
+      }
+    },
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Default size in pixels.",
+      "type": "number",
+      "typeSource": "jsdoc",
+      "value": "16",
+      "defaultValue": {
+        "raw": "16",
+        "kind": "literal",
+        "value": 16
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 2
+        },
+        "end": {
+          "line": 18,
+          "column": 33
+        }
+      }
+    },
+    {
+      "name": "config",
+      "kind": "let",
+      "description": "Animation configuration applied on mount.",
+      "type": "{ duration: number; easing: string }",
+      "typeSource": "jsdoc",
+      "value": "{ duration: 200, easing: \\"ease-in-out\\" }",
+      "defaultValue": {
+        "raw": "{ duration: 200, easing: \\"ease-in-out\\" }",
+        "kind": "object",
+        "value": {
+          "duration": 200,
+          "easing": "ease-in-out"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 26,
+          "column": 2
+        },
+        "end": {
+          "line": 26,
+          "column": 37
+        }
+      }
+    },
+    {
+      "name": "items",
+      "kind": "let",
+      "description": "Items rendered when no value is provided.",
+      "type": "string[]",
+      "typeSource": "jsdoc",
+      "value": "[\\"one\\", \\"two\\"]",
+      "defaultValue": {
+        "raw": "[\\"one\\", \\"two\\"]",
+        "kind": "array",
+        "value": [
+          "one",
+          "two"
+        ]
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 34,
+          "column": 2
+        },
+        "end": {
+          "line": 34,
+          "column": 35
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Fallback label shown when none is provided.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"Submit\\"",
+      "defaultValue": {
+        "raw": "\\"Submit\\"",
+        "kind": "literal",
+        "value": "Submit"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 39,
+          "column": 2
+        },
+        "end": {
+          "line": 39,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type PropDefaultIdentifierJsdocProps = {
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   */
+  copy?: (text: string) => void | Promise<void>;
+
+  /**
+   * Default size in pixels.
+   * @default 16
+   */
+  size?: number;
+
+  /**
+   * Animation configuration applied on mount.
+   * @default { duration: 200, easing: "ease-in-out" }
+   */
+  config?: { duration: number; easing: string };
+
+  /**
+   * Items rendered when no value is provided.
+   * @default ["one", "two"]
+   */
+  items?: string[];
+
+  /**
+   * Fallback label shown when none is provided.
+   * @default "Submit"
+   */
+  label?: string;
+};
+
+export default class PropDefaultIdentifierJsdoc extends SvelteComponentTyped<
+  PropDefaultIdentifierJsdocProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 29,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "copy",
+      "kind": "let",
+      "description": "Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.",
+      "type": "(text: string) => void | Promise<void>",
+      "typeSource": "jsdoc",
+      "defaultValue": {
+        "raw": "async (text) => {     await navigator.clipboard.writeText(text);   }",
+        "kind": "function"
+      },
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 8
+        },
+        "end": {
+          "line": 25,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Default size in pixels.",
+      "type": "number",
+      "typeSource": "jsdoc",
+      "value": "16",
+      "defaultValue": {
+        "raw": "16",
+        "kind": "literal",
+        "value": 16
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 28
+        },
+        "end": {
+          "line": 25,
+          "column": 47
+        }
+      }
+    },
+    {
+      "name": "config",
+      "kind": "let",
+      "description": "Animation configuration applied on mount.",
+      "type": "{ duration: number; easing: string }",
+      "typeSource": "jsdoc",
+      "value": "{ duration: 200, easing: \\"ease-in-out\\" }",
+      "defaultValue": {
+        "raw": "{ duration: 200, easing: \\"ease-in-out\\" }",
+        "kind": "object",
+        "value": {
+          "duration": 200,
+          "easing": "ease-in-out"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 49
+        },
+        "end": {
+          "line": 25,
+          "column": 72
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Fallback label shown when none is provided.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"Submit\\"",
+      "defaultValue": {
+        "raw": "\\"Submit\\"",
+        "kind": "literal",
+        "value": "Submit"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 74
+        },
+        "end": {
+          "line": 25,
+          "column": 95
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesPropDefaultIdentifierJsdocProps = {
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   */
+  copy?: (text: string) => void | Promise<void>;
+
+  /**
+   * Default size in pixels.
+   * @default 16
+   */
+  size?: number;
+
+  /**
+   * Animation configuration applied on mount.
+   * @default { duration: 200, easing: "ease-in-out" }
+   */
+  config?: { duration: number; easing: string };
+
+  /**
+   * Fallback label shown when none is provided.
+   * @default "Submit"
+   */
+  label?: string;
+};
+
+export default class RunesPropDefaultIdentifierJsdoc extends SvelteComponentTyped<
+  RunesPropDefaultIdentifierJsdocProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 156,

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 1,

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 4,

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 4,

--- a/tests/e2e/multi-folders/COMPONENT_API.json
+++ b/tests/e2e/multi-folders/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 5,

--- a/tests/e2e/path-aliases/COMPONENT_API.json
+++ b/tests/e2e/path-aliases/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 2,

--- a/tests/e2e/single-export-default-only/COMPONENT_API.json
+++ b/tests/e2e/single-export-default-only/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 1,

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 1,

--- a/tests/e2e/svelte5-legacy/COMPONENT_API.json
+++ b/tests/e2e/svelte5-legacy/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 1,

--- a/tests/e2e/svelte5-runes/COMPONENT_API.json
+++ b/tests/e2e/svelte5-runes/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 1,

--- a/tests/e2e/sveltekit/COMPONENT_API.json
+++ b/tests/e2e/sveltekit/COMPONENT_API.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "svelteVersion": "5.55.9"
   },
   "total": 1,

--- a/tests/fixtures/prop-default-identifier-jsdoc/input.svelte
+++ b/tests/fixtures/prop-default-identifier-jsdoc/input.svelte
@@ -1,0 +1,42 @@
+<script>
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   * @type {(text: string) => void | Promise<void>}
+   */
+  const defaultCopy = async (text) => {
+    await navigator.clipboard.writeText(text);
+  };
+
+  export let copy = defaultCopy;
+
+  /**
+   * Default size in pixels.
+   * @type {number}
+   */
+  const DEFAULT_SIZE = 16;
+
+  export let size = DEFAULT_SIZE;
+
+  /**
+   * Animation configuration applied on mount.
+   * @type {{ duration: number; easing: string }}
+   */
+  const DEFAULT_CONFIG = { duration: 200, easing: "ease-in-out" };
+
+  export let config = DEFAULT_CONFIG;
+
+  /**
+   * Items rendered when no value is provided.
+   * @type {string[]}
+   */
+  const DEFAULT_ITEMS = ["one", "two"];
+
+  export let items = DEFAULT_ITEMS;
+
+  /** Fallback label shown when none is provided. */
+  const DEFAULT_LABEL = "Submit";
+
+  export let label = DEFAULT_LABEL;
+</script>
+
+<button on:click={() => copy(label)}>{label} {size} {config.duration} {items.length}</button>

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.d.ts
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.d.ts
@@ -1,0 +1,38 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type PropDefaultIdentifierJsdocProps = {
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   */
+  copy?: (text: string) => void | Promise<void>;
+
+  /**
+   * Default size in pixels.
+   * @default 16
+   */
+  size?: number;
+
+  /**
+   * Animation configuration applied on mount.
+   * @default { duration: 200, easing: "ease-in-out" }
+   */
+  config?: { duration: number; easing: string };
+
+  /**
+   * Items rendered when no value is provided.
+   * @default ["one", "two"]
+   */
+  items?: string[];
+
+  /**
+   * Fallback label shown when none is provided.
+   * @default "Submit"
+   */
+  label?: string;
+};
+
+export default class PropDefaultIdentifierJsdoc extends SvelteComponentTyped<
+  PropDefaultIdentifierJsdocProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.json
@@ -1,0 +1,166 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 43,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "copy",
+      "kind": "let",
+      "description": "Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.",
+      "type": "(text: string) => void | Promise<void>",
+      "typeSource": "jsdoc",
+      "defaultValue": {
+        "raw": "async (text) => {     await navigator.clipboard.writeText(text);   }",
+        "kind": "function"
+      },
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 32
+        }
+      }
+    },
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Default size in pixels.",
+      "type": "number",
+      "typeSource": "jsdoc",
+      "value": "16",
+      "defaultValue": {
+        "raw": "16",
+        "kind": "literal",
+        "value": 16
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 2
+        },
+        "end": {
+          "line": 18,
+          "column": 33
+        }
+      }
+    },
+    {
+      "name": "config",
+      "kind": "let",
+      "description": "Animation configuration applied on mount.",
+      "type": "{ duration: number; easing: string }",
+      "typeSource": "jsdoc",
+      "value": "{ duration: 200, easing: \"ease-in-out\" }",
+      "defaultValue": {
+        "raw": "{ duration: 200, easing: \"ease-in-out\" }",
+        "kind": "object",
+        "value": {
+          "duration": 200,
+          "easing": "ease-in-out"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 26,
+          "column": 2
+        },
+        "end": {
+          "line": 26,
+          "column": 37
+        }
+      }
+    },
+    {
+      "name": "items",
+      "kind": "let",
+      "description": "Items rendered when no value is provided.",
+      "type": "string[]",
+      "typeSource": "jsdoc",
+      "value": "[\"one\", \"two\"]",
+      "defaultValue": {
+        "raw": "[\"one\", \"two\"]",
+        "kind": "array",
+        "value": [
+          "one",
+          "two"
+        ]
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 34,
+          "column": 2
+        },
+        "end": {
+          "line": 34,
+          "column": 35
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Fallback label shown when none is provided.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"Submit\"",
+      "defaultValue": {
+        "raw": "\"Submit\"",
+        "kind": "literal",
+        "value": "Submit"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 39,
+          "column": 2
+        },
+        "end": {
+          "line": 39,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/input.svelte
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/input.svelte
@@ -1,0 +1,28 @@
+<script>
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   * @type {(text: string) => void | Promise<void>}
+   */
+  const defaultCopy = async (text) => {
+    await navigator.clipboard.writeText(text);
+  };
+
+  /**
+   * Default size in pixels.
+   * @type {number}
+   */
+  const DEFAULT_SIZE = 16;
+
+  /**
+   * Animation configuration applied on mount.
+   * @type {{ duration: number; easing: string }}
+   */
+  const DEFAULT_CONFIG = { duration: 200, easing: "ease-in-out" };
+
+  /** Fallback label shown when none is provided. */
+  const DEFAULT_LABEL = "Submit";
+
+  let { copy = defaultCopy, size = DEFAULT_SIZE, config = DEFAULT_CONFIG, label = DEFAULT_LABEL } = $props();
+</script>
+
+<button onclick={() => copy(label)}>{label} {size} {config.duration}</button>

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.d.ts
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.d.ts
@@ -1,0 +1,32 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesPropDefaultIdentifierJsdocProps = {
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   */
+  copy?: (text: string) => void | Promise<void>;
+
+  /**
+   * Default size in pixels.
+   * @default 16
+   */
+  size?: number;
+
+  /**
+   * Animation configuration applied on mount.
+   * @default { duration: 200, easing: "ease-in-out" }
+   */
+  config?: { duration: number; easing: string };
+
+  /**
+   * Fallback label shown when none is provided.
+   * @default "Submit"
+   */
+  label?: string;
+};
+
+export default class RunesPropDefaultIdentifierJsdoc extends SvelteComponentTyped<
+  RunesPropDefaultIdentifierJsdocProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
@@ -1,0 +1,135 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 29,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "copy",
+      "kind": "let",
+      "description": "Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.",
+      "type": "(text: string) => void | Promise<void>",
+      "typeSource": "jsdoc",
+      "defaultValue": {
+        "raw": "async (text) => {     await navigator.clipboard.writeText(text);   }",
+        "kind": "function"
+      },
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 8
+        },
+        "end": {
+          "line": 25,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "size",
+      "kind": "let",
+      "description": "Default size in pixels.",
+      "type": "number",
+      "typeSource": "jsdoc",
+      "value": "16",
+      "defaultValue": {
+        "raw": "16",
+        "kind": "literal",
+        "value": 16
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 28
+        },
+        "end": {
+          "line": 25,
+          "column": 47
+        }
+      }
+    },
+    {
+      "name": "config",
+      "kind": "let",
+      "description": "Animation configuration applied on mount.",
+      "type": "{ duration: number; easing: string }",
+      "typeSource": "jsdoc",
+      "value": "{ duration: 200, easing: \"ease-in-out\" }",
+      "defaultValue": {
+        "raw": "{ duration: 200, easing: \"ease-in-out\" }",
+        "kind": "object",
+        "value": {
+          "duration": 200,
+          "easing": "ease-in-out"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 49
+        },
+        "end": {
+          "line": 25,
+          "column": 72
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "Fallback label shown when none is provided.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"Submit\"",
+      "defaultValue": {
+        "raw": "\"Submit\"",
+        "kind": "literal",
+        "value": "Submit"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 74
+        },
+        "end": {
+          "line": 25,
+          "column": 95
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": []
+}


### PR DESCRIPTION
Props like `export let copy = defaultCopy` resolved the referenced value but dropped its `@type`/description, emitting a generic `(...args: any[]) => any`. Now the prop inherits the referenced variable's JSDoc as a fallback, behind its own annotations.

Also clean up collected `vars` in `cleanup`.