### PR TITLE
fix(component-parser): inherit JSDoc from function-declaration defaults

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -783,6 +783,9 @@ export default class ComponentParser {
   /** Set of all variable declarations found in the component script */
   private readonly vars: Set<VariableDeclaration> = new Set();
 
+  /** Function declarations in the component script, by name */
+  private readonly funcDecls: Map<string, FunctionDeclaration> = new Map();
+
   /** Map of component props keyed by prop name */
   private readonly props: Map<string, ComponentProp> = new Map();
 
@@ -2568,6 +2571,20 @@ export default class ComponentParser {
             resolvedReturnType: resolvedJSDoc?.returnType ?? inner.resolvedReturnType,
           };
         }
+
+        // `function defaultX() {}` has no initializer. Read JSDoc off the declaration.
+        if (this.funcDecls.has(ident.name)) {
+          const resolvedJSDoc = this.resolveLocalVarJSDoc(ident.name);
+          return {
+            value: undefined,
+            type: undefined,
+            isFunction: true,
+            resolvedType: resolvedJSDoc?.type ?? this.buildFunctionTypeFromParts(resolvedJSDoc),
+            resolvedDescription: resolvedJSDoc?.description,
+            resolvedParams: resolvedJSDoc?.params,
+            resolvedReturnType: resolvedJSDoc?.returnType,
+          };
+        }
       }
       if ("start" in ident && "end" in ident && typeof ident.start === "number" && typeof ident.end === "number") {
         value = this.sourceAtPos(ident.start, ident.end);
@@ -2647,7 +2664,30 @@ export default class ComponentParser {
         return this.processNodeJSDoc(decl as unknown as { leadingComments?: unknown[]; start?: number });
       }
     }
+
+    const funcDecl = this.funcDecls.get(name);
+    if (funcDecl) {
+      return this.processNodeJSDoc(funcDecl as unknown as { leadingComments?: unknown[]; start?: number });
+    }
+
     return undefined;
+  }
+
+  /**
+   * Build a function type from `@param`/`@returns` when `@type` is missing.
+   * No params or return type? `(...args: any[]) => any`.
+   */
+  private buildFunctionTypeFromParts(jsdoc?: { params?: ComponentPropParam[]; returnType?: string }): string {
+    const returnType = jsdoc?.returnType ?? "any";
+    const params = jsdoc?.params;
+    if (params && params.length > 0) {
+      const paramsString = params.map((param) => `${param.name}${param.optional ? "?" : ""}: ${param.type}`).join(", ");
+      return `(${paramsString}) => ${returnType}`;
+    }
+    if (jsdoc?.returnType) {
+      return `() => ${returnType}`;
+    }
+    return "(...args: any[]) => any";
   }
 
   /**
@@ -4553,6 +4593,7 @@ export default class ComponentParser {
     this.componentCommentSource = undefined;
     this.reactive_vars.clear();
     this.vars.clear();
+    this.funcDecls.clear();
     this.props.clear();
     this.moduleExports.clear();
     this.slots.clear();
@@ -4930,6 +4971,13 @@ export default class ComponentParser {
             this.restPropLocals.has(spreadNode.expression?.name ?? "")
           ) {
             this.maybeSetRestProps(parent);
+          }
+        }
+
+        if (node.type === "FunctionDeclaration") {
+          const funcDecl = node as unknown as FunctionDeclaration;
+          if (funcDecl.id?.name) {
+            this.funcDecls.set(funcDecl.id.name, funcDecl);
           }
         }
 

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -18096,7 +18096,7 @@ exports[`fixtures (JSON) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
       "column": 0
     },
     "end": {
-      "line": 43,
+      "line": 92,
       "column": 0
     }
   },
@@ -18246,6 +18246,130 @@ exports[`fixtures (JSON) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
           "column": 35
         }
       }
+    },
+    {
+      "name": "shouldFilterItem",
+      "kind": "let",
+      "description": "Determine if an item should be filtered given the current value.",
+      "type": "(item: string, value: string) => boolean",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 49,
+          "column": 2
+        },
+        "end": {
+          "line": 49,
+          "column": 52
+        }
+      }
+    },
+    {
+      "name": "format",
+      "kind": "let",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 55,
+          "column": 2
+        },
+        "end": {
+          "line": 55,
+          "column": 36
+        }
+      }
+    },
+    {
+      "name": "renderEmpty",
+      "kind": "let",
+      "description": "Render the message shown when there are no items.",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 62,
+          "column": 2
+        },
+        "end": {
+          "line": 62,
+          "column": 46
+        }
+      }
+    },
+    {
+      "name": "getKey",
+      "kind": "let",
+      "description": "Resolve the unique key for an item.",
+      "type": "(item: string, index: number) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "item",
+          "type": "string",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 74,
+          "column": 2
+        },
+        "end": {
+          "line": 74,
+          "column": 36
+        }
+      }
+    },
+    {
+      "name": "translate",
+      "kind": "let",
+      "description": "Translate a label to the active locale.\\n@example translate(\\"submit\\") // => \\"Submit\\"",
+      "type": "(key: string) => string",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 85,
+          "column": 2
+        },
+        "end": {
+          "line": 85,
+          "column": 42
+        }
+      }
     }
   ],
   "moduleExports": [],
@@ -18290,6 +18414,29 @@ export type PropDefaultIdentifierJsdocProps = {
    * @default "Submit"
    */
   label?: string;
