### PR TITLE
feat: surface `@deprecated` across .d.ts, JSON, and Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ export default class Button extends SvelteComponentTyped<
     - [Extra JSDoc tags before `@slot`](#extra-jsdoc-tags-before-slot)
     - [Svelte 5 Snippet Compatibility](#svelte-5-snippet-compatibility)
   - [@event](#event)
+  - [@deprecated](#deprecated)
   - [Context API](#context-api)
   - [@restProps](#restprops)
   - [@extendProps](#extendprops)
@@ -1393,7 +1394,9 @@ Omit the `slot-name` to type the default slot.
 
 #### Extra JSDoc tags before `@slot`
 
-Tags such as `@example`, `@deprecated`, `@see`, or `@since` that appear after the prose description and before the `@slot` / `@snippet` line are copied into generated `.d.ts` files. The emitted JSDoc above each slot's snippet prop (and the traditional `SlotDefs` shape) lists the description, then those tags in source order. The same entries appear in JSON as `tags: [{ "name", "body" }, ...]`.
+Tags such as `@example`, `@see`, or `@since` that appear after the prose description and before the `@slot` / `@snippet` line are copied into generated `.d.ts` files. The emitted JSDoc above each slot's snippet prop (and the traditional `SlotDefs` shape) lists the description, then those tags in source order. The same entries appear in JSON as `tags: [{ "name", "body" }, ...]`.
+
+`@deprecated` is handled separately from passthrough slot tags. It fills the slot's `deprecated` JSON field, adds a Markdown badge, and emits `@deprecated` in the `.d.ts`. See [@deprecated](#deprecated).
 
 Put `@slot` / `@snippet` last in the block (description, optional extra tags, slot tag). Tags after `@slot` / `@snippet` in the same comment are not tied to that slot. Unknown tag names pass through as-is. Markdown docs render the description and these tags in the slot's **Description** column (newlines and tag boundaries become `<br />`), alongside TypeScript hover and JSON.
 
@@ -1834,6 +1837,53 @@ export default class Component extends SvelteComponentTyped<
 ```
 
 Any free-text prose after the tags is attached to the event description, not to a property doc.
+
+### `@deprecated`
+
+Add `@deprecated` to a prop, event, slot, or exported accessor. An optional message after the tag can explain why or name a replacement.
+
+```svelte
+<script>
+  /**
+   * The visible label.
+   * @deprecated Use the `text` prop instead.
+   */
+  export let label = "";
+
+  /**
+   * Programmatically focus the field.
+   * @deprecated Focus the underlying element directly.
+   */
+  export function focus() {}
+
+  /**
+   * @event {{ value: string }} change
+   * @deprecated Listen for the native `input` event instead.
+   */
+
+  /**
+   * Badge content rendered next to the label.
+   * @deprecated Render the badge inline instead.
+   * @slot {{ count: number }} badge
+   */
+</script>
+```
+
+For slots, put `@deprecated` before the `@slot` / `@snippet` line, alongside the description and any other [extra tags](#extra-jsdoc-tags-before-slot). For events, put it after the `@event` line.
+
+Generated `.d.ts` files include an `@deprecated` JSDoc line so editors strike the symbol through. JSON adds a `deprecated` field (the message string, or `true` when the tag has no message). Markdown strikes through the name and adds a **Deprecated** badge with the message when present.
+
+```ts
+/**
+ * The visible label.
+ * @deprecated Use the `text` prop instead.
+ */
+label?: string;
+```
+
+```json
+{ "name": "label", "deprecated": "Use the `text` prop instead." }
+```
 
 ### Context API
 

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -56,6 +56,10 @@
         "end": { "$ref": "#/$defs/sourcePosition" }
       }
     },
+    "deprecated": {
+      "oneOf": [{ "type": "string" }, { "const": true }],
+      "description": "Author-documented deprecation from `@deprecated`. A string is the message; `true` means the tag had no message."
+    },
     "component": {
       "type": "object",
       "required": [
@@ -156,6 +160,7 @@
           "const": true,
           "description": "Present only when the prop is explicitly declared with Svelte 5 $bindable()."
         },
+        "deprecated": { "$ref": "#/$defs/deprecated" },
         "source": { "$ref": "#/$defs/sourceRange" }
       }
     },
@@ -196,6 +201,7 @@
         "fallback": { "type": "string" },
         "slot_props": { "type": "string" },
         "description": { "type": "string" },
+        "deprecated": { "$ref": "#/$defs/deprecated" },
         "tags": {
           "type": "array",
           "items": { "$ref": "#/$defs/jsdocTag" }
@@ -224,6 +230,7 @@
         "name": { "type": "string" },
         "element": { "type": "string" },
         "description": { "type": "string" },
+        "deprecated": { "$ref": "#/$defs/deprecated" },
         "detail": { "type": "string" },
         "source": { "$ref": "#/$defs/sourceRange" }
       }
@@ -237,6 +244,7 @@
         "name": { "type": "string" },
         "detail": { "type": "string" },
         "description": { "type": "string" },
+        "deprecated": { "$ref": "#/$defs/deprecated" },
         "source": { "$ref": "#/$defs/sourceRange" }
       }
     },

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -116,6 +116,20 @@ function getInlineTagDescription(tagSource: { tokens: { description?: string } }
 }
 
 /**
+ * From `@deprecated` JSDoc: a message string, or `true` when the tag has no message.
+ */
+export type DeprecatedValue = string | true;
+
+function deprecatedValueFromBody(body: string): DeprecatedValue {
+  const message = body.trim();
+  return message === "" ? true : message;
+}
+
+function deprecatedValueFromParts(name: string | undefined, description: string | undefined): DeprecatedValue {
+  return deprecatedValueFromBody(`${name ?? ""}${description ? ` ${description}` : ""}`);
+}
+
+/**
  * Maps ESTree `VariableDeclaration.kind` to `ComponentProp.kind`.
  * `var` becomes `let` for Svelte-oriented output; `using` / `await using`
  * map to `const` (single binding, not a valid Svelte prop keyword).
@@ -362,6 +376,8 @@ interface ComponentProp {
   binding?: ComponentPropBinding;
   /** True when the prop is explicitly declared with Svelte 5 `$bindable()` */
   bindable?: true;
+  /** From `@deprecated` JSDoc. */
+  deprecated?: DeprecatedValue;
   /** Source range for the prop declaration, when available */
   source?: SourceRange;
 }
@@ -487,9 +503,11 @@ interface ComponentSlot {
   slot_props?: string;
   /** Description extracted from JSDoc `@slot` or `@snippet` tags */
   description?: string;
+  /** From `@deprecated` JSDoc. */
+  deprecated?: DeprecatedValue;
   /**
    * JSDoc tags that appeared after the prose description and before `@slot` / `@snippet`
-   * (e.g. `@example`, `@deprecated`), in source order.
+   * (e.g. `@example`), in source order.
    */
   tags?: Array<{ name: string; body: string }>;
   /** Source range for the slot/snippet declaration or documentation tag, when available */
@@ -526,6 +544,8 @@ interface ForwardedEvent {
   element: ComponentInlineElement | ComponentElement;
   /** Description extracted from JSDoc `@event` tags */
   description?: string;
+  /** From `@deprecated` JSDoc. */
+  deprecated?: DeprecatedValue;
   /** The detail type if explicitly specified in `@event` tag */
   detail?: string;
   /** Source range for the forwarded event declaration or documentation tag, when available */
@@ -547,6 +567,8 @@ interface DispatchedEvent {
   detail?: string;
   /** Description extracted from JSDoc `@event` tags */
   description?: string;
+  /** From `@deprecated` JSDoc. */
+  deprecated?: DeprecatedValue;
   /** Source range for the dispatched event call or documentation tag, when available */
   source?: SourceRange;
 }
@@ -581,6 +603,8 @@ export interface SerializedForwardedEvent {
   element: string;
   /** Description extracted from JSDoc `@event` tags */
   description?: string;
+  /** From `@deprecated` JSDoc. */
+  deprecated?: DeprecatedValue;
   /** The detail type if explicitly specified in `@event` tag */
   detail?: string;
   /** Source range for the forwarded event declaration or documentation tag, when available */
@@ -1892,12 +1916,14 @@ export default class ComponentParser {
       "typedef",
       "callback",
       "bindable",
+      "deprecated",
     ]);
 
     let typeTag: (typeof tags)[number] | undefined;
     const paramTags: typeof tags = [];
     let returnsTag: (typeof tags)[number] | undefined;
     let binding: ComponentPropBinding | undefined;
+    let deprecated: DeprecatedValue | undefined;
     const additionalTags: typeof tags = [];
 
     for (const tag of tags) {
@@ -1907,6 +1933,8 @@ export default class ComponentParser {
         paramTags.push(tag);
       } else if (tag.tag === "returns" || tag.tag === "return") {
         returnsTag = tag;
+      } else if (tag.tag === "deprecated") {
+        deprecated ??= deprecatedValueFromParts(tag.name, tag.description);
       } else if (tag.tag === "bindable") {
         if (tag.type) {
           this.logParserWarning(`Ignoring invalid @bindable value "${tag.type} ${tag.name}".`);
@@ -1929,6 +1957,7 @@ export default class ComponentParser {
       param: paramTags,
       returns: returnsTag,
       binding,
+      deprecated,
       additional: additionalTags,
       description: parsed[0]?.description,
     };
@@ -2039,6 +2068,7 @@ export default class ComponentParser {
         returnType?: string;
         description?: string;
         binding?: ComponentPropBinding;
+        deprecated?: DeprecatedValue;
       }
     | undefined {
     if (!leadingComments) return undefined;
@@ -2055,6 +2085,7 @@ export default class ComponentParser {
       param: paramTags,
       returns: returnsTag,
       binding,
+      deprecated,
       additional: additionalTags,
       description: commentDescription,
     } = this.getCommentTags(comment);
@@ -2087,7 +2118,7 @@ export default class ComponentParser {
 
     /**
      * Build description from comment description and non-param/non-type tags.
-     * Additional tags (like `@since`, `@deprecated`) are included in the description
+     * Additional tags (like `@since`) are included in the description
      * as formatted strings to preserve all metadata.
      */
     const formattedDescription = ComponentParser.assignValue(commentDescription?.trim());
@@ -2103,7 +2134,7 @@ export default class ComponentParser {
       description = descriptionParts.join("\n");
     }
 
-    return { type, params, returnType, description, binding };
+    return { type, params, returnType, description, binding, deprecated };
   }
 
   private buildRunesPropTypeMetadata() {
@@ -3011,6 +3042,7 @@ export default class ComponentParser {
           kind: "let",
           description: propertyJSDoc?.description ?? initResult.resolvedDescription,
           binding: propertyJSDoc?.binding,
+          deprecated: propertyJSDoc?.deprecated,
           ...(bindable ? { bindable: true as const } : {}),
           type,
           typeSource,
@@ -3383,6 +3415,7 @@ export default class ComponentParser {
     slot_props,
     slot_fallback,
     slot_description,
+    slot_deprecated,
     slot_tags,
     source,
   }: {
@@ -3390,6 +3423,7 @@ export default class ComponentParser {
     slot_props?: string;
     slot_fallback?: string;
     slot_description?: string;
+    slot_deprecated?: DeprecatedValue;
     slot_tags?: Array<{ name: string; body: string }>;
     source?: SourceRange;
   }) {
@@ -3408,6 +3442,7 @@ export default class ComponentParser {
           fallback,
           slot_props: existing_slot.slot_props === undefined ? props : existing_slot.slot_props,
           description: existing_slot.description || description,
+          deprecated: existing_slot.deprecated ?? slot_deprecated,
           tags: existing_slot.tags || slot_tags,
           source: source || existing_slot.source,
         });
@@ -3419,6 +3454,7 @@ export default class ComponentParser {
         fallback,
         slot_props,
         description,
+        deprecated: slot_deprecated,
         tags: slot_tags,
         source,
       });
@@ -3465,8 +3501,12 @@ export default class ComponentParser {
     detail,
     has_argument,
     description,
+    deprecated,
     source,
-  }: Pick<DispatchedEvent, "name" | "description" | "source"> & { detail: string; has_argument: boolean }) {
+  }: Pick<DispatchedEvent, "name" | "description" | "deprecated" | "source"> & {
+    detail: string;
+    has_argument: boolean;
+  }) {
     if (name === undefined) return;
 
     /**
@@ -3482,6 +3522,7 @@ export default class ComponentParser {
         ...existing_event,
         detail: existing_event.detail === undefined ? default_detail : existing_event.detail,
         description: existing_event.description || event_description,
+        deprecated: existing_event.deprecated ?? deprecated,
         source: source || existing_event.source,
       });
     } else {
@@ -3490,6 +3531,7 @@ export default class ComponentParser {
         name,
         detail: default_detail,
         description: event_description,
+        deprecated,
         source,
       });
     }
@@ -3565,6 +3607,7 @@ export default class ComponentParser {
       let currentEventName: string | undefined;
       let currentEventType: string | undefined;
       let currentEventDescription: string | undefined;
+      let currentEventDeprecated: DeprecatedValue | undefined;
       let currentEventSource: SourceRange | undefined;
       let currentEventTagLine: number | undefined;
       const eventProperties: Array<{
@@ -3603,6 +3646,8 @@ export default class ComponentParser {
       let commentDescriptionUsed = false;
       let isFirstTag = true;
       const pendingTags: Array<{ name: string; body: string }> = [];
+      /** `@deprecated` for the next `@slot` / `@snippet` in this block. */
+      let pendingDeprecated: DeprecatedValue | undefined;
 
       /**
        * Build a map of line numbers to their description content (for lines without tags).
@@ -3824,6 +3869,7 @@ export default class ComponentParser {
             detail: detailType,
             has_argument: false,
             description: currentEventDescription,
+            deprecated: currentEventDeprecated,
             source: currentEventSource,
           });
           this.eventDescriptions.set(currentEventName, currentEventDescription);
@@ -3832,6 +3878,7 @@ export default class ComponentParser {
           currentEventName = undefined;
           currentEventType = undefined;
           currentEventDescription = undefined;
+          currentEventDeprecated = undefined;
           currentEventSource = undefined;
           currentEventTagLine = undefined;
         }
@@ -4032,10 +4079,12 @@ export default class ComponentParser {
               slot_name: name,
               slot_props: type,
               slot_description: slotDesc || undefined,
+              slot_deprecated: pendingDeprecated,
               slot_tags: pendingTags.length > 0 ? [...pendingTags] : undefined,
               source: this.sourceRangeFromCommentTag(blockSource, tagSource, commentBlockStartOffset),
             });
             pendingTags.length = 0;
+            pendingDeprecated = undefined;
             break;
           }
           case "event": {
@@ -4174,6 +4223,15 @@ export default class ComponentParser {
               this.generics = [name, constraint];
             }
             if (isFirstTag) isFirstTag = false;
+            break;
+          }
+          case "deprecated": {
+            const deprecatedValue = deprecatedValueFromParts(name, description);
+            if (currentEventName === undefined) {
+              pendingDeprecated ??= deprecatedValue;
+            } else {
+              currentEventDeprecated ??= deprecatedValue;
+            }
             break;
           }
           case "enum":
@@ -5078,6 +5136,7 @@ export default class ComponentParser {
               name: prop_name,
               kind,
               description,
+              deprecated: jsdocInfo?.deprecated,
               type,
               typeSource,
               value,
@@ -5368,6 +5427,7 @@ export default class ComponentParser {
             kind,
             description,
             binding: jsdocInfo?.binding,
+            deprecated: jsdocInfo?.deprecated,
             type,
             typeSource,
             value,
@@ -5558,6 +5618,7 @@ export default class ComponentParser {
                  * Check if this event has a JSDoc description from `@event` tags.
                  */
                 const event_description = this.eventDescriptions.get(eventHandlerNode.name);
+                const event_deprecated = existing_event?.deprecated;
 
                 if (!existing_event) {
                   /**
@@ -5568,6 +5629,7 @@ export default class ComponentParser {
                     name: eventHandlerNode.name,
                     element: element,
                     description: event_description,
+                    deprecated: event_deprecated,
                     source: this.sourceRangeFromNode(node),
                   });
                 } else if (existing_event.type === "forwarded" && event_description && !existing_event.description) {
@@ -5577,6 +5639,7 @@ export default class ComponentParser {
                   this.events.set(eventHandlerNode.name, {
                     ...existing_event,
                     description: event_description,
+                    deprecated: existing_event.deprecated ?? event_deprecated,
                     source: existing_event.source || this.sourceRangeFromNode(node),
                   });
                 }
@@ -5710,6 +5773,7 @@ export default class ComponentParser {
           name: eventName,
           element: element,
           description: event_description,
+          deprecated: event.deprecated,
           source: event.source,
         };
         /**

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -1,3 +1,4 @@
+import type { DeprecatedValue } from "../ComponentParser";
 import { formatTsProps } from "./writer-ts-definitions-core";
 
 export const BACKTICK_REGEX = /`/g;
@@ -57,6 +58,24 @@ export function formatPropValue(value: string | undefined) {
 }
 
 /**
+ * Strike through deprecated prop, slot, and event names in markdown tables.
+ *
+ * @example
+ * ```ts
+ * formatNameWithDeprecation("size", "use width")
+ * // Returns: "<s>size</s><br />**Deprecated**: use width"
+ * ```
+ */
+export function formatNameWithDeprecation(name: string, deprecated: DeprecatedValue | undefined): string {
+  if (deprecated === undefined) return name;
+  const suffix =
+    typeof deprecated === "string" && deprecated.trim().length > 0
+      ? `: ${escapeHtml(deprecated).replace(NEWLINE_REGEX, " ").replace(PIPE_REGEX, "&#124;")}`
+      : "";
+  return `<s>${name}</s><br />**Deprecated**${suffix}`;
+}
+
+/**
  * Format a prop description; newlines become `<br />`.
  *
  * @example
@@ -107,8 +126,6 @@ export function formatSlotFallback(fallback?: string) {
  * ```ts
  * formatSlotDescription("Header content.", [{ name: "since", body: "1.0.0" }])
  * // Returns: "Header content.<br />@since 1.0.0"
- * formatSlotDescription(undefined, [{ name: "deprecated", body: "" }])
- * // Returns: "@deprecated"
  * formatSlotDescription(undefined, [])
  * // Returns: "--"
  * ```

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -3,6 +3,7 @@ import type { AppendType } from "./MarkdownWriterBase";
 import {
   EVENT_TABLE_HEADER,
   formatEventDetail,
+  formatNameWithDeprecation,
   formatPropDescription,
   formatPropType,
   formatPropValue,
@@ -72,7 +73,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
     for (const prop of sortedProps) {
       document.append(
         "raw",
-        `| ${prop.name} | ${prop.isRequired ? "Yes" : "No"} | ${`<code>${prop.kind}</code>`} | ${
+        `| ${formatNameWithDeprecation(prop.name, prop.deprecated)} | ${prop.isRequired ? "Yes" : "No"} | ${`<code>${prop.kind}</code>`} | ${
           prop.reactive ? "Yes" : "No"
         } | ${prop.binding ?? "--"} | ${formatPropType(prop.type)} | ${formatPropValue(prop.value)} | ${formatPropDescription(
           prop.description,
@@ -87,7 +88,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
     for (const slot of component.slots) {
       document.append(
         "raw",
-        `| ${slot.default ? MD_TYPE_UNDEFINED : slot.name} | ${slot.default ? "Yes" : "No"} | ${formatSlotProps(
+        `| ${formatNameWithDeprecation(slot.default ? MD_TYPE_UNDEFINED : (slot.name ?? MD_TYPE_UNDEFINED), slot.deprecated)} | ${slot.default ? "Yes" : "No"} | ${formatSlotProps(
           slot.slot_props,
         )} | ${formatSlotFallback(slot.fallback)} | ${formatSlotDescription(slot.description, slot.tags)} |\n`,
       );
@@ -100,7 +101,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
     for (const event of component.events) {
       document.append(
         "raw",
-        `| ${event.name} | ${event.type} | ${
+        `| ${formatNameWithDeprecation(event.name, event.deprecated)} | ${event.type} | ${
           event.type === "dispatched" ? formatEventDetail(event.detail) : MD_TYPE_UNDEFINED
         } | ${formatPropDescription(event.description)} |\n`,
       );

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -1,4 +1,4 @@
-import { getParsedComponentTypeScriptMetadata } from "../ComponentParser";
+import { type DeprecatedValue, getParsedComponentTypeScriptMetadata } from "../ComponentParser";
 import type { ComponentDocApi } from "../plugin";
 
 const ANY_TYPE = "any";
@@ -57,13 +57,35 @@ function formatMultiLineComment(description: string | undefined): string {
   return `/**\n * ${description.replace(NEWLINE_TO_COMMENT_REGEX, "\n * ")}\n */`;
 }
 
+/**
+ * Builds the `@deprecated` JSDoc line(s) for a symbol, or undefined when the
+ * symbol is not deprecated. `true` emits a bare `@deprecated`; a string appends
+ * the message.
+ */
+function formatDeprecatedJsDocLine(deprecated: DeprecatedValue | undefined): string | undefined {
+  if (deprecated === undefined) return undefined;
+  return deprecated === true ? "@deprecated" : `@deprecated ${deprecated}`;
+}
+
+/**
+ * Builds a `* @deprecated ...\n` comment fragment for `wrapCommentInJSDoc`, or
+ * undefined when the symbol is not deprecated.
+ */
+function deprecatedCommentLine(deprecated: DeprecatedValue | undefined): string | undefined {
+  const line = formatDeprecatedJsDocLine(deprecated);
+  if (line === undefined) return undefined;
+  return `* ${line.replace(NEWLINE_TO_COMMENT_REGEX, "\n* ")}\n`;
+}
+
 function formatSlotJsDoc(
   description: string | undefined,
   tags: Array<{ name: string; body: string }> | undefined,
+  deprecated?: DeprecatedValue,
 ): string {
+  const deprecatedLine = formatDeprecatedJsDocLine(deprecated);
   const hasTags = tags && tags.length > 0;
-  if (!description && !hasTags) return "";
-  if (!hasTags) {
+  if (!description && !hasTags && !deprecatedLine) return "";
+  if (!hasTags && !deprecatedLine) {
     return description?.includes("\n") ? formatMultiLineComment(description) : formatSingleLineComment(description);
   }
   const lines: string[] = [];
@@ -77,6 +99,7 @@ function formatSlotJsDoc(
       lines.push(`@${name} ${body}`);
     }
   }
+  if (deprecatedLine) lines.push(...deprecatedLine.split("\n"));
   return `/**\n * ${lines.join("\n * ")}\n */`;
 }
 
@@ -220,10 +243,12 @@ function addCommentLine(value: string | boolean | undefined, returnValue?: strin
 }
 
 /**
- * Creates a prop comment string from a description.
+ * Creates a prop comment string from a description and optional deprecation.
  */
-function createPropComment(description: string | undefined): string {
-  return [addCommentLine(formatDescriptionForComment(description))].filter(Boolean).join("");
+function createPropComment(description: string | undefined, deprecated?: DeprecatedValue): string {
+  return [addCommentLine(formatDescriptionForComment(description)), deprecatedCommentLine(deprecated)]
+    .filter(Boolean)
+    .join("");
 }
 
 /**
@@ -291,6 +316,7 @@ function genPropDef(
 
       const prop_comments = [
         addCommentLine(formatDescriptionForComment(prop.description)),
+        deprecatedCommentLine(prop.deprecated),
         addCommentLine(prop.constant, "@constant"),
         /**
          * Don't add @default for functions - they don't have meaningful default values.
@@ -329,7 +355,7 @@ function genPropDef(
     .map((slot) => {
       const slotName = slot.name;
       const key = clampKey(slotName);
-      const slotComment = formatSlotJsDoc(slot.description, slot.tags);
+      const slotComment = formatSlotJsDoc(slot.description, slot.tags, slot.deprecated);
       const description = slotComment ? `${slotComment}\n      ` : "";
       /**
        * Use Snippet-compatible type: (this: void, ...args: [Props]) => void for slots with props
@@ -350,7 +376,11 @@ function genPropDef(
   const children_snippet_prop =
     default_slot && !existingPropNames.has("children")
       ? (() => {
-          const defaultSlotComment = formatSlotJsDoc(default_slot.description, default_slot.tags);
+          const defaultSlotComment = formatSlotJsDoc(
+            default_slot.description,
+            default_slot.tags,
+            default_slot.deprecated,
+          );
           const description = defaultSlotComment ? `${defaultSlotComment}\n      ` : "";
           const hasSlotProps = default_slot.slot_props && default_slot.slot_props !== "Record<string, never>";
           const snippetType = hasSlotProps
@@ -529,7 +559,7 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
   const slotDefs = def.slots
     .map(({ name, slot_props, ...rest }) => {
       const key = rest.default || name === null ? "default" : clampKey(name ?? "");
-      const slotDefComment = formatSlotJsDoc(rest.description, rest.tags);
+      const slotDefComment = formatSlotJsDoc(rest.description, rest.tags, rest.deprecated);
       const description = slotDefComment ? `${slotDefComment}\n` : "";
       return `${description}${clampKey(key)}: ${formatTsProps(slot_props)};`;
     })
@@ -692,7 +722,9 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
   const events_map = def.events
     .map((event) => {
       let description = "";
-      if (event.description) {
+      if (event.deprecated !== undefined) {
+        description = `${wrapCommentInJSDoc(createPropComment(event.description, event.deprecated))}\n`;
+      } else if (event.description) {
         description = `${formatSingleLineComment(event.description)}\n`;
       }
 
@@ -778,7 +810,7 @@ function genAccessors(def: Pick<ComponentDocApi, "props">) {
   return def.props
     .filter((prop) => prop.isFunctionDeclaration || prop.kind === "const")
     .map((prop) => {
-      const prop_comments = createPropComment(prop.description);
+      const prop_comments = createPropComment(prop.description, prop.deprecated);
 
       const functionType = generateFunctionType(prop);
 
@@ -808,7 +840,7 @@ function genComponentComment(def: Pick<ComponentDocApi, "componentComment">) {
 function genModuleExports(def: Pick<ComponentDocApi, "moduleExports">) {
   return def.moduleExports
     .map((prop) => {
-      const prop_comments = createPropComment(prop.description);
+      const prop_comments = createPropComment(prop.description, prop.deprecated);
 
       let type_def: string;
 

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -194,4 +194,73 @@ describe("WriterMarkdown", () => {
     );
     expect(output).toContain("| footer | No | -- | -- | -- |");
   });
+
+  test("badges deprecated props, events, and slots", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [
+              {
+                name: "label",
+                kind: "let",
+                constant: false,
+                description: "Label text.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+                deprecated: "Use `text` instead.",
+              },
+              {
+                name: "id",
+                kind: "let",
+                constant: false,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+                deprecated: true,
+              },
+            ],
+            moduleExports: [],
+            slots: [
+              {
+                name: "badge",
+                default: false,
+                deprecated: "Render the badge inline instead.",
+              },
+            ],
+            events: [
+              {
+                type: "dispatched",
+                name: "change",
+                description: "Fires on change.",
+                deprecated: "Listen for `input` instead.",
+              },
+            ],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    // Deprecated entries are struck through and badged with the message.
+    expect(output).toContain(
+      "| <s>label</s><br />**Deprecated**: Use `text` instead. | No | <code>let</code> | No | -- | -- | -- | Label text. |",
+    );
+    // A bare `@deprecated` (no message) still badges, without a trailing message.
+    expect(output).toContain("| <s>id</s><br />**Deprecated** | No | <code>let</code> | No | -- | -- | -- | -- |");
+    expect(output).toContain("| <s>badge</s><br />**Deprecated**: Render the badge inline instead. | No |");
+    expect(output).toContain(
+      "| <s>change</s><br />**Deprecated**: Listen for `input` instead. | dispatched | -- | Fires on change. |",
+    );
+  });
 });

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -6129,6 +6129,149 @@ exports[`fixtures (JSON) "context-colon/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "deprecated-tags/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 46,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "The visible label.",
+      "deprecated": "Use the \`text\` prop instead.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"\\"",
+      "defaultValue": {
+        "raw": "\\"\\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 24
+        }
+      }
+    },
+    {
+      "name": "id",
+      "kind": "let",
+      "deprecated": true,
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"\\"",
+      "defaultValue": {
+        "raw": "\\"\\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 2
+        },
+        "end": {
+          "line": 15,
+          "column": 21
+        }
+      }
+    },
+    {
+      "name": "focus",
+      "kind": "function",
+      "description": "Programmatically focus the field.",
+      "deprecated": "Focus the underlying element directly.",
+      "type": "() => any",
+      "typeSource": "inferred",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 2
+        },
+        "end": {
+          "line": 21,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "badge",
+      "default": false,
+      "slot_props": "{ count: number }",
+      "description": "Badge content rendered next to the label.",
+      "deprecated": "Render the badge inline instead.",
+      "source": {
+        "start": {
+          "line": 41,
+          "column": 2
+        },
+        "end": {
+          "line": 44,
+          "column": 4
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "change",
+      "detail": "{ value: string }",
+      "description": "Fired when the value changes.",
+      "deprecated": "Listen for the native \`input\` event instead.",
+      "source": {
+        "start": {
+          "line": 35,
+          "column": 4
+        },
+        "end": {
+          "line": 35,
+          "column": 40
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "forwarded-events-typed/input.svelte" 1`] = `
 "{
   "source": {
@@ -8437,7 +8580,8 @@ exports[`fixtures (JSON) "prop-comments/input.svelte" 1`] = `
     {
       "name": "prop",
       "kind": "let",
-      "description": "This is a comment.\\n@see https://github.com/\\n@deprecated this prop will be removed in the next major release.",
+      "description": "This is a comment.\\n@see https://github.com/",
+      "deprecated": "this prop will be removed in the next major release.",
       "type": "boolean | string",
       "typeSource": "jsdoc",
       "value": "true",
@@ -10923,14 +11067,11 @@ exports[`fixtures (JSON) "slot-jsdoc-multiple-tags/input.svelte" 1`] = `
       "default": true,
       "slot_props": "{ props?: { \\"aria-current\\"?: string; class: \\"bx--link\\" } }",
       "description": "Spread \`props\` onto a custom element to inherit the link class\\nand \`aria-current\` attribute when \`isCurrentPage\` is set.",
+      "deprecated": "Prefer the \`link\` snippet.",
       "tags": [
         {
           "name": "example",
           "body": " \`\`\`svelte\\n <BreadcrumbItem let:props>\\n   <a {...props} href=\\"/\\">Home</a>\\n </BreadcrumbItem>\\n \`\`\`"
-        },
-        {
-          "name": "deprecated",
-          "body": "Prefer the \`link\` snippet."
         }
       ],
       "source": {
@@ -14330,12 +14471,7 @@ exports[`fixtures (JSON) "slot-jsdoc-tags-named-pair/input.svelte" 1`] = `
       "default": false,
       "slot_props": "{ message: string }",
       "description": "Status text for live regions; prefer \`aria-current=\\"page\\"\` on the active link.",
-      "tags": [
-        {
-          "name": "deprecated",
-          "body": "Use the \`live\` region pattern instead."
-        }
-      ],
+      "deprecated": "Use the \`live\` region pattern instead.",
       "source": {
         "start": {
           "line": 21,
@@ -16728,6 +16864,56 @@ export default class ContextColon extends SvelteComponentTyped<
   Record<string, any>,
   Record<string, never>
 > {}
+"
+`;
+
+exports[`fixtures (TypeScript) "deprecated-tags/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DeprecatedTagsProps = {
+  /**
+   * The visible label.
+   * @deprecated Use the \`text\` prop instead.
+   * @default ""
+   */
+  label?: string;
+
+  /**
+   * @deprecated
+   * @default ""
+   */
+  id?: string;
+
+  /**
+   * Badge content rendered next to the label.
+   * @deprecated Render the badge inline instead.
+   */
+  badge?: (this: void, ...args: [{ count: number }]) => void;
+};
+
+export default class DeprecatedTags extends SvelteComponentTyped<
+  DeprecatedTagsProps,
+  {
+    /**
+     * Fired when the value changes.
+     * @deprecated Listen for the native \`input\` event instead.
+     */
+    change: CustomEvent<{ value: string }>;
+  },
+  {
+    /**
+     * Badge content rendered next to the label.
+     * @deprecated Render the badge inline instead.
+     */
+    badge: { count: number };
+  }
+> {
+  /**
+   * Programmatically focus the field.
+   * @deprecated Focus the underlying element directly.
+   */
+  focus: () => any;
+}
 "
 `;
 

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -100,6 +100,44 @@ describe("component API JSON schema", () => {
     expect(objectProperty(propProperties, "defaultValue")).toMatchObject({ $ref: "#/$defs/defaultValue" });
   });
 
+  test("documents @deprecated across props, slots, and events", () => {
+    const schema = readJson("schema/component-api.schema.json");
+    const defs = objectProperty(schema, "$defs");
+
+    expect(objectProperty(defs, "deprecated")).toMatchObject({
+      oneOf: [{ type: "string" }, { const: true }],
+    });
+
+    for (const def of ["prop", "slot", "dispatchedEvent", "forwardedEvent"]) {
+      const properties = objectProperty(objectProperty(defs, def), "properties");
+      expect(objectProperty(properties, "deprecated")).toMatchObject({ $ref: "#/$defs/deprecated" });
+    }
+  });
+
+  test("represents @deprecated in focused fixture output", () => {
+    const focused = readJson("tests/fixtures/deprecated-tags/output.json");
+
+    const props = arrayProperty(focused, "props");
+    expect(findObjectByProperty(props, "name", "label")).toMatchObject({
+      deprecated: "Use the `text` prop instead.",
+    });
+    // A bare `@deprecated` is represented as `true`.
+    expect(findObjectByProperty(props, "name", "id")).toMatchObject({ deprecated: true });
+    expect(findObjectByProperty(props, "name", "focus")).toMatchObject({
+      deprecated: "Focus the underlying element directly.",
+    });
+
+    const slots = arrayProperty(focused, "slots");
+    expect(findObjectByProperty(slots, "name", "badge")).toMatchObject({
+      deprecated: "Render the badge inline instead.",
+    });
+
+    const events = arrayProperty(focused, "events");
+    expect(findObjectByProperty(events, "name", "change")).toMatchObject({
+      deprecated: "Listen for the native `input` event instead.",
+    });
+  });
+
   test("keeps representative combined output and focused fixture coverage", () => {
     const api = readJson("tests/e2e/svelte5-runes/COMPONENT_API.json");
 

--- a/tests/fixtures/deprecated-tags/input.svelte
+++ b/tests/fixtures/deprecated-tags/input.svelte
@@ -1,0 +1,45 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  /**
+   * The visible label.
+   * @deprecated Use the `text` prop instead.
+   */
+  export let label = "";
+
+  /**
+   * @deprecated
+   */
+  export let id = "";
+
+  /**
+   * Programmatically focus the field.
+   * @deprecated Focus the underlying element directly.
+   */
+  export function focus() {}
+
+  /**
+   * Fired when the value changes.
+   * @event {{ value: string }} change
+   * @deprecated Listen for the native `input` event instead.
+   */
+
+  /**
+   * Badge content rendered next to the label.
+   * @deprecated Render the badge inline instead.
+   * @slot {{ count: number }} badge
+   */
+  function dispatchChange() {
+    dispatch("change", { value: label });
+  }
+</script>
+
+<button on:click={dispatchChange}>
+  {label}
+  <slot
+    name="badge"
+    count={0}
+  />
+</button>

--- a/tests/fixtures/deprecated-tags/output.d.ts
+++ b/tests/fixtures/deprecated-tags/output.d.ts
@@ -1,0 +1,46 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DeprecatedTagsProps = {
+  /**
+   * The visible label.
+   * @deprecated Use the `text` prop instead.
+   * @default ""
+   */
+  label?: string;
+
+  /**
+   * @deprecated
+   * @default ""
+   */
+  id?: string;
+
+  /**
+   * Badge content rendered next to the label.
+   * @deprecated Render the badge inline instead.
+   */
+  badge?: (this: void, ...args: [{ count: number }]) => void;
+};
+
+export default class DeprecatedTags extends SvelteComponentTyped<
+  DeprecatedTagsProps,
+  {
+    /**
+     * Fired when the value changes.
+     * @deprecated Listen for the native `input` event instead.
+     */
+    change: CustomEvent<{ value: string }>;
+  },
+  {
+    /**
+     * Badge content rendered next to the label.
+     * @deprecated Render the badge inline instead.
+     */
+    badge: { count: number };
+  }
+> {
+  /**
+   * Programmatically focus the field.
+   * @deprecated Focus the underlying element directly.
+   */
+  focus: () => any;
+}

--- a/tests/fixtures/deprecated-tags/output.json
+++ b/tests/fixtures/deprecated-tags/output.json
@@ -1,0 +1,139 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 46,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "The visible label.",
+      "deprecated": "Use the `text` prop instead.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"\"",
+      "defaultValue": {
+        "raw": "\"\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 24
+        }
+      }
+    },
+    {
+      "name": "id",
+      "kind": "let",
+      "deprecated": true,
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"\"",
+      "defaultValue": {
+        "raw": "\"\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 2
+        },
+        "end": {
+          "line": 15,
+          "column": 21
+        }
+      }
+    },
+    {
+      "name": "focus",
+      "kind": "function",
+      "description": "Programmatically focus the field.",
+      "deprecated": "Focus the underlying element directly.",
+      "type": "() => any",
+      "typeSource": "inferred",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 2
+        },
+        "end": {
+          "line": 21,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "badge",
+      "default": false,
+      "slot_props": "{ count: number }",
+      "description": "Badge content rendered next to the label.",
+      "deprecated": "Render the badge inline instead.",
+      "source": {
+        "start": {
+          "line": 41,
+          "column": 2
+        },
+        "end": {
+          "line": 44,
+          "column": 4
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "change",
+      "detail": "{ value: string }",
+      "description": "Fired when the value changes.",
+      "deprecated": "Listen for the native `input` event instead.",
+      "source": {
+        "start": {
+          "line": 35,
+          "column": 4
+        },
+        "end": {
+          "line": 35,
+          "column": 40
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -15,7 +15,8 @@
     {
       "name": "prop",
       "kind": "let",
-      "description": "This is a comment.\n@see https://github.com/\n@deprecated this prop will be removed in the next major release.",
+      "description": "This is a comment.\n@see https://github.com/",
+      "deprecated": "this prop will be removed in the next major release.",
       "type": "boolean | string",
       "typeSource": "jsdoc",
       "value": "true",

--- a/tests/fixtures/slot-jsdoc-multiple-tags/output.json
+++ b/tests/fixtures/slot-jsdoc-multiple-tags/output.json
@@ -19,14 +19,11 @@
       "default": true,
       "slot_props": "{ props?: { \"aria-current\"?: string; class: \"bx--link\" } }",
       "description": "Spread `props` onto a custom element to inherit the link class\nand `aria-current` attribute when `isCurrentPage` is set.",
+      "deprecated": "Prefer the `link` snippet.",
       "tags": [
         {
           "name": "example",
           "body": " ```svelte\n <BreadcrumbItem let:props>\n   <a {...props} href=\"/\">Home</a>\n </BreadcrumbItem>\n ```"
-        },
-        {
-          "name": "deprecated",
-          "body": "Prefer the `link` snippet."
         }
       ],
       "source": {

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
@@ -41,12 +41,7 @@
       "default": false,
       "slot_props": "{ message: string }",
       "description": "Status text for live regions; prefer `aria-current=\"page\"` on the active link.",
-      "tags": [
-        {
-          "name": "deprecated",
-          "body": "Use the `live` region pattern instead."
-        }
-      ],
+      "deprecated": "Use the `live` region pattern instead.",
       "source": {
         "start": {
           "line": 21,


### PR DESCRIPTION
Promote JSDoc `@deprecated` from a slot-only passthrough tag to a first-class `deprecated` field on props, events, slots, and accessors so consumers get IDE strike-through, a queryable JSON field, and MD badges.