### PR TITLE
feat(plugin): add opt-in watch mode for incremental type generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 - **`jsonOptions`** (object, optional): Options for JSON output.
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.
 - **`markdownOptions`** (object, optional): Options for Markdown output.
+- **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 
 By default, only TypeScript definitions are generated.
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,0 +1,260 @@
+import { lstatSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
+import { parse as parseSvelte } from "svelte/compiler";
+import { globSync } from "tinyglobby";
+import { asRelativeSourcePath, type NormalizedPath } from "./brands";
+import ComponentParser, { type ParsedComponent } from "./ComponentParser";
+import { type ParsedExports, parseExports } from "./parse-exports";
+import { normalizeSeparators } from "./path";
+
+export interface ComponentDocApi extends ParsedComponent {
+  filePath: NormalizedPath;
+  moduleName: string;
+}
+
+export type ComponentDocs = Map<string, ComponentDocApi>;
+
+export interface GenerateBundleResult {
+  exports: ParsedExports;
+  components: ComponentDocs;
+  allComponentsForTypes: ComponentDocs;
+}
+
+/** A function that resolves a (possibly relative) component path to an absolute path. */
+export type ResolveComponentFilePath = (filePath: string) => string;
+
+const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
+const HYPHEN_REGEX = /-/g;
+
+function stripTopLevelStyleBlock(source: string) {
+  try {
+    const parsed = parseSvelte(source, { modern: false }) as { css?: { start?: number; end?: number } };
+    const start = parsed.css?.start;
+    const end = parsed.css?.end;
+
+    if (start === undefined || end === undefined) {
+      return source;
+    }
+
+    return `${source.slice(0, start)}${source.slice(end)}`;
+  } catch {
+    // Fall back to the previous regex behavior if the source cannot be parsed.
+    return source.replace(STYLE_TAG_REGEX, "");
+  }
+}
+
+/**
+ * Discovered component sources for an entry point, before parsing.
+ *
+ * `exports` holds explicitly exported components (used for JSON/Markdown);
+ * `allComponents` additionally includes glob-discovered components (used for
+ * `.d.ts` generation). `resolveComponentFilePath` maps a component `source`
+ * to its absolute path on disk.
+ */
+export interface CollectedComponents {
+  exports: ParsedExports;
+  allComponents: ParsedExports;
+  rootDir: string;
+  resolveComponentFilePath: ResolveComponentFilePath;
+}
+
+/**
+ * Discovers component sources for an entry point without parsing them.
+ *
+ * Parses the entry's exports (when `input` is a file) and, when `glob` is set,
+ * augments the set with every `.svelte` file under the entry directory.
+ */
+export function collectComponents(input: string, glob: boolean): CollectedComponents {
+  const isFile = lstatSync(input).isFile();
+  const dir = isFile ? dirname(input) : input;
+  const rootDir = resolve(dir);
+  const resolveComponentFilePath: ResolveComponentFilePath = (filePath) =>
+    isAbsolute(filePath) ? resolve(filePath) : resolve(rootDir, filePath);
+
+  /**
+   * Only parse exports if input is a file.
+   * Directory inputs don't have a single entry point to parse exports from.
+   */
+  let exports: ParsedExports = {};
+  if (isFile) {
+    const entry = readFileSync(input, "utf-8");
+    exports = parseExports(entry, rootDir);
+  }
+
+  const allComponents: ParsedExports = { ...exports };
+
+  if (glob) {
+    for (const matchedFile of globSync(["**/*.svelte"], { cwd: rootDir, absolute: true })) {
+      const file = resolve(matchedFile);
+      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
+      const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
+
+      if (exports[moduleName]) {
+        exports[moduleName].source = source;
+      }
+
+      if (allComponents[moduleName]) {
+        allComponents[moduleName].source = source;
+      } else {
+        allComponents[moduleName] = { source, default: false };
+      }
+    }
+  }
+
+  return { exports, allComponents, rootDir, resolveComponentFilePath };
+}
+
+/**
+ * Reads the given component file paths into a map of path -> contents.
+ *
+ * Failed reads are recorded as `null` (and logged) so callers can skip them
+ * gracefully rather than aborting the whole bundle.
+ */
+export async function readFileMap(filePaths: Iterable<string>): Promise<Map<string, string | null>> {
+  const fileContents = await Promise.all(
+    Array.from(filePaths).map(async (filePath) => {
+      try {
+        const content = await readFile(filePath, "utf-8");
+        return { path: filePath, content };
+      } catch (error) {
+        console.warn(`Warning: Failed to read file ${filePath}:`, error);
+        return { path: filePath, content: null };
+      }
+    }),
+  );
+
+  return new Map<string, string | null>(fileContents.map(({ path, content }) => [path, content]));
+}
+
+/**
+ * Parses a single component entry into its documentation API.
+ *
+ * Reads the component contents from `fileMap`, removes top-level styles for
+ * metadata parsing, and parses it to extract component metadata. Returns `null`
+ * for non-Svelte entries or files that could not be read.
+ *
+ * @param entry - Export entry tuple `[exportName, exportInfo]`
+ * @param entries - All sibling entries, used to resolve the module name
+ * @param fileMap - Map of resolved file paths to their contents
+ * @param resolveComponentFilePath - Resolves a component `source` to its absolute path
+ */
+export function processComponent(
+  [exportName, entry]: [string, ParsedExports[string]],
+  entries: Array<[string, ParsedExports[string]]>,
+  fileMap: Map<string, string | null>,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): ComponentDocApi | null {
+  const filePath = entry.source;
+  const { ext, name } = parse(filePath);
+
+  let moduleName = exportName;
+
+  if (entries.length === 1 && exportName === "default") {
+    moduleName = name;
+  }
+
+  if (ext === ".svelte") {
+    const resolvedPath = resolveComponentFilePath(filePath);
+    const source = fileMap.get(resolvedPath);
+
+    if (source === null || source === undefined) {
+      /**
+       * File was not found or failed to read, skip this component.
+       * This can happen if the file doesn't exist or if there was an error
+       * reading it (already logged as a warning).
+       */
+      return null;
+    }
+
+    const parser = new ComponentParser();
+    const parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
+      moduleName,
+      filePath: normalizeSeparators(filePath),
+    });
+
+    return {
+      moduleName,
+      filePath: normalizeSeparators(filePath),
+      ...parsed,
+    };
+  }
+
+  return null;
+}
+
+/** Collects the resolved, absolute paths of all `.svelte` entries. */
+export function collectSvelteFilePaths(
+  entriesList: Array<Array<[string, ParsedExports[string]]>>,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Set<string> {
+  const uniqueFilePaths = new Set<string>();
+  for (const entries of entriesList) {
+    for (const [, entry] of entries) {
+      if (parse(entry.source).ext === ".svelte") {
+        uniqueFilePaths.add(resolveComponentFilePath(entry.source));
+      }
+    }
+  }
+  return uniqueFilePaths;
+}
+
+/**
+ * Generates component documentation bundle from Svelte source files.
+ *
+ * Parses exports, discovers components (optionally via glob), and processes
+ * all Svelte files to extract component metadata. Returns both exported
+ * components (for JSON/Markdown) and all components (for TypeScript definitions).
+ *
+ * @param input - Entry point file or directory containing Svelte components
+ * @param glob - Whether to glob for all .svelte files in the directory
+ * @returns Bundle result containing exports, components, and allComponentsForTypes
+ *
+ * @example
+ * ```ts
+ * // Generate from single file:
+ * const result = await generateBundle("./src/App.svelte", false);
+ *
+ * // Generate from directory with glob:
+ * const result = await generateBundle("./src", true);
+ * ```
+ */
+export async function generateBundle(input: string, glob: boolean): Promise<GenerateBundleResult> {
+  const { exports, allComponents, resolveComponentFilePath } = collectComponents(input, glob);
+
+  const exportEntries = Object.entries(exports);
+  const allComponentEntries = Object.entries(allComponents);
+
+  const uniqueFilePaths = collectSvelteFilePaths([exportEntries, allComponentEntries], resolveComponentFilePath);
+  const fileMap = await readFileMap(uniqueFilePaths);
+
+  const components: ComponentDocs = new Map();
+  const allComponentsForTypes: ComponentDocs = new Map();
+
+  /**
+   * Process exported components (for metadata/JSON/Markdown).
+   * Only components that are explicitly exported are included in the
+   * components map for JSON and Markdown output.
+   */
+  for (const entry of exportEntries) {
+    const result = processComponent(entry, exportEntries, fileMap, resolveComponentFilePath);
+    if (result) components.set(result.moduleName, result);
+  }
+
+  /**
+   * Process all components (for .d.ts generation).
+   * All discovered components are included in allComponentsForTypes
+   * to ensure TypeScript definitions are generated for all components,
+   * even if they're not explicitly exported.
+   */
+  for (const entry of allComponentEntries) {
+    const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath);
+    if (result) allComponentsForTypes.set(result.moduleName, result);
+  }
+
+  return {
+    exports,
+    components,
+    allComponentsForTypes,
+  };
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,16 +1,25 @@
-import { lstatSync, readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
-import { parse as parseSvelte } from "svelte/compiler";
-import { globSync } from "tinyglobby";
-import { asRelativeSourcePath, type NormalizedPath } from "./brands";
-import ComponentParser, { type ParsedComponent } from "./ComponentParser";
+import { dirname } from "node:path";
+import { generateBundle, type GenerateBundleResult } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { type ParsedExports, parseExports } from "./parse-exports";
-import { normalizeSeparators } from "./path";
+import { createSveldBundle, type SveldBundle } from "./watch";
 import writeJson, { type WriteJsonOptions } from "./writer/writer-json";
 import writeMarkdown, { type WriteMarkdownOptions } from "./writer/writer-markdown";
 import writeTsDefinitions, { type WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
+
+export type {
+  CollectedComponents,
+  ComponentDocApi,
+  ComponentDocs,
+  GenerateBundleResult,
+  ResolveComponentFilePath,
+} from "./bundle";
+export {
+  collectComponents,
+  collectSvelteFilePaths,
+  generateBundle,
+  processComponent,
+  readFileMap,
+} from "./bundle";
 
 export interface PluginSveldOptions {
   /**
@@ -25,263 +34,100 @@ export interface PluginSveldOptions {
   jsonOptions?: Partial<Omit<WriteJsonOptions, "inputDir">>;
   markdown?: boolean;
   markdownOptions?: Partial<WriteMarkdownOptions>;
+  /**
+   * Regenerate output incrementally when `.svelte` source changes during
+   * `vite dev` / `vite build --watch`. Only the changed component and the
+   * components that depend on it via `@extendProps` / `@extends` are re-parsed.
+   * @default false
+   */
+  watch?: boolean;
 }
 
-export interface ComponentDocApi extends ParsedComponent {
-  filePath: NormalizedPath;
-  moduleName: string;
-}
-
-export type ComponentDocs = Map<string, ComponentDocApi>;
-
-const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
-const HYPHEN_REGEX = /-/g;
-
-function stripTopLevelStyleBlock(source: string) {
-  try {
-    const parsed = parseSvelte(source, { modern: false }) as { css?: { start?: number; end?: number } };
-    const start = parsed.css?.start;
-    const end = parsed.css?.end;
-
-    if (start === undefined || end === undefined) {
-      return source;
-    }
-
-    return `${source.slice(0, start)}${source.slice(end)}`;
-  } catch {
-    // Fall back to the previous regex behavior if the source cannot be parsed.
-    return source.replace(STYLE_TAG_REGEX, "");
-  }
+/** Subset of Vite/Rollup's HMR context that the watch hook relies on. */
+interface HotUpdateContext {
+  file: string;
 }
 
 interface SveldPlugin {
   name: string;
   apply?: "build" | "serve";
   enforce?: "pre" | "post";
-  buildStart(): void;
+  buildStart(): void | Promise<void>;
   generateBundle(): Promise<void>;
   writeBundle(): void;
+  /** Vite dev-server HMR hook (serve mode). */
+  handleHotUpdate?(ctx: HotUpdateContext): void;
+  /** Rollup/Vite watch hook (build `--watch`). */
+  watchChange?(id: string): void;
 }
 
+/** Debounce window (ms) for coalescing rapid file changes into one regeneration. */
+const WATCH_DEBOUNCE_MS = 50;
+
+const SVELTE_EXT_REGEX = /\.svelte$/;
+
 export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
+  const watch = opts?.watch === true;
   let result: GenerateBundleResult;
   let input: string | null;
 
+  // Watch-mode state: a long-lived bundle that supports scoped re-parsing.
+  let bundle: SveldBundle | null = null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const pending = new Set<string>();
+
+  const flush = async () => {
+    if (bundle == null || input == null || pending.size === 0) return;
+    const changed = Array.from(pending);
+    pending.clear();
+    try {
+      const { result: next } = await bundle.update(changed);
+      writeOutput(next, opts || {}, input);
+    } catch (error) {
+      console.error("sveld: failed to regenerate types in watch mode:", error);
+    }
+  };
+
+  const scheduleUpdate = (id: string) => {
+    if (!watch || bundle == null || !SVELTE_EXT_REGEX.test(id)) return;
+    pending.add(id);
+    clearTimeout(timer);
+    timer = setTimeout(flush, WATCH_DEBOUNCE_MS);
+  };
+
   return {
     name: "vite-plugin-sveld",
-    apply: "build",
+    // In watch mode the plugin must also run in `serve` (dev server), so leave
+    // `apply` unset. Otherwise keep the original build-only behavior.
+    apply: watch ? undefined : "build",
     enforce: "post",
-    buildStart() {
+    async buildStart() {
       input = getSvelteEntry(opts?.entry);
+      if (watch && input != null) {
+        // Produce the initial output and prime the incremental bundle. This
+        // covers both `vite dev` (where generateBundle/writeBundle never fire)
+        // and `vite build --watch`.
+        bundle = await createSveldBundle(input, opts?.glob === true);
+        writeOutput(bundle.result, opts || {}, input);
+      }
     },
     async generateBundle() {
+      // In watch mode the initial build happens in `buildStart`.
+      if (watch) return;
       if (input != null) {
         result = await generateBundle(input, opts?.glob === true);
       }
     },
     writeBundle() {
+      if (watch) return;
       if (input != null) writeOutput(result, opts || {}, input);
     },
-  };
-}
-
-interface GenerateBundleResult {
-  exports: ParsedExports;
-  components: ComponentDocs;
-  allComponentsForTypes: ComponentDocs;
-}
-
-/**
- * Generates component documentation bundle from Svelte source files.
- *
- * Parses exports, discovers components (optionally via glob), and processes
- * all Svelte files to extract component metadata. Returns both exported
- * components (for JSON/Markdown) and all components (for TypeScript definitions).
- *
- * @param input - Entry point file or directory containing Svelte components
- * @param glob - Whether to glob for all .svelte files in the directory
- * @returns Bundle result containing exports, components, and allComponentsForTypes
- *
- * @example
- * ```ts
- * // Generate from single file:
- * const result = await generateBundle("./src/App.svelte", false);
- *
- * // Generate from directory with glob:
- * const result = await generateBundle("./src", true);
- * ```
- */
-export async function generateBundle(input: string, glob: boolean) {
-  const isFile = lstatSync(input).isFile();
-  const dir = isFile ? dirname(input) : input;
-  const rootDir = resolve(dir);
-  const resolveComponentFilePath = (filePath: string) =>
-    isAbsolute(filePath) ? resolve(filePath) : resolve(rootDir, filePath);
-
-  /**
-   * Only parse exports if input is a file.
-   * Directory inputs don't have a single entry point to parse exports from.
-   */
-  let exports: ParsedExports = {};
-  if (isFile) {
-    const entry = readFileSync(input, "utf-8");
-    exports = parseExports(entry, rootDir);
-  }
-
-  const allComponents: ParsedExports = { ...exports };
-
-  if (glob) {
-    for (const matchedFile of globSync(["**/*.svelte"], { cwd: rootDir, absolute: true })) {
-      const file = resolve(matchedFile);
-      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
-      const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
-
-      if (exports[moduleName]) {
-        exports[moduleName].source = source;
-      }
-
-      if (allComponents[moduleName]) {
-        allComponents[moduleName].source = source;
-      } else {
-        allComponents[moduleName] = { source, default: false };
-      }
-    }
-  }
-
-  const components: ComponentDocs = new Map();
-  const allComponentsForTypes: ComponentDocs = new Map();
-  const exportEntries = Object.entries(exports);
-  const allComponentEntries = Object.entries(allComponents);
-
-  const uniqueFilePaths = new Set<string>();
-  for (const [, entry] of exportEntries) {
-    const filePath = entry.source;
-    const { ext } = parse(filePath);
-    if (ext === ".svelte") {
-      uniqueFilePaths.add(resolveComponentFilePath(filePath));
-    }
-  }
-  for (const [, entry] of allComponentEntries) {
-    const filePath = entry.source;
-    const { ext } = parse(filePath);
-    if (ext === ".svelte") {
-      uniqueFilePaths.add(resolveComponentFilePath(filePath));
-    }
-  }
-
-  const fileContents = await Promise.all(
-    Array.from(uniqueFilePaths).map(async (filePath) => {
-      try {
-        const content = await readFile(filePath, "utf-8");
-        return { path: filePath, content };
-      } catch (error) {
-        console.warn(`Warning: Failed to read file ${filePath}:`, error);
-        return { path: filePath, content: null };
-      }
-    }),
-  );
-
-  const fileMap = new Map<string, string | null>(fileContents.map(({ path, content }) => [path, content]));
-
-  /**
-   * Helper function to process a single component.
-   *
-   * Reads the component file, removes top-level styles for metadata parsing,
-   * and parses it to extract component metadata. Handles file read errors gracefully.
-   *
-   * @param entry - Export entry tuple [exportName, exportInfo]
-   * @param entries - All export entries for context
-   * @param fileMap - Map of file paths to their contents
-   * @returns Component documentation or null if processing failed
-   *
-   * @example
-   * ```ts
-   * const result = await processComponent(
-   *   ["Button", { source: "./Button.svelte", default: true }],
-   *   allEntries,
-   *   fileMap
-   * );
-   * // Returns: { moduleName: "Button", filePath: "./Button.svelte", props: [...], ... }
-   * ```
-   */
-  const processComponent = async (
-    [exportName, entry]: [string, ParsedExports[string]],
-    entries: Array<[string, ParsedExports[string]]>,
-    fileMap: Map<string, string | null>,
-  ) => {
-    const filePath = entry.source;
-    const { ext, name } = parse(filePath);
-
-    let moduleName = exportName;
-
-    if (entries.length === 1 && exportName === "default") {
-      moduleName = name;
-    }
-
-    if (ext === ".svelte") {
-      const resolvedPath = resolveComponentFilePath(filePath);
-      const source = fileMap.get(resolvedPath);
-
-      if (source === null || source === undefined) {
-        /**
-         * File was not found or failed to read, skip this component.
-         * This can happen if the file doesn't exist or if there was an error
-         * reading it (already logged as a warning).
-         */
-        return null;
-      }
-
-      const parser = new ComponentParser();
-      const parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
-        moduleName,
-        filePath: normalizeSeparators(filePath),
-      });
-
-      return {
-        moduleName,
-        filePath: normalizeSeparators(filePath),
-        ...parsed,
-      };
-    }
-
-    return null;
-  };
-
-  /**
-   * Process exported components (for metadata/JSON/Markdown).
-   * Only components that are explicitly exported are included in the
-   * components map for JSON and Markdown output.
-   */
-  const componentPromises = exportEntries.map((entry) => processComponent(entry, exportEntries, fileMap));
-
-  /**
-   * Process all components (for .d.ts generation).
-   * All discovered components are included in allComponentsForTypes
-   * to ensure TypeScript definitions are generated for all components,
-   * even if they're not explicitly exported.
-   */
-  const allComponentPromises = allComponentEntries.map((entry) =>
-    processComponent(entry, allComponentEntries, fileMap),
-  );
-
-  const [results, allResults] = await Promise.all([Promise.all(componentPromises), Promise.all(allComponentPromises)]);
-
-  for (const result of results) {
-    if (result) {
-      components.set(result.moduleName, result);
-    }
-  }
-
-  for (const result of allResults) {
-    if (result) {
-      allComponentsForTypes.set(result.moduleName, result);
-    }
-  }
-
-  return {
-    exports,
-    components,
-    allComponentsForTypes,
+    handleHotUpdate(ctx) {
+      scheduleUpdate(ctx.file);
+    },
+    watchChange(id) {
+      scheduleUpdate(id);
+    },
   };
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import { dirname } from "node:path";
-import { generateBundle, type GenerateBundleResult } from "./bundle";
+import { type GenerateBundleResult, generateBundle } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { createSveldBundle, type SveldBundle } from "./watch";
 import writeJson, { type WriteJsonOptions } from "./writer/writer-json";

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,223 @@
+import { dirname, resolve } from "node:path";
+import type { ParsedExports } from "./parse-exports";
+import {
+  collectComponents,
+  collectSvelteFilePaths,
+  type ComponentDocApi,
+  type ComponentDocs,
+  type GenerateBundleResult,
+  processComponent,
+  readFileMap,
+  type ResolveComponentFilePath,
+} from "./bundle";
+
+const SVELTE_EXT_REGEX = /\.svelte$/;
+
+/** Strips matching surrounding single/double quotes from an import specifier. */
+const SURROUNDING_QUOTES_REGEX = /^(['"])(.*)\1$/;
+
+/** Result of an incremental update. */
+export interface SveldBundleUpdate {
+  /** The full, updated bundle result (all components, with the affected ones re-parsed). */
+  result: GenerateBundleResult;
+  /**
+   * Absolute paths of the components that were re-parsed: the changed files
+   * plus their transitive `@extendProps` / `@extends` dependents. Other
+   * components are reused from the previous parse.
+   */
+  reparsed: string[];
+}
+
+/**
+ * A long-lived bundle that supports scoped, incremental re-parsing.
+ *
+ * `createSveldBundle` performs the initial full parse. `update` then re-parses
+ * only the components affected by a set of changed files, leaving every other
+ * component's previously-parsed output untouched. This is the core of the
+ * plugin's watch mode.
+ */
+export interface SveldBundle {
+  readonly result: GenerateBundleResult;
+  /** Re-parse the changed files plus their dependents and return the updated bundle. */
+  update(changedFilePaths: string[]): Promise<SveldBundleUpdate>;
+}
+
+/**
+ * Resolves a component's `@extendProps` / `@extends` target to an absolute path,
+ * or `null` when it doesn't point at a local `.svelte` file (e.g. it references
+ * an external package interface like `carbon-components-svelte`).
+ */
+function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): string | null {
+  const raw = api.extends?.import;
+  if (raw === undefined) return null;
+  // `extends.import` is stored verbatim from the JSDoc tag, including any
+  // surrounding quotes (e.g. `"./Button.svelte"`).
+  const target = raw.replace(SURROUNDING_QUOTES_REGEX, "$2");
+  if (!SVELTE_EXT_REGEX.test(target)) return null;
+  return resolve(dirname(componentPath), target);
+}
+
+/**
+ * Builds a reverse-dependency map: `dependencyPath -> set of dependent paths`.
+ *
+ * A component is a dependent of `X` when it extends `X` via `@extendProps` /
+ * `@extends`. When `X` changes, every dependent must be re-parsed.
+ */
+function buildReverseDeps(
+  components: ComponentDocs,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Map<string, Set<string>> {
+  const reverse = new Map<string, Set<string>>();
+
+  for (const api of components.values()) {
+    const componentPath = resolveComponentFilePath(api.filePath);
+    const dependency = resolveExtendsDependency(api, componentPath);
+    if (dependency === null) continue;
+
+    let dependents = reverse.get(dependency);
+    if (dependents === undefined) {
+      dependents = new Set();
+      reverse.set(dependency, dependents);
+    }
+    dependents.add(componentPath);
+  }
+
+  return reverse;
+}
+
+/**
+ * Expands the set of changed paths to include every transitive dependent via
+ * the reverse-dependency map (e.g. editing `Button.svelte` also marks the
+ * `SecondaryButton.svelte` that `@extendProps`-es it).
+ */
+function expandAffected(changed: Iterable<string>, reverseDeps: Map<string, Set<string>>): Set<string> {
+  const affected = new Set<string>();
+  const queue: string[] = [];
+
+  for (const path of changed) {
+    if (!affected.has(path)) {
+      affected.add(path);
+      queue.push(path);
+    }
+  }
+
+  while (queue.length > 0) {
+    // biome-ignore lint/style/noNonNullAssertion: queue is non-empty in the loop condition
+    const current = queue.shift()!;
+    const dependents = reverseDeps.get(current);
+    if (dependents === undefined) continue;
+    for (const dependent of dependents) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return affected;
+}
+
+/**
+ * Creates a watch-mode bundle for the given entry point, performing the initial
+ * full parse up front.
+ *
+ * @param input - Entry point file or directory containing Svelte components
+ * @param glob - Whether to glob for all `.svelte` files in the directory
+ */
+export async function createSveldBundle(input: string, glob: boolean): Promise<SveldBundle> {
+  // Discover sources once. The export/source maps only change when the entry
+  // file or the set of files on disk changes; for a single edit they are stable.
+  const { exports, allComponents, resolveComponentFilePath } = collectComponents(input, glob);
+
+  const exportEntries = Object.entries(exports);
+  const allComponentEntries = Object.entries(allComponents);
+
+  const components: ComponentDocs = new Map();
+  const allComponentsForTypes: ComponentDocs = new Map();
+
+  // Initial full parse.
+  {
+    const uniqueFilePaths = collectSvelteFilePaths([exportEntries, allComponentEntries], resolveComponentFilePath);
+    const fileMap = await readFileMap(uniqueFilePaths);
+
+    for (const entry of exportEntries) {
+      const result = processComponent(entry, exportEntries, fileMap, resolveComponentFilePath);
+      if (result) components.set(result.moduleName, result);
+    }
+    for (const entry of allComponentEntries) {
+      const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath);
+      if (result) allComponentsForTypes.set(result.moduleName, result);
+    }
+  }
+
+  // Dependency graph derived from the full parse; rebuilt after every update so
+  // that newly added/removed `@extends` edges stay accurate.
+  let reverseDeps = buildReverseDeps(allComponentsForTypes, resolveComponentFilePath);
+
+  /**
+   * Re-parses only the entries whose resolved source is in `affected`, writing
+   * results back into `target`. Returns the set of paths that were re-parsed.
+   */
+  const reparseInto = (
+    target: ComponentDocs,
+    entries: Array<[string, ParsedExports[string]]>,
+    affected: Set<string>,
+    fileMap: Map<string, string | null>,
+  ): Set<string> => {
+    const reparsed = new Set<string>();
+    for (const entry of entries) {
+      const resolvedPath = resolveComponentFilePath(entry[1].source);
+      if (!affected.has(resolvedPath)) continue;
+
+      const result = processComponent(entry, entries, fileMap, resolveComponentFilePath);
+      if (result) {
+        target.set(result.moduleName, result);
+        reparsed.add(resolvedPath);
+      } else {
+        // Source vanished or failed to parse: drop the stale entry.
+        for (const [moduleName, api] of target) {
+          if (resolveComponentFilePath(api.filePath) === resolvedPath) {
+            target.delete(moduleName);
+          }
+        }
+      }
+    }
+    return reparsed;
+  };
+
+  const update = async (changedFilePaths: string[]): Promise<SveldBundleUpdate> => {
+    const changed = changedFilePaths.filter((path) => SVELTE_EXT_REGEX.test(path)).map((path) => resolve(path));
+
+    if (changed.length === 0) {
+      return { result: { exports, components, allComponentsForTypes }, reparsed: [] };
+    }
+
+    const affected = expandAffected(changed, reverseDeps);
+
+    // Read fresh contents for the affected files only.
+    const fileMap = await readFileMap(affected);
+
+    const reparsed = new Set<string>();
+    for (const path of reparseInto(components, exportEntries, affected, fileMap)) {
+      reparsed.add(path);
+    }
+    for (const path of reparseInto(allComponentsForTypes, allComponentEntries, affected, fileMap)) {
+      reparsed.add(path);
+    }
+
+    // Refresh the dependency graph from the up-to-date parse.
+    reverseDeps = buildReverseDeps(allComponentsForTypes, resolveComponentFilePath);
+
+    return {
+      result: { exports, components, allComponentsForTypes },
+      reparsed: Array.from(reparsed),
+    };
+  };
+
+  return {
+    get result() {
+      return { exports, components, allComponentsForTypes };
+    },
+    update,
+  };
+}

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,18 +1,18 @@
 import { dirname, resolve } from "node:path";
-import type { ParsedExports } from "./parse-exports";
 import {
-  collectComponents,
-  collectSvelteFilePaths,
   type ComponentDocApi,
   type ComponentDocs,
   type ComponentParseError,
+  collectComponents,
+  collectSvelteFilePaths,
   type GenerateBundleResult,
-  processComponent,
   type ProcessComponentOptions,
+  processComponent,
+  type ResolveComponentFilePath,
   readFileMap,
   reportParseErrors,
-  type ResolveComponentFilePath,
 } from "./bundle";
+import type { ParsedExports } from "./parse-exports";
 
 const SVELTE_EXT_REGEX = /\.svelte$/;
 

--- a/tests/fixtures/runes-snippet-positional/output.d.ts
+++ b/tests/fixtures/runes-snippet-positional/output.d.ts
@@ -1,5 +1,5 @@
-import { SvelteComponentTyped } from "svelte";
 import type { Snippet } from "svelte";
+import { SvelteComponentTyped } from "svelte";
 
 interface Props {
   row: Snippet<[item: string, index: number]>;

--- a/tests/fixtures/runes-snippet-positional/output.d.ts
+++ b/tests/fixtures/runes-snippet-positional/output.d.ts
@@ -1,5 +1,5 @@
-import type { Snippet } from "svelte";
 import { SvelteComponentTyped } from "svelte";
+import type { Snippet } from "svelte";
 
 interface Props {
   row: Snippet<[item: string, index: number]>;

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import pluginSveld from "../src/plugin";
+import { createSveldBundle } from "../src/watch";
+
+const BUTTON = `<script>
+  /** @restProps {button} */
+  export let primary = false;
+</script>
+
+<button {...$$restProps}><slot /></button>`;
+
+// Wraps Button via @extendProps, so it depends on Button.svelte.
+const SECONDARY_BUTTON = `<script>
+  /** @extendProps {"./Button.svelte"} ButtonProps */
+  export let secondary = true;
+
+  import Button from "./Button.svelte";
+</script>
+
+<Button {...$$restProps}><slot /></Button>`;
+
+// Independent component with no relationship to Button.
+const STANDALONE = `<script>
+  export let label = "standalone";
+</script>
+
+<span>{label}</span>`;
+
+describe("watch mode (createSveldBundle)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-watch-"));
+    writeFileSync(join(dir, "Button.svelte"), BUTTON);
+    writeFileSync(join(dir, "SecondaryButton.svelte"), SECONDARY_BUTTON);
+    writeFileSync(join(dir, "Standalone.svelte"), STANDALONE);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("initial bundle parses every component", async () => {
+    const bundle = await createSveldBundle(dir, true);
+    const names = Array.from(bundle.result.allComponentsForTypes.keys()).sort();
+    expect(names).toEqual(["Button", "SecondaryButton", "Standalone"]);
+  });
+
+  test("editing a component re-parses it plus its @extendProps dependents only", async () => {
+    const bundle = await createSveldBundle(dir, true);
+
+    const buttonPath = resolve(dir, "Button.svelte");
+    writeFileSync(buttonPath, BUTTON.replace("primary = false", "primary = true"));
+
+    const { reparsed } = await bundle.update([buttonPath]);
+
+    // Button changed; SecondaryButton depends on it via @extendProps.
+    // Standalone is unrelated and must NOT be re-parsed.
+    expect(reparsed.sort()).toEqual([resolve(dir, "Button.svelte"), resolve(dir, "SecondaryButton.svelte")].sort());
+    expect(reparsed).not.toContain(resolve(dir, "Standalone.svelte"));
+    expect(reparsed.length).toBeLessThan(bundle.result.allComponentsForTypes.size);
+  });
+
+  test("editing an independent component re-parses only that component", async () => {
+    const bundle = await createSveldBundle(dir, true);
+
+    const standalonePath = resolve(dir, "Standalone.svelte");
+    writeFileSync(standalonePath, STANDALONE.replace('"standalone"', '"changed"'));
+
+    const { reparsed } = await bundle.update([standalonePath]);
+
+    expect(reparsed).toEqual([standalonePath]);
+  });
+
+  test("ignores non-svelte changes", async () => {
+    const bundle = await createSveldBundle(dir, true);
+    const { reparsed } = await bundle.update([resolve(dir, "README.md")]);
+    expect(reparsed).toEqual([]);
+  });
+
+  test("re-parsed output reflects the edited source", async () => {
+    const bundle = await createSveldBundle(dir, true);
+
+    const buttonPath = resolve(dir, "Button.svelte");
+    writeFileSync(buttonPath, BUTTON.replace("export let primary = false;", "export let danger = false;"));
+
+    const { result } = await bundle.update([buttonPath]);
+    const button = result.allComponentsForTypes.get("Button");
+    const propNames = button?.props.map((p) => p.name) ?? [];
+    expect(propNames).toContain("danger");
+    expect(propNames).not.toContain("primary");
+  });
+});
+
+describe("pluginSveld watch option", () => {
+  test("defaults to build-only apply when watch is not set", () => {
+    expect(pluginSveld().apply).toBe("build");
+    expect(pluginSveld({ watch: false }).apply).toBe("build");
+  });
+
+  test("runs in serve and build (apply unset) when watch is enabled", () => {
+    expect(pluginSveld({ watch: true }).apply).toBeUndefined();
+  });
+
+  test("hot updates are a no-op before the bundle is initialized", () => {
+    const plugin = pluginSveld({ watch: true });
+    // Should not throw when no bundle exists yet (e.g. invalid entry).
+    expect(() => plugin.handleHotUpdate?.({ file: "/tmp/Anything.svelte" })).not.toThrow();
+  });
+});


### PR DESCRIPTION
The plugin only ran during `vite build`, leaving no regenerated `.d.ts` during `vite dev`. Watch mode re-parses just the changed component and its `@extendProps`/`@extends` dependents per edit.

## What changed

- New `watch` plugin option (default `false`). When enabled, the plugin also runs in Vite `serve` mode and hooks `handleHotUpdate` / `watchChange`, with debounced (50ms) regeneration.
- Scoped re-parsing: on a `.svelte` edit, only the changed component plus its transitive `@extendProps` / `@extends` dependents are re-parsed; all other components reuse their previous parse.
- Extracted the reusable "process N components" path into `src/bundle.ts` (`collectComponents`, `processComponent`, `readFileMap`, `generateBundle`). `src/watch.ts` holds the long-lived incremental bundle (`createSveldBundle`). `src/plugin.ts` keeps the plugin lifecycle and re-exports the bundle API for back-compat.
- README "Available Options" documents the new `watch` option.

## Tests

`tests/watch.test.ts` proves a single-file edit triggers a **scoped** regeneration — editing `Button.svelte` re-parses only `Button` + its `@extendProps` dependent `SecondaryButton`, never the unrelated `Standalone`. Also covers independent edits, non-svelte changes, and that default (build-only) behavior is unchanged when `watch` is unset.

Default behavior with `watch` unset is unchanged: `apply: "build"` and the existing `generateBundle` / `writeBundle` path.