### PR TITLE
feat: opt-in TypeScript semantic resolution for imported prop types

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,36 @@ When both TypeScript syntax and JSDoc are present, `sveld` resolves prop types i
 
 `sveld` stays AST-only. It copies imported and local type text into generated `.d.ts` output but does not run project-wide semantic resolution with the TypeScript compiler. Opaque imported whole-object `$props()` types can therefore stay in declarations without being fully expanded into JSON metadata.
 
+#### Opt-in semantic resolution (`resolveTypes`)
+
+Imported whole-object `$props()` types stay opaque in JSON by default (`"props": []`). Turn on `resolveTypes` when a docs site or prop table needs the individual fields.
+
+```ts
+await sveld({ json: true, resolveTypes: true });
+```
+
+```svelte
+<script lang="ts">
+  import type { Props } from "./types";
+
+  let props: Props = $props();
+</script>
+```
+
+Without `resolveTypes`, JSON lists no props. With it, each field shows up with `"typeSource": "typescript"`:
+
+```jsonc
+{
+  "props": [
+    { "name": "disabled", "type": "boolean", "isRequired": false, "typeSource": "typescript" },
+    { "name": "href", "type": "string", "isRequired": true, "typeSource": "typescript" },
+    { "name": "variant", "type": "\"primary\" | \"secondary\"", "isRequired": true, "typeSource": "typescript" }
+  ]
+}
+```
+
+**Performance.** Off by default. This is the only path that loads TypeScript. It needs `typescript` and a `tsconfig.json`, runs slower than the AST-only pipeline, and gets slower as your types grow. Use it only when you need expanded JSON. `.d.ts` output is unchanged.
+
 ## Usage
 
 ### Installation

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -213,6 +213,39 @@ export function getParsedComponentTypeScriptMetadata(component: {
   return component[PARSED_COMPONENT_TYPE_SCRIPT_METADATA];
 }
 
+/** One prop returned by the TypeScript checker during `resolveTypes`. */
+export interface ResolvedComponentProp {
+  name: string;
+  type: string;
+  isRequired: boolean;
+  description?: string;
+}
+
+/** Append checker-resolved props. Names the AST walker already found are left alone. */
+export function applyResolvedProps(component: ParsedComponent, resolved: ResolvedComponentProp[]): void {
+  if (resolved.length === 0) return;
+
+  const existing = new Set(component.props.map((prop) => prop.name));
+
+  for (const prop of resolved) {
+    if (existing.has(prop.name)) continue;
+    existing.add(prop.name);
+
+    component.props.push({
+      name: prop.name,
+      kind: "let",
+      constant: false,
+      type: prop.type,
+      typeSource: "typescript",
+      ...(prop.description ? { description: prop.description } : {}),
+      isFunction: prop.type.includes("=>"),
+      isFunctionDeclaration: false,
+      isRequired: prop.isRequired,
+      reactive: false,
+    });
+  }
+}
+
 type SyntaxMode = "legacy" | "runes";
 type ScriptLanguage = "js" | "ts";
 type ScopeBindingKind = "prop" | "local";

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -4,7 +4,11 @@ import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
 import { parse as parseSvelte } from "svelte/compiler";
 import { globSync } from "tinyglobby";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
-import ComponentParser, { type ParsedComponent } from "./ComponentParser";
+import ComponentParser, {
+  applyResolvedProps,
+  getParsedComponentTypeScriptMetadata,
+  type ParsedComponent,
+} from "./ComponentParser";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { normalizeSeparators } from "./path";
@@ -46,6 +50,20 @@ export interface GenerateBundleOptions {
    * the failure and continuing with the remaining components.
    */
   failFast?: boolean;
+  /**
+   * Load the TypeScript program to expand opaque imported whole-object `$props()`
+   * types into JSON/Markdown props. Off by default; requires `typescript`.
+   */
+  resolveTypes?: boolean;
+}
+
+export function toGenerateBundleOptions(
+  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes">,
+): GenerateBundleOptions {
+  return {
+    failFast: opts?.failFast,
+    resolveTypes: opts?.resolveTypes === true,
+  };
 }
 
 /** A function that resolves a (possibly relative) component path to an absolute path. */
@@ -281,7 +299,7 @@ export function reportParseErrors(errors: ComponentParseError[]): void {
  *
  * @param input - Entry point file or directory containing Svelte components
  * @param glob - Whether to glob for all .svelte files in the directory
- * @param options - Bundle options (e.g. `failFast`)
+ * @param options - Bundle options (e.g. `failFast`, `resolveTypes`)
  * @returns Bundle result containing exports, components, allComponentsForTypes, and errors
  *
  * @example
@@ -301,7 +319,7 @@ export async function generateBundle(
   glob: boolean,
   options: GenerateBundleOptions = {},
 ): Promise<GenerateBundleResult> {
-  const { exports, allComponents, resolveComponentFilePath } = collectComponents(input, glob);
+  const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob);
 
   const exportEntries = Object.entries(exports);
   const allComponentEntries = Object.entries(allComponents);
@@ -346,6 +364,10 @@ export async function generateBundle(
   const errors = Array.from(parseErrors.values());
   reportParseErrors(errors);
 
+  if (options.resolveTypes) {
+    await resolveImportedPropTypes(components, rootDir, resolveComponentFilePath);
+  }
+
   // Same file can land in both export and all-components passes; dedupe before returning.
   const diagnostics = dedupeDiagnostics(
     Array.from(allComponentsForTypes.values()).flatMap((component) => component.diagnostics ?? []),
@@ -358,4 +380,44 @@ export async function generateBundle(
     errors,
     diagnostics,
   };
+}
+
+async function resolveImportedPropTypes(
+  components: ComponentDocs,
+  rootDir: string,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Promise<void> {
+  const candidates: Array<{
+    component: ComponentDocApi;
+    metadata: NonNullable<ReturnType<typeof getParsedComponentTypeScriptMetadata>>;
+  }> = [];
+
+  for (const component of components.values()) {
+    const metadata = getParsedComponentTypeScriptMetadata(component);
+    if (!metadata?.canonicalPropsType || component.props.length > 0) continue;
+    candidates.push({ component, metadata });
+  }
+
+  if (candidates.length === 0) return;
+
+  const { TypeResolver } = await import("./resolve-types");
+  const resolver = await TypeResolver.create(rootDir);
+  if (!resolver) return;
+
+  try {
+    const resolvedByModule = await resolver.expandAll(
+      candidates.map(({ component, metadata }) => ({
+        moduleName: component.moduleName,
+        metadata,
+        filePath: resolveComponentFilePath(component.filePath),
+      })),
+    );
+
+    for (const { component } of candidates) {
+      const resolved = resolvedByModule.get(component.moduleName);
+      if (resolved) applyResolvedProps(component, resolved);
+    }
+  } finally {
+    await resolver.dispose();
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { rollup } from "rollup";
 import svelte from "rollup-plugin-svelte";
 import { formatDiagnosticsSummary } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { generateBundle, type PluginSveldOptions, writeOutput } from "./plugin";
+import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
 
 /** CLI options layered on top of the shared plugin options. */
 interface CliOptions extends PluginSveldOptions {
@@ -26,6 +26,7 @@ function parseCliFlag(arg: string): Partial<CliOptions> {
     case "json":
     case "markdown":
     case "strict":
+    case "resolveTypes":
       return { [flag]: value === true || value === "true" };
     case "fail-fast":
       return { failFast: value === true || value === "true" };
@@ -66,7 +67,7 @@ export async function cli(process: NodeJS.Process) {
 
   await rollup_bundle.generate({});
 
-  const result = await generateBundle(input, options.glob === true, { failFast: options.failFast });
+  const result = await generateBundle(input, options.glob === true, toGenerateBundleOptions(options));
 
   writeOutput(result, options, input);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,10 @@
 import { dirname } from "node:path";
-import { type GenerateBundleResult, generateBundle } from "./bundle";
+import {
+  type GenerateBundleOptions,
+  type GenerateBundleResult,
+  generateBundle,
+  toGenerateBundleOptions,
+} from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { createSveldBundle, type SveldBundle } from "./watch";
 import writeJson, { type WriteJsonOptions } from "./writer/writer-json";
@@ -22,9 +27,10 @@ export {
   processComponent,
   readFileMap,
   reportParseErrors,
+  toGenerateBundleOptions,
 } from "./bundle";
 
-export interface PluginSveldOptions {
+export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolveTypes"> {
   /**
    * Specify the entry point to uncompiled Svelte source.
    * If not provided, sveld will use the "svelte" field from package.json.
@@ -124,7 +130,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
       // In watch mode the initial build happens in `buildStart`.
       if (watch) return;
       if (input != null) {
-        result = await generateBundle(input, opts?.glob === true, { failFast: opts?.failFast });
+        result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
       }
     },
     writeBundle() {

--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -1,0 +1,213 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import type { ParsedComponentTypeScriptMetadata, ResolvedComponentProp } from "./ComponentParser";
+import { normalizeSeparators } from "./path";
+
+export interface ResolveTarget {
+  moduleName: string;
+  filePath: string;
+  metadata: ParsedComponentTypeScriptMetadata;
+}
+
+// The opt-in resolution path talks to the TypeScript 7 native preview through
+// its (currently unstable) async client/server API. We type it structurally so
+// the default AST-only build never needs the `typescript` types.
+// biome-ignore lint/suspicious/noExplicitAny: native-preview API is loaded lazily and typed structurally.
+type TS = any;
+
+const VIRTUAL_PROPS_BINDING = "__sveld_resolved_props__";
+const VIRTUAL_PROPS_TYPE = "__SveldResolvedProps__";
+const TRAILING_UNDEFINED = / \| undefined$/;
+
+/**
+ * Expands opaque imported `$props()` types using the project's TypeScript program.
+ * Loaded only when `resolveTypes` is enabled.
+ */
+export class TypeResolver {
+  private readonly api: TS;
+  private readonly symbolFlags: TS;
+  private readonly tsconfigPath: string;
+  private readonly overlay = new Map<string, string>();
+
+  private constructor(api: TS, symbolFlags: TS, tsconfigPath: string) {
+    this.api = api;
+    this.symbolFlags = symbolFlags;
+    this.tsconfigPath = tsconfigPath;
+  }
+
+  /**
+   * Loads `typescript` and the nearest `tsconfig.json`.
+   * Returns `null` when either is missing.
+   */
+  static async create(cwd: string = process.cwd()): Promise<TypeResolver | null> {
+    const tsconfigPath = findTsConfig(cwd);
+    if (!tsconfigPath) {
+      console.warn("Warning: `resolveTypes` could not locate a tsconfig.json. Skipping semantic resolution.");
+      return null;
+    }
+
+    let mod: TS;
+    try {
+      mod = await import("typescript/unstable/async");
+    } catch (error) {
+      console.warn(
+        "Warning: `resolveTypes` requires the `typescript` package to be installed. Skipping semantic resolution.",
+        error,
+      );
+      return null;
+    }
+
+    const resolver = new TypeResolver(null, mod.SymbolFlags, tsconfigPath);
+    const api = new mod.API({ cwd, fs: resolver.createFileSystem() });
+    // biome-ignore lint/suspicious/noExplicitAny: assign after fs closure is created.
+    (resolver as any).api = api;
+    return resolver;
+  }
+
+  /** Resolves every target in one program snapshot. */
+  async expandAll(targets: ResolveTarget[]): Promise<Map<string, ResolvedComponentProp[]>> {
+    const results = new Map<string, ResolvedComponentProp[]>();
+    if (targets.length === 0) return results;
+
+    const virtualFiles = new Map<string, ResolveTarget>();
+    for (const target of targets) {
+      if (!target.metadata.canonicalPropsType) continue;
+      const virtualFile = this.virtualFileName(target.filePath, target.moduleName);
+      this.overlay.set(virtualFile, buildVirtualModule(target.metadata));
+      virtualFiles.set(virtualFile, target);
+    }
+
+    if (virtualFiles.size === 0) return results;
+
+    const snapshot = await this.api.updateSnapshot({
+      openProject: this.tsconfigPath,
+      fileChanges: { created: Array.from(virtualFiles.keys()) },
+    });
+
+    try {
+      const entries = await Promise.all(
+        Array.from(
+          virtualFiles,
+          async ([virtualFile, target]): Promise<[string, ResolvedComponentProp[]]> => [
+            target.moduleName,
+            await this.resolveFile(snapshot, virtualFile),
+          ],
+        ),
+      );
+      for (const [moduleName, props] of entries) {
+        results.set(moduleName, props);
+      }
+    } finally {
+      await snapshot.dispose?.();
+    }
+
+    return results;
+  }
+
+  /** Closes the TypeScript server process. */
+  async dispose(): Promise<void> {
+    this.overlay.clear();
+    await this.api?.close?.();
+  }
+
+  private async resolveFile(snapshot: TS, virtualFile: string): Promise<ResolvedComponentProp[]> {
+    const content = this.overlay.get(virtualFile);
+    if (!content) return [];
+
+    const project = await snapshot.getDefaultProjectForFile(virtualFile);
+    if (!project) return [];
+
+    const checker = project.checker;
+    const position = bindingPosition(content);
+    const type = await checker.getTypeAtPosition(virtualFile, position);
+    if (!type) return [];
+
+    const properties: TS[] = await checker.getPropertiesOfType(type);
+
+    const resolved = await Promise.all(
+      properties
+        // Skip synthetic/internal members.
+        .filter((symbol: TS) => symbol.name && !symbol.name.startsWith("__"))
+        .map(async (symbol: TS): Promise<ResolvedComponentProp> => {
+          const propType = await checker.getTypeOfSymbol(symbol);
+          const isOptional = (symbol.flags & this.symbolFlags.Optional) !== 0;
+          let typeText = propType ? await checker.typeToString(propType) : "any";
+          if (isOptional) typeText = typeText.replace(TRAILING_UNDEFINED, "");
+
+          return { name: symbol.name, type: typeText, isRequired: !isOptional };
+        }),
+    );
+
+    resolved.sort((a, b) => a.name.localeCompare(b.name));
+    return resolved;
+  }
+
+  private createFileSystem() {
+    return {
+      readFile: (fileName: string) => this.overlay.get(normalizeSeparators(fileName)),
+      fileExists: (fileName: string) => (this.overlay.has(normalizeSeparators(fileName)) ? true : undefined),
+      getAccessibleEntries: (directoryName: string) => {
+        const normalizedDir = normalizeSeparators(directoryName);
+        const extras = Array.from(this.overlay.keys()).filter(
+          (file) => normalizeSeparators(path.dirname(file)) === normalizedDir,
+        );
+        if (extras.length === 0) return undefined;
+
+        const files: string[] = [];
+        const directories: string[] = [];
+        try {
+          for (const entry of readdirSync(directoryName)) {
+            const full = path.join(directoryName, entry);
+            try {
+              (statSync(full).isDirectory() ? directories : files).push(entry);
+            } catch {
+              // Ignore unreadable entries.
+            }
+          }
+        } catch {
+          // Directory only exists virtually.
+        }
+
+        for (const file of extras) {
+          const base = path.basename(file);
+          if (!files.includes(base)) files.push(base);
+        }
+
+        return { files, directories };
+      },
+    };
+  }
+
+  private virtualFileName(componentFilePath: string, moduleName: string) {
+    const dir = path.dirname(path.resolve(componentFilePath));
+    return normalizeSeparators(path.join(dir, `__sveld_resolved_${moduleName}.ts`));
+  }
+}
+
+function buildVirtualModule(metadata: ParsedComponentTypeScriptMetadata): string {
+  return [
+    ...metadata.typeImportStatements,
+    ...metadata.localTypeDeclarations,
+    `type ${VIRTUAL_PROPS_TYPE} = ${metadata.canonicalPropsType};`,
+    `declare const ${VIRTUAL_PROPS_BINDING}: ${VIRTUAL_PROPS_TYPE};`,
+  ].join("\n");
+}
+
+/** Offset of the props binding identifier on the trailing `declare const` line. */
+function bindingPosition(content: string): number {
+  const declareIndex = content.lastIndexOf("declare const");
+  return content.indexOf(VIRTUAL_PROPS_BINDING, declareIndex) + 2;
+}
+
+/** Walks upward from `dir` to find the nearest `tsconfig.json`. */
+function findTsConfig(dir: string): string | null {
+  let current = path.resolve(dir);
+  while (true) {
+    const candidate = path.join(current, "tsconfig.json");
+    if (existsSync(candidate)) return candidate;
+
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,6 +1,6 @@
 import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { generateBundle, type PluginSveldOptions, writeOutput } from "./plugin";
+import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
 
 interface SveldOptions extends Omit<PluginSveldOptions, "entry"> {
   /**
@@ -40,7 +40,7 @@ interface SveldResult {
 export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   const input = getSvelteEntry(opts?.input);
   if (input === null) return { diagnostics: [] };
-  const result = await generateBundle(input, opts?.glob === true, { failFast: opts?.failFast });
+  const result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
   writeOutput(result, { ...opts, entry: opts?.input }, input);
 
   const { diagnostics } = result;

--- a/tests/resolve-types.test.ts
+++ b/tests/resolve-types.test.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+import { asNormalizedPath } from "../src/brands";
+import ComponentParser, { applyResolvedProps, getParsedComponentTypeScriptMetadata } from "../src/ComponentParser";
+import { TypeResolver } from "../src/resolve-types";
+
+const FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "runes-whole-props-imported");
+const COMPONENT_PATH = path.join(FIXTURE_DIR, "input.svelte");
+
+async function parseFixture() {
+  const source = await Bun.file(COMPONENT_PATH).text();
+  const parser = new ComponentParser();
+  return parser.parseSvelteComponent(source, {
+    moduleName: "RunesWholePropsImported",
+    filePath: asNormalizedPath(COMPONENT_PATH),
+  });
+}
+
+describe("opt-in TypeScript semantic resolution", () => {
+  test("default AST-only path leaves an imported whole-object props type opaque", async () => {
+    const parsed = await parseFixture();
+
+    expect(parsed.props).toEqual([]);
+    expect(getParsedComponentTypeScriptMetadata(parsed)?.canonicalPropsType).toBe("Props");
+  });
+
+  test("resolveTypes expands the imported props type into structured props", async () => {
+    const parsed = await parseFixture();
+    const metadata = getParsedComponentTypeScriptMetadata(parsed);
+    if (!metadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
+
+    const resolver = await TypeResolver.create(FIXTURE_DIR);
+    expect(resolver).not.toBeNull();
+    if (!resolver) return;
+
+    try {
+      const resolved = await resolver.expandAll([
+        {
+          moduleName: "RunesWholePropsImported",
+          metadata,
+          filePath: COMPONENT_PATH,
+        },
+      ]);
+
+      applyResolvedProps(parsed, resolved.get("RunesWholePropsImported") ?? []);
+    } finally {
+      await resolver.dispose();
+    }
+
+    const byName = Object.fromEntries(parsed.props.map((prop) => [prop.name, prop]));
+    expect(Object.keys(byName).sort()).toEqual(["disabled", "href", "variant"]);
+
+    expect(byName.disabled).toMatchObject({ type: "boolean", isRequired: false, typeSource: "typescript" });
+    expect(byName.href).toMatchObject({ type: "string", isRequired: true, typeSource: "typescript" });
+    expect(byName.variant).toMatchObject({
+      type: '"primary" | "secondary"',
+      isRequired: true,
+      typeSource: "typescript",
+    });
+  }, 30_000);
+});


### PR DESCRIPTION
Imported whole-object `$props()` types are opaque to the AST walker, so JSON consumers get `props: []`. `resolveTypes: true` loads the TS program to expand them, gated lazily so the default path never loads `typescript`.

## Motivation

`sveld` is deliberately AST-only: it copies imported/local type text into `.d.ts` but does not run project-wide semantic resolution. For an imported whole-object props type, the JSON metadata is therefore empty — limiting doc sites and prop tables that want expanded fields.

```svelte
<script lang="ts">
  import type { Props } from "./types";
  let props: Props = $props();
</script>
```

```jsonc
// Default (AST-only): the imported type stays opaque
{ "props": [] }
```

## What changed

Setting `resolveTypes: true` opts into a slower mode that loads the project's TypeScript program to expand opaque imported/aliased prop types into structured props (each marked `"typeSource": "typescript"`):

```jsonc
// resolveTypes: true
{
  "props": [
    { "name": "disabled", "type": "boolean", "isRequired": false, "typeSource": "typescript" },
    { "name": "href", "type": "string", "isRequired": true, "typeSource": "typescript" },
    { "name": "variant", "type": "\"primary\" | \"secondary\"", "isRequired": true, "typeSource": "typescript" }
  ]
}
```

```ts
await sveld({ json: true, resolveTypes: true });
```

- **`src/resolve-types.ts`** (new) — `TypeResolver` lazily loads the TypeScript 7 native-preview async API and overlays one in-memory virtual module per component, letting the checker enumerate the resolved type's members. Nothing is written to disk.
- **`src/ComponentParser.ts`** — pure `applyResolvedProps` hook merges resolved props additively (author annotations win); no `typescript` load.
- **`src/plugin.ts` / `sveld.ts` / `cli.ts`** — flag wiring and program lifecycle; only opaque components (`canonicalPropsType` set, `props: []`) are targeted, batched into a single snapshot, then disposed.
- **`schema/component-api.schema.json`** + **`README.md`** — documents the expanded shape and the performance tradeoff.

## Design notes

- The default path stays strictly AST-only: `typescript` is reachable only through two lazy `import()`s gated behind `resolveTypes`, so there is no perf regression.
- This repo pins the TS 7 native preview (`tsgo`), which lacks the classic `LanguageService` API; the sync client relies on Node internals unavailable under Bun, so the **async** client/server API is used with a virtual-FS overlay.
- Generated `.d.ts` is unaffected — it always preserves the original type reference.

## Testing

- `tests/resolve-types.test.ts` asserts both the opaque (default) and expanded (opt-in) outputs.
- `bun test`: 471 pass, 0 fail · `tsc --noEmit` clean · `biome lint .` clean