### PR TITLE
feat: isolate per-component parse failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 - **`jsonOptions`** (object, optional): Options for JSON output.
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.
 - **`markdownOptions`** (object, optional): Options for Markdown output.
+- **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
 
 By default, only TypeScript definitions are generated.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,8 @@ function parseCliFlag(arg: string): Partial<PluginSveldOptions> {
     case "json":
     case "markdown":
       return { [flag]: value === true || value === "true" };
+    case "fail-fast":
+      return { failFast: value === true || value === "true" };
     case "entry":
       return typeof value === "string" ? { entry: value } : {};
     default:
@@ -26,7 +28,7 @@ function parseCliFlag(arg: string): Partial<PluginSveldOptions> {
   }
 }
 
-function parseCliOptions(argv: string[]): PluginSveldOptions {
+export function parseCliOptions(argv: string[]): PluginSveldOptions {
   const options: PluginSveldOptions = {};
 
   for (const arg of argv) {
@@ -56,7 +58,7 @@ export async function cli(process: NodeJS.Process) {
 
   await rollup_bundle.generate({});
 
-  const result = await generateBundle(input, options.glob === true);
+  const result = await generateBundle(input, options.glob === true, { failFast: options.failFast });
 
   writeOutput(result, options, input);
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -25,6 +25,12 @@ export interface PluginSveldOptions {
   jsonOptions?: Partial<Omit<WriteJsonOptions, "inputDir">>;
   markdown?: boolean;
   markdownOptions?: Partial<WriteMarkdownOptions>;
+  /**
+   * Abort the entire run when a single component fails to parse.
+   * When `false` (the default), parse failures are collected as diagnostics
+   * and the remaining components still emit their output.
+   */
+  failFast?: boolean;
 }
 
 export interface ComponentDocApi extends ParsedComponent {
@@ -33,6 +39,17 @@ export interface ComponentDocApi extends ParsedComponent {
 }
 
 export type ComponentDocs = Map<string, ComponentDocApi>;
+
+/**
+ * A parse failure for a single component, captured so the rest of the run
+ * can continue. Surfaced via {@link GenerateBundleResult.errors}.
+ */
+export interface ComponentParseError {
+  filePath: string;
+  moduleName: string;
+  message: string;
+  stack?: string;
+}
 
 const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
 const HYPHEN_REGEX = /-/g;
@@ -76,7 +93,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
     },
     async generateBundle() {
       if (input != null) {
-        result = await generateBundle(input, opts?.glob === true);
+        result = await generateBundle(input, opts?.glob === true, { failFast: opts?.failFast });
       }
     },
     writeBundle() {
@@ -89,6 +106,19 @@ interface GenerateBundleResult {
   exports: ParsedExports;
   components: ComponentDocs;
   allComponentsForTypes: ComponentDocs;
+  /**
+   * Components that failed to parse. Empty unless `failFast` is disabled and
+   * one or more components threw during parsing.
+   */
+  errors: ComponentParseError[];
+}
+
+export interface GenerateBundleOptions {
+  /**
+   * Throw on the first component that fails to parse instead of collecting
+   * the failure and continuing with the remaining components.
+   */
+  failFast?: boolean;
 }
 
 /**
@@ -98,9 +128,14 @@ interface GenerateBundleResult {
  * all Svelte files to extract component metadata. Returns both exported
  * components (for JSON/Markdown) and all components (for TypeScript definitions).
  *
+ * A single component that fails to parse is captured as a diagnostic (see
+ * {@link GenerateBundleResult.errors}) so the remaining components still emit
+ * output. Pass `{ failFast: true }` to restore abort-on-first-error behavior.
+ *
  * @param input - Entry point file or directory containing Svelte components
  * @param glob - Whether to glob for all .svelte files in the directory
- * @returns Bundle result containing exports, components, and allComponentsForTypes
+ * @param options - Bundle options (e.g. `failFast`)
+ * @returns Bundle result containing exports, components, allComponentsForTypes, and errors
  *
  * @example
  * ```ts
@@ -109,9 +144,14 @@ interface GenerateBundleResult {
  *
  * // Generate from directory with glob:
  * const result = await generateBundle("./src", true);
+ *
+ * // Abort on the first parse failure:
+ * const result = await generateBundle("./src", true, { failFast: true });
  * ```
  */
-export async function generateBundle(input: string, glob: boolean) {
+export async function generateBundle(input: string, glob: boolean, options: GenerateBundleOptions = {}) {
+  const failFast = options.failFast === true;
+  const parseErrors = new Map<string, ComponentParseError>();
   const isFile = lstatSync(input).isFile();
   const dir = isFile ? dirname(input) : input;
   const rootDir = resolve(dir);
@@ -231,15 +271,38 @@ export async function generateBundle(input: string, glob: boolean) {
         return null;
       }
 
+      const normalizedFilePath = normalizeSeparators(filePath);
       const parser = new ComponentParser();
-      const parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
-        moduleName,
-        filePath: normalizeSeparators(filePath),
-      });
+
+      let parsed: ParsedComponent;
+      try {
+        parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
+          moduleName,
+          filePath: normalizedFilePath,
+        });
+      } catch (error) {
+        /**
+         * Capture the failure as a diagnostic so the remaining components can
+         * still be processed. When `failFast` is enabled we rethrow to restore
+         * the abort-on-first-error behavior.
+         */
+        if (failFast) {
+          throw error;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        const stack = error instanceof Error ? error.stack : undefined;
+        /**
+         * Dedupe by file path: the same component is parsed once for the
+         * exported set and once for the all-components set.
+         */
+        parseErrors.set(normalizedFilePath, { filePath: normalizedFilePath, moduleName, message, stack });
+        return null;
+      }
 
       return {
         moduleName,
-        filePath: normalizeSeparators(filePath),
+        filePath: normalizedFilePath,
         ...parsed,
       };
     }
@@ -278,10 +341,20 @@ export async function generateBundle(input: string, glob: boolean) {
     }
   }
 
+  const errors = Array.from(parseErrors.values());
+
+  if (errors.length > 0) {
+    console.error(`sveld: failed to parse ${errors.length} component(s):`);
+    for (const { filePath, message } of errors) {
+      console.error(`  - ${filePath}: ${message}`);
+    }
+  }
+
   return {
     exports,
     components,
     allComponentsForTypes,
+    errors,
   };
 }
 

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -27,6 +27,6 @@ interface SveldOptions extends Omit<PluginSveldOptions, "entry"> {
 export async function sveld(opts?: SveldOptions) {
   const input = getSvelteEntry(opts?.input);
   if (input === null) return;
-  const result = await generateBundle(input, opts?.glob === true);
+  const result = await generateBundle(input, opts?.glob === true, { failFast: opts?.failFast });
   writeOutput(result, { ...opts, entry: opts?.input }, input);
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,15 @@
+import { parseCliOptions } from "../src/cli";
+
+describe("parseCliOptions", () => {
+  test("--fail-fast enables failFast", () => {
+    expect(parseCliOptions(["--fail-fast"])).toEqual({ failFast: true });
+  });
+
+  test("--fail-fast=false disables failFast", () => {
+    expect(parseCliOptions(["--fail-fast=false"])).toEqual({ failFast: false });
+  });
+
+  test("failFast is absent by default", () => {
+    expect(parseCliOptions(["--glob", "--types"])).toEqual({ glob: true, types: true });
+  });
+});

--- a/tests/generate-bundle-errors.test.ts
+++ b/tests/generate-bundle-errors.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { generateBundle } from "../src/plugin";
+
+const VALID_COMPONENT = `<script>
+  /** @type {string} */
+  export let label = "ok";
+</script>
+<button>{label}</button>`;
+
+/**
+ * Unterminated JS expression in the script block — `compile()` throws a
+ * `js_parse_error`, which previously aborted the entire run.
+ */
+const BROKEN_COMPONENT = `<script>
+  export let value = ;
+</script>
+<div>{#if}</div>`;
+
+describe("generateBundle per-component error isolation", () => {
+  let dir: string;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-errors-"));
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("default: a broken component is captured and the rest still emit output", async () => {
+    writeFileSync(path.join(dir, "Valid.svelte"), VALID_COMPONENT);
+    writeFileSync(path.join(dir, "Broken.svelte"), BROKEN_COMPONENT);
+
+    const result = await generateBundle(dir, true);
+
+    // The valid component is parsed and present in the output.
+    expect(result.allComponentsForTypes.has("Valid")).toBe(true);
+    // The broken component is absent from the output but recorded as an error.
+    expect(result.allComponentsForTypes.has("Broken")).toBe(false);
+    expect(result.errors).toHaveLength(1);
+
+    const [error] = result.errors;
+    expect(error.moduleName).toBe("Broken");
+    expect(error.filePath).toContain("Broken.svelte");
+    expect(error.message).toBeTruthy();
+
+    // The failure is reported to the diagnostics surface (stderr).
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test("errors are deduped across the exported and all-components passes", async () => {
+    writeFileSync(path.join(dir, "Broken.svelte"), BROKEN_COMPONENT);
+
+    const result = await generateBundle(dir, true);
+
+    expect(result.errors).toHaveLength(1);
+  });
+
+  test("failFast: aborts on the first parse failure", async () => {
+    writeFileSync(path.join(dir, "Valid.svelte"), VALID_COMPONENT);
+    writeFileSync(path.join(dir, "Broken.svelte"), BROKEN_COMPONENT);
+
+    await expect(generateBundle(dir, true, { failFast: true })).rejects.toThrow();
+  });
+
+  test("no errors when all components parse", async () => {
+    writeFileSync(path.join(dir, "Valid.svelte"), VALID_COMPONENT);
+
+    const result = await generateBundle(dir, true);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.allComponentsForTypes.has("Valid")).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
A single un-parseable `.svelte` file previously threw and aborted the
whole run, blocking generation for every other component. Parse errors
are now captured as diagnostics so the rest still emit; `failFast` /
`--fail-fast` restores abort-on-first-error.