### PR TITLE
chore(playground): add tab icons, theme toggle, and matched light syntax

### DIFF
--- a/playground/bun.lock
+++ b/playground/bun.lock
@@ -7,6 +7,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/codemirror": "^5.60.17",
         "carbon-components-svelte": "^0.108.0",
+        "carbon-icons-svelte": "^13.12.0",
         "carbon-preprocess-svelte": "^0.11.33",
         "codemirror": "^5.65.20",
         "comment-parser": "^1.4.1",
@@ -97,6 +98,8 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "carbon-components-svelte": ["carbon-components-svelte@0.108.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-eMd5HL0CFFr7jtcQp42QNY5oSYDNlGyVcoa5QiEbIePI2pmkl9yI6DHAiYvqo3BBMDP2G9ZhKoKXC7t/xx+y/Q=="],
+
+    "carbon-icons-svelte": ["carbon-icons-svelte@13.12.0", "", {}, "sha512-VK/gSvzCEe3tNEHS2xAcih/GBuygHuUenV+EY/44A3nyYjk+MCbgpY20uwID8/81gEUxIkl4rA/EMRWb/3qs0A=="],
 
     "carbon-preprocess-svelte": ["carbon-preprocess-svelte@0.11.33", "", {}, "sha512-01h1wiY4y/aujn64+QOobmpFJAj4s9EaSD81Jkg6o/a4ic3p4FgwlOdB7uvAbQOrUs9VaMCJd+8F/MGZ7rAs1w=="],
 

--- a/playground/bun.lock
+++ b/playground/bun.lock
@@ -8,7 +8,7 @@
         "@types/codemirror": "^5.60.17",
         "carbon-components-svelte": "^0.108.0",
         "carbon-icons-svelte": "^13.12.0",
-        "carbon-preprocess-svelte": "^0.11.33",
+        "carbon-preprocess-svelte": "^0.11.34",
         "codemirror": "^5.65.20",
         "comment-parser": "^1.4.1",
         "estree-walker": "^3.0.3",
@@ -101,7 +101,7 @@
 
     "carbon-icons-svelte": ["carbon-icons-svelte@13.12.0", "", {}, "sha512-VK/gSvzCEe3tNEHS2xAcih/GBuygHuUenV+EY/44A3nyYjk+MCbgpY20uwID8/81gEUxIkl4rA/EMRWb/3qs0A=="],
 
-    "carbon-preprocess-svelte": ["carbon-preprocess-svelte@0.11.33", "", {}, "sha512-01h1wiY4y/aujn64+QOobmpFJAj4s9EaSD81Jkg6o/a4ic3p4FgwlOdB7uvAbQOrUs9VaMCJd+8F/MGZ7rAs1w=="],
+    "carbon-preprocess-svelte": ["carbon-preprocess-svelte@0.11.34", "", {}, "sha512-l97/JhzF9Kqs5aFAn7T904o9//KheLYL9DmE74+Qkf+Kfv7l/PlGXl2KlgRYP0o6oVY7DcPTOTYvhJGIE97d5A=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,9 +1,5 @@
 <!doctype html>
-<html
-  lang="en"
-  theme="g100"
-  style="color-scheme: dark"
->
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta
@@ -19,6 +15,19 @@
       name="description"
       content="Generate TypeScript definitions for your Svelte components."
     >
+    <script>
+      (() => {
+        var stored = localStorage.getItem("theme");
+        var theme;
+        if (stored === "white" || stored === "g100") {
+          theme = stored;
+        } else {
+          theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "g100" : "white";
+        }
+        document.documentElement.setAttribute("theme", theme);
+        document.documentElement.style.colorScheme = theme === "white" ? "light" : "dark";
+      })();
+    </script>
   </head>
 
   <body>

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,7 +11,7 @@
     "@types/codemirror": "^5.60.17",
     "carbon-components-svelte": "^0.108.0",
     "carbon-icons-svelte": "^13.12.0",
-    "carbon-preprocess-svelte": "^0.11.33",
+    "carbon-preprocess-svelte": "^0.11.34",
     "codemirror": "^5.65.20",
     "comment-parser": "^1.4.1",
     "estree-walker": "^3.0.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,6 +10,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/codemirror": "^5.60.17",
     "carbon-components-svelte": "^0.108.0",
+    "carbon-icons-svelte": "^13.12.0",
     "carbon-preprocess-svelte": "^0.11.33",
     "codemirror": "^5.65.20",
     "comment-parser": "^1.4.1",

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -10,6 +10,9 @@
     TabContent,
     Tabs,
   } from "carbon-components-svelte";
