### PR TITLE
fix(component-parser): preserve hyphens in `@event` descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,9 +1300,11 @@ Descriptions are optional for every slot, including the default slot. Put prose 
  * @slot {Type} slot-name [slot description]
  * @snippet {Type} snippet-name [snippet description]
  */
+```
 
 Omit the `slot-name` to type the default slot.
 
+```js
 /**
  * @slot {Type}
  * @snippet {Type}
@@ -1580,6 +1582,8 @@ export default class Component extends SvelteComponentTyped<
 #### Using `@property` for complex event details
 
 For events with complex object payloads, use `@property` to document individual fields. The main comment becomes the event description.
+
+This is the idiomatic way to describe each field of an event detail. An inline object literal such as `@event {{ items: string[]; added: string[] }} change` types the payload but cannot carry per-field descriptions, since a nested block comment would terminate the host JSDoc. Declare the detail with `@type {object}` and `@property` instead to document every field.
 
 **Signature:**
 
@@ -2118,8 +2122,7 @@ Because `sveld` targets JavaScript-only usage as a baseline, generics use the st
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @template {DataTableRow} <Row extends DataTableRow = DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
    */
 
   let {
@@ -2142,8 +2145,7 @@ Because `sveld` targets JavaScript-only usage as a baseline, generics use the st
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @template {DataTableRow} <Row extends DataTableRow = DataTableRow>
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
    */
 
   /** @type {ReadonlyArray<DataTableHeader<Row>>} */
@@ -2160,6 +2162,7 @@ Generated output looks like this:
 
 ```ts
 export type ComponentProps<Row extends DataTableRow = DataTableRow> = {
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
   rows?: ReadonlyArray<Row>;
 };
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -74,33 +74,6 @@ const ONLY_WHITESPACE_REGEX = /^\s*$/;
 const TRAILING_SEMICOLON_REGEX = /;$/;
 
 /**
- * Extracts description text after the last dash from JSDoc comments.
- *
- * Used for parsing inline descriptions in JSDoc tags like `@event` where the
- * description follows a dash separator.
- *
- * @param description - The description string that may contain a dash separator
- * @returns The description text after the last dash, or the trimmed description if no dash is found
- *
- * @example
- * ```ts
- * extractDescriptionAfterDash("@event click - Fires when clicked")
- * // Returns: "Fires when clicked"
- *
- * extractDescriptionAfterDash("Simple description")
- * // Returns: "Simple description"
- *
- * extractDescriptionAfterDash("@event change - Updates value")
- * // Returns: "Updates value"
- * ```
- */
-function extractDescriptionAfterDash(description: string | undefined): string | undefined {
-  if (!description) return undefined;
-  const dashIndex = description.lastIndexOf("-");
-  return dashIndex >= 0 ? description.substring(dashIndex + 1).trim() : description.trim();
-}
-
-/**
  * Removes leading dash and whitespace from a description string.
  *
  * Used for cleaning up inline descriptions in JSDoc tags that may have been
@@ -3445,7 +3418,7 @@ export default class ComponentParser {
      * where events without detail have `detail: null`.
      */
     const default_detail = !has_argument && !detail ? "null" : ComponentParser.assignValue(detail);
-    const event_description = extractDescriptionAfterDash(description);
+    const event_description = description;
     if (this.events.has(name)) {
       const existing_event = this.events.get(name) as DispatchedEvent;
       this.events.set(name, {
@@ -5508,8 +5481,7 @@ export default class ComponentParser {
                 /**
                  * Check if this event has a JSDoc description from `@event` tags.
                  */
-                const description = this.eventDescriptions.get(eventHandlerNode.name);
-                const event_description = extractDescriptionAfterDash(description);
+                const event_description = this.eventDescriptions.get(eventHandlerNode.name);
 
                 if (!existing_event) {
                   /**
@@ -5656,8 +5628,7 @@ export default class ComponentParser {
        * This happens when @event JSDoc is used but the event is actually forwarded via on: syntax.
        */
       if (event && event.type === "dispatched" && !actuallyDispatchedEvents.has(eventName)) {
-        const description = this.eventDescriptions.get(eventName);
-        const event_description = extractDescriptionAfterDash(description);
+        const event_description = this.eventDescriptions.get(eventName);
         const forwardedEvent: ForwardedEvent = {
           type: "forwarded",
           name: eventName,

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -11813,7 +11813,7 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
       "column": 0
     },
     "end": {
-      "line": 45,
+      "line": 64,
       "column": 0
     }
   },
@@ -11830,12 +11830,28 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
       "description": "Will be fired if value has been changed",
       "source": {
         "start": {
-          "line": 34,
+          "line": 48,
           "column": 4
         },
         "end": {
-          "line": 34,
+          "line": 48,
           "column": 24
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "items:change",
+      "detail": "ChangeDetail",
+      "description": "Fired when the collection changes. The detail reuses a named typedef so\\neach documented property survives into the generated definitions.",
+      "source": {
+        "start": {
+          "line": 56,
+          "column": 4
+        },
+        "end": {
+          "line": 56,
+          "column": 69
         }
       }
     },
@@ -11846,11 +11862,11 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
       "description": "Snowball event fired when throwing a snowball.",
       "source": {
         "start": {
-          "line": 27,
+          "line": 41,
           "column": 4
         },
         "end": {
-          "line": 30,
+          "line": 44,
           "column": 6
         }
       }
@@ -11862,17 +11878,24 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
       "description": "Form submission with value",
       "source": {
         "start": {
-          "line": 38,
+          "line": 52,
           "column": 4
         },
         "end": {
-          "line": 38,
+          "line": 52,
           "column": 43
         }
       }
     }
   ],
-  "typedefs": [],
+  "typedefs": [
+    {
+      "type": "{\\n  /** The full new set of items. */\\n  items: string[];\\n  /** Items added since the last change. */\\n  added: string[];\\n  /** Items removed since the last change. */\\n  removed?: string[];\\n}",
+      "name": "ChangeDetail",
+      "description": "The event detail described once as a named typedef, then reused via \`@event\`.",
+      "ts": "type ChangeDetail = {\\n  /** The full new set of items. */\\n  items: string[];\\n  /** Items added since the last change. */\\n  added: string[];\\n  /** Items removed since the last change. */\\n  removed?: string[];\\n}"
+    }
+  ],
   "generics": null,
   "contexts": []
 }
@@ -17257,6 +17280,18 @@ export default class ForwardedCustomEventNull extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "dispatched-events-jsdoc-properties/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
+/**
+ * The event detail described once as a named typedef, then reused via \`@event\`.
+ */
+export type ChangeDetail = {
+  /** The full new set of items. */
+  items: string[];
+  /** Items added since the last change. */
+  added: string[];
+  /** Items removed since the last change. */
+  removed?: string[];
+};
+
 export type DispatchedEventsJsdocPropertiesProps = Record<string, never>;
 
 export default class DispatchedEventsJsdocProperties extends SvelteComponentTyped<
@@ -17264,6 +17299,9 @@ export default class DispatchedEventsJsdocProperties extends SvelteComponentType
   {
     /** Will be fired if value has been changed */
     change: CustomEvent<null>;
+    /** Fired when the collection changes. The detail reuses a named typedef so
+each documented property survives into the generated definitions. */
+    "items:change": CustomEvent<ChangeDetail>;
     /** Snowball event fired when throwing a snowball. */
     snowball: CustomEvent<{
       /** Indicates whether the snowball is tightly packed. */

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -11843,7 +11843,7 @@ exports[`fixtures (JSON) "dispatched-events-jsdoc-properties/input.svelte" 1`] =
       "type": "dispatched",
       "name": "items:change",
       "detail": "ChangeDetail",
-      "description": "Fired when the collection changes. The detail reuses a named typedef so\\neach documented property survives into the generated definitions.",
+      "description": "Fired when the collection changes. The detail carries the up-to-date,\\nwell-formed set of items (hyphenated prose must survive verbatim).",
       "source": {
         "start": {
           "line": 56,
@@ -17299,8 +17299,8 @@ export default class DispatchedEventsJsdocProperties extends SvelteComponentType
   {
     /** Will be fired if value has been changed */
     change: CustomEvent<null>;
-    /** Fired when the collection changes. The detail reuses a named typedef so
-each documented property survives into the generated definitions. */
+    /** Fired when the collection changes. The detail carries the up-to-date,
+well-formed set of items (hyphenated prose must survive verbatim). */
     "items:change": CustomEvent<ChangeDetail>;
     /** Snowball event fired when throwing a snowball. */
     snowball: CustomEvent<{

--- a/tests/fixtures/dispatched-events-jsdoc-properties/input.svelte
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/input.svelte
@@ -19,6 +19,20 @@
    * @event {{ value: string }} submit - Form submission with value
    */
 
+  /**
+   * The event detail described once as a named typedef, then reused via `@event`.
+   * @typedef {object} ChangeDetail
+   * @property {string[]} items - The full new set of items.
+   * @property {string[]} added - Items added since the last change.
+   * @property {string[]} [removed] - Items removed since the last change.
+   */
+
+  /**
+   * Fired when the collection changes. The detail reuses a named typedef so
+   * each documented property survives into the generated definitions.
+   * @event {ChangeDetail} items:change
+   */
+
   import { createEventDispatcher } from "svelte";
 
   const dispatcher = createEventDispatcher();
@@ -37,8 +51,13 @@
   function handleSubmit() {
     dispatcher("submit", { value: "test" });
   }
+
+  function handleItemsChange() {
+    dispatcher("items:change", { items: [], added: [], removed: [] });
+  }
 </script>
 
 <button on:click={throwSnowball}>Throw</button>
 <button on:click={handleChange}>Change</button>
 <button on:click={handleSubmit}>Submit</button>
+<button on:click={handleItemsChange}>Change items</button>

--- a/tests/fixtures/dispatched-events-jsdoc-properties/input.svelte
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/input.svelte
@@ -28,8 +28,8 @@
    */
 
   /**
-   * Fired when the collection changes. The detail reuses a named typedef so
-   * each documented property survives into the generated definitions.
+   * Fired when the collection changes. The detail carries the up-to-date,
+   * well-formed set of items (hyphenated prose must survive verbatim).
    * @event {ChangeDetail} items:change
    */
 

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.d.ts
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.d.ts
@@ -19,8 +19,8 @@ export default class DispatchedEventsJsdocProperties extends SvelteComponentType
   {
     /** Will be fired if value has been changed */
     change: CustomEvent<null>;
-    /** Fired when the collection changes. The detail reuses a named typedef so
-each documented property survives into the generated definitions. */
+    /** Fired when the collection changes. The detail carries the up-to-date,
+well-formed set of items (hyphenated prose must survive verbatim). */
     "items:change": CustomEvent<ChangeDetail>;
     /** Snowball event fired when throwing a snowball. */
     snowball: CustomEvent<{

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.d.ts
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.d.ts
@@ -1,5 +1,17 @@
 import { SvelteComponentTyped } from "svelte";
 
+/**
+ * The event detail described once as a named typedef, then reused via `@event`.
+ */
+export type ChangeDetail = {
+  /** The full new set of items. */
+  items: string[];
+  /** Items added since the last change. */
+  added: string[];
+  /** Items removed since the last change. */
+  removed?: string[];
+};
+
 export type DispatchedEventsJsdocPropertiesProps = Record<string, never>;
 
 export default class DispatchedEventsJsdocProperties extends SvelteComponentTyped<
@@ -7,6 +19,9 @@ export default class DispatchedEventsJsdocProperties extends SvelteComponentType
   {
     /** Will be fired if value has been changed */
     change: CustomEvent<null>;
+    /** Fired when the collection changes. The detail reuses a named typedef so
+each documented property survives into the generated definitions. */
+    "items:change": CustomEvent<ChangeDetail>;
     /** Snowball event fired when throwing a snowball. */
     snowball: CustomEvent<{
       /** Indicates whether the snowball is tightly packed. */

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.json
@@ -35,7 +35,7 @@
       "type": "dispatched",
       "name": "items:change",
       "detail": "ChangeDetail",
-      "description": "Fired when the collection changes. The detail reuses a named typedef so\neach documented property survives into the generated definitions.",
+      "description": "Fired when the collection changes. The detail carries the up-to-date,\nwell-formed set of items (hyphenated prose must survive verbatim).",
       "source": {
         "start": {
           "line": 56,

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 45,
+      "line": 64,
       "column": 0
     }
   },
@@ -22,12 +22,28 @@
       "description": "Will be fired if value has been changed",
       "source": {
         "start": {
-          "line": 34,
+          "line": 48,
           "column": 4
         },
         "end": {
-          "line": 34,
+          "line": 48,
           "column": 24
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "items:change",
+      "detail": "ChangeDetail",
+      "description": "Fired when the collection changes. The detail reuses a named typedef so\neach documented property survives into the generated definitions.",
+      "source": {
+        "start": {
+          "line": 56,
+          "column": 4
+        },
+        "end": {
+          "line": 56,
+          "column": 69
         }
       }
     },
@@ -38,11 +54,11 @@
       "description": "Snowball event fired when throwing a snowball.",
       "source": {
         "start": {
-          "line": 27,
+          "line": 41,
           "column": 4
         },
         "end": {
-          "line": 30,
+          "line": 44,
           "column": 6
         }
       }
@@ -54,17 +70,24 @@
       "description": "Form submission with value",
       "source": {
         "start": {
-          "line": 38,
+          "line": 52,
           "column": 4
         },
         "end": {
-          "line": 38,
+          "line": 52,
           "column": 43
         }
       }
     }
   ],
-  "typedefs": [],
+  "typedefs": [
+    {
+      "type": "{\n  /** The full new set of items. */\n  items: string[];\n  /** Items added since the last change. */\n  added: string[];\n  /** Items removed since the last change. */\n  removed?: string[];\n}",
+      "name": "ChangeDetail",
+      "description": "The event detail described once as a named typedef, then reused via `@event`.",
+      "ts": "type ChangeDetail = {\n  /** The full new set of items. */\n  items: string[];\n  /** Items added since the last change. */\n  added: string[];\n  /** Items removed since the last change. */\n  removed?: string[];\n}"
+    }
+  ],
   "generics": null,
   "contexts": []
 }


### PR DESCRIPTION
`extractDescriptionAfterDash` truncated descriptions at the last `-`,
mangling prose like "up-to-date". The inline `name - desc` form is
already stripped upstream, so the call only ever corrupted hyphens.

This also updates stales docs in README (encouraging idiomatic
`@template` usage instead of bespoke `@generics`, and also
hardens an existing test fixture.