### PR TITLE
feat(markdown): add frontmatter, ToC, anchors, and split mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,45 @@ sveld({
 });
 ```
 
+#### `markdownOptions.split`
+
+With `markdown: true`, `sveld` writes a single `COMPONENT_INDEX.md` at the project root that documents all components.
+
+Enable `markdownOptions.split` to instead emit one Markdown file per component. Use `markdownOptions.outDir` to set the destination folder (defaults to `docs`).
+
+```js
+sveld({
+  markdown: true,
+  markdownOptions: {
+    // an individual Markdown file will be generated for each component
+    // e.g. "docs/Button.md"
+    split: true,
+    outDir: "docs",
+  },
+});
+```
+
+#### `markdownOptions.frontmatter`, `toc`, and `anchors`
+
+The following options are opt-in and can be combined with either single-file or `split` mode:
+
+- **`frontmatter`** (boolean): Emit YAML frontmatter (`name`, and `since`/`deprecated` parsed from the `@component` comment) at the top of each generated file. Only applies in `split` mode, where each file maps to one component.
+- **`toc`** (boolean): Emit a per-component table of contents linking to each section (Types, Props, Slots, Events).
+- **`anchors`** (boolean): Emit stable, slugified HTML anchors before each component and section heading so fragment links resolve consistently across Markdown renderers.
+
+```js
+sveld({
+  markdown: true,
+  markdownOptions: {
+    split: true,
+    outDir: "docs",
+    frontmatter: true,
+    toc: true,
+    anchors: true,
+  },
+});
+```
+
 ### Publishing to NPM
 
 TypeScript definitions land in the `types` folder by default. Include that folder in `package.json` when you publish to npm.
@@ -350,7 +389,7 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 - **`json`** (boolean, optional): Generate component documentation in JSON format.
 - **`jsonOptions`** (object, optional): Options for JSON output.
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.
-- **`markdownOptions`** (object, optional): Options for Markdown output.
+- **`markdownOptions`** (object, optional): Options for Markdown output, including `split`, `outDir`, `frontmatter`, `toc`, and `anchors`.
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
 

--- a/src/writer/MarkdownWriterBase.ts
+++ b/src/writer/MarkdownWriterBase.ts
@@ -1,4 +1,4 @@
-import { BACKTICK_REGEX, WHITESPACE_REGEX } from "./markdown-format-utils";
+import { slugify } from "./markdown-format-utils";
 
 export type AppendType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "quote" | "p" | "divider" | "raw";
 
@@ -83,7 +83,7 @@ export class MarkdownWriterBaseImpl implements MarkdownWriterBase {
       "<!-- __TOC__ -->",
       this.toc
         .map(({ array, raw }) => {
-          return `${array.join(" ")} - [${raw}](#${raw.toLowerCase().replace(BACKTICK_REGEX, "").replace(WHITESPACE_REGEX, "-")})`;
+          return `${array.join(" ")} - [${raw}](#${slugify(raw)})`;
         })
         .join("\n"),
     );

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -6,6 +6,23 @@ export const WHITESPACE_REGEX = /\s+/g;
 
 export const MD_TYPE_UNDEFINED = "--";
 
+/**
+ * Slugify heading text into a stable anchor fragment.
+ *
+ * Lowercases the text, strips backticks, and collapses whitespace runs
+ * into single hyphens. Used both for the global table of contents and for
+ * per-heading anchors so links resolve consistently.
+ *
+ * @example
+ * ```ts
+ * slugify("`Button`")   // Returns: "button"
+ * slugify("Props list") // Returns: "props-list"
+ * ```
+ */
+export function slugify(raw: string): string {
+  return raw.toLowerCase().replace(BACKTICK_REGEX, "").replace(WHITESPACE_REGEX, "-");
+}
+
 export const PROP_TABLE_HEADER =
   "| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |\n| :- | :- | :- | :- | :- | :- | :- | :- |\n";
 export const SLOT_TABLE_HEADER =

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -13,6 +13,7 @@ import {
   MD_TYPE_UNDEFINED,
   PROP_TABLE_HEADER,
   SLOT_TABLE_HEADER,
+  slugify,
 } from "./markdown-format-utils";
 import { getTypeDefs } from "./writer-ts-definitions-core";
 