+
+  /**
+   * Determine if an item should be filtered given the current value.
+   */
+  shouldFilterItem?: (item: string, value: string) => boolean;
+
+  format?: (...args: any[]) => any;
+
+  /**
+   * Render the message shown when there are no items.
+   */
+  renderEmpty?: (...args: any[]) => any;
+
+  /**
+   * Resolve the unique key for an item.
+   */
+  getKey?: (item: string, index: number) => string;
+
+  /**
+   * Translate a label to the active locale.
+   * @example translate("submit") // => "Submit"
+   */
+  translate?: (key: string) => string;
 };
 
 export default class PropDefaultIdentifierJsdoc extends SvelteComponentTyped<
@@ -18308,7 +18455,7 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
       "column": 0
     },
     "end": {
-      "line": 29,
+      "line": 78,
       "column": 0
     }
   },
@@ -18332,12 +18479,12 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 8
+          "line": 62,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 26
+          "line": 62,
+          "column": 22
         }
       }
     },
@@ -18360,12 +18507,12 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 28
+          "line": 63,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 47
+          "line": 63,
+          "column": 23
         }
       }
     },
@@ -18391,12 +18538,12 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 49
+          "line": 64,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 72
+          "line": 64,
+          "column": 27
         }
       }
     },
@@ -18419,12 +18566,136 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 74
+          "line": 65,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 95
+          "line": 65,
+          "column": 25
+        }
+      }
+    },
+    {
+      "name": "shouldFilterItem",
+      "kind": "let",
+      "description": "Determine if an item should be filtered given the current value.",
+      "type": "(item: string, value: string) => boolean",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 66,
+          "column": 4
+        },
+        "end": {
+          "line": 66,
+          "column": 42
+        }
+      }
+    },
+    {
+      "name": "format",
+      "kind": "let",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 67,
+          "column": 4
+        },
+        "end": {
+          "line": 67,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "renderEmpty",
+      "kind": "let",
+      "description": "Render the message shown when there are no items.",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 68,
+          "column": 4
+        },
+        "end": {
+          "line": 68,
+          "column": 36
+        }
+      }
+    },
+    {
+      "name": "getKey",
+      "kind": "let",
+      "description": "Resolve the unique key for an item.",
+      "type": "(item: string, index: number) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "item",
+          "type": "string",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 69,
+          "column": 4
+        },
+        "end": {
+          "line": 69,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "translate",
+      "kind": "let",
+      "description": "Translate a label to the active locale.\\n@example translate(\\"submit\\") // => \\"Submit\\"",
+      "type": "(key: string) => string",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 70,
+          "column": 4
+        },
+        "end": {
+          "line": 70,
+          "column": 32
         }
       }
     }
@@ -18465,6 +18736,29 @@ export type RunesPropDefaultIdentifierJsdocProps = {
    * @default "Submit"
    */
   label?: string;
+
+  /**
+   * Determine if an item should be filtered given the current value.
+   */
+  shouldFilterItem?: (item: string, value: string) => boolean;
+
+  format?: (...args: any[]) => any;
+
+  /**
+   * Render the message shown when there are no items.
+   */
+  renderEmpty?: (...args: any[]) => any;
+
+  /**
+   * Resolve the unique key for an item.
+   */
+  getKey?: (item: string, index: number) => string;
+
+  /**
+   * Translate a label to the active locale.
+   * @example translate("submit") // => "Submit"
+   */
+  translate?: (key: string) => string;
 };
 
 export default class RunesPropDefaultIdentifierJsdoc extends SvelteComponentTyped<