+  import Code from "carbon-icons-svelte/lib/Code.svelte";
+  import Json from "carbon-icons-svelte/lib/Json.svelte";
+  import TextCreation from "carbon-icons-svelte/lib/TextCreation.svelte";
   import { type Component, onMount, tick } from "svelte";
   import ComponentParser from "../../src/ComponentParser";
   import data from "./data";
@@ -123,10 +126,19 @@
           type="container"
           id="output"
         >
-          <Tab label="TypeScript" />
-          <Tab label="JSON" />
-          <Tab label="Markdown" />
-          <div slot="content">
+          <Tab
+            label="TypeScript"
+            icon={Code}
+          />
+          <Tab
+            label="JSON"
+            icon={Json}
+          />
+          <Tab
+            label="Markdown"
+            icon={TextCreation}
+          />
+          <svelte:fragment slot="content">
             {#if parse_error}
               <TabContentOverlay title="Parse error"> {parse_error} </TabContentOverlay>
             {/if}
@@ -163,7 +175,7 @@
                 <InlineLoading style="margin: var(--cds-spacing-05)" />
               {/if}
             </TabContent>
-          </div>
+          </svelte:fragment>
         </Tabs>
       </Column>
     </Row>

--- a/playground/src/CodeEditor.svelte
+++ b/playground/src/CodeEditor.svelte
@@ -4,6 +4,7 @@
 >
   import CodeMirror from "codemirror";
   import "codemirror/mode/htmlmixed/htmlmixed";
+  import "./codemirror-github.css";
   import "codemirror/theme/zenburn.css";
 </script>
 
@@ -12,16 +13,21 @@
   export let codemirror: CodeMirror.Editor | null = null;
 
   import { createEventDispatcher, onMount } from "svelte";
+  import { type Theme, theme } from "./theme";
 
   const dispatch = createEventDispatcher();
 
   let ref: HTMLDivElement;
 
+  function getCodeMirrorTheme(value: Theme) {
+    return value === "g100" ? "zenburn" : "github";
+  }
+
   onMount(() => {
     codemirror = CodeMirror(ref, {
       value: code,
       mode: "htmlmixed",
-      theme: "zenburn",
+      theme: getCodeMirrorTheme($theme),
     });
 
     codemirror.on("change", () => {
@@ -30,7 +36,12 @@
       }
     });
 
+    const unsubscribe = theme.subscribe((value) => {
+      codemirror?.setOption("theme", getCodeMirrorTheme(value));
+    });
+
     return () => {
+      unsubscribe();
       codemirror = null;
     };
   });
@@ -60,7 +71,8 @@
     }
   }
 
