### PR TITLE
fix(parser): keep `@template` generic when a referencing prop shares its `@slot` block

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -889,6 +889,9 @@ export default class ComponentParser {
   /** Component generic type parameters (null if no generics) */
   private generics: ComponentGenerics = null;
 
+  /** @template tags in a @slot/@snippet block (no @extends), held until finalization. */
+  private deferredSlotBlockGenerics: Array<{ name: string; constraint: string }> = [];
+
   /** Map of prop bindings (e.g., `bind:value`) keyed by prop name */
   private readonly bindings: Map<string, ComponentPropBindings> = new Map();
 
@@ -4279,8 +4282,6 @@ export default class ComponentParser {
             if (isFirstTag) isFirstTag = false;
             break;
           case "template": {
-            if (blockHasSlotOrSnippetTag && !blockHasExtendsTag) break;
-
             // Build constraint from standard JSDoc @template syntax:
             //   @template T              → type="", name="T", default=undefined
             //   @template {string} T     → type="string", name="T", default=undefined
@@ -4290,12 +4291,12 @@ export default class ComponentParser {
             if (type) constraint = `${name} extends ${type}`;
             if (defaultValue) constraint += ` = ${defaultValue}`;
 
-            if (this.generics) {
-              // Accumulate multiple @template tags
-              this.generics = [`${this.generics[0]},${name}`, `${this.generics[1]}, ${constraint}`];
-            } else {
-              this.generics = [name, constraint];
+            if (blockHasSlotOrSnippetTag && !blockHasExtendsTag) {
+              this.deferredSlotBlockGenerics.push({ name, constraint });
+              break;
             }
+
+            this.accumulateGeneric(name, constraint);
             if (isFirstTag) isFirstTag = false;
             break;
           }
@@ -4994,6 +4995,14 @@ export default class ComponentParser {
    * parser.parseSvelteComponent(source2, diagnostics2); // Fresh parse
    * ```
    */
+  private accumulateGeneric(name: string, constraint: string): void {
+    if (this.generics) {
+      this.generics = [`${this.generics[0]},${name}`, `${this.generics[1]}, ${constraint}`];
+    } else {
+      this.generics = [name, constraint];
+    }
+  }
+
   public cleanup() {
     this.syntaxMode = "legacy";
     this.scriptLanguage = undefined;
@@ -5015,6 +5024,7 @@ export default class ComponentParser {
     this.forwardedEvents.clear();
     this.typedefs.clear();
     this.generics = null;
+    this.deferredSlotBlockGenerics.length = 0;
     this.bindings.clear();
     this.contexts.clear();
     this.variableInfoCache.clear();
@@ -6020,6 +6030,18 @@ export default class ComponentParser {
         if (aName > bName) return 1;
         return 0;
       });
+
+    if (this.deferredSlotBlockGenerics.length > 0) {
+      const referencedTypeText = [
+        ...processedProps.map((prop) => prop.type ?? ""),
+        ...processedSlots.map((slot) => slot.slot_props ?? ""),
+      ].join("\n");
+      for (const { name, constraint } of this.deferredSlotBlockGenerics) {
+        const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        if (!new RegExp(`\\b${escapedName}\\b`).test(referencedTypeText)) continue;
+        this.accumulateGeneric(name, constraint);
+      }
+    }
 
     const moduleExportsArray = ComponentParser.mapToArray(this.moduleExports);
     /**

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -122,6 +122,102 @@ exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "slot-event-template-prop-reference/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 14,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "icon",
+      "kind": "let",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "icon",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "select",
+      "detail": "Icon",
+      "description": "\`@template\` shared by \`@event\` and \`@slot\` still becomes a component generic when a prop uses it.",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 25
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": [
+    "Icon",
+    "Icon = any"
+  ],
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "slot-event-template-prop-reference/input.svelte",
+      "kind": "event-no-source",
+      "name": "select",
+      "message": "@event \\"select\\" has no matching dispatch or callback prop."
+    }
+  ]
+}
+"
+`;
+
 exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
 "{
   "source": {
@@ -1109,6 +1205,80 @@ exports[`fixtures (JSON) "resolve-default-chained/input.svelte" 1`] = `
       "message": "Prop \\"deep6\\" type could not be inferred; falling back to \\"any\\"."
     }
   ]
+}
+"
+`;
+
+exports[`fixtures (JSON) "slot-template-prop-reference/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 17,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "icon",
+      "kind": "let",
+      "description": "Specify the icon to render.",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "icon",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "\`@template\` in a \`@slot\` block becomes a component generic when a prop uses the name.\\nWithout that, \`.d.ts\` references an undeclared type (TS2304).",
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 0
+        },
+        "end": {
+          "line": 16,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Icon",
+    "Icon = any"
+  ],
+  "contexts": [],
+  "diagnostics": []
 }
 "
 `;
@@ -2809,6 +2979,67 @@ exports[`fixtures (JSON) "empty-collection-defaults/input.svelte" 1`] = `
   "typedefs": [],
   "generics": null,
   "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "context-const-key/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 19
+        },
+        "end": {
+          "line": 21,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "simple-modal",
+      "typeName": "SimpleModalContext",
+      "properties": [
+        {
+          "name": "open",
+          "type": "(component: any, props?: any) => void",
+          "description": "Open the modal with content",
+          "optional": false
+        },
+        {
+          "name": "close",
+          "type": "() => void",
+          "description": "Close the modal",
+          "optional": false
+        }
+      ]
+    }
+  ],
   "diagnostics": []
 }
 "
@@ -6187,6 +6418,76 @@ exports[`fixtures (JSON) "runes-snippet-description-hyphens/input.svelte" 1`] = 
       "message": "Prop \\"col\\" type could not be inferred; falling back to \\"any\\"."
     }
   ]
+}
+"
+`;
+
+exports[`fixtures (JSON) "context-unresolvable-key/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "dynamicKey",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"modal\\"",
+      "defaultValue": {
+        "raw": "\\"modal\\"",
+        "kind": "literal",
+        "value": "modal"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 19
+        },
+        "end": {
+          "line": 15,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
 }
 "
 `;
@@ -10688,6 +10989,67 @@ exports[`fixtures (JSON) "forwarded-native-with-detail/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "context-symbol/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 18
+        },
+        "end": {
+          "line": 21,
+          "column": 26
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "tabs",
+      "typeName": "TabsContext",
+      "properties": [
+        {
+          "name": "activeTab",
+          "type": "number",
+          "description": "The currently active tab index.",
+          "optional": false
+        },
+        {
+          "name": "registerTab",
+          "type": "(label: string) => number",
+          "description": "Register a tab and return its index.",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-props-renamed/input.svelte" 1`] = `
 "{
   "source": {
@@ -13883,6 +14245,61 @@ exports[`fixtures (JSON) "legacy-bind-component-ref/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "context-symbol-for/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 14,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 27
+        },
+        "end": {
+          "line": 13,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "notification",
+      "typeName": "NotificationContext",
+      "properties": [
+        {
+          "name": "notify",
+          "type": "(message: string) => void",
+          "description": "Push a notification message.",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] = `
 "{
   "source": {
@@ -15486,6 +15903,27 @@ export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record
 "
 `;
 
+exports[`fixtures (TypeScript) "slot-event-template-prop-reference/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotEventTemplatePropReferenceProps<Icon = any> = {
+  /**
+   * @default undefined
+   */
+  icon?: Icon;
+};
+
+export default class SlotEventTemplatePropReference<Icon = any> extends SvelteComponentTyped<
+  SlotEventTemplatePropReferenceProps<Icon>,
+  {
+    /** \`@template\` shared by \`@event\` and \`@slot\` still becomes a component generic when a prop uses it. */
+    select: CustomEvent<Icon>;
+  },
+  { icon: Record<string, never> }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "slots-named/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -15810,6 +16248,31 @@ export default class ResolveDefaultChained extends SvelteComponentTyped<
   ResolveDefaultChainedProps,
   Record<string, any>,
   Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "slot-template-prop-reference/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotTemplatePropReferenceProps<Icon = any> = {
+  /**
+   * Specify the icon to render.
+   * @default undefined
+   */
+  icon?: Icon;
+};
+
+export default class SlotTemplatePropReference<Icon = any> extends SvelteComponentTyped<
+  SlotTemplatePropReferenceProps<Icon>,
+  Record<string, any>,
+  {
+    /**
+     * \`@template\` in a \`@slot\` block becomes a component generic when a prop uses the name.
+     * Without that, \`.d.ts\` references an undeclared type (TS2304).
+     */
+    icon: Record<string, never>;
+  }
 > {}
 "
 `;
@@ -16340,6 +16803,28 @@ export default class EmptyCollectionDefaults extends SvelteComponentTyped<
   EmptyCollectionDefaultsProps,
   Record<string, any>,
   Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-const-key/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SimpleModalContext = {
+  /** Open the modal with content */
+  open: (component: any, props?: any) => void;
+  /** Close the modal */
+  close: () => void;
+};
+
+export type ContextConstKeyProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextConstKey extends SvelteComponentTyped<
+  ContextConstKeyProps,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -17293,6 +17778,26 @@ export default class RunesSnippetDescriptionHyphens extends SvelteComponentTyped
      */
     default: { row: string; col: string };
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-unresolvable-key/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type ContextUnresolvableKeyProps = {
+  /**
+   * @default "modal"
+   */
+  dynamicKey?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class ContextUnresolvableKey extends SvelteComponentTyped<
+  ContextUnresolvableKeyProps,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -18539,6 +19044,28 @@ export default class ForwardedNativeWithDetail extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "context-symbol/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type TabsContext = {
+  /** The currently active tab index. */
+  activeTab: number;
+  /** Register a tab and return its index. */
+  registerTab: (label: string) => number;
+};
+
+export type ContextSymbolProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextSymbol extends SvelteComponentTyped<
+  ContextSymbolProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-props-renamed/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -19589,6 +20116,26 @@ export default class LegacyBindComponentRef extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "context-symbol-for/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type NotificationContext = {
+  /** Push a notification message. */
+  notify: (message: string) => void;
+};
+
+export type ContextSymbolForProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextSymbolFor extends SvelteComponentTyped<
+  ContextSymbolForProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -20182,337 +20729,6 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
     /** Row id maps to server-side UUID v4 (not v1-v3). */
     item: { id: string };
   }
-> {}
-"
-`;
-
-exports[`fixtures (JSON) "context-const-key/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 22,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "Record<string, never>",
-      "source": {
-        "start": {
-          "line": 21,
-          "column": 19
-        },
-        "end": {
-          "line": 21,
-          "column": 27
-        }
-      }
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [
-    {
-      "key": "simple-modal",
-      "typeName": "SimpleModalContext",
-      "properties": [
-        {
-          "name": "open",
-          "type": "(component: any, props?: any) => void",
-          "description": "Open the modal with content",
-          "optional": false
-        },
-        {
-          "name": "close",
-          "type": "() => void",
-          "description": "Close the modal",
-          "optional": false
-        }
-      ]
-    }
-  ],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (JSON) "context-unresolvable-key/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 16,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [
-    {
-      "name": "dynamicKey",
-      "kind": "let",
-      "type": "string",
-      "typeSource": "default",
-      "value": "\\"modal\\"",
-      "defaultValue": {
-        "raw": "\\"modal\\"",
-        "kind": "literal",
-        "value": "modal"
-      },
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 4,
-          "column": 2
-        },
-        "end": {
-          "line": 4,
-          "column": 34
-        }
-      }
-    }
-  ],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "Record<string, never>",
-      "source": {
-        "start": {
-          "line": 15,
-          "column": 19
-        },
-        "end": {
-          "line": 15,
-          "column": 27
-        }
-      }
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (JSON) "context-symbol/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 22,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "Record<string, never>",
-      "source": {
-        "start": {
-          "line": 21,
-          "column": 18
-        },
-        "end": {
-          "line": 21,
-          "column": 26
-        }
-      }
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [
-    {
-      "key": "tabs",
-      "typeName": "TabsContext",
-      "properties": [
-        {
-          "name": "activeTab",
-          "type": "number",
-          "description": "The currently active tab index.",
-          "optional": false
-        },
-        {
-          "name": "registerTab",
-          "type": "(label: string) => number",
-          "description": "Register a tab and return its index.",
-          "optional": false
-        }
-      ]
-    }
-  ],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (JSON) "context-symbol-for/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 14,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "Record<string, never>",
-      "source": {
-        "start": {
-          "line": 13,
-          "column": 27
-        },
-        "end": {
-          "line": 13,
-          "column": 35
-        }
-      }
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [
-    {
-      "key": "notification",
-      "typeName": "NotificationContext",
-      "properties": [
-        {
-          "name": "notify",
-          "type": "(message: string) => void",
-          "description": "Push a notification message.",
-          "optional": false
-        }
-      ]
-    }
-  ],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "context-const-key/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type SimpleModalContext = {
-  /** Open the modal with content */
-  open: (component: any, props?: any) => void;
-  /** Close the modal */
-  close: () => void;
-};
-
-export type ContextConstKeyProps = {
-  children?: (this: void) => void;
-};
-
-export default class ContextConstKey extends SvelteComponentTyped<
-  ContextConstKeyProps,
-  Record<string, any>,
-  { default: Record<string, never> }
-> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "context-unresolvable-key/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type ContextUnresolvableKeyProps = {
-  /**
-   * @default "modal"
-   */
-  dynamicKey?: string;
-
-  children?: (this: void) => void;
-};
-
-export default class ContextUnresolvableKey extends SvelteComponentTyped<
-  ContextUnresolvableKeyProps,
-  Record<string, any>,
-  { default: Record<string, never> }
-> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "context-symbol/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type TabsContext = {
-  /** The currently active tab index. */
-  activeTab: number;
-  /** Register a tab and return its index. */
-  registerTab: (label: string) => number;
-};
-
-export type ContextSymbolProps = {
-  children?: (this: void) => void;
-};
-
-export default class ContextSymbol extends SvelteComponentTyped<
-  ContextSymbolProps,
-  Record<string, any>,
-  { default: Record<string, never> }
-> {}
-"
-`;
-
-exports[`fixtures (TypeScript) "context-symbol-for/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type NotificationContext = {
-  /** Push a notification message. */
-  notify: (message: string) => void;
-};
-
-export type ContextSymbolForProps = {
-  children?: (this: void) => void;
-};
-
-export default class ContextSymbolFor extends SvelteComponentTyped<
-  ContextSymbolForProps,
-  Record<string, any>,
-  { default: Record<string, never> }
 > {}
 "
 `;

--- a/tests/fixtures/slot-event-template-prop-reference/input.svelte
+++ b/tests/fixtures/slot-event-template-prop-reference/input.svelte
@@ -1,0 +1,13 @@
+<script>
+  /**
+   * `@template` shared by `@event` and `@slot` still becomes a component generic when a prop uses it.
+   * @template [Icon=any]
+   * @event {Icon} select
+   * @slot {{}} icon
+   */
+
+  /** @type {Icon} */
+  export let icon = undefined;
+</script>
+
+<slot name="icon" />

--- a/tests/fixtures/slot-event-template-prop-reference/output.d.ts
+++ b/tests/fixtures/slot-event-template-prop-reference/output.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotEventTemplatePropReferenceProps<Icon = any> = {
+  /**
+   * @default undefined
+   */
+  icon?: Icon;
+};
+
+export default class SlotEventTemplatePropReference<Icon = any> extends SvelteComponentTyped<
+  SlotEventTemplatePropReferenceProps<Icon>,
+  {
+    /** `@template` shared by `@event` and `@slot` still becomes a component generic when a prop uses it. */
+    select: CustomEvent<Icon>;
+  },
+  { icon: Record<string, never> }
+> {}

--- a/tests/fixtures/slot-event-template-prop-reference/output.json
+++ b/tests/fixtures/slot-event-template-prop-reference/output.json
@@ -1,0 +1,92 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 14,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "icon",
+      "kind": "let",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "icon",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "select",
+      "detail": "Icon",
+      "description": "`@template` shared by `@event` and `@slot` still becomes a component generic when a prop uses it.",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 25
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": [
+    "Icon",
+    "Icon = any"
+  ],
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "slot-event-template-prop-reference/input.svelte",
+      "kind": "event-no-source",
+      "name": "select",
+      "message": "@event \"select\" has no matching dispatch or callback prop."
+    }
+  ]
+}

--- a/tests/fixtures/slot-template-prop-reference/input.svelte
+++ b/tests/fixtures/slot-template-prop-reference/input.svelte
@@ -1,0 +1,16 @@
+<script>
+  /**
+   * `@template` in a `@slot` block becomes a component generic when a prop uses the name.
+   * Without that, `.d.ts` references an undeclared type (TS2304).
+   * @template [Icon=any]
+   * @slot {{}} icon
+   */
+
+  /**
+   * Specify the icon to render.
+   * @type {Icon}
+   */
+  export let icon = undefined;
+</script>
+
+<slot name="icon" />

--- a/tests/fixtures/slot-template-prop-reference/output.d.ts
+++ b/tests/fixtures/slot-template-prop-reference/output.d.ts
@@ -1,0 +1,21 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type SlotTemplatePropReferenceProps<Icon = any> = {
+  /**
+   * Specify the icon to render.
+   * @default undefined
+   */
+  icon?: Icon;
+};
+
+export default class SlotTemplatePropReference<Icon = any> extends SvelteComponentTyped<
+  SlotTemplatePropReferenceProps<Icon>,
+  Record<string, any>,
+  {
+    /**
+     * `@template` in a `@slot` block becomes a component generic when a prop uses the name.
+     * Without that, `.d.ts` references an undeclared type (TS2304).
+     */
+    icon: Record<string, never>;
+  }
+> {}

--- a/tests/fixtures/slot-template-prop-reference/output.json
+++ b/tests/fixtures/slot-template-prop-reference/output.json
@@ -1,0 +1,70 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 17,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "icon",
+      "kind": "let",
+      "description": "Specify the icon to render.",
+      "type": "Icon",
+      "typeSource": "jsdoc",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "icon",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "`@template` in a `@slot` block becomes a component generic when a prop uses the name.\nWithout that, `.d.ts` references an undeclared type (TS2304).",
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 0
+        },
+        "end": {
+          "line": 16,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Icon",
+    "Icon = any"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
## Problem

When a `@template` tag shares a JSDoc block with a `@slot`/`@snippet` tag (and there is no `@extends`), the generic was discarded entirely. If a prop's type referenced that generic, the emitted `.d.ts` named a type that was never declared, failing type checking with `TS2304: Cannot find name 'Icon'`.

`@event` did not trigger the bug because only `@slot`/`@snippet` are part of the discard check.

### Input (`Foo.svelte`)

```svelte
<script>
  /**
   * @template [Icon=any]
   * @slot {{}} icon
   */

  /**
   * Specify the icon to render.
   * @type {Icon}
   */
  export let icon = undefined;
</script>

<slot name="icon" />
```

### Output before (broken)

`parsed.generics` was `null`, so `Icon` was referenced but never declared:

```ts
export type FooProps = {
  /** Specify the icon to render. */
  icon?: Icon; // Icon is never declared -> TS2304
};

export default class Foo extends SvelteComponentTyped<FooProps, ...> {}
```

### Output after (fixed)

```ts
export type FooProps<Icon = any> = {
  /** Specify the icon to render. */
  icon?: Icon;
};

export default class Foo<Icon = any> extends SvelteComponentTyped<
  FooProps<Icon>,
  ...
> {}
```

## Fix

Rather than dropping the generic, defer it into `deferredSlotBlockGenerics`. During finalization (once props and slots are parsed) promote it to a real component generic only when a prop or slot type actually references the generic name (word-boundary match, so `Icon` does not match `IconButton`). An unused generic stays slot documentation and is dropped, preserving prior intent.

## Trigger matrix

| JSDoc block contents | `parsed.generics` before | after |
| --- | --- | --- |
| `@template` alone | `["Icon", "Icon = any"]` | `["Icon", "Icon = any"]` |
| `@template` + `@event` | `["Icon", "Icon = any"]` | `["Icon", "Icon = any"]` |
| `@template` + `@slot` (prop refs it) | `null` | `["Icon", "Icon = any"]` |
| `@template` + `@event` + `@slot` (prop refs it) | `null` | `["Icon", "Icon = any"]` |
| `@template` + `@slot` (generic unused) | `null` | `null` |

## Tests

- Added fixtures `slot-template-prop-reference` and `slot-event-template-prop-reference`.
- Existing `slot-jsdoc-template-not-passthrough` (unused generic) and `slot-extends-template` outputs unchanged.
- `bun test`, `bun run typecheck`, `bun run test:fixtures-types`, and `biome check` all pass.