--- a/tests/fixtures/prop-default-identifier-jsdoc/input.svelte
+++ b/tests/fixtures/prop-default-identifier-jsdoc/input.svelte
@@ -37,6 +37,55 @@
   const DEFAULT_LABEL = "Submit";
 
   export let label = DEFAULT_LABEL;
+
+  /**
+   * Determine if an item should be filtered given the current value.
+   * @type {(item: string, value: string) => boolean}
+   */
+  function defaultShouldFilter() {
+    return true;
+  }
+
+  export let shouldFilterItem = defaultShouldFilter;
+
+  function defaultFormat(value) {
+    return String(value);
+  }
+
+  export let format = defaultFormat;
+
+  /** Render the message shown when there are no items. */
+  function defaultRenderEmpty() {
+    return "No results";
+  }
+
+  export let renderEmpty = defaultRenderEmpty;
+
+  /**
+   * Resolve the unique key for an item.
+   * @param {string} item
+   * @param {number} index
+   * @returns {string}
+   */
+  function defaultGetKey() {
+    return "";
+  }
+
+  export let getKey = defaultGetKey;
+
+  /**
+   * Translate a label to the active locale.
+   * @type {(key: string) => string}
+   * @example translate("submit") // => "Submit"
+   */
+  function defaultTranslate(key) {
+    return key;
+  }
+
+  export let translate = defaultTranslate;
 </script>
 
-<button on:click={() => copy(label)}>{label} {size} {config.duration} {items.length}</button>
+<button on:click={() => copy(label)}>
+  {label} {size} {config.duration} {items.length} {shouldFilterItem("a", "b")}
+  {format(1)} {renderEmpty()} {getKey("a", 0)} {translate("submit")}
+</button>

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.d.ts
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.d.ts
@@ -29,6 +29,29 @@ export type PropDefaultIdentifierJsdocProps = {
    * @default "Submit"
    */
   label?: string;
+
+  /**
+   * Determine if an item should be filtered given the current value.
+   */
+  shouldFilterItem?: (item: string, value: string) => boolean;
+
+  format?: (...args: any[]) => any;
+
+  /**
+   * Render the message shown when there are no items.
+   */
+  renderEmpty?: (...args: any[]) => any;
+
+  /**
+   * Resolve the unique key for an item.
+   */
+  getKey?: (item: string, index: number) => string;
+
+  /**
+   * Translate a label to the active locale.
+   * @example translate("submit") // => "Submit"
+   */
+  translate?: (key: string) => string;
 };
 
 export default class PropDefaultIdentifierJsdoc extends SvelteComponentTyped<

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 43,
+      "line": 92,
       "column": 0
     }
   },
@@ -153,6 +153,130 @@
         "end": {
           "line": 39,
           "column": 35
+        }
+      }
+    },
+    {
+      "name": "shouldFilterItem",
+      "kind": "let",
+      "description": "Determine if an item should be filtered given the current value.",
+      "type": "(item: string, value: string) => boolean",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 49,
+          "column": 2
+        },
+        "end": {
+          "line": 49,
+          "column": 52
+        }
+      }
+    },
+    {
+      "name": "format",
+      "kind": "let",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 55,
+          "column": 2
+        },
+        "end": {
+          "line": 55,
+          "column": 36
+        }
+      }
+    },
+    {
+      "name": "renderEmpty",
+      "kind": "let",
+      "description": "Render the message shown when there are no items.",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 62,
+          "column": 2
+        },
+        "end": {
+          "line": 62,
+          "column": 46
+        }
+      }
+    },
+    {
+      "name": "getKey",
+      "kind": "let",
+      "description": "Resolve the unique key for an item.",
+      "type": "(item: string, index: number) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "item",
+          "type": "string",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 74,
+          "column": 2
+        },
+        "end": {
+          "line": 74,
+          "column": 36
+        }
+      }
+    },
+    {
+      "name": "translate",
+      "kind": "let",
+      "description": "Translate a label to the active locale.\n@example translate(\"submit\") // => \"Submit\"",
+      "type": "(key: string) => string",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 85,
+          "column": 2
+        },
+        "end": {
+          "line": 85,
+          "column": 42
         }
       }
     }

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/input.svelte
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/input.svelte
@@ -22,7 +22,56 @@
   /** Fallback label shown when none is provided. */
   const DEFAULT_LABEL = "Submit";
 
