### PR TITLE
fix(component-parser): infer arity and return type for un-annotated function defaults

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -2479,7 +2479,7 @@ export default class ComponentParser {
       }
 
       if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
-        type = "(...args: any[]) => any";
+        type = this.inferFunctionTypeFromNode(init as ArrowFunctionExpression | FunctionExpression);
         value = undefined;
       }
     } else if (init.type === "UnaryExpression") {
@@ -2575,11 +2575,12 @@ export default class ComponentParser {
         // `function defaultX() {}` has no initializer. Read JSDoc off the declaration.
         if (this.funcDecls.has(ident.name)) {
           const resolvedJSDoc = this.resolveLocalVarJSDoc(ident.name);
+          const funcNode = this.funcDecls.get(ident.name);
           return {
             value: undefined,
             type: undefined,
             isFunction: true,
-            resolvedType: resolvedJSDoc?.type ?? this.buildFunctionTypeFromParts(resolvedJSDoc),
+            resolvedType: resolvedJSDoc?.type ?? this.buildFunctionTypeFromParts(resolvedJSDoc, funcNode),
             resolvedDescription: resolvedJSDoc?.description,
             resolvedParams: resolvedJSDoc?.params,
             resolvedReturnType: resolvedJSDoc?.returnType,
@@ -2675,9 +2676,13 @@ export default class ComponentParser {
 
   /**
    * Build a function type from `@param`/`@returns` when `@type` is missing.
-   * No params or return type? `(...args: any[]) => any`.
+   * If JSDoc has no params or return either, try the function `node`, then
+   * `(...args: any[]) => any`.
    */
-  private buildFunctionTypeFromParts(jsdoc?: { params?: ComponentPropParam[]; returnType?: string }): string {
+  private buildFunctionTypeFromParts(
+    jsdoc?: { params?: ComponentPropParam[]; returnType?: string },
+    node?: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
+  ): string {
     const returnType = jsdoc?.returnType ?? "any";
     const params = jsdoc?.params;
     if (params && params.length > 0) {
@@ -2687,7 +2692,142 @@ export default class ComponentParser {
     if (jsdoc?.returnType) {
       return `() => ${returnType}`;
     }
+    if (node) {
+      return this.inferFunctionTypeFromNode(node);
+    }
     return "(...args: any[]) => any";
+  }
+
+  /**
+   * Guess arity and return type for a function default with no JSDoc `@type`.
+   * Explicit `@type`/`@param`/`@returns` on the prop beat this every time.
+   * A default's body is a weak signal for the prop contract. We only read
+   * named params and literal returns. Everything else becomes `any`.
+   */
+  private inferFunctionTypeFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
+    return `(${this.inferParamsFromNode(node)}) => ${this.inferReturnTypeFromNode(node)}`;
+  }
+
+  /**
+   * Turn params into `name: any`, or use `...args: any[]` when arity is unclear:
+   * no params, destructuring, rest, or defaults.
+   */
+  private inferParamsFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
+    const params = node.params;
+    if (!Array.isArray(params) || params.length === 0) {
+      return "...args: any[]";
+    }
+    const names: string[] = [];
+    for (const param of params) {
+      if (
+        param &&
+        typeof param === "object" &&
+        "type" in param &&
+        param.type === "Identifier" &&
+        "name" in param &&
+        typeof param.name === "string"
+      ) {
+        names.push(`${param.name}: any`);
+      } else {
+        // Destructuring, rest, or default param: use ...args: any[]
+        return "...args: any[]";
+      }
+    }
+    return names.join(", ");
+  }
+
+  /**
+   * Infer return type from literal returns only. Every `return` must agree on
+   * the same primitive. Bare `return;`, no returns, identifiers, calls,
+   * objects, ternaries, async, or generators all become `any`.
+   */
+  private inferReturnTypeFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
+    if (node.async || node.generator) {
+      return "any";
+    }
+
+    const body = node.body;
+    let returnArgs: unknown[];
+    if (body && typeof body === "object" && "type" in body && body.type === "BlockStatement") {
+      returnArgs = this.collectReturnArguments(body);
+      if (returnArgs.length === 0) {
+        return "any";
+      }
+    } else {
+      // Expression-bodied arrow: body is the return value.
+      returnArgs = [body];
+    }
+
+    let inferred: string | null = null;
+    for (const arg of returnArgs) {
+      const primitive = this.inferReturnPrimitive(arg);
+      if (!primitive) {
+        return "any";
+      }
+      if (inferred === null) {
+        inferred = primitive;
+      } else if (inferred !== primitive) {
+        return "any";
+      }
+    }
+    return inferred ?? "any";
+  }
+
+  /**
+   * Walk a block body and collect each `return`'s argument, skipping nested
+   * functions. Bare `return;` becomes `null`.
+   */
+  private collectReturnArguments(body: unknown): unknown[] {
+    const returnArgs: unknown[] = [];
+    walk(body as Node, {
+      enter(node) {
+        if (
+          node.type === "FunctionDeclaration" ||
+          node.type === "FunctionExpression" ||
+          node.type === "ArrowFunctionExpression"
+        ) {
+          this.skip();
+          return;
+        }
+        if (node.type === "ReturnStatement") {
+          returnArgs.push((node as { argument?: unknown }).argument ?? null);
+        }
+      },
+    });
+    return returnArgs;
+  }
+
+  /**
+   * Map one return expression to `string`, `number`, or `boolean`, or `null`
+   * if it isn't a literal, template literal, or `String`/`Number`/`Boolean` call.
+   */
+  private inferReturnPrimitive(expr: unknown): "string" | "number" | "boolean" | null {
+    if (!expr || typeof expr !== "object" || !("type" in expr)) {
+      return null;
+    }
+    switch (expr.type) {
+      case "Literal": {
+        const value = (expr as Literal).value;
+        if (typeof value === "string") return "string";
+        if (typeof value === "number") return "number";
+        if (typeof value === "boolean") return "boolean";
+        return null;
+      }
+      case "TemplateLiteral":
+        return "string";
+      case "CallExpression": {
+        const callee = (expr as CallExpression).callee;
+        if (callee && typeof callee === "object" && "type" in callee && callee.type === "Identifier") {
+          const name = (callee as Identifier).name;
+          if (name === "String") return "string";
+          if (name === "Number") return "number";
+          if (name === "Boolean") return "boolean";
+        }
+        return null;
+      }
+      default:
+        return null;
+    }
   }
 
   /**

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1645,7 +1645,7 @@ exports[`fixtures (JSON) "prop-metadata-consolidated/input.svelte" 1`] = `
     {
       "name": "callbackDefault",
       "kind": "let",
-      "type": "(...args: any[]) => any",
+      "type": "(value: any) => any",
       "typeSource": "default",
       "defaultValue": {
         "raw": "(value: string) => value.toUpperCase()",
@@ -14186,7 +14186,7 @@ export type PropMetadataConsolidatedProps = {
    */
   objectDefault?: { size: "md"; count: 2 };
 
-  callbackDefault?: (...args: any[]) => any;
+  callbackDefault?: (value: any) => any;
 
   /**
    * @default makeDefault()
@@ -18272,7 +18272,7 @@ exports[`fixtures (JSON) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
     {
       "name": "format",
       "kind": "let",
-      "type": "(...args: any[]) => any",
+      "type": "(value: any) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -18294,7 +18294,7 @@ exports[`fixtures (JSON) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
       "name": "renderEmpty",
       "kind": "let",
       "description": "Render the message shown when there are no items.",
-      "type": "(...args: any[]) => any",
+      "type": "(...args: any[]) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -18420,12 +18420,12 @@ export type PropDefaultIdentifierJsdocProps = {
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
-  format?: (...args: any[]) => any;
+  format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
    */
-  renderEmpty?: (...args: any[]) => any;
+  renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.
@@ -18600,7 +18600,7 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
     {
       "name": "format",
       "kind": "let",
-      "type": "(...args: any[]) => any",
+      "type": "(value: any) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -18622,7 +18622,7 @@ exports[`fixtures (JSON) "runes-prop-default-identifier-jsdoc/input.svelte" 1`] 
       "name": "renderEmpty",
       "kind": "let",
       "description": "Render the message shown when there are no items.",
-      "type": "(...args: any[]) => any",
+      "type": "(...args: any[]) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -18742,12 +18742,12 @@ export type RunesPropDefaultIdentifierJsdocProps = {
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
-  format?: (...args: any[]) => any;
+  format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
    */
-  renderEmpty?: (...args: any[]) => any;
+  renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.d.ts
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.d.ts
@@ -35,12 +35,12 @@ export type PropDefaultIdentifierJsdocProps = {
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
-  format?: (...args: any[]) => any;
+  format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
    */
-  renderEmpty?: (...args: any[]) => any;
+  renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.json
@@ -181,7 +181,7 @@
     {
       "name": "format",
       "kind": "let",
-      "type": "(...args: any[]) => any",
+      "type": "(value: any) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -203,7 +203,7 @@
       "name": "renderEmpty",
       "kind": "let",
       "description": "Render the message shown when there are no items.",
-      "type": "(...args: any[]) => any",
+      "type": "(...args: any[]) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,

--- a/tests/fixtures/prop-metadata-consolidated/output.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output.d.ts
@@ -32,7 +32,7 @@ export type PropMetadataConsolidatedProps = {
    */
   objectDefault?: { size: "md"; count: 2 };
 
-  callbackDefault?: (...args: any[]) => any;
+  callbackDefault?: (value: any) => any;
 
   /**
    * @default makeDefault()

--- a/tests/fixtures/prop-metadata-consolidated/output.json
+++ b/tests/fixtures/prop-metadata-consolidated/output.json
@@ -179,7 +179,7 @@
     {
       "name": "callbackDefault",
       "kind": "let",
-      "type": "(...args: any[]) => any",
+      "type": "(value: any) => any",
       "typeSource": "default",
       "defaultValue": {
         "raw": "(value: string) => value.toUpperCase()",

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.d.ts
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.d.ts
@@ -29,12 +29,12 @@ export type RunesPropDefaultIdentifierJsdocProps = {
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
-  format?: (...args: any[]) => any;
+  format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
    */
-  renderEmpty?: (...args: any[]) => any;
+  renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
@@ -150,7 +150,7 @@
     {
       "name": "format",
       "kind": "let",
-      "type": "(...args: any[]) => any",
+      "type": "(value: any) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -172,7 +172,7 @@
       "name": "renderEmpty",
       "kind": "let",
       "description": "Render the message shown when there are no items.",
-      "type": "(...args: any[]) => any",
+      "type": "(...args: any[]) => string",
       "typeSource": "jsdoc",
       "isFunction": true,
       "isFunctionDeclaration": false,


### PR DESCRIPTION
Un-annotated function defaults emitted the maximally-permissive `(...args: any[]) => any`. Now infers named params and primitive returns conservatively — zero-param functions keep `...args` and ambiguous bodies fall back to `any`, so signatures are never wrong while explicit `@type`/`@param`/`@returns` still win.