### PR TITLE
feat: add `documentExports` for entry-level module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ export default class Button extends SvelteComponentTyped<
   - [Config File](#config-file)
   - [Publishing to NPM](#publishing-to-npm)
 - [Available Options](#available-options)
+- [Documenting Entry Exports](#documenting-entry-exports)
 - [JSON Output](#json-output)
 - [API Reference](#api-reference)
   - [@type](#type)
@@ -371,6 +372,7 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 
 - **`entry`** (string, optional): Specify the entry point to uncompiled Svelte source. If not provided, sveld will use the `"svelte"` field from `package.json`.
 - **`glob`** (boolean, optional): Enable glob mode to analyze all `*.svelte` files.
+- **`documentExports`** (boolean, optional): Include consts, functions, and types from the entry barrel in JSON (`exports`) and Markdown ("Exports"). Off by default. See [Documenting Entry Exports](#documenting-entry-exports).
 - **`types`** (boolean, optional, default: `true`): Generate TypeScript definitions.
 - **`typesOptions`** (object, optional): Options for TypeScript definition generation, including `outDir`, `preamble`, and `printWidth`.
 - **`json`** (boolean, optional): Generate component documentation in JSON format.
@@ -391,6 +393,32 @@ sveld({
 })
 ```
 
+## Documenting Entry Exports
+
+Most entry barrels re-export more than `.svelte` components. Set `documentExports: true` to add consts, functions, and types to the JSON and Markdown output.
+
+```diff
+sveld({
+  json: true,
+  markdown: true,
++  documentExports: true,
+})
+```
+
+Example entry file:
+
+```ts
+// src/index.ts
+export { default as Button } from "./Button.svelte";
+export { VERSION } from "./constants";
+export { clamp } from "./utils";
+export type { Theme } from "./types";
+```
+
+From that barrel, `sveld` documents `VERSION`, `clamp`, and `Theme`. `Button` still goes through the component path. Type text is copied from source, not resolved with `tsc`, same as the rest of the tool.
+
+JSON adds `exports` and `totalExports`. Markdown adds an "Exports" section. Each item has `name`, `kind`, type text, optional JSDoc `description`, and `source`.
+
 ## JSON Output
 
 When `json: true` is enabled, `sveld` emits a `COMPONENT_API.json` file with schema and generator metadata plus the parsed
@@ -408,6 +436,19 @@ interface ComponentApiJson {
   };
   total: number;
   components: ComponentDocApi[];
+  // Present only when `documentExports` is enabled.
+  totalExports?: number;
+  exports?: EntryExport[];
+}
+
+interface EntryExport {
+  name: string;
+  kind: "const" | "let" | "var" | "function" | "class" | "type" | "interface" | "enum";
+  type?: string;
+  value?: string;
+  description?: string;
+  source?: string;
+  isTypeOnly: boolean;
 }
 
 interface SourceRange {

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -29,6 +29,16 @@
     "components": {
       "type": "array",
       "items": { "$ref": "#/$defs/component" }
+    },
+    "totalExports": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of entry-barrel exports. Only when `documentExports` is on."
+    },
+    "exports": {
+      "type": "array",
+      "description": "Entry-barrel exports other than components. Only when `documentExports` is on.",
+      "items": { "$ref": "#/$defs/entryExport" }
     }
   },
   "$defs": {
@@ -326,6 +336,22 @@
       "properties": {
         "interface": { "type": "string" },
         "import": { "type": "string" }
+      }
+    },
+    "entryExport": {
+      "type": "object",
+      "required": ["name", "kind", "isTypeOnly"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "kind": {
+          "enum": ["const", "let", "var", "function", "class", "type", "interface", "enum"]
+        },
+        "type": { "type": "string" },
+        "value": { "type": "string" },
+        "description": { "type": "string" },
+        "source": { "type": "string" },
+        "isTypeOnly": { "type": "boolean" }
       }
     }
   }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -10,6 +10,7 @@ import ComponentParser, {
   type ParsedComponent,
 } from "./ComponentParser";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
+import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { normalizeSeparators } from "./path";
 
@@ -33,6 +34,8 @@ export interface ComponentParseError {
 
 export interface GenerateBundleResult {
   exports: ParsedExports;
+  /** Entry-barrel exports other than components. Empty when `documentExports` is off. */
+  entryExports: EntryExports;
   components: ComponentDocs;
   allComponentsForTypes: ComponentDocs;
   /**
@@ -55,14 +58,17 @@ export interface GenerateBundleOptions {
    * types into JSON/Markdown props. Off by default; requires `typescript`.
    */
   resolveTypes?: boolean;
+  /** Record consts, functions, and types from the entry barrel. Off by default. */
+  documentExports?: boolean;
 }
 
 export function toGenerateBundleOptions(
-  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes">,
+  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes" | "documentExports">,
 ): GenerateBundleOptions {
   return {
     failFast: opts?.failFast,
     resolveTypes: opts?.resolveTypes === true,
+    documentExports: opts?.documentExports === true,
   };
 }
 
@@ -117,8 +123,11 @@ export interface CollectedComponents {
  *
  * Parses the entry's exports (when `input` is a file) and, when `glob` is set,
  * augments the set with every `.svelte` file under the entry directory.
+ *
+ * @param documentExports - When `true`, log and continue if the entry file fails
+ *   the acorn component-export parse (TypeScript-only syntax is common).
  */
-export function collectComponents(input: string, glob: boolean): CollectedComponents {
+export function collectComponents(input: string, glob: boolean, documentExports = false): CollectedComponents {
   const isFile = lstatSync(input).isFile();
   const dir = isFile ? dirname(input) : input;
   const rootDir = resolve(dir);
@@ -132,7 +141,14 @@ export function collectComponents(input: string, glob: boolean): CollectedCompon
   let exports: ParsedExports = {};
   if (isFile) {
     const entry = readFileSync(input, "utf-8");
-    exports = parseExports(entry, rootDir);
+    try {
+      exports = parseExports(entry, rootDir);
+    } catch (error) {
+      // Without documentExports, throw. With it, warn and continue.
+      if (!documentExports) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Warning: Failed to parse component exports from ${input}: ${message}`);
+    }
   }
 
   const allComponents: ParsedExports = { ...exports };
@@ -299,8 +315,8 @@ export function reportParseErrors(errors: ComponentParseError[]): void {
  *
  * @param input - Entry point file or directory containing Svelte components
  * @param glob - Whether to glob for all .svelte files in the directory
- * @param options - Bundle options (e.g. `failFast`, `resolveTypes`)
- * @returns Bundle result containing exports, components, allComponentsForTypes, and errors
+ * @param options - Bundle options (e.g. `failFast`, `resolveTypes`, `documentExports`)
+ * @returns Bundle result containing exports, entryExports, components, allComponentsForTypes, and errors
  *
  * @example
  * ```ts
@@ -319,7 +335,12 @@ export async function generateBundle(
   glob: boolean,
   options: GenerateBundleOptions = {},
 ): Promise<GenerateBundleResult> {
-  const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob);
+  const documentExports = options.documentExports === true;
+  const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
+
+  // File entry only; directory inputs have no barrel.
+  const entryExports: EntryExports =
+    documentExports && lstatSync(input).isFile() ? parseEntryExports(resolve(input)) : [];
 
   const exportEntries = Object.entries(exports);
   const allComponentEntries = Object.entries(allComponents);
@@ -375,6 +396,7 @@ export async function generateBundle(
 
   return {
     exports,
+    entryExports,
     components,
     allComponentsForTypes,
     errors,

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -1,0 +1,437 @@
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { parse } from "svelte/compiler";
+import { normalizeSeparators } from "./path";
+import { resolvePathAliasAbsolute } from "./resolve-alias";
+
+/** One named export from the entry barrel (not a `.svelte` component). */
+export interface EntryExport {
+  name: string;
+  kind: "const" | "let" | "var" | "function" | "class" | "type" | "interface" | "enum";
+  /** Type text from the source, when present. */
+  type?: string;
+  /** Initializer text for simple constants. */
+  value?: string;
+  description?: string;
+  /** Declaring module, relative to the entry file. */
+  source?: string;
+  isTypeOnly: boolean;
+}
+
+export type EntryExports = EntryExport[];
+
+/** Extensions probed when resolving a bare module specifier to a file. */
+const CANDIDATE_EXTENSIONS = [".ts", ".mts", ".cts", ".tsx", ".js", ".mjs", ".cjs", ".jsx", ".d.ts"];
+
+/** Splits a JSDoc comment body into lines. */
+const NEWLINE_REGEX = /\r?\n/;
+/** Strips leading whitespace and asterisks from a JSDoc line. */
+const JSDOC_LINE_PREFIX_REGEX = /^\s*\*+/;
+
+/** Minimal AST node shape exposed by the Svelte/acorn-typescript parser. */
+interface AstNode {
+  type: string;
+  start: number;
+  end: number;
+  [key: string]: unknown;
+}
+
+/** Internal export record that tracks the absolute declaring file. */
+interface InternalExport extends Omit<EntryExport, "source"> {
+  declFile: string;
+}
+
+/** Parsed-source context shared while walking a single module. */
+interface ModuleSource {
+  /** Full `<script lang="ts">`-wrapped source the offsets index into. */
+  text: string;
+  /** Absolute path of the parsed file. */
+  filePath: string;
+  /** Directory used to resolve relative imports. */
+  dir: string;
+}
+
+/** Resolution state shared across the recursive module walk. */
+interface ResolveContext {
+  /** Memoized exports per file so repeated lookups stay cheap. */
+  cache: Map<string, InternalExport[]>;
+  /** Files currently being resolved, used to break import cycles. */
+  computing: Set<string>;
+}
+
+function asNode(value: unknown): AstNode | undefined {
+  return value && typeof value === "object" ? (value as AstNode) : undefined;
+}
+
+function asNodeArray(value: unknown): AstNode[] {
+  return Array.isArray(value) ? (value as AstNode[]) : [];
+}
+
+function identifierName(node: AstNode | undefined): string | undefined {
+  if (node && node.type === "Identifier" && typeof node.name === "string") return node.name as string;
+  return undefined;
+}
+
+/**
+ * Resolves a module specifier to an on-disk source file.
+ *
+ * Tries the path verbatim, with each candidate extension, and finally an
+ * `index.*` file when the specifier points at a directory.
+ *
+ * @example
+ * ```ts
+ * resolveModuleFile("./utils", "/abs/src") // "/abs/src/utils.ts"
+ * ```
+ */
+function resolveModuleFile(specifier: string, fromDir: string): string | null {
+  const aliased = resolvePathAliasAbsolute(specifier, fromDir);
+  const base = resolve(fromDir, aliased);
+
+  if (existsSync(base) && lstatSync(base).isFile()) return base;
+
+  for (const ext of CANDIDATE_EXTENSIONS) {
+    const candidate = base + ext;
+    if (existsSync(candidate)) return candidate;
+  }
+
+  if (existsSync(base) && lstatSync(base).isDirectory()) {
+    for (const ext of CANDIDATE_EXTENSIONS) {
+      const candidate = join(base, `index${ext}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+/** Reads and cleans the JSDoc block immediately preceding `start`, if any. */
+function leadingJsDoc(text: string, start: number): string | undefined {
+  // Only a JSDoc block directly adjacent to the declaration (separated by
+  // whitespace alone) documents it. Anchor to the nearest `*/` so earlier
+  // comments and intervening code are never absorbed.
+  const before = text.slice(0, start).trimEnd();
+  if (!before.endsWith("*/")) return undefined;
+
+  const close = before.length - 2;
+  const open = before.lastIndexOf("/**", close);
+  if (open === -1) return undefined;
+
+  const description: string[] = [];
+  for (const line of before.slice(open + 3, close).split(NEWLINE_REGEX)) {
+    const cleaned = line.replace(JSDOC_LINE_PREFIX_REGEX, "").trim();
+    if (cleaned.startsWith("@")) break;
+    if (cleaned) description.push(cleaned);
+  }
+
+  return description.join(" ") || undefined;
+}
+
+/** Slices the verbatim source text spanned by a node. */
+function textOf(source: ModuleSource, node: AstNode | undefined): string | undefined {
+  if (!node) return undefined;
+  return source.text.slice(node.start, node.end);
+}
+
+/** Extracts the annotated type text from a `TSTypeAnnotation`, if present. */
+function annotationText(source: ModuleSource, annotated: AstNode | undefined): string | undefined {
+  const annotation = asNode(annotated?.typeAnnotation);
+  if (annotation?.type !== "TSTypeAnnotation") return undefined;
+  return textOf(source, asNode(annotation.typeAnnotation));
+}
+
+/** Builds a callable type signature from a function-like node. */
+function buildSignature(source: ModuleSource, fn: AstNode): string {
+  const params = asNodeArray(fn.params)
+    .map((param) => textOf(source, param) ?? "")
+    .join(", ");
+  // Functions and arrows expose their return type via `returnType`.
+  const returnAnnotation = asNode(fn.returnType);
+  const returnType =
+    returnAnnotation?.type === "TSTypeAnnotation" ? textOf(source, asNode(returnAnnotation.typeAnnotation)) : undefined;
+  return `(${params})${returnType ? ` => ${returnType}` : ""}`;
+}
+
+/** Infers a primitive type name from a literal initializer. */
+function inferLiteralType(init: AstNode): string | undefined {
+  if (init.type === "Literal") {
+    const value = init.value;
+    if (typeof value === "string") return "string";
+    if (typeof value === "number") return "number";
+    if (typeof value === "boolean") return "boolean";
+  }
+  if (init.type === "TemplateLiteral") return "string";
+  return undefined;
+}
+
+/** Pull type text from a declaration node. */
+function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocStart: number): InternalExport[] {
+  const declFile = source.filePath;
+  const description = leadingJsDoc(source.text, jsdocStart);
+
+  if (declaration.type === "VariableDeclaration") {
+    const kind = (declaration.kind as "const" | "let" | "var") ?? "const";
+    const results: InternalExport[] = [];
+
+    for (const declarator of asNodeArray(declaration.declarations)) {
+      const id = asNode(declarator.id);
+      const name = identifierName(id);
+      if (!name) continue;
+
+      let type = annotationText(source, id);
+      let value: string | undefined;
+      const init = asNode(declarator.init);
+
+      if (init) {
+        if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
+          if (!type) type = buildSignature(source, init);
+        } else {
+          value = textOf(source, init);
+          if (!type) type = inferLiteralType(init);
+        }
+      }
+
+      results.push({ name, kind, type, value, description, declFile, isTypeOnly: false });
+    }
+
+    return results;
+  }
+
+  if (declaration.type === "FunctionDeclaration") {
+    const name = identifierName(asNode(declaration.id));
+    if (!name) return [];
+    return [
+      { name, kind: "function", type: buildSignature(source, declaration), description, declFile, isTypeOnly: false },
+    ];
+  }
+
+  if (declaration.type === "ClassDeclaration") {
+    const name = identifierName(asNode(declaration.id));
+    if (!name) return [];
+    return [{ name, kind: "class", type: name, description, declFile, isTypeOnly: false }];
+  }
+
+  if (declaration.type === "TSTypeAliasDeclaration") {
+    const name = identifierName(asNode(declaration.id));
+    if (!name) return [];
+    return [
+      {
+        name,
+        kind: "type",
+        type: textOf(source, asNode(declaration.typeAnnotation)),
+        description,
+        declFile,
+        isTypeOnly: true,
+      },
+    ];
+  }
+
+  if (declaration.type === "TSInterfaceDeclaration") {
+    const name = identifierName(asNode(declaration.id));
+    if (!name) return [];
+    return [
+      {
+        name,
+        kind: "interface",
+        type: textOf(source, asNode(declaration.body)),
+        description,
+        declFile,
+        isTypeOnly: true,
+      },
+    ];
+  }
+
+  if (declaration.type === "TSEnumDeclaration") {
+    const name = identifierName(asNode(declaration.id));
+    if (!name) return [];
+    return [{ name, kind: "enum", type: name, description, declFile, isTypeOnly: false }];
+  }
+
+  return [];
+}
+
+/**
+ * Parses a module file into the top-level statements of its script body.
+ *
+ * The source is wrapped in `<script lang="ts">` so the Svelte parser
+ * (backed by acorn-typescript) yields a TypeScript-aware AST with byte
+ * offsets for verbatim text extraction.
+ */
+function parseModule(filePath: string): { source: ModuleSource; body: AstNode[] } | null {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const text = `<script lang="ts">\n${raw}\n</script>`;
+
+  try {
+    const ast = parse(text, { modern: true }) as { instance?: { content?: { body?: unknown } } };
+    const body = asNodeArray(ast.instance?.content?.body);
+    return { source: { text, filePath, dir: dirname(filePath) }, body };
+  } catch {
+    return null;
+  }
+}
+
+/** Finds the module a local name was imported from, if any. */
+function findImportSource(body: AstNode[], name: string): { specifier: string; importedName: string } | null {
+  for (const node of body) {
+    if (node.type !== "ImportDeclaration") continue;
+    const specifierValue = asNode(node.source)?.value;
+    if (typeof specifierValue !== "string") continue;
+
+    for (const specifier of asNodeArray(node.specifiers)) {
+      if (specifier.type !== "ImportSpecifier") continue;
+      if (identifierName(asNode(specifier.local)) === name) {
+        const importedName = identifierName(asNode(specifier.imported)) ?? name;
+        return { specifier: specifierValue, importedName };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Collects every named export declared or re-exported by a module.
+ *
+ * Walks `export ... from` and `export *` chains. Skips `.svelte` re-exports.
+ */
+function collectModuleExports(filePath: string, ctx: ResolveContext): InternalExport[] {
+  const cached = ctx.cache.get(filePath);
+  if (cached) return cached;
+  // A module currently being resolved is part of an import cycle.
+  if (ctx.computing.has(filePath)) return [];
+  ctx.computing.add(filePath);
+
+  const parsed = parseModule(filePath);
+  if (!parsed) {
+    ctx.computing.delete(filePath);
+    ctx.cache.set(filePath, []);
+    return [];
+  }
+
+  const { source, body } = parsed;
+  const results: InternalExport[] = [];
+
+  /** Local declarations indexed by name for `export { x }` lookups. */
+  const localDeclarations = new Map<string, InternalExport>();
+  for (const node of body) {
+    const declaration = node.type === "ExportNamedDeclaration" ? asNode(node.declaration) : node;
+    if (!declaration) continue;
+    for (const described of describeDeclaration(source, declaration, declaration.start)) {
+      localDeclarations.set(described.name, described);
+    }
+  }
+
+  /** Resolves a name within `filePath`, following one level of import. */
+  const resolveLocal = (name: string): InternalExport | null => {
+    const local = localDeclarations.get(name);
+    if (local) return local;
+
+    const imported = findImportSource(body, name);
+    if (!imported || imported.specifier.endsWith(".svelte")) return null;
+
+    const target = resolveModuleFile(imported.specifier, source.dir);
+    if (!target) return null;
+
+    return collectModuleExports(target, ctx).find((entry) => entry.name === imported.importedName) ?? null;
+  };
+
+  for (const node of body) {
+    if (node.type === "ExportAllDeclaration") {
+      const specifierValue = asNode(node.source)?.value;
+      if (typeof specifierValue !== "string" || specifierValue.endsWith(".svelte")) continue;
+      const target = resolveModuleFile(specifierValue, source.dir);
+      if (!target) continue;
+      const isTypeOnly = node.exportKind === "type";
+      for (const entry of collectModuleExports(target, ctx)) {
+        results.push(isTypeOnly ? { ...entry, isTypeOnly: true } : entry);
+      }
+      continue;
+    }
+
+    if (node.type !== "ExportNamedDeclaration") continue;
+
+    // Inline `export const/function/class/type/interface/enum`.
+    const declaration = asNode(node.declaration);
+    if (declaration) {
+      results.push(...describeDeclaration(source, declaration, node.start));
+      continue;
+    }
+
+    const specifierValue = asNode(node.source)?.value;
+    const moduleSpecifier = typeof specifierValue === "string" ? specifierValue : undefined;
+    if (moduleSpecifier?.endsWith(".svelte")) continue;
+
+    const stmtIsTypeOnly = node.exportKind === "type";
+
+    for (const specifier of asNodeArray(node.specifiers)) {
+      if (specifier.type !== "ExportSpecifier") continue;
+      const exportedName = identifierName(asNode(specifier.exported));
+      const localName = identifierName(asNode(specifier.local));
+      if (!exportedName || !localName || localName === "default" || exportedName === "default") continue;
+
+      const elementIsTypeOnly = stmtIsTypeOnly || specifier.exportKind === "type";
+
+      let resolved: InternalExport | null = null;
+      if (moduleSpecifier) {
+        const target = resolveModuleFile(moduleSpecifier, source.dir);
+        if (target) {
+          resolved = collectModuleExports(target, ctx).find((entry) => entry.name === localName) ?? null;
+        }
+      } else {
+        resolved = resolveLocal(localName);
+      }
+
+      if (resolved?.declFile.endsWith(".svelte")) continue;
+
+      if (resolved) {
+        results.push({ ...resolved, name: exportedName, isTypeOnly: resolved.isTypeOnly || elementIsTypeOnly });
+      } else {
+        results.push({
+          name: exportedName,
+          kind: elementIsTypeOnly ? "type" : "const",
+          declFile: filePath,
+          isTypeOnly: elementIsTypeOnly,
+        });
+      }
+    }
+  }
+
+  ctx.computing.delete(filePath);
+  ctx.cache.set(filePath, results);
+  return results;
+}
+
+/**
+ * List consts, functions, and types exported from an entry barrel.
+ *
+ * Follows re-exports with AST-only traversal. Skips `.svelte` files.
+ *
+ * @param entryFile - Absolute path to the entry module.
+ * @returns Exports deduplicated by name, sorted alphabetically.
+ *
+ * @example
+ * ```ts
+ * // entry: export { VERSION } from "./constants"; export type { Theme } from "./types";
+ * parseEntryExports("/abs/src/index.ts");
+ * // [{ name: "Theme", kind: "type", isTypeOnly: true, ... }, { name: "VERSION", kind: "const", ... }]
+ * ```
+ */
+export function parseEntryExports(entryFile: string): EntryExports {
+  const resolved = resolve(entryFile);
+  const entryDir = dirname(resolved);
+  const collected = collectModuleExports(resolved, { cache: new Map(), computing: new Set() });
+
+  const byName = new Map<string, EntryExport>();
+  for (const entry of collected) {
+    const { declFile, ...rest } = entry;
+    const source = normalizeSeparators(`./${relative(entryDir, declFile)}`);
+    byName.set(entry.name, { ...rest, source });
+  }
+
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,6 +37,8 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
    */
   entry?: string;
   glob?: boolean;
+  /** Record consts, functions, and types from the entry barrel. Off by default. */
+  documentExports?: boolean;
   types?: boolean;
   typesOptions?: Partial<Omit<WriteTsDefinitionsOptions, "inputDir">>;
   json?: boolean;
@@ -122,7 +124,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
         // Produce the initial output and prime the incremental bundle. This
         // covers both `vite dev` (where generateBundle/writeBundle never fire)
         // and `vite build --watch`.
-        bundle = await createSveldBundle(input, opts?.glob === true);
+        bundle = await createSveldBundle(input, opts?.glob === true, opts?.documentExports === true);
         writeOutput(bundle.result, opts || {}, input);
       }
     },
@@ -196,6 +198,7 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
       ...opts?.jsonOptions,
       input,
       inputDir,
+      entryExports: result.entryExports,
     });
   }
 
@@ -208,6 +211,7 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
     writeMarkdown(result.components, {
       outFile: "COMPONENT_INDEX.md",
       ...opts?.markdownOptions,
+      entryExports: result.entryExports,
     });
   }
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,3 +1,4 @@
+import { lstatSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import {
   type ComponentDocApi,
@@ -13,6 +14,7 @@ import {
   reportParseErrors,
 } from "./bundle";
 import { dedupeDiagnostics } from "./diagnostics";
+import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import type { ParsedExports } from "./parse-exports";
 
 const SVELTE_EXT_REGEX = /\.svelte$/;
@@ -127,11 +129,16 @@ function expandAffected(changed: Iterable<string>, reverseDeps: Map<string, Set<
  *
  * @param input - Entry point file or directory containing Svelte components
  * @param glob - Whether to glob for all `.svelte` files in the directory
+ * @param documentExports - Record consts, functions, and types from the entry barrel
  */
-export async function createSveldBundle(input: string, glob: boolean): Promise<SveldBundle> {
+export async function createSveldBundle(input: string, glob: boolean, documentExports = false): Promise<SveldBundle> {
   // Discover sources once. The export/source maps only change when the entry
   // file or the set of files on disk changes; for a single edit they are stable.
-  const { exports, allComponents, resolveComponentFilePath } = collectComponents(input, glob);
+  const { exports, allComponents, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
+
+  // Entry exports only change when the barrel changes; resolve once.
+  const entryExports: EntryExports =
+    documentExports && lstatSync(input).isFile() ? parseEntryExports(resolve(input)) : [];
 
   const exportEntries = Object.entries(exports);
   const allComponentEntries = Object.entries(allComponents);
@@ -148,6 +155,7 @@ export async function createSveldBundle(input: string, glob: boolean): Promise<S
 
   const buildResult = (): GenerateBundleResult => ({
     exports,
+    entryExports,
     components,
     allComponentsForTypes,
     errors: Array.from(parseErrors.values()),

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -11,6 +11,7 @@ export const PROP_TABLE_HEADER =
 export const SLOT_TABLE_HEADER =
   "| Slot name | Default | Props | Fallback | Description |\n| :- | :- | :- | :- | :- |\n";
 export const EVENT_TABLE_HEADER = "| Event name | Type | Detail | Description |\n| :- | :- | :- | :- |\n";
+export const EXPORT_TABLE_HEADER = "| Name | Kind | Type | Description |\n| :- | :- | :- | :- |\n";
 
 const PIPE_REGEX = /\|/g;
 const LT_REGEX = /</g;

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -1,7 +1,9 @@
+import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import type { AppendType } from "./MarkdownWriterBase";
 import {
   EVENT_TABLE_HEADER,
+  EXPORT_TABLE_HEADER,
   formatEventDetail,
   formatNameWithDeprecation,
   formatPropDescription,
@@ -13,6 +15,7 @@ import {
   MD_TYPE_UNDEFINED,
   PROP_TABLE_HEADER,
   SLOT_TABLE_HEADER,
+  WHITESPACE_REGEX,
 } from "./markdown-format-utils";
 import { getTypeDefs } from "./writer-ts-definitions-core";
 
@@ -22,10 +25,18 @@ interface MarkdownDocument {
   tableOfContents(): MarkdownDocument;
 }
 
-export function renderComponentsToMarkdown(document: MarkdownDocument, components: ComponentDocs) {
+export function renderComponentsToMarkdown(
+  document: MarkdownDocument,
+  components: ComponentDocs,
+  entryExports?: EntryExports,
+) {
   document.append("h1", "Component Index");
   document.append("h2", "Components").tableOfContents();
   document.append("divider");
+
+  if (entryExports && entryExports.length > 0) {
+    renderExports(document, entryExports);
+  }
 
   const keys = Array.from(components.keys()).sort();
 
@@ -35,6 +46,25 @@ export function renderComponentsToMarkdown(document: MarkdownDocument, component
 
     renderComponent(document, component);
   }
+}
+
+function renderExports(document: MarkdownDocument, entryExports: EntryExports) {
+  document.append("h2", "Exports");
+  document.append("raw", EXPORT_TABLE_HEADER);
+
+  for (const entry of entryExports) {
+    // Collapse whitespace so multi-line types (e.g. interface bodies) stay on a
+    // single table row. JSON retains the verbatim type text.
+    const type = (entry.type ?? entry.value)?.replace(WHITESPACE_REGEX, " ").trim();
+    document.append(
+      "raw",
+      `| ${entry.name} | ${`<code>${entry.kind}</code>`} | ${formatPropType(type)} | ${formatPropDescription(
+        entry.description,
+      )} |\n`,
+    );
+  }
+
+  document.append("divider");
 }
 
 function renderSectionIfNotEmpty<TItem>(

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { version as svelteVersion } from "svelte/package.json";
 import { name as packageName, version as packageVersion } from "../../package.json";
+import type { EntryExports } from "../parse-entry-exports";
 import { normalizeSeparators } from "../path";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import { createJsonWriter } from "./Writer";
@@ -10,6 +11,8 @@ export interface WriteJsonOptions {
   inputDir: string;
   outFile: string;
   outDir?: string;
+  /** Entry-barrel exports when `documentExports` is on. */
+  entryExports?: EntryExports;
 }
 
 /**
@@ -27,6 +30,9 @@ interface JsonOutput {
   };
   total: number;
   components: ComponentDocApi[];
+  /** Only when `documentExports` is on. */
+  totalExports?: number;
+  exports?: EntryExports;
 }
 
 const JSON_SCHEMA_VERSION = 1;
@@ -121,6 +127,11 @@ async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptio
     total: components.size,
     components: transformAndSortComponents(components, options.inputDir),
   };
+
+  if (options.entryExports && options.entryExports.length > 0) {
+    output.totalExports = options.entryExports.length;
+    output.exports = options.entryExports;
+  }
 
   const output_path = path.join(process.cwd(), options.outFile);
   const writer = createJsonWriter();

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocs } from "../plugin";
 import { renderComponentsToMarkdown } from "./markdown-render-utils";
 import WriterMarkdown, { type AppendType } from "./WriterMarkdown";
@@ -6,6 +7,8 @@ import WriterMarkdown, { type AppendType } from "./WriterMarkdown";
 export interface WriteMarkdownOptions {
   write?: boolean;
   outFile: string;
+  /** Entry-barrel exports when `documentExports` is on. */
+  entryExports?: EntryExports;
   onAppend?: (type: AppendType, document: WriterMarkdown, components: ComponentDocs) => void;
 }
 
@@ -31,7 +34,7 @@ export default async function writeMarkdown(components: ComponentDocs, options: 
     },
   });
 
-  renderComponentsToMarkdown(document, components);
+  renderComponentsToMarkdown(document, components, options.entryExports);
 
   if (write) {
     const outFile = join(process.cwd(), options.outFile);

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -85,6 +85,33 @@ describe("component API JSON schema", () => {
     );
   });
 
+  test("documents the optional entry exports collection", () => {
+    const schema = readJson("schema/component-api.schema.json");
+    const properties = objectProperty(schema, "properties");
+    const defs = objectProperty(schema, "$defs");
+
+    // Optional: not part of the required root keys so default output is unchanged.
+    expect(stringArrayProperty(schema, "required")).not.toContain("exports");
+    expect(Object.keys(properties)).toEqual(expect.arrayContaining(["totalExports", "exports"]));
+    expect(objectProperty(properties, "exports")).toMatchObject({
+      type: "array",
+      items: { $ref: "#/$defs/entryExport" },
+    });
+
+    const entryExportProperties = objectProperty(objectProperty(defs, "entryExport"), "properties");
+    expect(Object.keys(entryExportProperties)).toEqual(
+      expect.arrayContaining(["name", "kind", "type", "value", "description", "source", "isTypeOnly"]),
+    );
+    expect(objectProperty(entryExportProperties, "kind")).toMatchObject({
+      enum: ["const", "let", "var", "function", "class", "type", "interface", "enum"],
+    });
+    expect(stringArrayProperty(objectProperty(defs, "entryExport"), "required")).toEqual([
+      "name",
+      "kind",
+      "isTypeOnly",
+    ]);
+  });
+
   test("covers recent prop metadata fields", () => {
     const schema = readJson("schema/component-api.schema.json");
     const defs = objectProperty(schema, "$defs");

--- a/tests/fixtures-entry-exports/Button.svelte
+++ b/tests/fixtures-entry-exports/Button.svelte
@@ -1,0 +1,5 @@
+<script>
+  export let label = "";
+</script>
+
+<button type="button">{label}</button>

--- a/tests/fixtures-entry-exports/constants.ts
+++ b/tests/fixtures-entry-exports/constants.ts
@@ -1,0 +1,4 @@
+/** The current library version. */
+export const VERSION = "1.2.3";
+
+export const MAX_RETRIES: number = 5;

--- a/tests/fixtures-entry-exports/entry.js
+++ b/tests/fixtures-entry-exports/entry.js
@@ -1,0 +1,9 @@
+// JS entry so the acorn component-export parser can read it. documentExports
+// still picks up the rest.
+export { default as Button } from "./Button.svelte";
+export { MAX_RETRIES, VERSION } from "./constants";
+export { Theme, ThemeConfig } from "./types";
+export { clamp, invertTheme } from "./utils";
+
+/** Default theme applied when none is configured. */
+export const DEFAULT_THEME = "light";

--- a/tests/fixtures-entry-exports/index.ts
+++ b/tests/fixtures-entry-exports/index.ts
@@ -1,0 +1,9 @@
+// Component; documented separately.
+export { default as Button } from "./Button.svelte";
+
+export { MAX_RETRIES, VERSION } from "./constants";
+export type { Theme, ThemeConfig } from "./types";
+export { clamp, invertTheme } from "./utils";
+
+/** Default theme applied when none is configured. */
+export const DEFAULT_THEME = "light";

--- a/tests/fixtures-entry-exports/types.ts
+++ b/tests/fixtures-entry-exports/types.ts
@@ -1,0 +1,7 @@
+/** Supported color themes. */
+export type Theme = "light" | "dark";
+
+export interface ThemeConfig {
+  theme: Theme;
+  persist: boolean;
+}

--- a/tests/fixtures-entry-exports/utils.ts
+++ b/tests/fixtures-entry-exports/utils.ts
@@ -1,0 +1,11 @@
+import type { Theme } from "./types";
+
+/**
+ * Clamps a number between a lower and upper bound.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/** Returns the inverse of a theme. */
+export const invertTheme = (theme: Theme): Theme => (theme === "light" ? "dark" : "light");

--- a/tests/markdown-entry-exports.test.ts
+++ b/tests/markdown-entry-exports.test.ts
@@ -1,0 +1,52 @@
+import type { EntryExports } from "../src/parse-entry-exports";
+import type { ComponentDocs } from "../src/plugin";
+import { renderComponentsToMarkdown } from "../src/writer/markdown-render-utils";
+import { BrowserWriterMarkdown } from "../src/writer/writer-markdown-core";
+
+function render(components: ComponentDocs, entryExports?: EntryExports): string {
+  const document = new BrowserWriterMarkdown({});
+  renderComponentsToMarkdown(document, components, entryExports);
+  return document.end();
+}
+
+describe("renderComponentsToMarkdown (entry exports)", () => {
+  const entryExports: EntryExports = [
+    {
+      name: "VERSION",
+      kind: "const",
+      type: "string",
+      value: '"1.0.0"',
+      description: "Library version.",
+      isTypeOnly: false,
+    },
+    { name: "clamp", kind: "function", type: "(value: number) => number", isTypeOnly: false },
+    { name: "Theme", kind: "type", type: '"light" | "dark"', isTypeOnly: true },
+  ];
+
+  test("renders an Exports section with a row per export", () => {
+    const output = render(new Map(), entryExports);
+
+    expect(output).toContain("## Exports");
+    expect(output).toContain("| Name | Kind | Type | Description |");
+    expect(output).toContain("| VERSION | <code>const</code> | <code>string</code> | Library version. |");
+    expect(output).toContain("| clamp | <code>function</code> | <code>(value: number) => number</code> | -- |");
+    expect(output).toContain('| Theme | <code>type</code> | <code>"light" &#124; "dark"</code> | -- |');
+  });
+
+  test("flattens multi-line types onto a single table row", () => {
+    const output = render(new Map(), [
+      { name: "ThemeConfig", kind: "interface", type: "{\n  theme: Theme;\n  persist: boolean;\n}", isTypeOnly: true },
+    ]);
+
+    expect(output).toContain(
+      "| ThemeConfig | <code>interface</code> | <code>{ theme: Theme; persist: boolean; }</code> | -- |",
+    );
+    // The type cell must not introduce a raw newline that would break the table.
+    expect(output).not.toContain("theme: Theme;\n");
+  });
+
+  test("omits the Exports section when there are no entry exports", () => {
+    expect(render(new Map(), [])).not.toContain("## Exports");
+    expect(render(new Map())).not.toContain("## Exports");
+  });
+});

--- a/tests/parse-entry-exports.test.ts
+++ b/tests/parse-entry-exports.test.ts
@@ -1,0 +1,132 @@
+import path from "node:path";
+import { type EntryExport, parseEntryExports } from "../src/parse-entry-exports";
+
+const entryFile = path.join(process.cwd(), "tests", "fixtures-entry-exports", "index.ts");
+
+function byName(exports: EntryExport[], name: string): EntryExport {
+  const match = exports.find((entry) => entry.name === name);
+  if (!match) throw new Error(`Expected an export named "${name}"`);
+  return match;
+}
+
+describe("parseEntryExports", () => {
+  test("documents re-exported consts, functions, and types", () => {
+    const exports = parseEntryExports(entryFile);
+    const names = exports.map((entry) => entry.name);
+
+    // Components are documented separately and excluded here.
+    expect(names).not.toContain("Button");
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "VERSION",
+        "MAX_RETRIES",
+        "clamp",
+        "invertTheme",
+        "Theme",
+        "ThemeConfig",
+        "DEFAULT_THEME",
+      ]),
+    );
+  });
+
+  test("documents a re-exported const with its value and JSDoc", () => {
+    const exports = parseEntryExports(entryFile);
+
+    expect(byName(exports, "VERSION")).toMatchObject({
+      name: "VERSION",
+      kind: "const",
+      type: "string",
+      value: '"1.2.3"',
+      description: "The current library version.",
+      isTypeOnly: false,
+    });
+  });
+
+  test("copies an explicit const type annotation verbatim", () => {
+    const exports = parseEntryExports(entryFile);
+
+    expect(byName(exports, "MAX_RETRIES")).toMatchObject({
+      name: "MAX_RETRIES",
+      kind: "const",
+      type: "number",
+      isTypeOnly: false,
+    });
+  });
+
+  test("documents a re-exported function declaration as a signature", () => {
+    const exports = parseEntryExports(entryFile);
+
+    expect(byName(exports, "clamp")).toMatchObject({
+      name: "clamp",
+      kind: "function",
+      type: "(value: number, min: number, max: number) => number",
+      description: "Clamps a number between a lower and upper bound.",
+      isTypeOnly: false,
+    });
+  });
+
+  test("documents a re-exported arrow function const", () => {
+    const exports = parseEntryExports(entryFile);
+
+    expect(byName(exports, "invertTheme")).toMatchObject({
+      name: "invertTheme",
+      kind: "const",
+      type: "(theme: Theme) => Theme",
+      // Only the adjacent JSDoc documents the value; a preceding declaration's
+      // comment must not bleed into it.
+      description: "Returns the inverse of a theme.",
+      isTypeOnly: false,
+    });
+  });
+
+  test("leaves the description undefined when there is no adjacent JSDoc", () => {
+    const exports = parseEntryExports(entryFile);
+    expect(byName(exports, "MAX_RETRIES").description).toBeUndefined();
+  });
+
+  test("documents a re-exported type alias verbatim", () => {
+    const exports = parseEntryExports(entryFile);
+
+    expect(byName(exports, "Theme")).toMatchObject({
+      name: "Theme",
+      kind: "type",
+      type: '"light" | "dark"',
+      isTypeOnly: true,
+    });
+  });
+
+  test("documents a re-exported interface", () => {
+    const exports = parseEntryExports(entryFile);
+    const themeConfig = byName(exports, "ThemeConfig");
+
+    expect(themeConfig.kind).toBe("interface");
+    expect(themeConfig.isTypeOnly).toBe(true);
+    expect(themeConfig.type).toContain("theme: Theme");
+    expect(themeConfig.type).toContain("persist: boolean");
+  });
+
+  test("documents an inline const declaration on the entry", () => {
+    const exports = parseEntryExports(entryFile);
+
+    expect(byName(exports, "DEFAULT_THEME")).toMatchObject({
+      name: "DEFAULT_THEME",
+      kind: "const",
+      value: '"light"',
+      description: "Default theme applied when none is configured.",
+      isTypeOnly: false,
+    });
+  });
+
+  test("sorts exports alphabetically and resolves source paths", () => {
+    const exports = parseEntryExports(entryFile);
+
+    const sorted = [...exports].sort((a, b) => a.name.localeCompare(b.name));
+    expect(exports).toEqual(sorted);
+
+    expect(byName(exports, "VERSION").source).toBe("./constants.ts");
+    expect(byName(exports, "clamp").source).toBe("./utils.ts");
+    expect(byName(exports, "Theme").source).toBe("./types.ts");
+    expect(byName(exports, "DEFAULT_THEME").source).toBe("./index.ts");
+  });
+});

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -85,4 +85,25 @@ describe("generateBundle", () => {
     expect(result.exports).toBeDefined();
     expect(result.components).toBeDefined();
   });
+
+  describe("documentExports", () => {
+    const entryFile = path.join(process.cwd(), "tests", "fixtures-entry-exports", "entry.js");
+
+    test("does not document entry exports by default", async () => {
+      const result = await generateBundle(entryFile, false);
+      expect(result.entryExports).toEqual([]);
+    });
+
+    test("documents non-component entry exports when enabled", async () => {
+      const result = await generateBundle(entryFile, false, { documentExports: true });
+      const byName = new Map(result.entryExports.map((entry) => [entry.name, entry]));
+
+      // Components are excluded from the entry exports collection.
+      expect(byName.has("Button")).toBe(false);
+
+      expect(byName.get("VERSION")).toMatchObject({ kind: "const", type: "string" });
+      expect(byName.get("clamp")).toMatchObject({ kind: "function" });
+      expect(byName.get("Theme")).toMatchObject({ kind: "type", isTypeOnly: true });
+    });
+  });
 });

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -51,4 +51,61 @@ describe("writeJson", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  test("omits entry exports collection when documentExports is off", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+    const components: ComponentDocs = new Map([["Alpha", createComponent("Alpha", "Alpha.svelte")]]);
+
+    try {
+      await writeJson(components, { input: "src", inputDir: "src", outFile });
+
+      const output = JSON.parse(readFileSync(path.join(tempDir, "COMPONENT_API.json"), "utf-8"));
+      expect(output.exports).toBeUndefined();
+      expect(output.totalExports).toBeUndefined();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes the entry exports collection when provided", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+    const components: ComponentDocs = new Map([["Alpha", createComponent("Alpha", "Alpha.svelte")]]);
+
+    try {
+      await writeJson(components, {
+        input: "src",
+        inputDir: "src",
+        outFile,
+        entryExports: [
+          {
+            name: "VERSION",
+            kind: "const",
+            type: "string",
+            value: '"1.0.0"',
+            isTypeOnly: false,
+            source: "./constants.ts",
+          },
+          { name: "Theme", kind: "type", type: '"light" | "dark"', isTypeOnly: true, source: "./types.ts" },
+        ],
+      });
+
+      const output = JSON.parse(readFileSync(path.join(tempDir, "COMPONENT_API.json"), "utf-8"));
+      expect(output.totalExports).toBe(2);
+      expect(output.exports).toEqual([
+        {
+          name: "VERSION",
+          kind: "const",
+          type: "string",
+          value: '"1.0.0"',
+          isTypeOnly: false,
+          source: "./constants.ts",
+        },
+        { name: "Theme", kind: "type", type: '"light" | "dark"', isTypeOnly: true, source: "./types.ts" },
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Components were the only documented surface; a library's barrel also
re-exports consts, functions, and types. This opt-in pass records them
into JSON (`exports`) and a Markdown "Exports" section.

Resolution stays AST-only via the Svelte/acorn-typescript parser,
copying type text verbatim rather than running `tsc` semantic analysis.