### PR TITLE
fix(writer): parameterize context type for multiple `@template`s

### DIFF
--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -96,6 +96,38 @@ export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">) {
 }
 
 /**
+ * Splits a string on top-level commas, ignoring commas nested inside
+ * `<>`, `()`, `[]`, or `{}`. Used to separate generic constraint declarations
+ * that may themselves contain commas (e.g. `Value extends Record<string, any>`).
+ */
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === "<" || char === "(" || char === "[" || char === "{") depth++;
+    else if (char === ">" || char === ")" || char === "]" || char === "}") depth--;
+    else if (char === "," && depth === 0) {
+      parts.push(value.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+}
+
+/**
+ * Returns whether a property type references a generic type parameter by name,
+ * matching on word boundaries so `Value` doesn't match `ValueType`.
+ */
+function referencesGeneric(propType: string, name: string): boolean {
+  return new RegExp(`\\b${name}\\b`).test(propType);
+}
+
+/**
  * Generates TypeScript type definitions for component contexts.
  *
  * Creates exported type definitions for each context, including generic
@@ -121,11 +153,22 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
   if (!def.contexts || def.contexts.length === 0) return EMPTY_STR;
 
   /**
-   * Extract generic parameter for context types if generics are defined
-   * and the context properties reference the generic type.
+   * Pair each generic name with its constraint declaration so the context type
+   * can be parameterized with only the generics it actually references.
+   *
+   * A component may declare multiple `@template`s, in which case `generics` holds
+   * comma-joined names (`"Value,Icon"`) and constraints
+   * (`"Value extends string = string, Icon = any"`). Constraints may themselves
+   * contain commas (e.g. `Record<string, any>`), so names drive the pairing and
+   * constraints are split only at top-level commas.
    */
-  const genericsName = def.generics ? def.generics[0] : null;
-  const genericsType = def.generics ? def.generics[1] : null;
+  const genericParams =
+    def.generics === null
+      ? []
+      : def.generics[0].split(",").map((name, index) => ({
+          name: name.trim(),
+          constraint: (splitTopLevel(def.generics?.[1] ?? "")[index] ?? name).trim(),
+        }));
 
   return def.contexts
     .map((context) => {
@@ -139,11 +182,16 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
 
       const contextComment = context.description ? `${formatMultiLineComment(context.description)}\n` : "";
 
-      // If context properties reference the generic type, parameterize the context type
-      const referencesGeneric = genericsName && context.properties.some((prop) => prop.type.includes(genericsName));
+      /**
+       * Parameterize the context type with the generics its properties reference,
+       * preserving declaration order (e.g. `ModalContext<Value, Icon>`). Generics
+       * that aren't referenced are omitted so the type stays as narrow as possible.
+       */
+      const referencedConstraints = genericParams
+        .filter(({ name }) => context.properties.some((prop) => referencesGeneric(prop.type, name)))
+        .map(({ constraint }) => constraint);
 
-      // Build generic suffix if context references generics (e.g., `ModalContext<T>`)
-      const genericSuffix = referencesGeneric && genericsType ? `<${genericsType}>` : "";
+      const genericSuffix = referencedConstraints.length > 0 ? `<${referencedConstraints.join(", ")}>` : "";
 
       /**
        * Use Record<string, never> for empty context objects instead of {}.

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -18907,3 +18907,148 @@ export default class SlotExtendsTemplate<Icon = any> extends SvelteComponentType
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "context-template-tag-multiple/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "selected",
+      "kind": "let",
+      "type": "Value | undefined",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 8,
+          "column": 34
+        }
+      }
+    },
+    {
+      "name": "icon",
+      "kind": "let",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 22,
+          "column": 0
+        },
+        "end": {
+          "line": 22,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Value,Icon",
+    "Value extends string = string, Icon = any"
+  ],
+  "contexts": [
+    {
+      "key": "demo:Wrapper",
+      "typeName": "DemoWrapperContext",
+      "properties": [
+        {
+          "name": "selectedValue",
+          "type": "import(\\"svelte/store\\").Writable<Value | undefined>",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "icon",
+          "type": "Icon",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-template-tag-multiple/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DemoWrapperContext<Value extends string = string, Icon = any> = {
+  selectedValue: import("svelte/store").Writable<Value | undefined>;
+  icon: Icon;
+};
+
+export type ContextTemplateTagMultipleProps<Value extends string = string, Icon = any> = {
+  /**
+   * @default undefined
+   */
+  selected?: Value | undefined;
+
+  /**
+   * @default undefined
+   */
+  icon?: Icon;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextTemplateTagMultiple<Value extends string = string, Icon = any> extends SvelteComponentTyped<
+  ContextTemplateTagMultipleProps<Value, Icon>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;

--- a/tests/fixtures/context-template-tag-multiple/input.svelte
+++ b/tests/fixtures/context-template-tag-multiple/input.svelte
@@ -1,0 +1,22 @@
+<script>
+  /**
+   * @template {string} [Value=string]
+   * @template [Icon=any]
+   */
+
+  /** @type {Value | undefined} */
+  export let selected = undefined;
+
+  /** @type {Icon} */
+  export let icon = undefined;
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  /** @type {import("svelte/store").Writable<Value | undefined>} */
+  const selectedValue = writable(selected);
+
+  setContext("demo:Wrapper", { selectedValue, icon });
+</script>
+
+<slot />

--- a/tests/fixtures/context-template-tag-multiple/output.d.ts
+++ b/tests/fixtures/context-template-tag-multiple/output.d.ts
@@ -1,0 +1,26 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DemoWrapperContext<Value extends string = string, Icon = any> = {
+  selectedValue: import("svelte/store").Writable<Value | undefined>;
+  icon: Icon;
+};
+
+export type ContextTemplateTagMultipleProps<Value extends string = string, Icon = any> = {
+  /**
+   * @default undefined
+   */
+  selected?: Value | undefined;
+
+  /**
+   * @default undefined
+   */
+  icon?: Icon;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextTemplateTagMultiple<Value extends string = string, Icon = any> extends SvelteComponentTyped<
+  ContextTemplateTagMultipleProps<Value, Icon>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-template-tag-multiple/output.json
+++ b/tests/fixtures/context-template-tag-multiple/output.json
@@ -1,0 +1,111 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "selected",
+      "kind": "let",
+      "type": "Value | undefined",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 8,
+          "column": 34
+        }
+      }
+    },
+    {
+      "name": "icon",
+      "kind": "let",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 22,
+          "column": 0
+        },
+        "end": {
+          "line": 22,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Value,Icon",
+    "Value extends string = string, Icon = any"
+  ],
+  "contexts": [
+    {
+      "key": "demo:Wrapper",
+      "typeName": "DemoWrapperContext",
+      "properties": [
+        {
+          "name": "selectedValue",
+          "type": "import(\"svelte/store\").Writable<Value | undefined>",
+          "description": "",
+          "optional": false
+        },
+        {
+          "name": "icon",
+          "type": "Icon",
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -218,6 +218,80 @@ describe("writerTsDefinition", () => {
     );
   });
 
+  test("getContextDefs with multiple generics referenced", () => {
+    // Context referencing two `@template` generics should emit the full parameter list
+    expect(
+      getContextDefs({
+        contexts: [
+          {
+            key: "demo:Wrapper",
+            typeName: "DemoWrapperContext",
+            properties: [
+              {
+                name: "selectedValue",
+                type: 'import("svelte/store").Writable<Value | undefined>',
+                optional: false,
+              },
+              {
+                name: "icon",
+                type: "Icon",
+                optional: false,
+              },
+            ],
+          },
+        ],
+        generics: ["Value,Icon", "Value extends string = string, Icon = any"],
+      }),
+    ).toEqual(
+      'export type DemoWrapperContext<Value extends string = string, Icon = any> = {\n  selectedValue: import("svelte/store").Writable<Value | undefined>;\n  icon: Icon;\n};',
+    );
+  });
+
+  test("getContextDefs with multiple generics, only one referenced", () => {
+    // Only the generics actually referenced by the context should be emitted
+    expect(
+      getContextDefs({
+        contexts: [
+          {
+            key: "demo:Wrapper",
+            typeName: "DemoWrapperContext",
+            properties: [
+              {
+                name: "selectedValue",
+                type: 'import("svelte/store").Writable<Value | undefined>',
+                optional: false,
+              },
+            ],
+          },
+        ],
+        generics: ["Value,Icon", "Value extends string = string, Icon = any"],
+      }),
+    ).toEqual(
+      'export type DemoWrapperContext<Value extends string = string> = {\n  selectedValue: import("svelte/store").Writable<Value | undefined>;\n};',
+    );
+  });
+
+  test("getContextDefs splits constraints with nested commas", () => {
+    // Constraints that contain commas (e.g. inside `<>`) must not be split apart
+    expect(
+      getContextDefs({
+        contexts: [
+          {
+            key: "demo:Wrapper",
+            typeName: "DemoWrapperContext",
+            properties: [
+              { name: "row", type: "Row", optional: false },
+              { name: "icon", type: "Icon", optional: false },
+            ],
+          },
+        ],
+        generics: ["Row,Icon", "Row extends Record<string, any> = Record<string, any>, Icon = any"],
+      }),
+    ).toEqual(
+      "export type DemoWrapperContext<Row extends Record<string, any> = Record<string, any>, Icon = any> = {\n  row: Row;\n  icon: Icon;\n};",
+    );
+  });
+
   test("getContextDefs without generics reference", () => {
     // Context that doesn't reference generic types should NOT include the generic parameter
     expect(


### PR DESCRIPTION
`getContextDefs` matched the comma-joined generic names as a single
string, so a component with 2+ `@template`s emitted `<Module>Context`
without a parameter list, leaving `Value`/`Icon` unbound (TS2304).
Now pairs each generic with its constraint and emits only the ones a
context references.

## Before / After

Given a component declaring two generics whose `setContext` value references both:

```svelte
<script>
  /**
   * @template {string} [Value=string]
   * @template [Icon=any]
   */
  /** @type {Value | undefined} */
  export let selected = undefined;
  /** @type {Icon} */
  export let icon = undefined;

  import { setContext } from "svelte";
  import { writable } from "svelte/store";

  /** @type {import("svelte/store").Writable<Value | undefined>} */
  const selectedValue = writable(selected);
  setContext("demo:Wrapper", { selectedValue, icon });
</script>
```

**Before** — context type omits the parameter list, so `Value`/`Icon` are unbound:

```ts
export type DemoWrapperContext = {
  selectedValue: import("svelte/store").Writable<Value | undefined>;
  icon: Icon;
};
// Wrapper.svelte.d.ts: error TS2304: Cannot find name 'Value'.
// Wrapper.svelte.d.ts: error TS2304: Cannot find name 'Icon'.
```

**After** — full parameter list is emitted; the `.d.ts` type-checks cleanly:

```ts
export type DemoWrapperContext<Value extends string = string, Icon = any> = {
  selectedValue: import("svelte/store").Writable<Value | undefined>;
  icon: Icon;
};
```

Only the generics a context actually references are included, generalizing the
prior single-generic filtering to N generics (constraints with nested commas
like `Record<string, any>` are split safely).

## Tests

- Unit tests in `tests/writer-ts-definitions.test.ts`: both generics referenced,
  one referenced, and a nested-comma constraint.
- Regression fixture `tests/fixtures/context-template-tag-multiple/` whose
  generated `output.d.ts` type-checks under `test:fixtures-types` (no TS2304).