### PR TITLE
Add JSDoc comments to exported items in test type definitions

### DIFF
--- a/tests/e2e/glob/types/index.d.ts
+++ b/tests/e2e/glob/types/index.d.ts
@@ -1,2 +1,4 @@
+/** 导出Action类型 */
 export { Action } from "./action/";
+/** 导出Button组件 */
 export { default as Button } from "./button/Button.svelte";


### PR DESCRIPTION
## Problem Background
The exported statements in the test type definition file `tests/e2e/glob/types/index.d.ts` lacked documentation comments, which can reduce code readability and maintainability. As an open-source project, adding docstrings aligns with best practices for clarity and helps developers and tools understand the exports better.

## Changes Made
- Added JSDoc comment `/** 导出Action类型 */` above the export of `Action` type from `./action/`.
- Added JSDoc comment `/** 导出Button组件 */` above the export of `Button` component from `./button/Button.svelte`.

## Verification
This change only adds documentation comments and does not modify any functionality or API. It can be verified by code review to ensure comments are correctly placed. The existing test suite should pass without issues, as no logic was altered.