### PR TITLE
fix(component-parser): keep `@template` generics when `@slot` and `@extends` share a block

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -3921,8 +3921,14 @@ export default class ComponentParser {
        * `@template` in the same block as `@slot` / `@snippet` is slot documentation only
        * (e.g. describing a generic for prose); it must not set component-level generics or
        * passthrough to slot output.
+       *
+       * Exception: when the same block also declares `@extends` / `@extendProps`, the
+       * `@template` parameter is component-level — it parameterizes the inherited props
+       * (e.g. `ButtonProps<Icon>`) and the component class. In that case the `@template`
+       * must still set generics even though a `@slot` shares the block.
        */
       const blockHasSlotOrSnippetTag = tags.some((t) => t.tag === "slot" || t.tag === "snippet");
+      const blockHasExtendsTag = tags.some((t) => t.tag === "extends" || t.tag === "extendProps");
 
       for (const {
         tag,
@@ -4119,7 +4125,7 @@ export default class ComponentParser {
             if (isFirstTag) isFirstTag = false;
             break;
           case "template": {
-            if (blockHasSlotOrSnippetTag) break;
+            if (blockHasSlotOrSnippetTag && !blockHasExtendsTag) break;
 
             // Build constraint from standard JSDoc @template syntax:
             //   @template T              → type="", name="T", default=undefined

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -18768,3 +18768,104 @@ export default class RunesPropDefaultIdentifierJsdoc extends SvelteComponentType
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "slot-extends-template/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 15,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "icon",
+      "kind": "let",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 52
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "badge",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "Optional badge overlay.",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 21
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Icon",
+    "Icon = any"
+  ],
+  "extends": {
+    "interface": "ButtonProps",
+    "import": "\\"./Button.svelte\\""
+  },
+  "contexts": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-extends-template/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { ButtonProps } from "./Button.svelte";
+
+export type SlotExtendsTemplateProps<Icon = any> = ButtonProps & {
+  /**
+   * @default undefined
+   */
+  icon?: Icon;
+
+  /** Optional badge overlay. */
+  badge?: (this: void) => void;
+};
+
+export default class SlotExtendsTemplate<Icon = any> extends SvelteComponentTyped<
+  SlotExtendsTemplateProps<Icon>,
+  Record<string, any>,
+  {
+    /** Optional badge overlay. */
+    badge: Record<string, never>;
+  }
+> {}
+"
+`;

--- a/tests/fixtures/slot-extends-template/Button.svelte
+++ b/tests/fixtures/slot-extends-template/Button.svelte
@@ -1,0 +1,11 @@
+<script>
+  /** @type {string} */
+  export let type = "button";
+</script>
+
+<button
+  {type}
+  {...$$restProps}
+>
+  <slot />
+</button>

--- a/tests/fixtures/slot-extends-template/Button.svelte.d.ts
+++ b/tests/fixtures/slot-extends-template/Button.svelte.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type $RestProps = SvelteHTMLElements["button"];
+
+type $Props = {
+  type?: string;
+  [key: `data-${string}`]: unknown;
+};
+
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
+
+export default class Button extends SvelteComponentTyped<
+  ButtonProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/slot-extends-template/input.svelte
+++ b/tests/fixtures/slot-extends-template/input.svelte
@@ -1,0 +1,14 @@
+<script>
+  /**
+   * `@template` co-located with `@slot` still sets component generics when the block
+   * also declares `@extends` (the generic parameterizes the inherited props).
+   * @template [Icon=any]
+   * @extends {"./Button.svelte"} ButtonProps
+   * @slot {{}} badge - Optional badge overlay.
+   */
+
+  /** @type {Icon} */
+  export let icon = /** @type {Icon} */ (undefined);
+</script>
+
+<slot name="badge" />

--- a/tests/fixtures/slot-extends-template/output.d.ts
+++ b/tests/fixtures/slot-extends-template/output.d.ts
@@ -1,0 +1,21 @@
+import { SvelteComponentTyped } from "svelte";
+import type { ButtonProps } from "./Button.svelte";
+
+export type SlotExtendsTemplateProps<Icon = any> = ButtonProps & {
+  /**
+   * @default undefined
+   */
+  icon?: Icon;
+
+  /** Optional badge overlay. */
+  badge?: (this: void) => void;
+};
+
+export default class SlotExtendsTemplate<Icon = any> extends SvelteComponentTyped<
+  SlotExtendsTemplateProps<Icon>,
+  Record<string, any>,
+  {
+    /** Optional badge overlay. */
+    badge: Record<string, never>;
+  }
+> {}

--- a/tests/fixtures/slot-extends-template/output.json
+++ b/tests/fixtures/slot-extends-template/output.json
@@ -1,0 +1,72 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 15,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "icon",
+      "kind": "let",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 52
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "badge",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "Optional badge overlay.",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 21
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Icon",
+    "Icon = any"
+  ],
+  "extends": {
+    "interface": "ButtonProps",
+    "import": "\"./Button.svelte\""
+  },
+  "contexts": []
+}


### PR DESCRIPTION
A `@template` co-located with `@slot`/`@snippet` was always treated as slot-doc prose, but when the block also declares `@extends` the generic parameterizes the inherited props and class, so it must still set generics.