-  let { copy = defaultCopy, size = DEFAULT_SIZE, config = DEFAULT_CONFIG, label = DEFAULT_LABEL } = $props();
+  /**
+   * Determine if an item should be filtered given the current value.
+   * @type {(item: string, value: string) => boolean}
+   */
+  function defaultShouldFilter() {
+    return true;
+  }
+
+  function defaultFormat(value) {
+    return String(value);
+  }
+
+  /** Render the message shown when there are no items. */
+  function defaultRenderEmpty() {
+    return "No results";
+  }
+
+  /**
+   * Resolve the unique key for an item.
+   * @param {string} item
+   * @param {number} index
+   * @returns {string}
+   */
+  function defaultGetKey() {
+    return "";
+  }
+
+  /**
+   * Translate a label to the active locale.
+   * @type {(key: string) => string}
+   * @example translate("submit") // => "Submit"
+   */
+  function defaultTranslate(key) {
+    return key;
+  }
+
+  let {
+    copy = defaultCopy,
+    size = DEFAULT_SIZE,
+    config = DEFAULT_CONFIG,
+    label = DEFAULT_LABEL,
+    shouldFilterItem = defaultShouldFilter,
+    format = defaultFormat,
+    renderEmpty = defaultRenderEmpty,
+    getKey = defaultGetKey,
+    translate = defaultTranslate,
+  } = $props();
 </script>
 
-<button onclick={() => copy(label)}>{label} {size} {config.duration}</button>
+<button onclick={() => copy(label)}>
+  {label} {size} {config.duration} {shouldFilterItem("a", "b")}
+  {format(1)} {renderEmpty()} {getKey("a", 0)} {translate("submit")}
+</button>

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.d.ts
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.d.ts
@@ -23,6 +23,29 @@ export type RunesPropDefaultIdentifierJsdocProps = {
    * @default "Submit"
    */
   label?: string;
+
+  /**
+   * Determine if an item should be filtered given the current value.
+   */
+  shouldFilterItem?: (item: string, value: string) => boolean;
+
+  format?: (...args: any[]) => any;
+
+  /**
+   * Render the message shown when there are no items.
+   */
+  renderEmpty?: (...args: any[]) => any;
+
+  /**
+   * Resolve the unique key for an item.
+   */
+  getKey?: (item: string, index: number) => string;
+
+  /**
+   * Translate a label to the active locale.
+   * @example translate("submit") // => "Submit"
+   */
+  translate?: (key: string) => string;
 };
 
 export default class RunesPropDefaultIdentifierJsdoc extends SvelteComponentTyped<

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 29,
+      "line": 78,
       "column": 0
     }
   },
@@ -29,12 +29,12 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 8
+          "line": 62,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 26
+          "line": 62,
+          "column": 22
         }
       }
     },
@@ -57,12 +57,12 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 28
+          "line": 63,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 47
+          "line": 63,
+          "column": 23
         }
       }
     },
@@ -88,12 +88,12 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 49
+          "line": 64,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 72
+          "line": 64,
+          "column": 27
         }
       }
     },
@@ -116,12 +116,136 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 25,
-          "column": 74
+          "line": 65,
+          "column": 4
         },
         "end": {
-          "line": 25,
-          "column": 95
+          "line": 65,
+          "column": 25
+        }
+      }
+    },
+    {
+      "name": "shouldFilterItem",
+      "kind": "let",
+      "description": "Determine if an item should be filtered given the current value.",
+      "type": "(item: string, value: string) => boolean",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 66,
+          "column": 4
+        },
+        "end": {
+          "line": 66,
+          "column": 42
+        }
+      }
+    },
+    {
+      "name": "format",
+      "kind": "let",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 67,
+          "column": 4
+        },
+        "end": {
+          "line": 67,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "renderEmpty",
+      "kind": "let",
+      "description": "Render the message shown when there are no items.",
+      "type": "(...args: any[]) => any",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 68,
+          "column": 4
+        },
+        "end": {
+          "line": 68,
+          "column": 36
+        }
+      }
+    },
+    {
+      "name": "getKey",
+      "kind": "let",
+      "description": "Resolve the unique key for an item.",
+      "type": "(item: string, index: number) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "item",
+          "type": "string",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 69,
+          "column": 4
+        },
+        "end": {
+          "line": 69,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "translate",
+      "kind": "let",
+      "description": "Translate a label to the active locale.\n@example translate(\"submit\") // => \"Submit\"",
+      "type": "(key: string) => string",
+      "typeSource": "jsdoc",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 70,
+          "column": 4
+        },
+        "end": {
+          "line": 70,
+          "column": 32
         }
       }
     }


### PR DESCRIPTION
Identifier resolution only consulted variable declarations, so a prop defaulting to a hoisted `function defaultX() {}` lost its `@type` and description and collapsed to `undefined`. Track function declarations by name too, reaching parity with the existing `const` default path.