### PR TITLE
feat: support sveld.config.{js,ts,mjs} config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ export default class Button extends SvelteComponentTyped<
   - [Vite](#vite)
   - [Node.js](#nodejs)
   - [CLI](#cli)
+  - [Config File](#config-file)
   - [Publishing to NPM](#publishing-to-npm)
 - [Available Options](#available-options)
 - [JSON Output](#json-output)
@@ -321,6 +322,31 @@ sveld({
   },
 });
 ```
+
+### Config File
+
+Put a `sveld.config.js`, `sveld.config.mjs`, or `sveld.config.ts` at your project root to set defaults for the CLI and the programmatic `sveld()` API.
+
+Import `defineConfig` from `sveld` for typed options. Config files must use ESM syntax (`export default`).
+
+```js
+// sveld.config.js
+import { defineConfig } from "sveld";
+
+export default defineConfig({
+  glob: true,
+  json: true,
+  markdown: true,
+});
+```
+
+Later sources win when options overlap:
+
+CLI flags > config file > `package.json#svelte` inference / defaults
+
+With the config above, `npx sveld --json` keeps `glob` and `markdown` from the file. A CLI flag overrides the same key in the config.
+
+A bad config (syntax error, throws at load time, or no default-export object) fails with an error that names the file.
 
 ### Publishing to NPM
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { rollup } from "rollup";
 import svelte from "rollup-plugin-svelte";
 import { formatDiagnosticsSummary } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
+import { loadConfig, mergeConfig } from "./load-config";
 import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
 
 /** CLI options layered on top of the shared plugin options. */
@@ -48,7 +49,8 @@ export function parseCliOptions(argv: string[]): CliOptions {
 }
 
 /**
- * CLI entry point: parse flags, run Rollup, generate docs, write outputs.
+ * CLI entry point: parse flags, load any config file, run Rollup, generate
+ * docs, write outputs.
  *
  * @example
  * ```ts
@@ -57,9 +59,11 @@ export function parseCliOptions(argv: string[]): CliOptions {
  * ```
  */
 export async function cli(process: NodeJS.Process) {
-  const options = parseCliOptions(process.argv.slice(2));
+  const cliOptions = parseCliOptions(process.argv.slice(2));
+  const fileConfig = await loadConfig();
+  const options = mergeConfig<CliOptions>(fileConfig, cliOptions);
 
-  const input = getSvelteEntry() || "src/index.js";
+  const input = getSvelteEntry(options.entry) || "src/index.js";
   const rollup_bundle = await rollup({
     input,
     plugins: [svelte(), resolve()],

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ export { default as ComponentParser, type SerializedComponentEvent } from "./Com
 export { cli } from "./cli";
 export type { SveldDiagnostic, SveldDiagnosticKind } from "./diagnostics";
 export type { SvelteEntryPoint } from "./get-svelte-entry";
+export { defineConfig, type SveldConfig } from "./load-config";
 export { default } from "./plugin";
 export { sveld } from "./sveld";

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -1,0 +1,99 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { PluginSveldOptions } from "./plugin";
+import { isRecord } from "./validate";
+
+/**
+ * Public shape of a `sveld.config.{js,ts,mjs}` file. Identical to the options
+ * accepted by the Vite/Rollup plugin and the CLI.
+ */
+export type SveldConfig = PluginSveldOptions;
+
+/** Config file names probed at the project root. First existing file wins. */
+export const CONFIG_FILE_NAMES = ["sveld.config.js", "sveld.config.mjs", "sveld.config.ts"] as const;
+
+/**
+ * Identity helper that fully types a `sveld` config object.
+ *
+ * @example
+ * ```ts
+ * // sveld.config.js
+ * import { defineConfig } from "sveld";
+ *
+ * export default defineConfig({
+ *   glob: true,
+ *   json: true,
+ *   markdown: true,
+ * });
+ * ```
+ */
+export function defineConfig(config: SveldConfig): SveldConfig {
+  return config;
+}
+
+/** Locate a `sveld.config.{js,mjs,ts}` file in `cwd`, or `null` if none exists. */
+export function resolveConfigPath(cwd: string = process.cwd()): string | null {
+  for (const name of CONFIG_FILE_NAMES) {
+    const candidate = join(cwd, name);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Load and validate a `sveld` config file by absolute path.
+ *
+ * The package is ESM-only, so the file is loaded via dynamic `import()`. A
+ * cache-busting query is appended so repeated loads (e.g. across tests or
+ * watch runs) reflect the latest contents.
+ *
+ * @throws if the module cannot be imported (e.g. a syntax error or a config
+ * that throws at evaluation time) or if it does not default-export an object.
+ */
+export async function loadConfigFrom(configPath: string): Promise<SveldConfig> {
+  let mod: { default?: unknown };
+
+  try {
+    const href = `${pathToFileURL(configPath).href}?t=${Date.now()}`;
+    mod = await import(href);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`sveld: failed to load config file "${configPath}".\n${message}`);
+  }
+
+  const config = mod.default;
+
+  if (!isRecord(config) || Array.isArray(config)) {
+    throw new Error(
+      `sveld: config file "${configPath}" must export a configuration object as its default export. ` +
+        "Did you forget `export default defineConfig({ ... })`?",
+    );
+  }
+
+  return config as SveldConfig;
+}
+
+/**
+ * Discover and load a `sveld.config.{js,mjs,ts}` file from `cwd`.
+ * Returns an empty object when no config file is present.
+ */
+export async function loadConfig(cwd: string = process.cwd()): Promise<SveldConfig> {
+  const configPath = resolveConfigPath(cwd);
+
+  if (configPath === null) {
+    return {};
+  }
+
+  return loadConfigFrom(configPath);
+}
+
+/** Shallow-merge option sources. Later sources override earlier ones. */
+export function mergeConfig<T extends PluginSveldOptions = PluginSveldOptions>(
+  ...sources: Array<Partial<T> | undefined>
+): Partial<T> {
+  return Object.assign({}, ...sources.filter(Boolean));
+}

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,5 +1,6 @@
 import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
+import { loadConfig, mergeConfig } from "./load-config";
 import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
 
 interface SveldOptions extends Omit<PluginSveldOptions, "entry"> {
@@ -38,16 +39,19 @@ interface SveldResult {
  * ```
  */
 export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
-  const input = getSvelteEntry(opts?.input);
+  const { input: inputOverride, strict, ...runtimeOpts } = opts ?? {};
+  const fileConfig = await loadConfig();
+  const input = getSvelteEntry(inputOverride ?? fileConfig.entry);
   if (input === null) return { diagnostics: [] };
-  const result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
-  writeOutput(result, { ...opts, entry: opts?.input }, input);
+  const merged = mergeConfig<PluginSveldOptions>(fileConfig, runtimeOpts, { entry: input });
+  const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));
+  writeOutput(result, merged, input);
 
   const { diagnostics } = result;
   if (diagnostics.length > 0) {
     console.warn(formatDiagnosticsSummary(diagnostics));
 
-    if (opts?.strict) {
+    if (strict) {
       process.exitCode = 1;
     }
   }

--- a/tests/load-config.test.ts
+++ b/tests/load-config.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { loadConfig, loadConfigFrom, mergeConfig, resolveConfigPath } from "../src/load-config";
+import type { PluginSveldOptions } from "../src/plugin";
+
+function withTempDir(prefix: string, run: (dir: string) => void | Promise<void>) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  try {
+    return run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("resolveConfigPath", () => {
+  test("returns null when no config file exists", () => {
+    withTempDir("sveld-config-resolve-", (dir) => {
+      expect(resolveConfigPath(dir)).toBeNull();
+    });
+  });
+
+  test("discovers a config file at the root", () => {
+    withTempDir("sveld-config-resolve-", (dir) => {
+      const configPath = path.join(dir, "sveld.config.js");
+      writeFileSync(configPath, "export default {};");
+      expect(resolveConfigPath(dir)).toBe(configPath);
+    });
+  });
+
+  test("prefers sveld.config.js over sveld.config.ts", () => {
+    withTempDir("sveld-config-resolve-", (dir) => {
+      writeFileSync(path.join(dir, "sveld.config.ts"), "export default {};");
+      writeFileSync(path.join(dir, "sveld.config.js"), "export default {};");
+      expect(resolveConfigPath(dir)).toBe(path.join(dir, "sveld.config.js"));
+    });
+  });
+});
+
+describe("loadConfig", () => {
+  test("returns an empty object when no config file is present", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      await expect(loadConfig(dir)).resolves.toEqual({});
+    });
+  });
+
+  test("loads the default-exported options object", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      writeFileSync(path.join(dir, "sveld.config.js"), "export default { glob: true, json: true, types: false };");
+      await expect(loadConfig(dir)).resolves.toEqual({ glob: true, json: true, types: false });
+    });
+  });
+
+  test("supports the defineConfig helper", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      const helperPath = path.join(import.meta.dir, "..", "src", "load-config.ts");
+      writeFileSync(
+        path.join(dir, "sveld.config.ts"),
+        `import { defineConfig } from ${JSON.stringify(helperPath)};\n` +
+          "export default defineConfig({ markdown: true });",
+      );
+      await expect(loadConfig(dir)).resolves.toEqual({ markdown: true });
+    });
+  });
+
+  test("throws when the config throws at evaluation time", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      const configPath = path.join(dir, "sveld.config.js");
+      writeFileSync(configPath, "throw new Error('boom');");
+      await expect(loadConfigFrom(configPath)).rejects.toThrow(`sveld: failed to load config file "${configPath}".`);
+      await expect(loadConfigFrom(configPath)).rejects.toThrow("boom");
+    });
+  });
+
+  test("throws when the default export is not an object", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      const configPath = path.join(dir, "sveld.config.js");
+      writeFileSync(configPath, "export default 42;");
+      await expect(loadConfigFrom(configPath)).rejects.toThrow(
+        "must export a configuration object as its default export",
+      );
+    });
+  });
+
+  test("throws when the default export is an array", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      const configPath = path.join(dir, "sveld.config.js");
+      writeFileSync(configPath, "export default [];");
+      await expect(loadConfigFrom(configPath)).rejects.toThrow(
+        "must export a configuration object as its default export",
+      );
+    });
+  });
+
+  test("throws when there is no default export", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      const configPath = path.join(dir, "sveld.config.js");
+      writeFileSync(configPath, "export const glob = true;");
+      await expect(loadConfigFrom(configPath)).rejects.toThrow(
+        "must export a configuration object as its default export",
+      );
+    });
+  });
+});
+
+describe("mergeConfig", () => {
+  test("later sources override earlier ones", () => {
+    const fileConfig: Partial<PluginSveldOptions> = { glob: true, types: false, json: true };
+    expect(mergeConfig(fileConfig, { types: true })).toEqual({
+      glob: true,
+      types: true,
+      json: true,
+    });
+  });
+
+  test("ignores undefined sources", () => {
+    expect(mergeConfig(undefined, { json: true }, undefined)).toEqual({ json: true });
+  });
+
+  test("returns an empty object with no sources", () => {
+    expect(mergeConfig()).toEqual({});
+  });
+
+  test("leaves config keys alone when a later source omits them", () => {
+    expect(mergeConfig({ markdown: true }, {})).toEqual({ markdown: true });
+  });
+});


### PR DESCRIPTION
Lets CLI and multi-tool setups declare options once instead of
repeating them inline or as flags. `defineConfig` types the object;
precedence is CLI flags > config file > `package.json#svelte`.