### PR TITLE
feat: add API diff command and config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ export default class Button extends SvelteComponentTyped<
   - [Vite](#vite)
   - [Node.js](#nodejs)
   - [CLI](#cli)
+    - [API diff](#api-diff)
   - [Config File](#config-file)
   - [Publishing to NPM](#publishing-to-npm)
 - [Available Options](#available-options)
@@ -275,6 +276,37 @@ Generate documentation in JSON and/or Markdown formats using the following flags
 
 ```sh
 npx sveld --json --markdown
+```
+
+#### API diff
+
+Compare two `COMPONENT_API.json` snapshots and classify each change as **breaking**, **additive**, or **doc-only**:
+
+```sh
+npx sveld diff old/COMPONENT_API.json new/COMPONENT_API.json
+```
+
+By default the command exits with code `1` when breaking changes are present. Use `--fail-on=additive` to fail on any API change, or `--no-fail` to always exit `0`. Pass `--json` for machine-readable output.
+
+```sh
+# CI: fail on breaking changes only (default)
+npx sveld diff baseline.json COMPONENT_API.json
+
+# Fail on any prop/event/slot/component change
+npx sveld diff baseline.json COMPONENT_API.json --fail-on=additive
+
+# Structured output for changelogs or PR comments
+npx sveld diff baseline.json COMPONENT_API.json --json
+```
+
+The same logic is available programmatically:
+
+```js
+import { diffComponentApi, formatDiffReport } from "sveld";
+
+const result = diffComponentApi(oldApi, newApi);
+if (result.hasBreaking) process.exit(1);
+console.log(formatDiffReport(result));
 ```
 
 ### Node.js

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,9 @@
+import { readFileSync } from "node:fs";
 import resolve from "@rollup/plugin-node-resolve";
 import { rollup } from "rollup";
 import svelte from "rollup-plugin-svelte";
 import { formatDiagnosticsSummary } from "./diagnostics";
+import { type ComponentApiFile, type DiffResult, diffComponentApi, formatDiffReport } from "./diff";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig } from "./load-config";
 import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
@@ -48,9 +50,104 @@ export function parseCliOptions(argv: string[]): CliOptions {
   return options;
 }
 
+/** Severity level at which the `diff` subcommand exits non-zero. */
+type DiffFailOn = "breaking" | "additive" | "none";
+
+interface DiffCliOptions {
+  oldPath?: string;
+  newPath?: string;
+  json: boolean;
+  failOn: DiffFailOn;
+  detectRenames: boolean;
+}
+
+function parseDiffArgs(argv: string[]): DiffCliOptions {
+  const options: DiffCliOptions = {
+    json: false,
+    failOn: "breaking",
+    detectRenames: true,
+  };
+  const positionals: string[] = [];
+
+  for (const arg of argv) {
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--no-rename-detection") {
+      options.detectRenames = false;
+    } else if (arg === "--no-fail-on-breaking" || arg === "--no-fail") {
+      options.failOn = "none";
+    } else if (arg.startsWith("--fail-on=")) {
+      const value = arg.slice("--fail-on=".length);
+      if (value === "breaking" || value === "additive" || value === "none") {
+        options.failOn = value;
+      } else {
+        throw new Error(`Invalid --fail-on value "${value}". Expected: breaking, additive, or none.`);
+      }
+    } else if (arg.startsWith("--")) {
+      throw new Error(`Unknown flag "${arg}" for "sveld diff".`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  options.oldPath = positionals[0];
+  options.newPath = positionals[1];
+  return options;
+}
+
+function readComponentApi(filePath: string): ComponentApiFile {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf-8");
+  } catch {
+    throw new Error(`Could not read "${filePath}".`);
+  }
+  try {
+    return JSON.parse(raw) as ComponentApiFile;
+  } catch {
+    throw new Error(`"${filePath}" is not valid JSON.`);
+  }
+}
+
+function shouldFail(result: DiffResult, failOn: DiffFailOn): boolean {
+  if (failOn === "none") return false;
+  if (failOn === "additive") return result.summary.breaking + result.summary.additive > 0;
+  return result.hasBreaking;
+}
+
+/**
+ * Runs `sveld diff <old.json> <new.json>`: compares two `COMPONENT_API.json`
+ * snapshots, prints a report (human-readable or `--json`), and returns the
+ * process exit code (non-zero when failing changes are present).
+ */
+export function diffCli(process: NodeJS.Process): number {
+  const options = parseDiffArgs(process.argv.slice(3));
+
+  if (!options.oldPath || !options.newPath) {
+    process.stderr.write(
+      "Usage: sveld diff <old.json> <new.json> [--json] [--fail-on=breaking|additive|none] [--no-rename-detection]\n",
+    );
+    return 2;
+  }
+
+  const oldApi = readComponentApi(options.oldPath);
+  const newApi = readComponentApi(options.newPath);
+  const result = diffComponentApi(oldApi, newApi, { detectRenames: options.detectRenames });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatDiffReport(result)}\n`);
+  }
+
+  return shouldFail(result, options.failOn) ? 1 : 0;
+}
+
 /**
  * CLI entry point: parse flags, load any config file, run Rollup, generate
  * docs, write outputs.
+ *
+ * Dispatches to the `diff` subcommand when invoked as `sveld diff ...`.
  *
  * @example
  * ```ts
@@ -59,6 +156,16 @@ export function parseCliOptions(argv: string[]): CliOptions {
  * ```
  */
 export async function cli(process: NodeJS.Process) {
+  if (process.argv[2] === "diff") {
+    try {
+      process.exitCode = diffCli(process);
+    } catch (error) {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 2;
+    }
+    return;
+  }
+
   const cliOptions = parseCliOptions(process.argv.slice(2));
   const fileConfig = await loadConfig();
   const options = mergeConfig<CliOptions>(fileConfig, cliOptions);

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,652 @@
+/**
+ * Diff two `COMPONENT_API.json` snapshots and classify each change as
+ * **breaking**, **additive**, or **doc-only**.
+ *
+ * The stable, deterministically-sorted shape emitted by sveld (with a
+ * `schemaVersion` and generator metadata) makes it possible to compare two
+ * API snapshots and gate CI on breaking changes or generate changelogs.
+ *
+ * This module is intentionally free of any filesystem access so it can be
+ * reused in any environment; the CLI is responsible for reading files.
+ */
+
+/** Severity bucket assigned to each detected change. */
+export type DiffSeverity = "breaking" | "additive" | "doc-only";
+
+/** Specific kind of change, useful for changelog grouping and tooling. */
+export type DiffChangeKind =
+  | "component-removed"
+  | "component-added"
+  | "prop-removed"
+  | "prop-added"
+  | "prop-renamed"
+  | "prop-type-narrowed"
+  | "prop-type-widened"
+  | "prop-type-changed"
+  | "prop-required-added"
+  | "prop-optional"
+  | "prop-doc-changed"
+  | "event-removed"
+  | "event-added"
+  | "event-detail-changed"
+  | "event-doc-changed"
+  | "slot-removed"
+  | "slot-added"
+  | "slot-props-changed"
+  | "slot-doc-changed";
+
+/** A single classified difference between two snapshots. */
+export interface DiffChange {
+  severity: DiffSeverity;
+  kind: DiffChangeKind;
+  /** The component (moduleName) the change belongs to. */
+  component: string;
+  /** Prop / event / slot name the change targets, when applicable. */
+  target?: string;
+  /** Human-readable explanation of the change. */
+  message: string;
+  /** Previous value (type, description, name, ...), when applicable. */
+  from?: string;
+  /** New value (type, description, name, ...), when applicable. */
+  to?: string;
+}
+
+/** Aggregated counts per severity. */
+export interface DiffSummary {
+  breaking: number;
+  additive: number;
+  docOnly: number;
+  total: number;
+}
+
+/** Result of {@link diffComponentApi}. */
+export interface DiffResult {
+  /** All detected changes, ordered deterministically. */
+  changes: DiffChange[];
+  summary: DiffSummary;
+  /** True when at least one breaking change was detected. */
+  hasBreaking: boolean;
+}
+
+/** Options controlling diff behavior. */
+export interface DiffOptions {
+  /**
+   * Treat a prop being added or renamed as a rename when the candidate
+   * props share the same TypeScript type. Enabled by default.
+   */
+  detectRenames?: boolean;
+}
+
+// --- Minimal structural types for the parts of COMPONENT_API.json we read ---
+
+interface ApiProp {
+  name: string;
+  type?: string;
+  isRequired?: boolean;
+  isFunction?: boolean;
+  kind?: string;
+  description?: string;
+}
+
+interface ApiEvent {
+  name: string;
+  type?: string;
+  detail?: string;
+  description?: string;
+}
+
+interface ApiSlot {
+  name?: string | null;
+  default?: boolean;
+  slot_props?: string;
+  description?: string;
+}
+
+interface ApiComponent {
+  moduleName: string;
+  props?: ApiProp[];
+  events?: ApiEvent[];
+  slots?: ApiSlot[];
+}
+
+/** Shape of a parsed `COMPONENT_API.json` file. */
+export interface ComponentApiFile {
+  schemaVersion?: number;
+  components?: ApiComponent[];
+}
+
+const SLOT_DEFAULT_KEY = "__default__";
+
+/**
+ * Split a TypeScript type into its top-level union members, ignoring `|`
+ * that appear inside brackets, parentheses, or string literals.
+ *
+ * @example
+ * splitUnion('"a" | "b" | "c"') // ['"a"', '"b"', '"c"']
+ * splitUnion('Array<A | B> | C') // ['Array<A | B>', 'C']
+ */
+function splitUnion(type: string): string[] {
+  const members: string[] = [];
+  let depth = 0;
+  let quote: '"' | "'" | "`" | null = null;
+  let current = "";
+
+  for (let i = 0; i < type.length; i++) {
+    const ch = type[i];
+
+    if (quote !== null) {
+      current += ch;
+      if (ch === "\\") {
+        current += type[++i] ?? "";
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "<" || ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ">" || ch === ")" || ch === "]" || ch === "}") depth--;
+
+    if (ch === "|" && depth === 0) {
+      members.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (current.trim() !== "") members.push(current.trim());
+  return members.filter(Boolean);
+}
+
+type TypeComparison = "same" | "narrowed" | "widened" | "changed";
+
+const TOP_TYPES = new Set(["any", "unknown"]);
+
+/**
+ * Compare an old and new type string and classify the relationship from the
+ * consumer's perspective: a smaller set of accepted values is **narrowed**
+ * (breaking), a larger set is **widened** (additive).
+ */
+function compareTypes(oldType: string, newType: string): TypeComparison {
+  const a = oldType.trim();
+  const b = newType.trim();
+  if (a === b) return "same";
+
+  // `any`/`unknown` accept everything. Going to a top type widens; leaving a
+  // top type for something specific narrows.
+  const aTop = TOP_TYPES.has(a);
+  const bTop = TOP_TYPES.has(b);
+  if (aTop && !bTop) return "narrowed";
+  if (!aTop && bTop) return "widened";
+
+  const oldMembers = new Set(splitUnion(a));
+  const newMembers = new Set(splitUnion(b));
+
+  const oldSubsetOfNew = [...oldMembers].every((m) => newMembers.has(m));
+  const newSubsetOfOld = [...newMembers].every((m) => oldMembers.has(m));
+
+  if (oldSubsetOfNew && !newSubsetOfOld) return "widened";
+  if (newSubsetOfOld && !oldSubsetOfNew) return "narrowed";
+  return "changed";
+}
+
+function indexByName<T extends { name: string }>(items: T[] | undefined): Map<string, T> {
+  const map = new Map<string, T>();
+  for (const item of items ?? []) map.set(item.name, item);
+  return map;
+}
+
+function slotKey(slot: ApiSlot): string {
+  return slot.name == null ? SLOT_DEFAULT_KEY : slot.name;
+}
+
+function slotLabel(slot: ApiSlot): string {
+  return slot.name == null ? "default" : slot.name;
+}
+
+function normalizeDescription(value?: string): string {
+  return (value ?? "").trim();
+}
+
+/**
+ * Compare two props that exist in both snapshots and push any classified
+ * changes (type, required, doc) onto `changes`.
+ */
+function diffProp(component: string, oldProp: ApiProp, newProp: ApiProp, changes: DiffChange[]): void {
+  const name = newProp.name;
+
+  // Required transitions.
+  const wasRequired = oldProp.isRequired === true;
+  const isRequired = newProp.isRequired === true;
+  if (!wasRequired && isRequired) {
+    changes.push({
+      severity: "breaking",
+      kind: "prop-required-added",
+      component,
+      target: name,
+      message: `Prop "${name}" became required`,
+    });
+  } else if (wasRequired && !isRequired) {
+    changes.push({
+      severity: "additive",
+      kind: "prop-optional",
+      component,
+      target: name,
+      message: `Prop "${name}" is no longer required`,
+    });
+  }
+
+  // Type transitions (only when both sides declare a type).
+  if (oldProp.type != null && newProp.type != null) {
+    const comparison = compareTypes(oldProp.type, newProp.type);
+    if (comparison === "narrowed") {
+      changes.push({
+        severity: "breaking",
+        kind: "prop-type-narrowed",
+        component,
+        target: name,
+        message: `Prop "${name}" type narrowed`,
+        from: oldProp.type,
+        to: newProp.type,
+      });
+    } else if (comparison === "widened") {
+      changes.push({
+        severity: "additive",
+        kind: "prop-type-widened",
+        component,
+        target: name,
+        message: `Prop "${name}" type widened`,
+        from: oldProp.type,
+        to: newProp.type,
+      });
+    } else if (comparison === "changed") {
+      changes.push({
+        severity: "breaking",
+        kind: "prop-type-changed",
+        component,
+        target: name,
+        message: `Prop "${name}" type changed`,
+        from: oldProp.type,
+        to: newProp.type,
+      });
+    }
+  }
+
+  // Description-only change.
+  const oldDesc = normalizeDescription(oldProp.description);
+  const newDesc = normalizeDescription(newProp.description);
+  if (oldDesc !== newDesc) {
+    changes.push({
+      severity: "doc-only",
+      kind: "prop-doc-changed",
+      component,
+      target: name,
+      message: `Prop "${name}" description changed`,
+      from: oldProp.description,
+      to: newProp.description,
+    });
+  }
+}
+
+/**
+ * Pair up removed and added props that share an identical type signature as
+ * renames. Returns the matched pairs and the leftover removed/added props.
+ */
+function matchRenames(
+  removed: ApiProp[],
+  added: ApiProp[],
+): { renames: Array<[ApiProp, ApiProp]>; removed: ApiProp[]; added: ApiProp[] } {
+  const renames: Array<[ApiProp, ApiProp]> = [];
+  const remainingRemoved: ApiProp[] = [];
+  const usedAdded = new Set<ApiProp>();
+
+  for (const oldProp of removed) {
+    if (oldProp.type == null) {
+      remainingRemoved.push(oldProp);
+      continue;
+    }
+    const match = added.find(
+      (newProp) =>
+        !usedAdded.has(newProp) &&
+        newProp.type != null &&
+        compareTypes(oldProp.type as string, newProp.type) === "same" &&
+        (oldProp.isRequired === true) === (newProp.isRequired === true),
+    );
+    if (match) {
+      usedAdded.add(match);
+      renames.push([oldProp, match]);
+    } else {
+      remainingRemoved.push(oldProp);
+    }
+  }
+
+  const remainingAdded = added.filter((newProp) => !usedAdded.has(newProp));
+  return { renames, removed: remainingRemoved, added: remainingAdded };
+}
+
+function diffProps(
+  component: string,
+  oldProps: ApiProp[],
+  newProps: ApiProp[],
+  options: DiffOptions,
+  changes: DiffChange[],
+): void {
+  const oldByName = indexByName(oldProps);
+  const newByName = indexByName(newProps);
+
+  const removed: ApiProp[] = [];
+  for (const oldProp of oldProps) {
+    if (!newByName.has(oldProp.name)) removed.push(oldProp);
+  }
+
+  const added: ApiProp[] = [];
+  for (const newProp of newProps) {
+    if (!oldByName.has(newProp.name)) added.push(newProp);
+  }
+
+  // Props present in both: compare attributes.
+  for (const newProp of newProps) {
+    const oldProp = oldByName.get(newProp.name);
+    if (oldProp) diffProp(component, oldProp, newProp, changes);
+  }
+
+  let pendingRemoved = removed;
+  let pendingAdded = added;
+
+  if (options.detectRenames !== false) {
+    const result = matchRenames(removed, added);
+    for (const [oldProp, newProp] of result.renames) {
+      changes.push({
+        severity: "breaking",
+        kind: "prop-renamed",
+        component,
+        target: newProp.name,
+        message: `Prop "${oldProp.name}" renamed to "${newProp.name}"`,
+        from: oldProp.name,
+        to: newProp.name,
+      });
+    }
+    pendingRemoved = result.removed;
+    pendingAdded = result.added;
+  }
+
+  for (const oldProp of pendingRemoved) {
+    changes.push({
+      severity: "breaking",
+      kind: "prop-removed",
+      component,
+      target: oldProp.name,
+      message: `Prop "${oldProp.name}" was removed`,
+    });
+  }
+
+  for (const newProp of pendingAdded) {
+    if (newProp.isRequired === true) {
+      changes.push({
+        severity: "breaking",
+        kind: "prop-required-added",
+        component,
+        target: newProp.name,
+        message: `New required prop "${newProp.name}" was added`,
+      });
+    } else {
+      changes.push({
+        severity: "additive",
+        kind: "prop-added",
+        component,
+        target: newProp.name,
+        message: `New optional prop "${newProp.name}" was added`,
+      });
+    }
+  }
+}
+
+function diffEvents(component: string, oldEvents: ApiEvent[], newEvents: ApiEvent[], changes: DiffChange[]): void {
+  const oldByName = indexByName(oldEvents);
+  const newByName = indexByName(newEvents);
+
+  for (const oldEvent of oldEvents) {
+    if (!newByName.has(oldEvent.name)) {
+      changes.push({
+        severity: "breaking",
+        kind: "event-removed",
+        component,
+        target: oldEvent.name,
+        message: `Event "${oldEvent.name}" was removed`,
+      });
+    }
+  }
+
+  for (const newEvent of newEvents) {
+    const oldEvent = oldByName.get(newEvent.name);
+    if (!oldEvent) {
+      changes.push({
+        severity: "additive",
+        kind: "event-added",
+        component,
+        target: newEvent.name,
+        message: `Event "${newEvent.name}" was added`,
+      });
+      continue;
+    }
+
+    const oldDetail = (oldEvent.detail ?? "").trim();
+    const newDetail = (newEvent.detail ?? "").trim();
+    if (oldDetail !== newDetail) {
+      changes.push({
+        severity: "breaking",
+        kind: "event-detail-changed",
+        component,
+        target: newEvent.name,
+        message: `Event "${newEvent.name}" detail type changed`,
+        from: oldEvent.detail,
+        to: newEvent.detail,
+      });
+    }
+
+    const oldDesc = normalizeDescription(oldEvent.description);
+    const newDesc = normalizeDescription(newEvent.description);
+    if (oldDesc !== newDesc) {
+      changes.push({
+        severity: "doc-only",
+        kind: "event-doc-changed",
+        component,
+        target: newEvent.name,
+        message: `Event "${newEvent.name}" description changed`,
+        from: oldEvent.description,
+        to: newEvent.description,
+      });
+    }
+  }
+}
+
+function diffSlots(component: string, oldSlots: ApiSlot[], newSlots: ApiSlot[], changes: DiffChange[]): void {
+  const oldByKey = new Map(oldSlots.map((slot) => [slotKey(slot), slot]));
+  const newByKey = new Map(newSlots.map((slot) => [slotKey(slot), slot]));
+
+  for (const oldSlot of oldSlots) {
+    if (!newByKey.has(slotKey(oldSlot))) {
+      changes.push({
+        severity: "breaking",
+        kind: "slot-removed",
+        component,
+        target: slotLabel(oldSlot),
+        message: `Slot "${slotLabel(oldSlot)}" was removed`,
+      });
+    }
+  }
+
+  for (const newSlot of newSlots) {
+    const oldSlot = oldByKey.get(slotKey(newSlot));
+    if (!oldSlot) {
+      changes.push({
+        severity: "additive",
+        kind: "slot-added",
+        component,
+        target: slotLabel(newSlot),
+        message: `Slot "${slotLabel(newSlot)}" was added`,
+      });
+      continue;
+    }
+
+    const oldProps = (oldSlot.slot_props ?? "").trim();
+    const newProps = (newSlot.slot_props ?? "").trim();
+    if (oldProps !== newProps) {
+      changes.push({
+        severity: "breaking",
+        kind: "slot-props-changed",
+        component,
+        target: slotLabel(newSlot),
+        message: `Slot "${slotLabel(newSlot)}" props changed`,
+        from: oldSlot.slot_props,
+        to: newSlot.slot_props,
+      });
+    }
+
+    const oldDesc = normalizeDescription(oldSlot.description);
+    const newDesc = normalizeDescription(newSlot.description);
+    if (oldDesc !== newDesc) {
+      changes.push({
+        severity: "doc-only",
+        kind: "slot-doc-changed",
+        component,
+        target: slotLabel(newSlot),
+        message: `Slot "${slotLabel(newSlot)}" description changed`,
+        from: oldSlot.description,
+        to: newSlot.description,
+      });
+    }
+  }
+}
+
+function indexComponents(file: ComponentApiFile): Map<string, ApiComponent> {
+  const map = new Map<string, ApiComponent>();
+  for (const component of file.components ?? []) map.set(component.moduleName, component);
+  return map;
+}
+
+const SEVERITY_ORDER: Record<DiffSeverity, number> = { breaking: 0, additive: 1, "doc-only": 2 };
+
+/**
+ * Compare two parsed `COMPONENT_API.json` snapshots and classify every change.
+ *
+ * @param oldApi - The baseline snapshot (e.g. the published API).
+ * @param newApi - The candidate snapshot (e.g. the current branch).
+ * @param options - Optional behavior overrides.
+ * @returns A {@link DiffResult} with classified changes and summary counts.
+ *
+ * @example
+ * ```ts
+ * const result = diffComponentApi(oldApi, newApi);
+ * if (result.hasBreaking) process.exit(1);
+ * ```
+ */
+export function diffComponentApi(
+  oldApi: ComponentApiFile,
+  newApi: ComponentApiFile,
+  options: DiffOptions = {},
+): DiffResult {
+  const changes: DiffChange[] = [];
+  const oldComponents = indexComponents(oldApi);
+  const newComponents = indexComponents(newApi);
+
+  // Removed components.
+  for (const [name] of oldComponents) {
+    if (!newComponents.has(name)) {
+      changes.push({
+        severity: "breaking",
+        kind: "component-removed",
+        component: name,
+        message: `Component "${name}" was removed`,
+      });
+    }
+  }
+
+  // Added components and per-component diffs.
+  for (const [name, newComponent] of newComponents) {
+    const oldComponent = oldComponents.get(name);
+    if (!oldComponent) {
+      changes.push({
+        severity: "additive",
+        kind: "component-added",
+        component: name,
+        message: `Component "${name}" was added`,
+      });
+      continue;
+    }
+
+    diffProps(name, oldComponent.props ?? [], newComponent.props ?? [], options, changes);
+    diffEvents(name, oldComponent.events ?? [], newComponent.events ?? [], changes);
+    diffSlots(name, oldComponent.slots ?? [], newComponent.slots ?? [], changes);
+  }
+
+  // Deterministic ordering: severity, then component, then kind, then target.
+  changes.sort((a, b) => {
+    if (SEVERITY_ORDER[a.severity] !== SEVERITY_ORDER[b.severity]) {
+      return SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    }
+    if (a.component !== b.component) return a.component.localeCompare(b.component);
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
+    return (a.target ?? "").localeCompare(b.target ?? "");
+  });
+
+  const summary: DiffSummary = {
+    breaking: changes.filter((c) => c.severity === "breaking").length,
+    additive: changes.filter((c) => c.severity === "additive").length,
+    docOnly: changes.filter((c) => c.severity === "doc-only").length,
+    total: changes.length,
+  };
+
+  return { changes, summary, hasBreaking: summary.breaking > 0 };
+}
+
+const SEVERITY_LABELS: Record<DiffSeverity, string> = {
+  breaking: "BREAKING",
+  additive: "ADDITIVE",
+  "doc-only": "DOC-ONLY",
+};
+
+/**
+ * Render a {@link DiffResult} as a human-readable, grouped report.
+ *
+ * @example
+ * ```ts
+ * console.log(formatDiffReport(diffComponentApi(oldApi, newApi)));
+ * ```
+ */
+export function formatDiffReport(result: DiffResult): string {
+  const lines: string[] = [];
+
+  if (result.changes.length === 0) {
+    return "No API changes detected.";
+  }
+
+  for (const severity of ["breaking", "additive", "doc-only"] as const) {
+    const group = result.changes.filter((c) => c.severity === severity);
+    if (group.length === 0) continue;
+
+    lines.push(`${SEVERITY_LABELS[severity]} (${group.length})`);
+    for (const change of group) {
+      let line = `  • [${change.component}] ${change.message}`;
+      if (change.from != null && change.to != null) {
+        line += `: ${change.from} → ${change.to}`;
+      }
+      lines.push(line);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    `Summary: ${result.summary.breaking} breaking, ${result.summary.additive} additive, ${result.summary.docOnly} doc-only.`,
+  );
+
+  return lines.join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,17 @@
 export { default as ComponentParser, type SerializedComponentEvent } from "./ComponentParser";
 export { cli } from "./cli";
 export type { SveldDiagnostic, SveldDiagnosticKind } from "./diagnostics";
+export {
+  type ComponentApiFile,
+  type DiffChange,
+  type DiffChangeKind,
+  type DiffOptions,
+  type DiffResult,
+  type DiffSeverity,
+  type DiffSummary,
+  diffComponentApi,
+  formatDiffReport,
+} from "./diff";
 export type { SvelteEntryPoint } from "./get-svelte-entry";
 export { defineConfig, type SveldConfig } from "./load-config";
 export { default } from "./plugin";

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,256 @@
+import { type ComponentApiFile, diffComponentApi, formatDiffReport } from "../src/diff";
+
+interface PropInput {
+  name: string;
+  type?: string;
+  isRequired?: boolean;
+  description?: string;
+}
+
+function api(props: PropInput[], extra: Record<string, unknown> = {}): ComponentApiFile {
+  return {
+    schemaVersion: 1,
+    components: [
+      {
+        moduleName: "Button",
+        props,
+        events: [],
+        slots: [],
+        ...extra,
+      },
+    ],
+  };
+}
+
+function kinds(result: ReturnType<typeof diffComponentApi>): string[] {
+  return result.changes.map((c) => c.kind);
+}
+
+describe("diffComponentApi", () => {
+  describe("props", () => {
+    test("classifies a removed prop as breaking", () => {
+      const result = diffComponentApi(api([{ name: "size", type: "string" }]), api([]));
+      expect(result.changes).toHaveLength(1);
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "prop-removed", target: "size" });
+      expect(result.hasBreaking).toBe(true);
+    });
+
+    test("classifies a new optional prop as additive", () => {
+      const result = diffComponentApi(api([]), api([{ name: "size", type: "string", isRequired: false }]));
+      expect(result.changes[0]).toMatchObject({ severity: "additive", kind: "prop-added", target: "size" });
+      expect(result.hasBreaking).toBe(false);
+    });
+
+    test("classifies a new required prop as breaking", () => {
+      const result = diffComponentApi(api([]), api([{ name: "size", type: "string", isRequired: true }]));
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "prop-required-added", target: "size" });
+    });
+
+    test("classifies a prop becoming required as breaking", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: "string", isRequired: false }]),
+        api([{ name: "size", type: "string", isRequired: true }]),
+      );
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "prop-required-added" });
+    });
+
+    test("classifies a prop becoming optional as additive", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: "string", isRequired: true }]),
+        api([{ name: "size", type: "string", isRequired: false }]),
+      );
+      expect(result.changes[0]).toMatchObject({ severity: "additive", kind: "prop-optional" });
+    });
+
+    test("classifies a narrowed union type as breaking", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: '"sm" | "md" | "lg"' }]),
+        api([{ name: "size", type: '"sm" | "md"' }]),
+      );
+      expect(result.changes[0]).toMatchObject({
+        severity: "breaking",
+        kind: "prop-type-narrowed",
+        from: '"sm" | "md" | "lg"',
+        to: '"sm" | "md"',
+      });
+    });
+
+    test("classifies a widened union type as additive", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: '"sm" | "md"' }]),
+        api([{ name: "size", type: '"sm" | "md" | "lg"' }]),
+      );
+      expect(result.changes[0]).toMatchObject({ severity: "additive", kind: "prop-type-widened" });
+    });
+
+    test("treats moving from `any` to a concrete type as narrowing", () => {
+      const result = diffComponentApi(api([{ name: "x", type: "any" }]), api([{ name: "x", type: "string" }]));
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "prop-type-narrowed" });
+    });
+
+    test("classifies an unrelated type change as breaking", () => {
+      const result = diffComponentApi(api([{ name: "x", type: "string" }]), api([{ name: "x", type: "number" }]));
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "prop-type-changed" });
+    });
+
+    test("classifies a description-only change as doc-only", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: "string", description: "old" }]),
+        api([{ name: "size", type: "string", description: "new" }]),
+      );
+      expect(result.changes).toHaveLength(1);
+      expect(result.changes[0]).toMatchObject({ severity: "doc-only", kind: "prop-doc-changed" });
+      expect(result.hasBreaking).toBe(false);
+    });
+
+    test("ignores props with no changes", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: "string", description: "same" }]),
+        api([{ name: "size", type: "string", description: "same" }]),
+      );
+      expect(result.changes).toHaveLength(0);
+    });
+  });
+
+  describe("rename heuristic", () => {
+    test("detects a rename when a removed and added prop share a type", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: '"sm" | "lg"' }]),
+        api([{ name: "scale", type: '"sm" | "lg"' }]),
+      );
+      expect(result.changes).toHaveLength(1);
+      expect(result.changes[0]).toMatchObject({
+        severity: "breaking",
+        kind: "prop-renamed",
+        from: "size",
+        to: "scale",
+      });
+    });
+
+    test("does not treat differing types as a rename", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: "string" }]),
+        api([{ name: "scale", type: "number" }]),
+      );
+      expect(kinds(result).sort()).toEqual(["prop-added", "prop-removed"]);
+    });
+
+    test("can be disabled, reporting a plain remove + add", () => {
+      const result = diffComponentApi(
+        api([{ name: "size", type: '"sm" | "lg"' }]),
+        api([{ name: "scale", type: '"sm" | "lg"' }]),
+        { detectRenames: false },
+      );
+      expect(kinds(result).sort()).toEqual(["prop-added", "prop-removed"]);
+    });
+  });
+
+  describe("events", () => {
+    const withEvents = (events: unknown[]): ComponentApiFile =>
+      ({
+        schemaVersion: 1,
+        components: [{ moduleName: "Button", props: [], slots: [], events }],
+      }) as ComponentApiFile;
+
+    test("classifies a removed event as breaking", () => {
+      const result = diffComponentApi(withEvents([{ type: "dispatched", name: "select" }]), withEvents([]));
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "event-removed", target: "select" });
+    });
+
+    test("classifies a new event as additive", () => {
+      const result = diffComponentApi(withEvents([]), withEvents([{ type: "dispatched", name: "select" }]));
+      expect(result.changes[0]).toMatchObject({ severity: "additive", kind: "event-added", target: "select" });
+    });
+
+    test("classifies a changed event detail as breaking", () => {
+      const result = diffComponentApi(
+        withEvents([{ type: "dispatched", name: "select", detail: "{ id: string }" }]),
+        withEvents([{ type: "dispatched", name: "select", detail: "{ id: number }" }]),
+      );
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "event-detail-changed" });
+    });
+
+    test("classifies an event description change as doc-only", () => {
+      const result = diffComponentApi(
+        withEvents([{ type: "dispatched", name: "select", description: "old" }]),
+        withEvents([{ type: "dispatched", name: "select", description: "new" }]),
+      );
+      expect(result.changes[0]).toMatchObject({ severity: "doc-only", kind: "event-doc-changed" });
+    });
+  });
+
+  describe("slots", () => {
+    const withSlots = (slots: unknown[]): ComponentApiFile =>
+      ({
+        schemaVersion: 1,
+        components: [{ moduleName: "Button", props: [], events: [], slots }],
+      }) as ComponentApiFile;
+
+    test("classifies a removed named slot as breaking", () => {
+      const result = diffComponentApi(withSlots([{ name: "header", default: false }]), withSlots([]));
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "slot-removed", target: "header" });
+    });
+
+    test("classifies a new slot as additive", () => {
+      const result = diffComponentApi(withSlots([]), withSlots([{ name: "header", default: false }]));
+      expect(result.changes[0]).toMatchObject({ severity: "additive", kind: "slot-added", target: "header" });
+    });
+
+    test("treats the default slot by a stable label", () => {
+      const result = diffComponentApi(withSlots([{ name: null, default: true }]), withSlots([]));
+      expect(result.changes[0]).toMatchObject({ kind: "slot-removed", target: "default" });
+    });
+
+    test("classifies a slot_props change as breaking", () => {
+      const result = diffComponentApi(
+        withSlots([{ name: null, default: true, slot_props: "{ value: string }" }]),
+        withSlots([{ name: null, default: true, slot_props: "{ value: number }" }]),
+      );
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "slot-props-changed" });
+    });
+  });
+
+  describe("components", () => {
+    test("classifies a removed component as breaking", () => {
+      const result = diffComponentApi(api([]), { schemaVersion: 1, components: [] });
+      expect(result.changes[0]).toMatchObject({ severity: "breaking", kind: "component-removed", component: "Button" });
+    });
+
+    test("classifies an added component as additive", () => {
+      const result = diffComponentApi({ schemaVersion: 1, components: [] }, api([]));
+      expect(result.changes[0]).toMatchObject({ severity: "additive", kind: "component-added", component: "Button" });
+    });
+  });
+
+  describe("summary, ordering, and report", () => {
+    test("counts and orders changes by severity", () => {
+      const result = diffComponentApi(
+        api([
+          { name: "removed", type: "string" },
+          { name: "doc", type: "string", description: "old" },
+        ]),
+        api([
+          { name: "added", type: "number", isRequired: false },
+          { name: "doc", type: "string", description: "new" },
+        ]),
+      );
+      expect(result.summary).toEqual({ breaking: 1, additive: 1, docOnly: 1, total: 3 });
+      expect(result.changes.map((c) => c.severity)).toEqual(["breaking", "additive", "doc-only"]);
+    });
+
+    test("renders a grouped human-readable report", () => {
+      const result = diffComponentApi(api([{ name: "size", type: "string" }]), api([]));
+      const report = formatDiffReport(result);
+      expect(report).toContain("BREAKING (1)");
+      expect(report).toContain('[Button] Prop "size" was removed');
+      expect(report).toContain("Summary: 1 breaking, 0 additive, 0 doc-only.");
+    });
+
+    test("reports no changes for identical snapshots", () => {
+      const same = api([{ name: "size", type: "string" }]);
+      const result = diffComponentApi(same, same);
+      expect(result.changes).toHaveLength(0);
+      expect(formatDiffReport(result)).toBe("No API changes detected.");
+    });
+  });
+});


### PR DESCRIPTION
Adds `sveld diff` to gate CI on breaking API changes between two
`COMPONENT_API.json` snapshots, plus auto-discovered
`sveld.config.{js,mjs,ts}` and `defineConfig` so CLI and multi-tool
setups stop repeating options.