### PR TITLE
feat: abroaden setContext key resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1961,9 +1961,26 @@ label?: string;
 When you call `setContext` in a component, `sveld`:
 
 1. Detects the `setContext` call
-2. Extracts the context key (must be a string literal)
+2. Resolves the context key (see [Supported context keys](#supported-context-keys))
 3. Finds JSDoc `@type` annotations on the variables being passed
 4. Generates a TypeScript type export for the context
+
+#### Supported context keys
+
+The key becomes the `{PascalCase}Context` type name. `sveld` can resolve:
+
+| Key form | Example | Generated type |
+| --- | --- | --- |
+| String literal | `setContext("simple-modal", …)` | `SimpleModalContext` |
+| Static template literal | `` setContext(`simple-modal`, …) `` | `SimpleModalContext` |
+| `const`-bound string | `const KEY = "simple-modal";`<br>`setContext(KEY, …)` | `SimpleModalContext` |
+| `Symbol()` / `Symbol.for()` | `setContext(Symbol("tabs"), …)` | `TabsContext` |
+
+`const` identifiers are followed up to 5 levels deep (`const A = "x"; const B = A;`). Only `const` bindings count. `let`, `var`, and props are skipped because they can change at runtime.
+
+Symbol keys take their name from the description: `Symbol("tabs")` and `Symbol.for("tabs")` both become `TabsContext`. For `const ModalKey = Symbol()` with no description, the binding name wins: `ModalKeyContext`.
+
+Anything else (dynamic identifiers, template interpolation, other function calls) logs a warning. No context type is generated.
 
 #### Example
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -2766,6 +2766,35 @@ export default class ComponentParser {
   }
 
   /**
+   * Look up the initializer for a local `const` by name.
+   *
+   * {@link resolveLocalVarInitializer} also walks `let`/`var`. This method does not.
+   * Props and mutable bindings can change at runtime, so they cannot be context keys.
+   *
+   * @param name - The variable name to look up
+   * @returns The initializer node for a matching `const` binding, or undefined
+   */
+  private resolveConstInitializer(name: string): unknown | undefined {
+    for (const decl of this.vars) {
+      if (decl.kind !== "const") continue;
+      for (const declarator of decl.declarations) {
+        if (
+          declarator.id &&
+          typeof declarator.id === "object" &&
+          "type" in declarator.id &&
+          declarator.id.type === "Identifier" &&
+          "name" in declarator.id &&
+          declarator.id.name === name &&
+          declarator.init
+        ) {
+          return declarator.init;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Look up JSDoc on a local variable declaration by name.
    */
   private resolveLocalVarJSDoc(name: string) {
@@ -4795,11 +4824,98 @@ export default class ComponentParser {
   }
 
   /**
+   * Resolve a `setContext` key to the string used in `{PascalCase}Context`.
+   *
+   * Accepts string literals, static template literals, `const`-bound identifiers
+   * (up to 5 indirection levels, same as `@default`), and `Symbol()` /
+   * `Symbol.for()`. Description-less symbols fall back to the binding name.
+   *
+   * @param keyArg - The first argument of the `setContext` call
+   * @param depth - Current identifier-resolution depth (internal recursion guard)
+   * @returns The resolved key string, or `null` when the key cannot be resolved at parse time
+   */
+  private resolveContextKey(keyArg: unknown, depth = 0): string | null {
+    if (!keyArg || typeof keyArg !== "object" || !("type" in keyArg)) return null;
+    const node = keyArg as Expression;
+
+    if (node.type === "Literal") {
+      return typeof node.value === "string" ? node.value : node.value == null ? null : String(node.value);
+    }
+
+    if (node.type === "TemplateLiteral") {
+      /** Static template only; interpolated templates return null. */
+      if (node.quasis?.length === 1) {
+        const cooked = node.quasis[0].value.cooked;
+        return cooked == null ? null : cooked;
+      }
+      return null;
+    }
+
+    if (node.type === "CallExpression" || node.type === "NewExpression") {
+      return this.resolveSymbolKeyDescription(node);
+    }
+
+    if (node.type === "Identifier") {
+      /** Follow const bindings, same 5-level cap as @default. */
+      if (depth >= 5) return null;
+      const resolvedInit = this.resolveConstInitializer(node.name);
+      if (resolvedInit && typeof resolvedInit === "object" && "type" in resolvedInit) {
+        const init = resolvedInit as Expression;
+        /** No description: use the binding name (e.g. KEY from `const KEY = Symbol()`). */
+        if (
+          (init.type === "CallExpression" || init.type === "NewExpression") &&
+          this.resolveSymbolKeyDescription(init) === ""
+        ) {
+          return node.name;
+        }
+        return this.resolveContextKey(init, depth + 1);
+      }
+      return null;
+    }
+
+    return null;
+  }
+
+  /**
+   * Extracts the description string from a `Symbol(...)` or `Symbol.for(...)` call
+   * used as a context key.
+   *
+   * @param node - A CallExpression or NewExpression AST node
+   * @returns The symbol description (`""` when the symbol has no static description),
+   *   or `null` when the node is not a `Symbol()` / `Symbol.for()` call
+   */
+  private resolveSymbolKeyDescription(node: CallExpression | NewExpression): string | null {
+    const callee = node.callee;
+    if (!callee || typeof callee !== "object" || !("type" in callee)) return null;
+
+    const isSymbolCall = callee.type === "Identifier" && callee.name === "Symbol";
+    const isSymbolFor =
+      callee.type === "MemberExpression" &&
+      !callee.computed &&
+      callee.object.type === "Identifier" &&
+      callee.object.name === "Symbol" &&
+      callee.property.type === "Identifier" &&
+      callee.property.name === "for";
+
+    if (!isSymbolCall && !isSymbolFor) return null;
+
+    const firstArg = node.arguments[0];
+    if (!firstArg || typeof firstArg !== "object" || !("type" in firstArg)) return "";
+
+    if (firstArg.type === "Literal" && typeof firstArg.value === "string") return firstArg.value;
+    if (firstArg.type === "TemplateLiteral" && firstArg.quasis?.length === 1) {
+      return firstArg.quasis[0].value.cooked ?? "";
+    }
+
+    /** Non-string description: treat as unnamed symbol. */
+    return "";
+  }
+
+  /**
    * Parses a `setContext` call expression to extract context information.
    *
-   * Extracts the context key from the first argument (must be a string literal
-   * or simple template literal) and the context value from the second argument.
-   * Only processes static keys - dynamic keys are skipped with a warning.
+   * Reads the context key from the first argument and the value from the second.
+   * Unresolved keys log a warning and are skipped.
    *
    * @param node - The AST node (should be a CallExpression)
    * @param _parent - The parent node (unused)
@@ -4809,7 +4925,10 @@ export default class ComponentParser {
    * // Parses: setContext('modal', { open, close })
    * // Extracts: key = "modal", value = { open, close }
    *
-   * // Skips: setContext(dynamicKey, value) // key is not a literal
+   * // Parses: const KEY = "modal"; setContext(KEY, value) // resolves to "modal"
+   * // Parses: setContext(Symbol("modal"), value)          // resolves to "modal"
+   *
+   * // Diagnostic: setContext(dynamicKey, value) // key cannot be statically resolved
    * ```
    */
   private parseSetContextCall(node: Node, _parent?: Node) {
@@ -4824,26 +4943,16 @@ export default class ComponentParser {
     const keyArg = callExpr.arguments[0];
     if (!keyArg) return;
 
-    let contextKey: string | null = null;
-    if (keyArg.type === "Literal") {
-      const literal = keyArg as Literal;
-      contextKey = typeof literal.value === "string" ? literal.value : String(literal.value);
-    } else if (keyArg.type === "TemplateLiteral") {
-      /**
-       * Handle simple template literals (static strings only).
-       * Dynamic template literals with expressions are skipped.
-       */
-      if (keyArg.quasis?.length === 1) {
-        const cooked = keyArg.quasis[0].value.cooked;
-        contextKey = cooked == null ? null : cooked;
-      } else if (this.options?.verbose) {
-        console.warn("Warning: Skipping setContext with dynamic template literal key");
-      }
-    } else if (this.options?.verbose) {
-      console.warn(`Warning: Skipping setContext with non-literal key (type: ${keyArg.type})`);
-    }
+    const contextKey = this.resolveContextKey(keyArg);
 
-    if (!contextKey) return;
+    if (!contextKey) {
+      /** Dynamic key: warn and skip. */
+      const location = this.componentFilePath ? ` in ${this.componentFilePath}` : "";
+      console.warn(
+        `Warning: Could not resolve setContext key${location}. Use a string literal, const-bound string, or Symbol(). Skipping context type generation.`,
+      );
+      return;
+    }
 
     /**
      * Extract context value (second argument).

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -1289,4 +1289,126 @@ describe("ComponentParser", () => {
     const result = parser.parseSvelteComponent(source, diagnostics);
     expect(result.props).toHaveLength(0);
   });
+
+  test("resolves a const-bound string key to the same context type as a literal", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        const CONTEXT_KEY = "simple-modal";
+        /** @type {() => void} */
+        const close = () => {};
+        setContext(CONTEXT_KEY, { close });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts).toHaveLength(1);
+    expect(result.contexts?.[0].key).toBe("simple-modal");
+    expect(result.contexts?.[0].typeName).toBe("SimpleModalContext");
+  });
+
+  test("follows const indirection for string keys", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        const BASE_KEY = "tabs";
+        const CONTEXT_KEY = BASE_KEY;
+        /** @type {number} */
+        let activeTab = 0;
+        setContext(CONTEXT_KEY, { activeTab });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts?.[0].typeName).toBe("TabsContext");
+  });
+
+  test("names Symbol() context keys from their description", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        const KEY = Symbol("tabs");
+        /** @type {number} */
+        let activeTab = 0;
+        setContext(KEY, { activeTab });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts?.[0].typeName).toBe("TabsContext");
+  });
+
+  test("supports inline Symbol.for() context keys", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        /** @type {() => void} */
+        const notify = () => {};
+        setContext(Symbol.for("notification"), { notify });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts?.[0].typeName).toBe("NotificationContext");
+  });
+
+  test("falls back to the binding name for a description-less const Symbol", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        const ModalKey = Symbol();
+        /** @type {() => void} */
+        const close = () => {};
+        setContext(ModalKey, { close });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts?.[0].typeName).toBe("ModalKeyContext");
+  });
+
+  test("emits a diagnostic and skips context for an unresolvable key", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        export let dynamicKey = "modal";
+        /** @type {() => void} */
+        const close = () => {};
+        setContext(dynamicKey, { close });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts ?? []).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Could not resolve setContext key"));
+
+    warn.mockRestore();
+  });
+
+  test("does not resolve mutable (let) bindings as static keys", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        let mutableKey = "modal";
+        /** @type {() => void} */
+        const close = () => {};
+        setContext(mutableKey, { close });
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+    expect(result.contexts ?? []).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Could not resolve setContext key"));
+
+    warn.mockRestore();
+  });
 });

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -20185,3 +20185,334 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "context-const-key/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 19
+        },
+        "end": {
+          "line": 21,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "simple-modal",
+      "typeName": "SimpleModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props?: any) => void",
+          "description": "Open the modal with content",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => void",
+          "description": "Close the modal",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "context-unresolvable-key/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "dynamicKey",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"modal\\"",
+      "defaultValue": {
+        "raw": "\\"modal\\"",
+        "kind": "literal",
+        "value": "modal"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 19
+        },
+        "end": {
+          "line": 15,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "context-symbol/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 18
+        },
+        "end": {
+          "line": 21,
+          "column": 26
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "tabs",
+      "typeName": "TabsContext",
+      "properties": [
+        {
+          "name": "activeTab",
+          "type": "number",
+          "description": "The currently active tab index.",
+          "optional": false
+        },
+        {
+          "name": "registerTab",
+          "type": "(label: string) => number",
+          "description": "Register a tab and return its index.",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "context-symbol-for/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 14,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 27
+        },
+        "end": {
+          "line": 13,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "notification",
+      "typeName": "NotificationContext",
+      "properties": [
+        {
+          "name": "notify",
+          "type": "(message: string) => void",
+          "description": "Push a notification message.",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-const-key/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SimpleModalContext = {
+  /** Open the modal with content */
+  open: (component: any, props?: any) => void;
+  /** Close the modal */
+  close: () => void;
+};
+
+export type ContextConstKeyProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextConstKey extends SvelteComponentTyped<
+  ContextConstKeyProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-unresolvable-key/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type ContextUnresolvableKeyProps = {
+  /**
+   * @default "modal"
+   */
+  dynamicKey?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextUnresolvableKey extends SvelteComponentTyped<
+  ContextUnresolvableKeyProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-symbol/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type TabsContext = {
+  /** The currently active tab index. */
+  activeTab: number;
+  /** Register a tab and return its index. */
+  registerTab: (label: string) => number;
+};
+
+export type ContextSymbolProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextSymbol extends SvelteComponentTyped<
+  ContextSymbolProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-symbol-for/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type NotificationContext = {
+  /** Push a notification message. */
+  notify: (message: string) => void;
+};
+
+export type ContextSymbolForProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextSymbolFor extends SvelteComponentTyped<
+  ContextSymbolForProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;

--- a/tests/fixtures/context-const-key/input.svelte
+++ b/tests/fixtures/context-const-key/input.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { setContext } from "svelte";
+
+  const CONTEXT_KEY = "simple-modal";
+
+  /**
+   * Close the modal
+   * @type {() => void}
+   */
+  const close = () => {};
+
+  /**
+   * Open the modal with content
+   * @type {(component: any, props?: any) => void}
+   */
+  const open = (component, props) => {};
+
+  setContext(CONTEXT_KEY, { open, close });
+</script>
+
+<div class="modal"><slot /></div>

--- a/tests/fixtures/context-const-key/output.d.ts
+++ b/tests/fixtures/context-const-key/output.d.ts
@@ -1,0 +1,18 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SimpleModalContext = {
+  /** Open the modal with content */
+  open: (component: any, props?: any) => void;
+  /** Close the modal */
+  close: () => void;
+};
+
+export type ContextConstKeyProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextConstKey extends SvelteComponentTyped<
+  ContextConstKeyProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-const-key/output.json
+++ b/tests/fixtures/context-const-key/output.json
@@ -1,0 +1,57 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 19
+        },
+        "end": {
+          "line": 21,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "simple-modal",
+      "typeName": "SimpleModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props?: any) => void",
+          "description": "Open the modal with content",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => void",
+          "description": "Close the modal",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}

--- a/tests/fixtures/context-symbol-for/input.svelte
+++ b/tests/fixtures/context-symbol-for/input.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { setContext } from "svelte";
+
+  /**
+   * Push a notification message.
+   * @type {(message: string) => void}
+   */
+  const notify = (message) => {};
+
+  setContext(Symbol.for("notification"), { notify });
+</script>
+
+<div class="notifications"><slot /></div>

--- a/tests/fixtures/context-symbol-for/output.d.ts
+++ b/tests/fixtures/context-symbol-for/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type NotificationContext = {
+  /** Push a notification message. */
+  notify: (message: string) => void;
+};
+
+export type ContextSymbolForProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextSymbolFor extends SvelteComponentTyped<
+  ContextSymbolForProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-symbol-for/output.json
+++ b/tests/fixtures/context-symbol-for/output.json
@@ -1,0 +1,51 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 14,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 27
+        },
+        "end": {
+          "line": 13,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "notification",
+      "typeName": "NotificationContext",
+      "properties": [
+        {
+          "name": "notify",
+          "type": "(message: string) => void",
+          "description": "Push a notification message.",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}

--- a/tests/fixtures/context-symbol/input.svelte
+++ b/tests/fixtures/context-symbol/input.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { setContext } from "svelte";
+
+  const KEY = Symbol("tabs");
+
+  /**
+   * The currently active tab index.
+   * @type {number}
+   */
+  let activeTab = 0;
+
+  /**
+   * Register a tab and return its index.
+   * @type {(label: string) => number}
+   */
+  const registerTab = (label) => 0;
+
+  setContext(KEY, { activeTab, registerTab });
+</script>
+
+<div class="tabs"><slot /></div>

--- a/tests/fixtures/context-symbol/output.d.ts
+++ b/tests/fixtures/context-symbol/output.d.ts
@@ -1,0 +1,18 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type TabsContext = {
+  /** The currently active tab index. */
+  activeTab: number;
+  /** Register a tab and return its index. */
+  registerTab: (label: string) => number;
+};
+
+export type ContextSymbolProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextSymbol extends SvelteComponentTyped<
+  ContextSymbolProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-symbol/output.json
+++ b/tests/fixtures/context-symbol/output.json
@@ -1,0 +1,57 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 18
+        },
+        "end": {
+          "line": 21,
+          "column": 26
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "tabs",
+      "typeName": "TabsContext",
+      "properties": [
+        {
+          "name": "activeTab",
+          "type": "number",
+          "description": "The currently active tab index.",
+          "optional": false
+        },
+        {
+          "name": "registerTab",
+          "type": "(label: string) => number",
+          "description": "Register a tab and return its index.",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}

--- a/tests/fixtures/context-unresolvable-key/input.svelte
+++ b/tests/fixtures/context-unresolvable-key/input.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { setContext } from "svelte";
+
+  export let dynamicKey = "modal";
+
+  /**
+   * Close the modal
+   * @type {() => void}
+   */
+  const close = () => {};
+
+  setContext(dynamicKey, { close });
+</script>
+
+<div class="modal"><slot /></div>

--- a/tests/fixtures/context-unresolvable-key/output.d.ts
+++ b/tests/fixtures/context-unresolvable-key/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type ContextUnresolvableKeyProps = {
+  /**
+   * @default "modal"
+   */
+  dynamicKey?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextUnresolvableKey extends SvelteComponentTyped<
+  ContextUnresolvableKeyProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-unresolvable-key/output.json
+++ b/tests/fixtures/context-unresolvable-key/output.json
@@ -1,0 +1,66 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "dynamicKey",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"modal\"",
+      "defaultValue": {
+        "raw": "\"modal\"",
+        "kind": "literal",
+        "value": "modal"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 19
+        },
+        "end": {
+          "line": 15,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
Resolve `const`-bound string and `Symbol()` context keys like `@default`
indirection; emit a diagnostic for unresolvable keys instead of
silently dropping the context.