@@ -22,7 +23,85 @@ interface MarkdownDocument {
   tableOfContents(): MarkdownDocument;
 }
 
-export function renderComponentsToMarkdown(document: MarkdownDocument, components: ComponentDocs) {
+/**
+ * Opt-in enhancements for doc-site consumption.
+ *
+ * All options default to `false` so that the single-file output remains
+ * byte-stable unless a caller explicitly turns a feature on.
+ */
+export interface MarkdownRenderOptions {
+  /** Emit YAML frontmatter (name, since, deprecated). Applies to split files. */
+  frontmatter?: boolean;
+  /** Emit a per-component table of contents linking to each section. */
+  toc?: boolean;
+  /** Emit stable, slugified heading anchors before each component heading. */
+  anchors?: boolean;
+}
+
+const SINCE_REGEX = /@since\s+(\S+)/;
+const DEPRECATED_REGEX = /@deprecated\b[ \t]*([^\n]*)/;
+
+interface ComponentMeta {
+  since?: string;
+  deprecated?: string | true;
+}
+
+/**
+ * Extract `@since` and `@deprecated` metadata from a component's `@component`
+ * comment. `@deprecated` resolves to the trailing reason text when present,
+ * otherwise `true`.
+ */
+function extractComponentMeta(component: ComponentDocApi): ComponentMeta {
+  const comment = component.componentComment ?? "";
+  const meta: ComponentMeta = {};
+
+  const since = comment.match(SINCE_REGEX)?.[1];
+  if (since) meta.since = since;
+
+  const deprecated = comment.match(DEPRECATED_REGEX);
+  if (deprecated) {
+    const reason = deprecated[1].trim();
+    meta.deprecated = reason.length > 0 ? reason : true;
+  }
+
+  return meta;
+}
+
+/** Render a YAML frontmatter block describing the component. */
+function renderFrontmatter(document: MarkdownDocument, component: ComponentDocApi) {
+  const { since, deprecated } = extractComponentMeta(component);
+  const lines = [`name: ${JSON.stringify(component.moduleName)}`];
+
+  if (since) lines.push(`since: ${JSON.stringify(since)}`);
+  if (deprecated !== undefined) {
+    lines.push(typeof deprecated === "string" ? `deprecated: ${JSON.stringify(deprecated)}` : "deprecated: true");
+  }
+
+  document.append("raw", `---\n${lines.join("\n")}\n---\n\n`);
+}
+
+/**
+ * Append a heading, optionally preceded by a stable HTML anchor.
+ *
+ * The explicit `<a id>` anchor keeps fragment links stable across markdown
+ * renderers (some derive ids from heading text, some do not).
+ */
+function appendHeading(
+  document: MarkdownDocument,
+  type: AppendType,
+  text: string,
+  slug: string,
+  options: MarkdownRenderOptions,
+) {
+  if (options.anchors) document.append("raw", `<a id="${slug}"></a>\n\n`);
+  document.append(type, text);
+}
+
+export function renderComponentsToMarkdown(
+  document: MarkdownDocument,
+  components: ComponentDocs,
+  options: MarkdownRenderOptions = {},
+) {
   document.append("h1", "Component Index");
   document.append("h2", "Components").tableOfContents();
   document.append("divider");
@@ -33,8 +112,24 @@ export function renderComponentsToMarkdown(document: MarkdownDocument, component
     const component = components.get(key);
     if (!component) continue;
 
-    renderComponent(document, component);
+    renderComponent(document, component, options);
   }
+}
+
+/**
+ * Render a single component as a standalone document (used by split mode).
+ *
+ * Emits optional frontmatter at the top of the file followed by the component
+ * body. Frontmatter is only meaningful at the top of a file, which is why it
+ * lives here rather than in {@link renderComponentsToMarkdown}.
+ */
+export function renderComponentFile(
+  document: MarkdownDocument,
+  component: ComponentDocApi,
+  options: MarkdownRenderOptions = {},
+) {
+  if (options.frontmatter) renderFrontmatter(document, component);
+  renderComponent(document, component, options);
 }
 
 function renderSectionIfNotEmpty<TItem>(
@@ -50,11 +145,28 @@ function renderSectionIfNotEmpty<TItem>(
   }
 }
 
-function renderComponent(document: MarkdownDocument, component: ComponentDocApi) {
-  document.append("h2", `\`${component.moduleName}\``);
+/** Render the per-component table of contents linking to each section anchor. */
+function renderComponentToc(document: MarkdownDocument, sections: string[], slugBase: string) {
+  for (const section of sections) {
+    document.append("raw", `- [${section}](#${slugBase}-${slugify(section)})\n`);
+  }
+  document.append("raw", "\n");
+}
 
-  if (component.typedefs.length > 0) {
-    document.append("h3", "Types").append(
+function renderComponent(document: MarkdownDocument, component: ComponentDocApi, options: MarkdownRenderOptions = {}) {
+  const slugBase = slugify(component.moduleName);
+  const hasTypes = component.typedefs.length > 0;
+
+  appendHeading(document, "h2", `\`${component.moduleName}\``, slugBase, options);
+
+  if (options.toc) {
+    const sections = [...(hasTypes ? ["Types"] : []), "Props", "Slots", "Events"];
+    renderComponentToc(document, sections, slugBase);
+  }
+
+  if (hasTypes) {
+    appendHeading(document, "h3", "Types", `${slugBase}-types`, options);
+    document.append(
       "raw",
       `\`\`\`ts\n${getTypeDefs({
         typedefs: component.typedefs,
@@ -62,7 +174,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
     );
   }
 
-  document.append("h3", "Props");
+  appendHeading(document, "h3", "Props", `${slugBase}-props`, options);
   renderSectionIfNotEmpty(document, component.props, () => {
     document.append("raw", PROP_TABLE_HEADER);
     const sortedProps = [...component.props].sort((a) => {
@@ -82,7 +194,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
     }
   });
 
-  document.append("h3", "Slots");
+  appendHeading(document, "h3", "Slots", `${slugBase}-slots`, options);
   renderSectionIfNotEmpty(document, component.slots, () => {
     document.append("raw", SLOT_TABLE_HEADER);
     for (const slot of component.slots) {
@@ -95,7 +207,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
     }
   });
 
-  document.append("h3", "Events");
+  appendHeading(document, "h3", "Events", `${slugBase}-events`, options);
   renderSectionIfNotEmpty(document, component.events, () => {
     document.append("raw", EVENT_TABLE_HEADER);
     for (const event of component.events) {

--- a/src/writer/writer-markdown-core.ts
+++ b/src/writer/writer-markdown-core.ts
@@ -1,8 +1,8 @@
 import type { ComponentDocs } from "../plugin";
 import { type AppendType, MarkdownWriterBaseImpl } from "./MarkdownWriterBase";
-import { renderComponentsToMarkdown } from "./markdown-render-utils";
+import { type MarkdownRenderOptions, renderComponentFile, renderComponentsToMarkdown } from "./markdown-render-utils";
 
-export type { AppendType };
+export type { AppendType, MarkdownRenderOptions };
 
 type OnAppend = (type: AppendType, document: BrowserWriterMarkdown) => void;
 
@@ -41,7 +41,7 @@ export class BrowserWriterMarkdown extends MarkdownWriterBaseImpl {
   }
 }
 
-export interface WriteMarkdownCoreOptions {
+export interface WriteMarkdownCoreOptions extends MarkdownRenderOptions {
   onAppend?: (type: AppendType, document: BrowserWriterMarkdown, components: ComponentDocs) => void;
 }
 
@@ -52,7 +52,36 @@ export function writeMarkdownCore(components: ComponentDocs, options?: WriteMark
     },
   });
 
-  renderComponentsToMarkdown(document, components);
+  renderComponentsToMarkdown(document, components, options);
 
   return document.end();
+}
+
+/**
+ * Render one markdown document per component.
+ *
+ * Browser-safe counterpart to split mode: returns a map of module name to
+ * rendered markdown without touching the file system. Components are sorted by
+ * module name to match the single-file ordering.
+ *
+ * @example
+ * ```ts
+ * const files = splitMarkdownCore(components, { frontmatter: true });
+ * files.get("Button"); // "---\nname: \"Button\"\n---\n\n## `Button`\n\n..."
+ * ```
+ */
+export function splitMarkdownCore(components: ComponentDocs, options?: MarkdownRenderOptions): Map<string, string> {
+  const files = new Map<string, string>();
+  const keys = Array.from(components.keys()).sort();
+
+  for (const key of keys) {
+    const component = components.get(key);
+    if (!component) continue;
+
+    const document = new BrowserWriterMarkdown({});
+    renderComponentFile(document, component, options);
+    files.set(component.moduleName, document.end());
+  }
+
+  return files;
 }

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -1,16 +1,67 @@
 import { join } from "node:path";
 import type { ComponentDocs } from "../plugin";
-import { renderComponentsToMarkdown } from "./markdown-render-utils";
+import { type MarkdownRenderOptions, renderComponentFile, renderComponentsToMarkdown } from "./markdown-render-utils";
 import WriterMarkdown, { type AppendType } from "./WriterMarkdown";
 
-export interface WriteMarkdownOptions {
+/** Default directory for split markdown output, mirroring `jsonOptions.outDir`. */
+export const DEFAULT_MARKDOWN_OUT_DIR = "docs";
+
+export interface WriteMarkdownOptions extends MarkdownRenderOptions {
   write?: boolean;
   outFile: string;
+  /** Write one markdown file per component instead of a single document. */
+  split?: boolean;
+  /** Directory for split output. Defaults to {@link DEFAULT_MARKDOWN_OUT_DIR}. */
+  outDir?: string;
   onAppend?: (type: AppendType, document: WriterMarkdown, components: ComponentDocs) => void;
 }
 
+function pickRenderOptions(options: WriteMarkdownOptions): MarkdownRenderOptions {
+  return { frontmatter: options.frontmatter, toc: options.toc, anchors: options.anchors };
+}
+
 /**
- * Renders component docs to markdown and optionally writes `outFile`.
+ * Write one markdown file per component into `outDir`.
+ *
+ * Returns a map of module name to rendered markdown so callers can inspect or
+ * snapshot the output without reading the file system back.
+ */
+async function writeMarkdownSplit(components: ComponentDocs, options: WriteMarkdownOptions) {
+  const write = options?.write !== false;
+  const outDir = options.outDir ?? DEFAULT_MARKDOWN_OUT_DIR;
+  const renderOptions = pickRenderOptions(options);
+  const files = new Map<string, string>();
+
+  const keys = Array.from(components.keys()).sort();
+  for (const key of keys) {
+    const component = components.get(key);
+    if (!component) continue;
+
+    const document = new WriterMarkdown({});
+    renderComponentFile(document, component, renderOptions);
+    files.set(component.moduleName, document.end());
+  }
+
+  if (write) {
+    await Promise.all(
+      Array.from(files, async ([moduleName, content]) => {
+        const relativePath = join(outDir, `${moduleName}.md`);
+        const writer = new WriterMarkdown({});
+        await writer.write(join(process.cwd(), relativePath), content);
+        console.log(`created "${relativePath}".`);
+      }),
+    );
+  }
+
+  return files;
+}
+
+/**
+ * Renders component docs to markdown and optionally writes them.
+ *
+ * Writes a single document to `outFile` by default. When `split` is enabled,
+ * writes one file per component into `outDir` and resolves to a map of module
+ * name to rendered markdown.
  *
  * @example
  * ```ts
@@ -21,9 +72,21 @@ export interface WriteMarkdownOptions {
  *     console.log(`Appended ${type}`);
  *   }
  * });
+ *
+ * // Split mode (one file per component):
+ * await writeMarkdown(components, {
+ *   outFile: "COMPONENTS.md",
+ *   split: true,
+ *   outDir: "docs",
+ *   frontmatter: true
+ * });
  * ```
  */
 export default async function writeMarkdown(components: ComponentDocs, options: WriteMarkdownOptions) {
+  if (options.split) {
+    return writeMarkdownSplit(components, options);
+  }
+
   const write = options?.write !== false;
   const document = new WriterMarkdown({
     onAppend: (type, document) => {
@@ -31,7 +94,7 @@ export default async function writeMarkdown(components: ComponentDocs, options: 
     },
   });
 
-  renderComponentsToMarkdown(document, components);
+  renderComponentsToMarkdown(document, components, pickRenderOptions(options));
 
   if (write) {
     const outFile = join(process.cwd(), options.outFile);

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -1,7 +1,25 @@
 import { asNormalizedPath } from "../src/brands";
+import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
 import type { AppendType } from "../src/writer/WriterMarkdown";
 import WriterMarkdown from "../src/writer/WriterMarkdown";
-import { writeMarkdownCore } from "../src/writer/writer-markdown-core";
+import { splitMarkdownCore, writeMarkdownCore } from "../src/writer/writer-markdown-core";
+
+function createComponent(moduleName: string, overrides?: Partial<ComponentDocApi>): ComponentDocApi {
+  return {
+    moduleName,
+    filePath: asNormalizedPath(`${moduleName}.svelte`),
+    syntaxMode: "legacy",
+    props: [],
+    moduleExports: [],
+    slots: [],
+    events: [],
+    typedefs: [],
+    generics: null,
+    rest_props: undefined,
+    contexts: [],
+    ...overrides,
+  };
+}
 
 describe("WriterMarkdown", () => {
   test("basic functionality", () => {
@@ -262,5 +280,101 @@ describe("WriterMarkdown", () => {
     expect(output).toContain(
       "| <s>change</s><br />**Deprecated**: Listen for `input` instead. | dispatched | -- | Fires on change. |",
     );
+  });
+
+  test("single-file output is unchanged when no options are passed", () => {
+    const components: ComponentDocs = new Map([
+      ["Button", createComponent("Button")],
+      ["Input", createComponent("Input")],
+    ]);
+
+    const baseline = writeMarkdownCore(components);
+    expect(baseline).not.toContain("<a id=");
+    expect(baseline).not.toContain("---\nname:");
+    expect(baseline).toMatchSnapshot();
+  });
+
+  test("single-file output supports opt-in toc and anchors", () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Button",
+        createComponent("Button", {
+          typedefs: [{ type: "type ButtonSize = 'sm' | 'lg'", name: "ButtonSize", ts: "type ButtonSize" }],
+          props: [
+            {
+              name: "size",
+              kind: "let",
+              constant: false,
+              description: "Button size.",
+              isFunction: false,
+              isFunctionDeclaration: false,
+              isRequired: false,
+              reactive: false,
+            },
+          ],
+          events: [{ type: "forwarded", name: "click", element: "button" }],
+        }),
+      ],
+    ]);
+
+    const output = writeMarkdownCore(components, { toc: true, anchors: true });
+
+    expect(output).toContain('<a id="button"></a>');
+    expect(output).toContain('<a id="button-props"></a>');
+    expect(output).toContain("- [Types](#button-types)");
+    expect(output).toContain("- [Events](#button-events)");
+    expect(output).toMatchSnapshot();
+  });
+
+  test("split mode emits one document per component with frontmatter", () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Button",
+        createComponent("Button", {
+          componentComment: "A button.\n@since 1.2.0",
+          props: [
+            {
+              name: "disabled",
+              kind: "let",
+              constant: false,
+              description: "Disable the button.",
+              isFunction: false,
+              isFunctionDeclaration: false,
+              isRequired: false,
+              reactive: false,
+            },
+          ],
+        }),
+      ],
+      [
+        "LegacyInput",
+        createComponent("LegacyInput", {
+          componentComment: "@deprecated Use `Input` instead.",
+        }),
+      ],
+    ]);
+
+    const files = splitMarkdownCore(components, { frontmatter: true, toc: true, anchors: true });
+
+    expect(Array.from(files.keys())).toEqual(["Button", "LegacyInput"]);
+
+    const button = files.get("Button") ?? "";
+    expect(button).toContain('name: "Button"');
+    expect(button).toContain('since: "1.2.0"');
+    expect(button).not.toContain("# Component Index");
+
+    const legacy = files.get("LegacyInput") ?? "";
+    expect(legacy).toContain('deprecated: "Use `Input` instead."');
+
+    expect(button).toMatchSnapshot();
+    expect(legacy).toMatchSnapshot();
+  });
+
+  test("split mode omits frontmatter when not requested", () => {
+    const components: ComponentDocs = new Map([["Button", createComponent("Button")]]);
+
+    const files = splitMarkdownCore(components);
+
+    expect(files.get("Button")).not.toContain("---\nname:");
   });
 });

--- a/tests/__snapshots__/WriterMarkdown.test.ts.snap
+++ b/tests/__snapshots__/WriterMarkdown.test.ts.snap
@@ -29,6 +29,96 @@ None.
 "
 `;
 
+exports[`WriterMarkdown single-file output is unchanged when no options are passed 1`] = `
+"# Component Index
+
+## Components
+
+  - [\`Button\`](#button)
+  - [\`Input\`](#input)
+
+---
+
+## \`Button\`
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
+
+## \`Input\`
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
+
+"
+`;
+
+exports[`WriterMarkdown single-file output supports opt-in toc and anchors 1`] = `
+"# Component Index
+
+## Components
+
+  - [\`Button\`](#button)
+
+---
+
+<a id="button"></a>
+
+## \`Button\`
+
+- [Types](#button-types)
+- [Props](#button-props)
+- [Slots](#button-slots)
+- [Events](#button-events)
+
+<a id="button-types"></a>
+
+### Types
+
+\`\`\`ts
+export type ButtonSize
+\`\`\`
+
+<a id="button-props"></a>
+
+### Props
+
+| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
+| :- | :- | :- | :- | :- | :- | :- | :- |
+| size | No | <code>let</code> | No | -- | -- | -- | Button size. |
+<a id="button-slots"></a>
+
+### Slots
+
+None.
+
+<a id="button-events"></a>
+
+### Events
+
+| Event name | Type | Detail | Description |
+| :- | :- | :- | :- |
+| click | forwarded | -- | -- |
+"
+`;
+
 exports[`WriterMarkdown slots table renders descriptions and pass-through tags 1`] = `
 "# Component Index
 
@@ -51,6 +141,77 @@ None.
 | -- | Yes | <code>{ prop: number } </code> | -- | Default content.<br />Spans two lines.<br />@deprecated Prefer the \`body\` slot.<br />@since 1.2.0 |
 | title | No | -- | -- | Heading content.<br />@example &lt;Example&gt;Hi&lt;/Example&gt; |
 | footer | No | -- | -- | -- |
+### Events
+
+None.
+
+"
+`;
+
+exports[`WriterMarkdown split mode emits one document per component with frontmatter 1`] = `
+"---
+name: "Button"
+since: "1.2.0"
+---
+
+<a id="button"></a>
+
+## \`Button\`
+
+- [Props](#button-props)
+- [Slots](#button-slots)
+- [Events](#button-events)
+
+<a id="button-props"></a>
+
+### Props
+
+| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
+| :- | :- | :- | :- | :- | :- | :- | :- |
+| disabled | No | <code>let</code> | No | -- | -- | -- | Disable the button. |
+<a id="button-slots"></a>
+
+### Slots
+
+None.
+
+<a id="button-events"></a>
+
+### Events
+
+None.
+
+"
+`;
+
+exports[`WriterMarkdown split mode emits one document per component with frontmatter 2`] = `
+"---
+name: "LegacyInput"
+deprecated: "Use \`Input\` instead."
+---
+
+<a id="legacyinput"></a>
+
+## \`LegacyInput\`
+
+- [Props](#legacyinput-props)
+- [Slots](#legacyinput-slots)
+- [Events](#legacyinput-events)
+
+<a id="legacyinput-props"></a>
+
+### Props
+
+None.
+
+<a id="legacyinput-slots"></a>
+
+### Slots
+
+None.
+
+<a id="legacyinput-events"></a>
+
 ### Events
 
 None.


### PR DESCRIPTION
Single-file Markdown suits quick reference but not doc sites. Add opt-in per-component frontmatter (`@since`/`deprecated`), section ToC, and stable slug anchors, plus a `split` mode mirroring `jsonOptions.outDir`. Default single-file output stays byte-stable.