### PR TITLE
feat: add golden-file API test helper and config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ export default class Button extends SvelteComponentTyped<
 - [Available Options](#available-options)
 - [Documenting Entry Exports](#documenting-entry-exports)
 - [JSON Output](#json-output)
+- [Testing](#testing)
 - [API Reference](#api-reference)
   - [@type](#type)
   - [@default](#default)
@@ -543,6 +544,81 @@ Prop metadata is additive and keeps the older public fields:
 - `typeSource` identifies the conservative source of the emitted `type`: TypeScript annotation, JSDoc, initializer/default inference, other parser inference, or unknown fallback.
 - `value` remains the raw default expression string. `defaultValue` adds structured metadata with the same raw expression, a coarse `kind`, and a parsed `value` only for JSON-safe literals, arrays, and plain objects. `sveld` does not evaluate arbitrary code.
 - `bindable: true` is emitted only for props explicitly declared with Svelte 5 `$bindable(...)`. Missing `bindable` should be treated as false.
+
+## Testing
+
+`sveld/testing` is a small, framework-agnostic helper for guarding a library's generated component API against unintended drift. It generates the API in-memory and asserts it matches a committed **golden snapshot**, failing with a readable diff that classifies the drift as **breaking**, **additive**, or **doc-only**.
+
+It throws a plain `Error` on mismatch, so it works from Bun, Jest, Vitest, or a standalone script — no test-framework integration required.
+
+```ts
+// component-api.test.ts
+import { test } from "vitest"; // or: import { test } from "bun:test"
+import { assertComponentApi } from "sveld/testing";
+
+test("component API is stable", async () => {
+  await assertComponentApi({
+    // Entry file (re-exporting components) or a directory of `.svelte` files.
+    // Defaults to the `svelte` field of package.json when omitted.
+    input: "src/index.js",
+    // Committed golden snapshot, relative to the current working directory.
+    snapshot: "test/__snapshots__/component-api.json",
+  });
+});
+```
+
+### Creating and updating the snapshot
+
+The first run needs a snapshot to compare against. Generate (or refresh) it by passing `update: true`, or by setting the `SVELD_UPDATE_SNAPSHOT` environment variable:
+
+```ts
+await assertComponentApi({ input: "src/index.js", snapshot, update: true });
+```
+
+```bash
+SVELD_UPDATE_SNAPSHOT=1 vitest run
+```
+
+Commit the generated `component-api.json`. It is a deterministic, position-free projection of your component API — it omits volatile data (the generator version, absolute file paths, and source ranges), so it only changes when the public API actually changes.
+
+### Failure output
+
+When the API drifts, the assertion throws a `ComponentApiDriftError` with a grouped, classified report:
+
+```text
+Component API drift detected (3 changes: 1 breaking, 1 additive, 1 doc-only).
+
+BREAKING
+  ✖ Button: prop `size` type changed: "small" | "large" → "sm" | "lg"
+
+ADDITIVE
+  + Button: prop `disabled` was added
+
+DOC-ONLY
+  ~ Button: prop `type` description changed
+```
+
+The thrown error exposes the structured diff for programmatic use:
+
+```ts
+import { assertComponentApi, ComponentApiDriftError } from "sveld/testing";
+
+try {
+  await assertComponentApi({ input: "src/index.js", snapshot });
+} catch (error) {
+  if (error instanceof ComponentApiDriftError) {
+    error.diff.classification; // "breaking" | "additive" | "doc-only"
+    error.diff.breaking; // ApiChange[]
+  }
+}
+```
+
+### Lower-level helpers
+
+- `generateComponentApi(options)` — returns the in-memory `ComponentApi` snapshot without asserting.
+- `diffComponentApi(previous, next)` — classifies the differences between two snapshots.
+- `formatApiDiff(diff)` — renders a diff as the readable report shown above.
+- `writeComponentApiSnapshot(path, api)` / `serializeComponentApi(api)` — persist a snapshot.
 
 ## API Reference
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./testing": {
+      "types": "./lib/testing.d.ts",
+      "import": "./lib/testing.js",
+      "default": "./lib/testing.js"
     }
   },
   "scripts": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -17,7 +17,7 @@ async function emitTypeDeclarations() {
 
 async function buildProject() {
   const result = await build({
-    entrypoints: ["./src/index.ts"],
+    entrypoints: ["./src/index.ts", "./src/testing.ts"],
     outdir: "./lib",
     format: "esm",
     target: "node",

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,566 @@
+/**
+ * Structural diff and change classification for sveld component APIs.
+ *
+ * This module is intentionally free of any filesystem, parser, or test-framework
+ * dependencies so it can be reused by:
+ *
+ * - the `sveld/testing` golden-file helper (see `./testing`), and
+ * - a future API diff / breaking-change detector.
+ *
+ * It operates on the normalized {@link ComponentApi} snapshot shape, which is a
+ * deterministic, position-free projection of the parsed component metadata.
+ */
+
+/**
+ * Severity bucket for a single API change.
+ *
+ * - `breaking` — a consumer of the previous API could break (a member was
+ *   removed, a type changed, an optional prop became required, etc.).
+ * - `additive` — the surface grew or loosened in a backwards-compatible way
+ *   (a new optional prop/slot/event, a required prop became optional, etc.).
+ * - `doc-only` — only human-facing documentation changed (descriptions,
+ *   the `@component` comment); the type contract is unchanged.
+ */
+export type ChangeKind = "breaking" | "additive" | "doc-only";
+
+/** The kind of API member a change applies to. */
+export type ChangeCategory = "component" | "prop" | "moduleExport" | "slot" | "event" | "typedef" | "meta";
+
+/** A single classified difference between two component API snapshots. */
+export interface ApiChange {
+  kind: ChangeKind;
+  category: ChangeCategory;
+  /** The component (module) name the change belongs to. */
+  component: string;
+  /** The member name (prop/slot/event/typedef), when applicable. */
+  member?: string;
+  /** Human-readable, single-line description of the change. */
+  message: string;
+}
+
+/** The result of diffing two component API snapshots. */
+export interface ApiDiff {
+  /** All changes, in a stable order (breaking, then additive, then doc-only). */
+  changes: ApiChange[];
+  breaking: ApiChange[];
+  additive: ApiChange[];
+  docOnly: ApiChange[];
+  /** True when the two snapshots are identical (no changes). */
+  matches: boolean;
+  /**
+   * The overall severity of the drift: the most severe change present, or
+   * `null` when the snapshots match.
+   */
+  classification: ChangeKind | null;
+}
+
+/** Snapshot format version, bumped if this projection shape changes incompatibly. */
+export const SNAPSHOT_VERSION = 1;
+
+/** Normalized prop (or module export) projection used for diffing. */
+export interface ComponentApiProp {
+  type?: string;
+  kind: "let" | "const" | "function";
+  constant: boolean;
+  isRequired: boolean;
+  isFunction: boolean;
+  reactive: boolean;
+  bindable?: true;
+  binding?: "readonly" | "writable";
+  value?: string;
+  returnType?: string;
+  params?: Array<{ name: string; type: string; optional?: boolean; description?: string }>;
+  description?: string;
+}
+
+/** Normalized slot projection used for diffing. */
+export interface ComponentApiSlot {
+  default: boolean;
+  slot_props?: string;
+  fallback?: string;
+  description?: string;
+}
+
+/** Normalized event projection used for diffing. */
+export interface ComponentApiEvent {
+  type: "forwarded" | "dispatched";
+  detail?: string;
+  description?: string;
+}
+
+/** Normalized typedef projection used for diffing. */
+export interface ComponentApiTypedef {
+  ts: string;
+  type: string;
+  description?: string;
+}
+
+/** Normalized single-component projection used for diffing. */
+export interface ComponentApiComponent {
+  props: Record<string, ComponentApiProp>;
+  moduleExports: Record<string, ComponentApiProp>;
+  slots: Record<string, ComponentApiSlot>;
+  events: Record<string, ComponentApiEvent>;
+  typedefs: Record<string, ComponentApiTypedef>;
+  /** Whether the component spreads `$$restProps` onto an element/component. */
+  rest_props: boolean;
+  generics: [name: string, type: string] | null;
+  /** Component-level description from the `@component` comment. */
+  description?: string;
+}
+
+/**
+ * Deterministic, position-free projection of a parsed component bundle.
+ *
+ * This is the value that downstream libraries commit as their golden snapshot.
+ * It deliberately omits volatile data (generator version, absolute file paths,
+ * source ranges) so the snapshot only changes when the public API changes.
+ */
+export interface ComponentApi {
+  version: number;
+  components: Record<string, ComponentApiComponent>;
+}
+
+const CHANGE_ORDER: Record<ChangeKind, number> = { breaking: 0, additive: 1, "doc-only": 2 };
+
+function quote(value: unknown): string {
+  if (value === undefined) return "(none)";
+  if (typeof value === "string") return JSON.stringify(value);
+  return String(value);
+}
+
+/** Strict, order-independent structural equality for the small projection values. */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const aKeys = Object.keys(a as object).sort();
+    const bKeys = Object.keys(b as object).sort();
+    if (!deepEqual(aKeys, bKeys)) return false;
+    return aKeys.every((key) => deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]));
+  }
+  return false;
+}
+
+interface PropField {
+  key: keyof ComponentApiProp;
+  label: string;
+  /** Classify a change of this field given the before/after values. */
+  classify: (previous: ComponentApiProp, next: ComponentApiProp) => ChangeKind;
+}
+
+/**
+ * Signature and documentation fields compared for props and module exports,
+ * with the classification rule for each.
+ */
+const PROP_FIELDS: PropField[] = [
+  { key: "type", label: "type", classify: () => "breaking" },
+  { key: "kind", label: "kind", classify: () => "breaking" },
+  { key: "isFunction", label: "function-ness", classify: () => "breaking" },
+  { key: "returnType", label: "return type", classify: () => "breaking" },
+  { key: "params", label: "parameters", classify: () => "breaking" },
+  { key: "value", label: "default value", classify: () => "additive" },
+  { key: "reactive", label: "reactivity", classify: () => "additive" },
+  {
+    // Optional -> required is breaking; required -> optional is a loosening.
+    key: "isRequired",
+    label: "required",
+    classify: (previous, next) => (!previous.isRequired && next.isRequired ? "breaking" : "additive"),
+  },
+  {
+    // Gaining `$bindable()` is additive; losing it removes a capability.
+    key: "bindable",
+    label: "bindable",
+    classify: (previous, next) => (previous.bindable && !next.bindable ? "breaking" : "additive"),
+  },
+  {
+    // writable -> readonly removes a capability; readonly -> writable adds one.
+    key: "binding",
+    label: "binding direction",
+    classify: (previous, next) =>
+      previous.binding === "writable" && next.binding === "readonly" ? "breaking" : "additive",
+  },
+  { key: "constant", label: "constant-ness", classify: () => "additive" },
+  { key: "description", label: "description", classify: () => "doc-only" },
+];
+
+function diffProps(
+  component: string,
+  category: "prop" | "moduleExport",
+  noun: string,
+  previous: Record<string, ComponentApiProp>,
+  next: Record<string, ComponentApiProp>,
+  changes: ApiChange[],
+): void {
+  for (const name of memberNames(previous, next)) {
+    const before = previous[name];
+    const after = next[name];
+
+    if (before && !after) {
+      changes.push({ kind: "breaking", category, component, member: name, message: `${noun} \`${name}\` was removed` });
+      continue;
+    }
+
+    if (!before && after) {
+      changes.push({
+        kind: after.isRequired ? "breaking" : "additive",
+        category,
+        component,
+        member: name,
+        message: after.isRequired ? `required ${noun} \`${name}\` was added` : `${noun} \`${name}\` was added`,
+      });
+      continue;
+    }
+
+    if (!before || !after) continue;
+
+    for (const field of PROP_FIELDS) {
+      if (deepEqual(before[field.key], after[field.key])) continue;
+      const summary =
+        field.key === "params"
+          ? `${noun} \`${name}\` ${field.label} changed`
+          : `${noun} \`${name}\` ${field.label} changed: ${quote(before[field.key])} → ${quote(after[field.key])}`;
+      changes.push({ kind: field.classify(before, after), category, component, member: name, message: summary });
+    }
+  }
+}
+
+function diffSlots(
+  component: string,
+  previous: Record<string, ComponentApiSlot>,
+  next: Record<string, ComponentApiSlot>,
+  changes: ApiChange[],
+): void {
+  for (const name of memberNames(previous, next)) {
+    const before = previous[name];
+    const after = next[name];
+
+    if (before && !after) {
+      changes.push({
+        kind: "breaking",
+        category: "slot",
+        component,
+        member: name,
+        message: `slot \`${name}\` was removed`,
+      });
+      continue;
+    }
+    if (!before && after) {
+      changes.push({
+        kind: "additive",
+        category: "slot",
+        component,
+        member: name,
+        message: `slot \`${name}\` was added`,
+      });
+      continue;
+    }
+    if (!before || !after) continue;
+
+    if (!deepEqual(before.slot_props, after.slot_props)) {
+      changes.push({
+        kind: "breaking",
+        category: "slot",
+        component,
+        member: name,
+        message: `slot \`${name}\` props changed: ${quote(before.slot_props)} → ${quote(after.slot_props)}`,
+      });
+    }
+    if (!deepEqual(before.fallback, after.fallback)) {
+      changes.push({
+        kind: "additive",
+        category: "slot",
+        component,
+        member: name,
+        message: `slot \`${name}\` fallback content changed`,
+      });
+    }
+    if (!deepEqual(before.description, after.description)) {
+      changes.push({
+        kind: "doc-only",
+        category: "slot",
+        component,
+        member: name,
+        message: `slot \`${name}\` description changed`,
+      });
+    }
+  }
+}
+
+function diffEvents(
+  component: string,
+  previous: Record<string, ComponentApiEvent>,
+  next: Record<string, ComponentApiEvent>,
+  changes: ApiChange[],
+): void {
+  for (const name of memberNames(previous, next)) {
+    const before = previous[name];
+    const after = next[name];
+
+    if (before && !after) {
+      changes.push({
+        kind: "breaking",
+        category: "event",
+        component,
+        member: name,
+        message: `event \`${name}\` was removed`,
+      });
+      continue;
+    }
+    if (!before && after) {
+      changes.push({
+        kind: "additive",
+        category: "event",
+        component,
+        member: name,
+        message: `event \`${name}\` was added`,
+      });
+      continue;
+    }
+    if (!before || !after) continue;
+
+    if (before.type !== after.type) {
+      changes.push({
+        kind: "breaking",
+        category: "event",
+        component,
+        member: name,
+        message: `event \`${name}\` kind changed: ${before.type} → ${after.type}`,
+      });
+    }
+    if (!deepEqual(before.detail, after.detail)) {
+      changes.push({
+        kind: "breaking",
+        category: "event",
+        component,
+        member: name,
+        message: `event \`${name}\` detail type changed: ${quote(before.detail)} → ${quote(after.detail)}`,
+      });
+    }
+    if (!deepEqual(before.description, after.description)) {
+      changes.push({
+        kind: "doc-only",
+        category: "event",
+        component,
+        member: name,
+        message: `event \`${name}\` description changed`,
+      });
+    }
+  }
+}
+
+function diffTypedefs(
+  component: string,
+  previous: Record<string, ComponentApiTypedef>,
+  next: Record<string, ComponentApiTypedef>,
+  changes: ApiChange[],
+): void {
+  for (const name of memberNames(previous, next)) {
+    const before = previous[name];
+    const after = next[name];
+
+    if (before && !after) {
+      changes.push({
+        kind: "breaking",
+        category: "typedef",
+        component,
+        member: name,
+        message: `typedef \`${name}\` was removed`,
+      });
+      continue;
+    }
+    if (!before && after) {
+      changes.push({
+        kind: "additive",
+        category: "typedef",
+        component,
+        member: name,
+        message: `typedef \`${name}\` was added`,
+      });
+      continue;
+    }
+    if (!before || !after) continue;
+
+    if (!deepEqual(before.ts, after.ts)) {
+      changes.push({
+        kind: "breaking",
+        category: "typedef",
+        component,
+        member: name,
+        message: `typedef \`${name}\` changed: ${quote(before.ts)} → ${quote(after.ts)}`,
+      });
+    }
+    if (!deepEqual(before.description, after.description)) {
+      changes.push({
+        kind: "doc-only",
+        category: "typedef",
+        component,
+        member: name,
+        message: `typedef \`${name}\` description changed`,
+      });
+    }
+  }
+}
+
+function diffComponent(
+  name: string,
+  before: ComponentApiComponent,
+  after: ComponentApiComponent,
+  changes: ApiChange[],
+): void {
+  diffProps(name, "prop", "prop", before.props, after.props, changes);
+  diffProps(name, "moduleExport", "module export", before.moduleExports, after.moduleExports, changes);
+  diffSlots(name, before.slots, after.slots, changes);
+  diffEvents(name, before.events, after.events, changes);
+  diffTypedefs(name, before.typedefs, after.typedefs, changes);
+
+  if (before.rest_props !== after.rest_props) {
+    changes.push({
+      kind: after.rest_props ? "additive" : "breaking",
+      category: "meta",
+      component: name,
+      message: after.rest_props ? "now spreads `$$restProps`" : "no longer spreads `$$restProps`",
+    });
+  }
+  if (!deepEqual(before.generics, after.generics)) {
+    changes.push({
+      kind: "breaking",
+      category: "meta",
+      component: name,
+      message: `generics changed: ${quote(before.generics?.join(": "))} → ${quote(after.generics?.join(": "))}`,
+    });
+  }
+  if (!deepEqual(before.description, after.description)) {
+    changes.push({ kind: "doc-only", category: "meta", component: name, message: "component description changed" });
+  }
+}
+
+function memberNames(...records: Array<Record<string, unknown>>): string[] {
+  const names = new Set<string>();
+  for (const record of records) {
+    for (const name of Object.keys(record)) names.add(name);
+  }
+  return Array.from(names).sort();
+}
+
+/**
+ * Diffs two normalized component API snapshots and classifies every difference.
+ *
+ * @param previous - The committed (golden) snapshot.
+ * @param next - The freshly generated snapshot.
+ * @returns A structured, classified diff.
+ *
+ * @example
+ * ```ts
+ * const diff = diffComponentApi(golden, current);
+ * if (!diff.matches) {
+ *   console.error(formatApiDiff(diff));
+ * }
+ * ```
+ */
+export function diffComponentApi(previous: ComponentApi, next: ComponentApi): ApiDiff {
+  const changes: ApiChange[] = [];
+
+  for (const name of memberNames(previous.components, next.components)) {
+    const before = previous.components[name];
+    const after = next.components[name];
+
+    if (before && !after) {
+      changes.push({
+        kind: "breaking",
+        category: "component",
+        component: name,
+        message: `component \`${name}\` was removed`,
+      });
+      continue;
+    }
+    if (!before && after) {
+      changes.push({
+        kind: "additive",
+        category: "component",
+        component: name,
+        message: `component \`${name}\` was added`,
+      });
+      continue;
+    }
+    if (!before || !after) continue;
+
+    diffComponent(name, before, after, changes);
+  }
+
+  changes.sort((a, b) => {
+    if (CHANGE_ORDER[a.kind] !== CHANGE_ORDER[b.kind]) return CHANGE_ORDER[a.kind] - CHANGE_ORDER[b.kind];
+    if (a.component !== b.component) return a.component.localeCompare(b.component);
+    return (a.member ?? "").localeCompare(b.member ?? "");
+  });
+
+  const breaking = changes.filter((change) => change.kind === "breaking");
+  const additive = changes.filter((change) => change.kind === "additive");
+  const docOnly = changes.filter((change) => change.kind === "doc-only");
+
+  let classification: ChangeKind | null = null;
+  if (breaking.length > 0) classification = "breaking";
+  else if (additive.length > 0) classification = "additive";
+  else if (docOnly.length > 0) classification = "doc-only";
+
+  return { changes, breaking, additive, docOnly, matches: changes.length === 0, classification };
+}
+
+const KIND_LABEL: Record<ChangeKind, string> = {
+  breaking: "BREAKING",
+  additive: "ADDITIVE",
+  "doc-only": "DOC-ONLY",
+};
+
+const KIND_MARKER: Record<ChangeKind, string> = {
+  breaking: "✖",
+  additive: "+",
+  "doc-only": "~",
+};
+
+/**
+ * Renders a classified diff as a readable, multi-line report suitable for a
+ * test failure message.
+ *
+ * @example
+ * ```text
+ * Component API drift detected (2 changes: 1 breaking, 1 doc-only).
+ *
+ * BREAKING
+ *   ✖ Button: prop `size` type changed: "small" | "large" → "sm" | "lg"
+ *
+ * DOC-ONLY
+ *   ~ Button: component description changed
+ * ```
+ */
+export function formatApiDiff(diff: ApiDiff): string {
+  if (diff.matches) return "Component API matches the golden snapshot.";
+
+  const counts = [
+    diff.breaking.length ? `${diff.breaking.length} breaking` : null,
+    diff.additive.length ? `${diff.additive.length} additive` : null,
+    diff.docOnly.length ? `${diff.docOnly.length} doc-only` : null,
+  ].filter((part): part is string => part !== null);
+
+  const total = diff.changes.length;
+  const lines: string[] = [
+    `Component API drift detected (${total} change${total === 1 ? "" : "s"}: ${counts.join(", ")}).`,
+  ];
+
+  for (const kind of ["breaking", "additive", "doc-only"] as const) {
+    const group = diff.changes.filter((change) => change.kind === kind);
+    if (group.length === 0) continue;
+    lines.push("", KIND_LABEL[kind]);
+    for (const change of group) {
+      const location = change.member ? `${change.component}` : change.component;
+      lines.push(`  ${KIND_MARKER[kind]} ${location}: ${change.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,0 +1,284 @@
+/**
+ * `sveld/testing` — golden-file helper for guarding a Svelte library's
+ * generated component API against unintended drift.
+ *
+ * A downstream library commits a golden snapshot of its component API and, in a
+ * test, calls {@link assertComponentApi}. The helper regenerates the API
+ * in-memory, diffs it against the committed snapshot, and throws a readable,
+ * classified error (breaking / additive / doc-only) on any drift. It depends on
+ * no test framework, so it works from Bun, Jest, Vitest, or a plain script.
+ *
+ * @example
+ * ```ts
+ * import { test } from "vitest";
+ * import { assertComponentApi } from "sveld/testing";
+ *
+ * test("component API is stable", async () => {
+ *   await assertComponentApi({
+ *     input: "src/index.js",
+ *     snapshot: "test/__snapshots__/component-api.json",
+ *   });
+ * });
+ * ```
+ */
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { ParsedComponent } from "./ComponentParser";
+import {
+  type ApiDiff,
+  type ComponentApi,
+  type ComponentApiComponent,
+  type ComponentApiEvent,
+  type ComponentApiProp,
+  type ComponentApiSlot,
+  type ComponentApiTypedef,
+  diffComponentApi,
+  formatApiDiff,
+  SNAPSHOT_VERSION,
+} from "./diff";
+import { type ComponentDocs, generateBundle } from "./plugin";
+
+export {
+  type ApiChange,
+  type ApiDiff,
+  type ChangeCategory,
+  type ChangeKind,
+  type ComponentApi,
+  diffComponentApi,
+  formatApiDiff,
+  SNAPSHOT_VERSION,
+} from "./diff";
+
+type SourceProp = ParsedComponent["props"][number];
+type SourceSlot = ParsedComponent["slots"][number];
+type SourceEvent = ParsedComponent["events"][number];
+type SourceTypedef = ParsedComponent["typedefs"][number];
+
+/** Options shared by API generation and assertion. */
+export interface GenerateComponentApiOptions {
+  /**
+   * Entry point to the uncompiled Svelte source: either a file (e.g. the
+   * library's `index.js` with re-exports) or a directory. If omitted, the
+   * `svelte` field of the nearest `package.json` is used.
+   */
+  input?: string;
+  /**
+   * Glob the input directory for all `.svelte` files. Defaults to `true` when
+   * `input` resolves to a directory, `false` otherwise.
+   */
+  glob?: boolean;
+}
+
+function normalizeProp(prop: SourceProp): ComponentApiProp {
+  return {
+    type: prop.type,
+    kind: prop.kind,
+    constant: prop.constant,
+    isRequired: prop.isRequired,
+    isFunction: prop.isFunction,
+    reactive: prop.reactive,
+    bindable: prop.bindable,
+    binding: prop.binding,
+    value: prop.value,
+    returnType: prop.returnType,
+    params: prop.params?.map((param) => ({
+      name: param.name,
+      type: param.type,
+      optional: param.optional,
+      description: param.description,
+    })),
+    description: prop.description,
+  };
+}
+
+function normalizeSlot(slot: SourceSlot): ComponentApiSlot {
+  return {
+    default: slot.default,
+    slot_props: slot.slot_props,
+    fallback: slot.fallback,
+    description: slot.description,
+  };
+}
+
+function normalizeEvent(event: SourceEvent): ComponentApiEvent {
+  return {
+    type: event.type,
+    detail: event.detail,
+    description: event.description,
+  };
+}
+
+function normalizeTypedef(typedef: SourceTypedef): ComponentApiTypedef {
+  return { ts: typedef.ts, type: typedef.type, description: typedef.description };
+}
+
+/** Builds a record keyed by `name`, inserting keys in sorted order for determinism. */
+function toRecord<T, U>(items: T[], name: (item: T) => string, map: (item: T) => U): Record<string, U> {
+  const entries = items.map((item) => [name(item), map(item)] as const).sort(([a], [b]) => a.localeCompare(b));
+  const record: Record<string, U> = {};
+  for (const [key, value] of entries) record[key] = value;
+  return record;
+}
+
+function normalizeComponent(component: ParsedComponent): ComponentApiComponent {
+  return {
+    props: toRecord(component.props, (prop) => prop.name, normalizeProp),
+    moduleExports: toRecord(component.moduleExports, (prop) => prop.name, normalizeProp),
+    slots: toRecord(
+      component.slots,
+      (slot) => (slot.default || slot.name == null ? "default" : slot.name),
+      normalizeSlot,
+    ),
+    events: toRecord(component.events, (event) => event.name, normalizeEvent),
+    typedefs: toRecord(component.typedefs, (typedef) => typedef.name, normalizeTypedef),
+    rest_props: component.rest_props !== undefined,
+    generics: component.generics,
+    description: component.componentComment,
+  };
+}
+
+/**
+ * Projects the parsed component bundle into the deterministic, position-free
+ * {@link ComponentApi} snapshot shape.
+ */
+function toComponentApi(components: ComponentDocs): ComponentApi {
+  const entries = Array.from(components.values()).sort((a, b) => a.moduleName.localeCompare(b.moduleName));
+  const normalized: Record<string, ComponentApiComponent> = {};
+  for (const component of entries) {
+    normalized[component.moduleName] = normalizeComponent(component);
+  }
+  return { version: SNAPSHOT_VERSION, components: normalized };
+}
+
+/**
+ * Generates the component API for a Svelte library in-memory, returning a
+ * deterministic snapshot that is safe to commit as a golden file.
+ *
+ * @example
+ * ```ts
+ * const api = await generateComponentApi({ input: "src/index.js" });
+ * console.log(Object.keys(api.components)); // ["Button", "Modal", ...]
+ * ```
+ */
+export async function generateComponentApi(options?: GenerateComponentApiOptions): Promise<ComponentApi> {
+  const input = options?.input ? resolve(options.input) : resolveDefaultEntry();
+  if (input === null) {
+    throw new Error(
+      "sveld/testing: could not determine an entry point. Pass `input` or set the `svelte` field in package.json.",
+    );
+  }
+
+  const glob = options?.glob ?? isDirectory(input);
+  const { components } = await generateBundle(input, glob);
+  return toComponentApi(components);
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function resolveDefaultEntry(): string | null {
+  const pkgPath = resolve(process.cwd(), "package.json");
+  if (!existsSync(pkgPath)) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { svelte?: string };
+    if (typeof pkg.svelte === "string" && pkg.svelte.trim()) return resolve(process.cwd(), pkg.svelte);
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/** Serializes a snapshot to stable, pretty-printed JSON with a trailing newline. */
+export function serializeComponentApi(api: ComponentApi): string {
+  return `${JSON.stringify(api, null, 2)}\n`;
+}
+
+/** Writes a snapshot to `snapshotPath`, creating parent directories as needed. */
+export function writeComponentApiSnapshot(snapshotPath: string, api: ComponentApi): void {
+  const target = resolve(snapshotPath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, serializeComponentApi(api));
+}
+
+/** Error thrown by {@link assertComponentApi} when the generated API drifts from the golden snapshot. */
+export class ComponentApiDriftError extends Error {
+  /** The structured, classified diff between the golden snapshot and the current API. */
+  readonly diff: ApiDiff;
+
+  constructor(diff: ApiDiff) {
+    super(formatApiDiff(diff));
+    this.name = "ComponentApiDriftError";
+    this.diff = diff;
+  }
+}
+
+/** Options for {@link assertComponentApi}. */
+export interface AssertComponentApiOptions extends GenerateComponentApiOptions {
+  /** Path to the committed golden snapshot JSON file. */
+  snapshot: string;
+  /**
+   * When `true`, (re)write the golden snapshot from the current API instead of
+   * asserting against it. Also enabled when the `SVELD_UPDATE_SNAPSHOT`
+   * environment variable is set to a truthy value (e.g. `1` or `true`).
+   */
+  update?: boolean;
+}
+
+function shouldUpdate(option?: boolean): boolean {
+  if (option !== undefined) return option;
+  const flag = process.env.SVELD_UPDATE_SNAPSHOT;
+  return flag === "1" || flag === "true";
+}
+
+/**
+ * Asserts that the library's current component API matches the committed golden
+ * snapshot, throwing a {@link ComponentApiDriftError} with a readable,
+ * classified diff on any drift.
+ *
+ * Run with `update: true` (or `SVELD_UPDATE_SNAPSHOT=1`) to create or refresh
+ * the snapshot. The first run for a new snapshot path requires update mode.
+ *
+ * @throws {ComponentApiDriftError} when the API drifts from the snapshot.
+ * @throws {Error} when the snapshot file is missing and update mode is off.
+ *
+ * @example
+ * ```ts
+ * await assertComponentApi({
+ *   input: "src/index.js",
+ *   snapshot: "test/__snapshots__/component-api.json",
+ * });
+ * ```
+ */
+export async function assertComponentApi(options: AssertComponentApiOptions): Promise<ApiDiff> {
+  const current = await generateComponentApi(options);
+  const snapshotPath = resolve(options.snapshot);
+
+  if (shouldUpdate(options.update)) {
+    writeComponentApiSnapshot(snapshotPath, current);
+    return { changes: [], breaking: [], additive: [], docOnly: [], matches: true, classification: null };
+  }
+
+  if (!existsSync(snapshotPath)) {
+    throw new Error(
+      `sveld/testing: golden snapshot not found at "${snapshotPath}". ` +
+        "Create it by running this assertion once with `update: true` (or SVELD_UPDATE_SNAPSHOT=1).",
+    );
+  }
+
+  let golden: ComponentApi;
+  try {
+    golden = JSON.parse(readFileSync(snapshotPath, "utf-8")) as ComponentApi;
+  } catch (error) {
+    throw new Error(`sveld/testing: failed to parse golden snapshot at "${snapshotPath}": ${(error as Error).message}`);
+  }
+
+  const diff = diffComponentApi(golden, current);
+  if (!diff.matches) throw new ComponentApiDriftError(diff);
+  return diff;
+}

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,189 @@
+import {
+  type ComponentApi,
+  type ComponentApiComponent,
+  type ComponentApiProp,
+  diffComponentApi,
+  formatApiDiff,
+  SNAPSHOT_VERSION,
+} from "../src/diff";
+
+function prop(overrides: Partial<ComponentApiProp> = {}): ComponentApiProp {
+  return {
+    kind: "let",
+    constant: false,
+    isRequired: false,
+    isFunction: false,
+    reactive: false,
+    ...overrides,
+  };
+}
+
+function component(overrides: Partial<ComponentApiComponent> = {}): ComponentApiComponent {
+  return {
+    props: {},
+    moduleExports: {},
+    slots: {},
+    events: {},
+    typedefs: {},
+    rest_props: false,
+    generics: null,
+    ...overrides,
+  };
+}
+
+function api(components: Record<string, ComponentApiComponent>): ComponentApi {
+  return { version: SNAPSHOT_VERSION, components };
+}
+
+describe("diffComponentApi", () => {
+  test("reports no changes for identical snapshots", () => {
+    const snapshot = api({ Button: component({ props: { type: prop({ type: "string" }) } }) });
+    const diff = diffComponentApi(snapshot, snapshot);
+
+    expect(diff.matches).toBe(true);
+    expect(diff.classification).toBeNull();
+    expect(diff.changes).toEqual([]);
+  });
+
+  test("classifies a removed prop as breaking", () => {
+    const before = api({ Button: component({ props: { type: prop(), size: prop() } }) });
+    const after = api({ Button: component({ props: { type: prop() } }) });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.matches).toBe(false);
+    expect(diff.classification).toBe("breaking");
+    expect(diff.breaking).toHaveLength(1);
+    expect(diff.breaking[0]).toMatchObject({ category: "prop", component: "Button", member: "size" });
+    expect(diff.breaking[0].message).toContain("removed");
+  });
+
+  test("classifies a removed component as breaking", () => {
+    const before = api({ Button: component(), Modal: component() });
+    const after = api({ Button: component() });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.classification).toBe("breaking");
+    expect(diff.breaking[0]).toMatchObject({ category: "component", component: "Modal" });
+  });
+
+  test("classifies a new optional prop as additive", () => {
+    const before = api({ Button: component({ props: { type: prop() } }) });
+    const after = api({ Button: component({ props: { type: prop(), disabled: prop({ type: "boolean" }) } }) });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.classification).toBe("additive");
+    expect(diff.additive[0]).toMatchObject({ category: "prop", member: "disabled" });
+  });
+
+  test("classifies a new required prop as breaking", () => {
+    const before = api({ Button: component() });
+    const after = api({ Button: component({ props: { value: prop({ isRequired: true }) } }) });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.classification).toBe("breaking");
+    expect(diff.breaking[0].message).toContain("required");
+  });
+
+  test("classifies a prop type change as breaking", () => {
+    const before = api({ Button: component({ props: { size: prop({ type: '"sm" | "lg"' }) } }) });
+    const after = api({ Button: component({ props: { size: prop({ type: '"small" | "large"' }) } }) });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.classification).toBe("breaking");
+    expect(diff.breaking[0].message).toContain("type changed");
+  });
+
+  test("classifies optional -> required as breaking but required -> optional as additive", () => {
+    const optionalToRequired = diffComponentApi(
+      api({ Button: component({ props: { x: prop({ isRequired: false }) } }) }),
+      api({ Button: component({ props: { x: prop({ isRequired: true }) } }) }),
+    );
+    expect(optionalToRequired.classification).toBe("breaking");
+
+    const requiredToOptional = diffComponentApi(
+      api({ Button: component({ props: { x: prop({ isRequired: true }) } }) }),
+      api({ Button: component({ props: { x: prop({ isRequired: false }) } }) }),
+    );
+    expect(requiredToOptional.classification).toBe("additive");
+  });
+
+  test("classifies a description-only change as doc-only", () => {
+    const before = api({ Button: component({ props: { type: prop({ description: "old" }) } }) });
+    const after = api({ Button: component({ props: { type: prop({ description: "new" }) } }) });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.classification).toBe("doc-only");
+    expect(diff.docOnly[0]).toMatchObject({ category: "prop", member: "type" });
+  });
+
+  test("classifies a component-comment change as doc-only", () => {
+    const before = api({ Button: component({ description: "A button." }) });
+    const after = api({ Button: component({ description: "A nice button." }) });
+
+    expect(diffComponentApi(before, after).classification).toBe("doc-only");
+  });
+
+  test("classifies slot and event additions and removals", () => {
+    const before = api({
+      Button: component({
+        slots: { default: { default: true } },
+        events: { click: { type: "forwarded" } },
+      }),
+    });
+    const after = api({
+      Button: component({
+        slots: { default: { default: true }, icon: { default: false } },
+        events: {},
+      }),
+    });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.additive.some((c) => c.category === "slot" && c.member === "icon")).toBe(true);
+    expect(diff.breaking.some((c) => c.category === "event" && c.member === "click")).toBe(true);
+    expect(diff.classification).toBe("breaking");
+  });
+
+  test("reports the most severe change as the overall classification", () => {
+    const before = api({ Button: component({ props: { a: prop({ type: "string", description: "x" }) } }) });
+    const after = api({
+      Button: component({ props: { a: prop({ type: "number", description: "y" }), b: prop() } }),
+    });
+
+    const diff = diffComponentApi(before, after);
+
+    expect(diff.breaking.length).toBeGreaterThan(0);
+    expect(diff.additive.length).toBeGreaterThan(0);
+    expect(diff.docOnly.length).toBeGreaterThan(0);
+    expect(diff.classification).toBe("breaking");
+  });
+});
+
+describe("formatApiDiff", () => {
+  test("renders a friendly message when snapshots match", () => {
+    const snapshot = api({ Button: component() });
+    expect(formatApiDiff(diffComponentApi(snapshot, snapshot))).toContain("matches the golden snapshot");
+  });
+
+  test("groups changes by severity with counts and markers", () => {
+    const before = api({ Button: component({ props: { size: prop({ type: "string" }) } }) });
+    const after = api({
+      Button: component({ props: { size: prop({ type: "number" }), disabled: prop() }, description: "new" }),
+    });
+
+    const report = formatApiDiff(diffComponentApi(before, after));
+
+    expect(report).toContain("Component API drift detected");
+    expect(report).toContain("1 breaking");
+    expect(report).toContain("BREAKING");
+    expect(report).toContain("ADDITIVE");
+    expect(report).toContain("✖");
+    expect(report).toContain("+");
+  });
+});

--- a/tests/fixtures/runes-snippet-positional/output.d.ts
+++ b/tests/fixtures/runes-snippet-positional/output.d.ts
@@ -1,5 +1,5 @@
-import type { Snippet } from "svelte";
 import { SvelteComponentTyped } from "svelte";
+import type { Snippet } from "svelte";
 
 interface Props {
   row: Snippet<[item: string, index: number]>;

--- a/tests/testing.test.ts
+++ b/tests/testing.test.ts
@@ -1,0 +1,187 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  assertComponentApi,
+  ComponentApiDriftError,
+  generateComponentApi,
+  writeComponentApiSnapshot,
+} from "../src/testing";
+
+const SNAPSHOT_NOT_FOUND_REGEX = /golden snapshot not found/;
+
+const BUTTON = `<script>
+  /** The button type. */
+  export let type = "button";
+  export let primary = false;
+</script>
+
+<!-- @component A clickable button. -->
+<button {...$$restProps} {type} class:primary on:click>
+  <slot>Click me</slot>
+</button>
+`;
+
+interface Fixture {
+  dir: string;
+  entry: string;
+  snapshot: string;
+  /** Overwrite the Button component source. */
+  setButton(source: string): void;
+}
+
+function createFixture(buttonSource = BUTTON): Fixture {
+  const dir = mkdtempSync(path.join(tmpdir(), "sveld-testing-"));
+  writeFileSync(path.join(dir, "index.js"), 'import Button from "./Button.svelte";\nexport { Button };\n');
+  writeFileSync(path.join(dir, "Button.svelte"), buttonSource);
+  return {
+    dir,
+    entry: path.join(dir, "index.js"),
+    snapshot: path.join(dir, "__snapshots__", "component-api.json"),
+    setButton(source: string) {
+      writeFileSync(path.join(dir, "Button.svelte"), source);
+    },
+  };
+}
+
+describe("generateComponentApi", () => {
+  let fixture: Fixture;
+  afterEach(() => rmSync(fixture.dir, { recursive: true, force: true }));
+
+  test("projects the parsed component into a deterministic snapshot", async () => {
+    fixture = createFixture();
+    const api = await generateComponentApi({ input: fixture.entry });
+
+    expect(api.version).toBe(1);
+    expect(Object.keys(api.components)).toEqual(["Button"]);
+
+    const button = api.components.Button;
+    expect(Object.keys(button.props)).toEqual(["primary", "type"]);
+    expect(button.props.type).toMatchObject({ type: "string", description: "The button type." });
+    expect(button.rest_props).toBe(true);
+    expect(button.description).toContain("A clickable button.");
+    // No volatile data (file paths, source ranges, generator version) leaks in.
+    expect(JSON.stringify(api)).not.toContain("filePath");
+    expect(JSON.stringify(api)).not.toContain('"source"');
+  });
+
+  test("is stable across repeated generation", async () => {
+    fixture = createFixture();
+    const first = await generateComponentApi({ input: fixture.entry });
+    const second = await generateComponentApi({ input: fixture.entry });
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+});
+
+describe("assertComponentApi", () => {
+  let fixture: Fixture;
+  afterEach(() => rmSync(fixture.dir, { recursive: true, force: true }));
+
+  test("throws a helpful error when the snapshot is missing", async () => {
+    fixture = createFixture();
+    await expect(assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot })).rejects.toThrow(
+      SNAPSHOT_NOT_FOUND_REGEX,
+    );
+  });
+
+  test("writes the snapshot in update mode, then passes on a matching run", async () => {
+    fixture = createFixture();
+    const written = await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot, update: true });
+    expect(written.matches).toBe(true);
+    expect(existsSync(fixture.snapshot)).toBe(true);
+
+    const matched = await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot });
+    expect(matched.matches).toBe(true);
+  });
+
+  test("honors the SVELD_UPDATE_SNAPSHOT environment variable", async () => {
+    fixture = createFixture();
+    process.env.SVELD_UPDATE_SNAPSHOT = "1";
+    try {
+      await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot });
+    } finally {
+      delete process.env.SVELD_UPDATE_SNAPSHOT;
+    }
+    expect(existsSync(fixture.snapshot)).toBe(true);
+  });
+
+  test("fails with a breaking classification when a prop is removed", async () => {
+    fixture = createFixture();
+    await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot, update: true });
+
+    fixture.setButton(BUTTON.replace("  export let primary = false;\n", ""));
+
+    const error = (await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot }).catch(
+      (e) => e,
+    )) as ComponentApiDriftError;
+
+    expect(error).toBeInstanceOf(ComponentApiDriftError);
+    expect(error.diff.classification).toBe("breaking");
+    expect(error.message).toContain("prop `primary` was removed");
+  });
+
+  test("fails with an additive classification when an optional prop is added", async () => {
+    fixture = createFixture();
+    await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot, update: true });
+
+    fixture.setButton(
+      BUTTON.replace(
+        "  export let primary = false;\n",
+        "  export let primary = false;\n  export let disabled = false;\n",
+      ),
+    );
+
+    const error = (await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot }).catch(
+      (e) => e,
+    )) as ComponentApiDriftError;
+
+    expect(error.diff.classification).toBe("additive");
+    expect(error.message).toContain("prop `disabled` was added");
+  });
+
+  test("fails with a doc-only classification when only a description changes", async () => {
+    fixture = createFixture();
+    await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot, update: true });
+
+    fixture.setButton(BUTTON.replace("The button type.", "The kind of button."));
+
+    const error = (await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot }).catch(
+      (e) => e,
+    )) as ComponentApiDriftError;
+
+    expect(error.diff.classification).toBe("doc-only");
+    expect(error.diff.docOnly).toHaveLength(1);
+  });
+
+  test("passes after the snapshot is refreshed to match the new API", async () => {
+    fixture = createFixture();
+    await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot, update: true });
+
+    fixture.setButton(
+      BUTTON.replace(
+        "  export let primary = false;\n",
+        "  export let primary = false;\n  export let disabled = false;\n",
+      ),
+    );
+    await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot, update: true });
+
+    const matched = await assertComponentApi({ input: fixture.entry, snapshot: fixture.snapshot });
+    expect(matched.matches).toBe(true);
+  });
+});
+
+describe("writeComponentApiSnapshot", () => {
+  let fixture: Fixture;
+  afterEach(() => rmSync(fixture.dir, { recursive: true, force: true }));
+
+  test("writes pretty-printed JSON with a trailing newline and nested dirs", async () => {
+    fixture = createFixture();
+    const api = await generateComponentApi({ input: fixture.entry });
+    writeComponentApiSnapshot(fixture.snapshot, api);
+
+    const contents = readFileSync(fixture.snapshot, "utf-8");
+    expect(contents.endsWith("}\n")).toBe(true);
+    expect(contents).toContain('\n  "version": 1');
+    expect(JSON.parse(contents)).toEqual(api);
+  });
+});


### PR DESCRIPTION
Give downstream libraries a first-class API drift guard:
`sveld/testing` diffs against a committed golden snapshot and
classifies breaking/additive/doc-only changes. Add
`sveld.config.{js,mjs,ts}` + `defineConfig` (CLI > config > pkg).