-  :global(.cm-s-zenburn.CodeMirror) {
+  :global(.cm-s-zenburn.CodeMirror),
+  :global(.cm-s-github.CodeMirror) {
     background-color: var(--cds-ui-01);
   }
 
@@ -99,21 +111,6 @@
 
   :global(.CodeMirror-lines) {
     cursor: text;
-  }
-
-  :global(.CodeMirror ::-webkit-scrollbar) {
-    width: 10px;
-    height: 10px;
-  }
-
-  :global(.CodeMirror ::-webkit-scrollbar-track) {
-    background: var(--cds-ui-02);
-    border-radius: 10px;
-  }
-
-  :global(.CodeMirror ::-webkit-scrollbar-thumb) {
-    border-radius: 10px;
-    background: var(--cds-ui-04);
   }
 
   :global(.CodeMirror-vscrollbar) {

--- a/playground/src/CodeHighlighter.svelte
+++ b/playground/src/CodeHighlighter.svelte
@@ -4,8 +4,34 @@
   export let noWrap = false;
 
   import { CopyButton } from "carbon-components-svelte";
+  import { onMount } from "svelte";
   import Highlight from "svelte-highlight";
-  import "svelte-highlight/styles/zenburn.css";
+  import githubStyles from "svelte-highlight/styles/github.css?url";
+  import zenburnStyles from "svelte-highlight/styles/zenburn.css?url";
+  import { type Theme, theme } from "./theme";
+
+  const HIGHLIGHT_STYLES: Record<Theme, string> = {
+    g100: zenburnStyles,
+    white: githubStyles,
+  };
+
+  let highlightStylesheet: HTMLLinkElement | undefined;
+
+  function setHighlightTheme(value: Theme) {
+    if (!highlightStylesheet) {
+      highlightStylesheet = document.createElement("link");
+      highlightStylesheet.rel = "stylesheet";
+      document.head.appendChild(highlightStylesheet);
+    }
+
+    highlightStylesheet.href = HIGHLIGHT_STYLES[value];
+  }
+
+  onMount(() => {
+    setHighlightTheme($theme);
+
+    return theme.subscribe(setHighlightTheme);
+  });
 </script>
 
 <div
@@ -34,7 +60,7 @@
   }
 
   :global(code.hljs) {
-    background: var(--cds-ui-01); /** TODO: use token */
+    background: var(--cds-ui-01);
     font-family: var(--cds-code-02-font-family);
     font-size: var(--cds-code-02-font-size);
     font-weight: var(--cds-code-02-font-weight);

--- a/playground/src/Header.svelte
+++ b/playground/src/Header.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
-  import { Content, Header, HeaderActionLink, HeaderUtilities, SkipToContent } from "carbon-components-svelte";
+  import {
+    Content,
+    Header,
+    HeaderActionLink,
+    HeaderGlobalAction,
+    HeaderUtilities,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Asleep from "carbon-icons-svelte/lib/Asleep.svelte";
+  import Light from "carbon-icons-svelte/lib/Light.svelte";
   import pkg from "../../package.json";
   import LogoGithub20 from "./LogoGithub20.svelte";
+  import { theme, toggleTheme } from "./theme";
 </script>
 
 <svelte:head> <title>{pkg.name}</title> </svelte:head>
@@ -16,6 +26,11 @@
     <code title="Version {pkg.version}">v{pkg.version}</code>
   </span>
   <HeaderUtilities>
+    <HeaderGlobalAction
+      icon={$theme === "g100" ? Light : Asleep}
+      iconDescription="Toggle theme"
+      on:click={toggleTheme}
+    />
     <HeaderActionLink
       icon={LogoGithub20}
       href={pkg.homepage}
@@ -43,6 +58,5 @@
     font-weight: var(--cds-code-01-font-weight);
     letter-spacing: var(--cds-code-01-letter-spacing);
     line-height: var(--cds-code-01-line-height);
-    color: #c6c6c6;
   }
 </style>

--- a/playground/src/codemirror-github.css
+++ b/playground/src/codemirror-github.css
@@ -1,0 +1,83 @@
+/**
+ * CodeMirror theme aligned with svelte-highlight/styles/github.css
+ * @see https://github.com/highlightjs/highlight.js/blob/main/src/styles/github.css
+ */
+
+.cm-s-github.CodeMirror {
+  color: var(--cds-text-01);
+}
+
+.cm-s-github span.cm-keyword,
+.cm-s-github span.cm-operator {
+  color: #d73a49;
+}
+
+.cm-s-github span.cm-def {
+  color: #6f42c1;
+}
+
+.cm-s-github span.cm-atom,
+.cm-s-github span.cm-number,
+.cm-s-github span.cm-property,
+.cm-s-github span.cm-attribute,
+.cm-s-github span.cm-variable-2,
+.cm-s-github span.cm-variable-3,
+.cm-s-github span.cm-type {
+  color: #005cc5;
+}
+
+.cm-s-github span.cm-string,
+.cm-s-github span.cm-string-2 {
+  color: #032f62;
+}
+
+.cm-s-github span.cm-builtin {
+  color: #e36209;
+}
+
+.cm-s-github span.cm-comment {
+  color: #6a737d;
+}
+
+.cm-s-github span.cm-tag,
+.cm-s-github span.cm-qualifier {
+  color: #22863a;
+}
+
+.cm-s-github span.cm-variable,
+.cm-s-github span.cm-meta {
+  color: var(--cds-text-01);
+}
+
+.cm-s-github span.cm-bracket,
+.cm-s-github span.cm-punctuation,
+.cm-s-github span.cm-unit {
+  color: var(--cds-text-01);
+}
+
+.cm-s-github span.cm-link {
+  color: #032f62;
+}
+
+.cm-s-github span.cm-header {
+  color: #005cc5;
+  font-weight: bold;
+}
+
+.cm-s-github span.cm-error,
+.cm-s-github span.cm-invalidchar {
+  color: #b31d28;
+}
+
+.cm-s-github .CodeMirror-activeline-background {
+  background: var(--cds-ui-02);
+}
+
+.cm-s-github .CodeMirror-matchingbracket {
+  color: var(--cds-text-01);
+  outline: 1px solid var(--cds-ui-04);
+}
+
+.cm-s-github .CodeMirror-cursor {
+  border-left: 1px solid var(--cds-text-01);
+}

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -1,5 +1,7 @@
 import { mount } from "svelte";
 import "carbon-components-svelte/css/all.css";
 import App from "./App.svelte";
+import { initTheme } from "./theme";
 
+initTheme();
 mount(App, { target: document.body });

--- a/playground/src/theme.ts
+++ b/playground/src/theme.ts
@@ -1,0 +1,67 @@
+import { writable } from "svelte/store";
+
+export type Theme = "white" | "g100";
+
+const STORAGE_KEY = "theme";
+
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "g100";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "g100" : "white";
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "white" || stored === "g100") {
+    return stored;
+  }
+
+  return null;
+}
+
+function getInitialTheme(): Theme {
+  return getStoredTheme() ?? getSystemTheme();
+}
+
+export function applyTheme(value: Theme) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.setAttribute("theme", value);
+  document.documentElement.style.colorScheme = value === "white" ? "light" : "dark";
+}
+
+export const theme = writable<Theme>(getInitialTheme());
+
+theme.subscribe((value) => {
+  applyTheme(value);
+});
+
+export function initTheme() {
+  applyTheme(getInitialTheme());
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (event) => {
+    if (!getStoredTheme()) {
+      theme.set(event.matches ? "g100" : "white");
+    }
+  });
+}
+
+export function toggleTheme() {
+  theme.update((value) => {
+    const next = value === "g100" ? "white" : "g100";
+    localStorage.setItem(STORAGE_KEY, next);
+    return next;
+  });
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -15,12 +15,7 @@ export default defineConfig({
       "estree-walker": path.join(playgroundDir, "node_modules/estree-walker"),
     },
   },
-  plugins: [
-    svelte({
-      preprocess: [optimizeImports()],
-    }),
-    optimizeCss({ experimental: { strict: true } }),
-  ],
+  plugins: [svelte({ preprocess: [optimizeImports()] }), optimizeCss({ experimental: { strict: true } })],
   optimizeDeps: {
     exclude: ["carbon-components-svelte"],
   },


### PR DESCRIPTION
Add Carbon icons to output tabs and a header theme toggle that defaults to system preference and persists overrides to localStorage. Sync CodeMirror and svelte-highlight themes so light/dark code panes stay visually consistent.

---

<img width="1564" height="873" alt="Screenshot 2026-06-06 at 11 48 57 AM" src="https://github.com/user-attachments/assets/729d8327-0d94-4fb7-a30a-fa6c18471198" />
