### PR TITLE
feat: add persistent cross-run parse cache (cache option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ Without `resolveTypes`, JSON lists no props. With it, each field shows up with `
 
 **Performance.** Off by default. This is the only path that loads TypeScript. It needs `typescript` and a `tsconfig.json`, runs slower than the AST-only pipeline, and gets slower as your types grow. Use it only when you need expanded JSON. `.d.ts` output is unchanged.
 
+#### Persistent parse cache (`cache`)
+
+By default, every component is re-parsed on every run. With `cache`, parsed output is written to disk and reused when the source file has not changed. That applies across runs, including CI on a fresh checkout.
+
+```ts
+await sveld({ json: true, cache: true });
+```
+
+`cache: true` writes to `node_modules/.cache/sveld/parse-cache.json`. Pass a string to use a different location, e.g. `cache: ".cache/sveld.json"`. Also available as `--cache` / `--cache=<path>` on the CLI.
+
+If a component [`@extendProps`](#extendprops) / [`@extends`](#extendprops) another file, it is re-parsed when that dependency changes, same as in [`watch`](#available-options) mode. Bumping the `sveld` or Svelte version clears the cache.
+
 ## Usage
 
 ### Installation
@@ -381,6 +393,7 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 - **`markdownOptions`** (object, optional): Options for Markdown output.
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
+- **`cache`** (boolean | string, optional, default: `false`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path. Also available as `--cache` / `--cache=<path>`. See [Persistent parse cache](#persistent-parse-cache-cache).
 
 By default, only TypeScript definitions are generated.
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -9,7 +9,9 @@ import ComponentParser, {
   getParsedComponentTypeScriptMetadata,
   type ParsedComponent,
 } from "./ComponentParser";
+import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
+import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { normalizeSeparators } from "./path";
@@ -60,15 +62,22 @@ export interface GenerateBundleOptions {
   resolveTypes?: boolean;
   /** Record consts, functions, and types from the entry barrel. Off by default. */
   documentExports?: boolean;
+  /**
+   * Cache parsed component output to disk. Unchanged files skip re-parsing on
+   * later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a
+   * string sets a custom path. Off by default.
+   */
+  cache?: boolean | string;
 }
 
 export function toGenerateBundleOptions(
-  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes" | "documentExports">,
+  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes" | "documentExports" | "cache">,
 ): GenerateBundleOptions {
   return {
     failFast: opts?.failFast,
     resolveTypes: opts?.resolveTypes === true,
     documentExports: opts?.documentExports === true,
+    cache: opts?.cache,
   };
 }
 
@@ -81,6 +90,8 @@ export interface ProcessComponentOptions {
   failFast?: boolean;
   /** Invoked with a diagnostic when a component fails to parse (and `failFast` is off). */
   onParseError?: (error: ComponentParseError) => void;
+  /** When set, reuse a component's previous parse if its content hash is unchanged. */
+  cache?: ParseCache;
 }
 
 const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
@@ -243,28 +254,39 @@ export function processComponent(
     }
 
     const normalizedFilePath = normalizeSeparators(filePath);
-    const parser = new ComponentParser();
+
+    const hash = options.cache ? hashSource(source) : undefined;
+    const cached = hash === undefined ? null : options.cache?.get(resolvedPath, hash);
 
     let parsed: ParsedComponent;
-    try {
-      parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
-        moduleName,
-        filePath: normalizedFilePath,
-      });
-    } catch (error) {
-      /**
-       * Capture the failure as a diagnostic so the remaining components can
-       * still be processed. When `failFast` is enabled we rethrow to restore
-       * the abort-on-first-error behavior.
-       */
-      if (options.failFast) {
-        throw error;
+    if (cached) {
+      parsed = cached;
+    } else {
+      const parser = new ComponentParser();
+      try {
+        parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
+          moduleName,
+          filePath: normalizedFilePath,
+        });
+      } catch (error) {
+        /**
+         * Capture the failure as a diagnostic so the remaining components can
+         * still be processed. When `failFast` is enabled we rethrow to restore
+         * the abort-on-first-error behavior.
+         */
+        if (options.failFast) {
+          throw error;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        const stack = error instanceof Error ? error.stack : undefined;
+        options.onParseError?.({ filePath: normalizedFilePath, moduleName, message, stack });
+        return null;
       }
 
-      const message = error instanceof Error ? error.message : String(error);
-      const stack = error instanceof Error ? error.stack : undefined;
-      options.onParseError?.({ filePath: normalizedFilePath, moduleName, message, stack });
-      return null;
+      if (hash !== undefined) {
+        options.cache?.set(resolvedPath, hash, parsed);
+      }
     }
 
     return {
@@ -351,6 +373,20 @@ export async function generateBundle(
   const components: ComponentDocs = new Map();
   const allComponentsForTypes: ComponentDocs = new Map();
 
+  const cache = options.cache ? new ParseCache(resolveCacheFilePath(rootDir, options.cache)) : undefined;
+
+  // Files that changed or were never cached. Used to invalidate @extends dependents.
+  const misses = new Set<string>();
+  if (cache) {
+    for (const filePath of uniqueFilePaths) {
+      const source = fileMap.get(filePath);
+      if (source === null || source === undefined) continue;
+      if (!cache.has(filePath, hashSource(source))) {
+        misses.add(filePath);
+      }
+    }
+  }
+
   /**
    * Dedupe by file path: the same component is parsed once for the exported
    * set and once for the all-components set.
@@ -359,6 +395,7 @@ export async function generateBundle(
   const processOptions: ProcessComponentOptions = {
     failFast: options.failFast === true,
     onParseError: (error) => parseErrors.set(error.filePath, error),
+    cache,
   };
 
   /**
@@ -382,12 +419,38 @@ export async function generateBundle(
     if (result) allComponentsForTypes.set(result.moduleName, result);
   }
 
+  if (cache && misses.size > 0) {
+    // Reparse unchanged files that extend something that changed.
+    const reverseDeps = buildReverseDeps(allComponentsForTypes, resolveComponentFilePath);
+    const affected = expandAffected(misses, reverseDeps);
+
+    for (const filePath of affected) {
+      if (misses.has(filePath)) continue;
+      cache.invalidate(filePath);
+    }
+
+    for (const entry of exportEntries) {
+      const resolvedPath = resolveComponentFilePath(entry[1].source);
+      if (!affected.has(resolvedPath) || misses.has(resolvedPath)) continue;
+      const result = processComponent(entry, exportEntries, fileMap, resolveComponentFilePath, processOptions);
+      if (result) components.set(result.moduleName, result);
+    }
+    for (const entry of allComponentEntries) {
+      const resolvedPath = resolveComponentFilePath(entry[1].source);
+      if (!affected.has(resolvedPath) || misses.has(resolvedPath)) continue;
+      const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath, processOptions);
+      if (result) allComponentsForTypes.set(result.moduleName, result);
+    }
+  }
+
   const errors = Array.from(parseErrors.values());
   reportParseErrors(errors);
 
   if (options.resolveTypes) {
     await resolveImportedPropTypes(components, rootDir, resolveComponentFilePath);
   }
+
+  cache?.save();
 
   // Same file can land in both export and all-components passes; dedupe before returning.
   const diagnostics = dedupeDiagnostics(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,11 @@ function parseCliFlag(arg: string): Partial<CliOptions> {
       return { failFast: value === true || value === "true" };
     case "entry":
       return typeof value === "string" ? { entry: value } : {};
+    case "cache":
+      // Bare `--cache` enables the default cache location; `--cache=<path>`
+      // overrides it; `--cache=false` disables it.
+      if (value === "false") return { cache: false };
+      return { cache: typeof value === "string" ? value : true };
     default:
       return {};
   }

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -1,0 +1,82 @@
+import { dirname, resolve } from "node:path";
+import type { ComponentDocApi, ComponentDocs, ResolveComponentFilePath } from "./bundle";
+
+const SVELTE_EXT_REGEX = /\.svelte$/;
+
+/** Strips matching surrounding single/double quotes from an import specifier. */
+const SURROUNDING_QUOTES_REGEX = /^(['"])(.*)\1$/;
+
+/**
+ * Resolves a component's `@extendProps` / `@extends` target to an absolute path,
+ * or `null` when it doesn't point at a local `.svelte` file (e.g. it references
+ * an external package interface like `carbon-components-svelte`).
+ */
+export function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): string | null {
+  const raw = api.extends?.import;
+  if (raw === undefined) return null;
+  // `extends.import` is stored verbatim from the JSDoc tag, including any
+  // surrounding quotes (e.g. `"./Button.svelte"`).
+  const target = raw.replace(SURROUNDING_QUOTES_REGEX, "$2");
+  if (!SVELTE_EXT_REGEX.test(target)) return null;
+  return resolve(dirname(componentPath), target);
+}
+
+/**
+ * Builds a reverse-dependency map: `dependencyPath -> set of dependent paths`.
+ *
+ * A component is a dependent of `X` when it extends `X` via `@extendProps` /
+ * `@extends`. When `X` changes, every dependent must be re-parsed.
+ */
+export function buildReverseDeps(
+  components: ComponentDocs,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Map<string, Set<string>> {
+  const reverse = new Map<string, Set<string>>();
+
+  for (const api of components.values()) {
+    const componentPath = resolveComponentFilePath(api.filePath);
+    const dependency = resolveExtendsDependency(api, componentPath);
+    if (dependency === null) continue;
+
+    let dependents = reverse.get(dependency);
+    if (dependents === undefined) {
+      dependents = new Set();
+      reverse.set(dependency, dependents);
+    }
+    dependents.add(componentPath);
+  }
+
+  return reverse;
+}
+
+/**
+ * Expands the set of changed paths to include every transitive dependent via
+ * the reverse-dependency map (e.g. editing `Button.svelte` also marks the
+ * `SecondaryButton.svelte` that `@extendProps`-es it).
+ */
+export function expandAffected(changed: Iterable<string>, reverseDeps: Map<string, Set<string>>): Set<string> {
+  const affected = new Set<string>();
+  const queue: string[] = [];
+
+  for (const path of changed) {
+    if (!affected.has(path)) {
+      affected.add(path);
+      queue.push(path);
+    }
+  }
+
+  while (queue.length > 0) {
+    // biome-ignore lint/style/noNonNullAssertion: queue is non-empty in the loop condition
+    const current = queue.shift()!;
+    const dependents = reverseDeps.get(current);
+    if (dependents === undefined) continue;
+    for (const dependent of dependents) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return affected;
+}

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { version as svelteVersion } from "svelte/package.json";
+import { version as sveldVersion } from "../package.json";
+import {
+  PARSED_COMPONENT_TYPE_SCRIPT_METADATA,
+  type ParsedComponent,
+  type ParsedComponentTypeScriptMetadata,
+} from "./ComponentParser";
+
+/** Bumped whenever the on-disk cache shape changes in a way old caches can't read. */
+const CACHE_FORMAT_VERSION = 1;
+
+/** Default on-disk location for the persistent parse cache, relative to the project root. */
+export const DEFAULT_CACHE_FILE = join("node_modules", ".cache", "sveld", "parse-cache.json");
+
+/** One cached parse for a component file. */
+interface ParseCacheEntry {
+  /** sha256 of the raw source at cache time. */
+  hash: string;
+  parsed: ParsedComponent;
+  /**
+   * `parsed[PARSED_COMPONENT_TYPE_SCRIPT_METADATA]`, captured explicitly:
+   * `JSON.stringify` drops symbol-keyed properties, so it can't ride along
+   * on `parsed` through a disk round-trip.
+   */
+  typeScriptMetadata?: ParsedComponentTypeScriptMetadata;
+}
+
+interface ParseCacheFile {
+  formatVersion: number;
+  /** Invalidates the whole cache when sveld or the Svelte compiler upgrades. */
+  toolchainVersion: string;
+  entries: Record<string, ParseCacheEntry>;
+}
+
+function currentToolchainVersion(): string {
+  return `${sveldVersion}+svelte@${svelteVersion}`;
+}
+
+/** Resolves the effective cache file path for `cache: true | string`. */
+export function resolveCacheFilePath(rootDir: string, cache: boolean | string): string {
+  if (typeof cache === "string") {
+    return isAbsolute(cache) ? cache : resolve(rootDir, cache);
+  }
+  return resolve(rootDir, DEFAULT_CACHE_FILE);
+}
+
+export function hashSource(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function emptyCacheFile(): ParseCacheFile {
+  return { formatVersion: CACHE_FORMAT_VERSION, toolchainVersion: currentToolchainVersion(), entries: {} };
+}
+
+function readCacheFile(cacheFilePath: string): ParseCacheFile {
+  try {
+    const raw = readFileSync(cacheFilePath, "utf-8");
+    const parsed = JSON.parse(raw) as ParseCacheFile;
+    if (parsed.formatVersion !== CACHE_FORMAT_VERSION || parsed.toolchainVersion !== currentToolchainVersion()) {
+      return emptyCacheFile();
+    }
+    return parsed;
+  } catch {
+    // Missing, unreadable, or corrupt cache file: start fresh.
+    return emptyCacheFile();
+  }
+}
+
+/**
+ * Cross-run parse cache. Entries match on file path and sha256 of source.
+ * Symbol-keyed TypeScript metadata is stored separately because JSON drops symbols.
+ */
+export class ParseCache {
+  private readonly cacheFilePath: string;
+  private readonly file: ParseCacheFile;
+  private readonly next = new Map<string, ParseCacheEntry>();
+  /** Paths forced to miss this run (e.g. dependents of a changed `@extends` target). */
+  private readonly blocked = new Set<string>();
+
+  constructor(cacheFilePath: string) {
+    this.cacheFilePath = cacheFilePath;
+    this.file = readCacheFile(cacheFilePath);
+  }
+
+  /** True when `get()` would return a hit for `resolvedPath` and `hash`. */
+  has(resolvedPath: string, hash: string): boolean {
+    if (this.blocked.has(resolvedPath)) return false;
+    const entry = this.file.entries[resolvedPath];
+    return entry !== undefined && entry.hash === hash;
+  }
+
+  /** Returns the cached parse for `resolvedPath` when its content hash still matches. */
+  get(resolvedPath: string, hash: string): ParsedComponent | null {
+    if (this.blocked.has(resolvedPath)) return null;
+
+    const entry = this.file.entries[resolvedPath];
+    if (entry === undefined || entry.hash !== hash) return null;
+
+    // Keep the entry for save() even if nothing else touches it this run.
+    this.next.set(resolvedPath, entry);
+
+    if (entry.typeScriptMetadata !== undefined) {
+      entry.parsed[PARSED_COMPONENT_TYPE_SCRIPT_METADATA] = entry.typeScriptMetadata;
+    }
+    return entry.parsed;
+  }
+
+  /** Records a freshly parsed component so it can be reused on a future run. */
+  set(resolvedPath: string, hash: string, parsed: ParsedComponent): void {
+    this.next.set(resolvedPath, {
+      hash,
+      parsed,
+      typeScriptMetadata: parsed[PARSED_COMPONENT_TYPE_SCRIPT_METADATA],
+    });
+  }
+
+  /** Skip cache for `resolvedPath` this run (e.g. an @extends dependent). */
+  invalidate(resolvedPath: string): void {
+    this.blocked.add(resolvedPath);
+  }
+
+  /** Persists this run's cache entries back to disk. */
+  save(): void {
+    mkdirSync(dirname(this.cacheFilePath), { recursive: true });
+    const file: ParseCacheFile = {
+      formatVersion: CACHE_FORMAT_VERSION,
+      toolchainVersion: currentToolchainVersion(),
+      entries: Object.fromEntries(this.next),
+    };
+    writeFileSync(this.cacheFilePath, JSON.stringify(file));
+  }
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -30,7 +30,7 @@ export {
   toGenerateBundleOptions,
 } from "./bundle";
 
-export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolveTypes"> {
+export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolveTypes" | "cache"> {
   /**
    * Specify the entry point to uncompiled Svelte source.
    * If not provided, sveld will use the "svelte" field from package.json.

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,7 +1,6 @@
 import { lstatSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import {
-  type ComponentDocApi,
   type ComponentDocs,
   type ComponentParseError,
   collectComponents,
@@ -9,18 +8,15 @@ import {
   type GenerateBundleResult,
   type ProcessComponentOptions,
   processComponent,
-  type ResolveComponentFilePath,
   readFileMap,
   reportParseErrors,
 } from "./bundle";
+import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics } from "./diagnostics";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import type { ParsedExports } from "./parse-exports";
 
 const SVELTE_EXT_REGEX = /\.svelte$/;
-
-/** Strips matching surrounding single/double quotes from an import specifier. */
-const SURROUNDING_QUOTES_REGEX = /^(['"])(.*)\1$/;
 
 /** Result of an incremental update. */
 export interface SveldBundleUpdate {
@@ -46,81 +42,6 @@ export interface SveldBundle {
   readonly result: GenerateBundleResult;
   /** Re-parse the changed files plus their dependents and return the updated bundle. */
   update(changedFilePaths: string[]): Promise<SveldBundleUpdate>;
-}
-
-/**
- * Resolves a component's `@extendProps` / `@extends` target to an absolute path,
- * or `null` when it doesn't point at a local `.svelte` file (e.g. it references
- * an external package interface like `carbon-components-svelte`).
- */
-function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): string | null {
-  const raw = api.extends?.import;
-  if (raw === undefined) return null;
-  // `extends.import` is stored verbatim from the JSDoc tag, including any
-  // surrounding quotes (e.g. `"./Button.svelte"`).
-  const target = raw.replace(SURROUNDING_QUOTES_REGEX, "$2");
-  if (!SVELTE_EXT_REGEX.test(target)) return null;
-  return resolve(dirname(componentPath), target);
-}
-
-/**
- * Builds a reverse-dependency map: `dependencyPath -> set of dependent paths`.
- *
- * A component is a dependent of `X` when it extends `X` via `@extendProps` /
- * `@extends`. When `X` changes, every dependent must be re-parsed.
- */
-function buildReverseDeps(
-  components: ComponentDocs,
-  resolveComponentFilePath: ResolveComponentFilePath,
-): Map<string, Set<string>> {
-  const reverse = new Map<string, Set<string>>();
-
-  for (const api of components.values()) {
-    const componentPath = resolveComponentFilePath(api.filePath);
-    const dependency = resolveExtendsDependency(api, componentPath);
-    if (dependency === null) continue;
-
-    let dependents = reverse.get(dependency);
-    if (dependents === undefined) {
-      dependents = new Set();
-      reverse.set(dependency, dependents);
-    }
-    dependents.add(componentPath);
-  }
-
-  return reverse;
-}
-
-/**
- * Expands the set of changed paths to include every transitive dependent via
- * the reverse-dependency map (e.g. editing `Button.svelte` also marks the
- * `SecondaryButton.svelte` that `@extendProps`-es it).
- */
-function expandAffected(changed: Iterable<string>, reverseDeps: Map<string, Set<string>>): Set<string> {
-  const affected = new Set<string>();
-  const queue: string[] = [];
-
-  for (const path of changed) {
-    if (!affected.has(path)) {
-      affected.add(path);
-      queue.push(path);
-    }
-  }
-
-  while (queue.length > 0) {
-    // biome-ignore lint/style/noNonNullAssertion: queue is non-empty in the loop condition
-    const current = queue.shift()!;
-    const dependents = reverseDeps.get(current);
-    if (dependents === undefined) continue;
-    for (const dependent of dependents) {
-      if (!affected.has(dependent)) {
-        affected.add(dependent);
-        queue.push(dependent);
-      }
-    }
-  }
-
-  return affected;
 }
 
 /**

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -12,4 +12,16 @@ describe("parseCliOptions", () => {
   test("failFast is absent by default", () => {
     expect(parseCliOptions(["--glob", "--types"])).toEqual({ glob: true, types: true });
   });
+
+  test("--cache enables the default cache location", () => {
+    expect(parseCliOptions(["--cache"])).toEqual({ cache: true });
+  });
+
+  test("--cache=<path> sets a custom cache location", () => {
+    expect(parseCliOptions(["--cache=.cache/sveld.json"])).toEqual({ cache: ".cache/sveld.json" });
+  });
+
+  test("--cache=false disables the cache", () => {
+    expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
+  });
 });

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { generateBundle } from "../src/bundle";
+import ComponentParser from "../src/ComponentParser";
+
+const BUTTON = `<script>
+  /** @restProps {button} */
+  export let primary = false;
+</script>
+
+<button {...$$restProps}><slot /></button>`;
+
+const SECONDARY_BUTTON = `<script>
+  /** @extendProps {"./Button.svelte"} ButtonProps */
+  export let secondary = true;
+
+  import Button from "./Button.svelte";
+</script>
+
+<Button {...$$restProps}><slot /></Button>`;
+
+const STANDALONE = `<script>
+  export let label = "standalone";
+</script>
+
+<span>{label}</span>`;
+
+describe("parse cache", () => {
+  let dir: string;
+  let cacheFile: string;
+  let parseSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-parse-cache-"));
+    cacheFile = join(dir, ".cache", "parse-cache.json");
+    writeFileSync(join(dir, "Button.svelte"), BUTTON);
+    writeFileSync(join(dir, "SecondaryButton.svelte"), SECONDARY_BUTTON);
+    writeFileSync(join(dir, "Standalone.svelte"), STANDALONE);
+    parseSpy = jest.spyOn(ComponentParser.prototype, "parseSvelteComponent");
+  });
+
+  afterEach(() => {
+    parseSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("persists a cache file to disk after a run", async () => {
+    await generateBundle(dir, true, { cache: cacheFile });
+
+    const cache = JSON.parse(readFileSync(cacheFile, "utf-8"));
+    expect(Object.keys(cache.entries).sort()).toEqual(
+      [resolve(dir, "Button.svelte"), resolve(dir, "SecondaryButton.svelte"), resolve(dir, "Standalone.svelte")].sort(),
+    );
+  });
+
+  test("a second run with unchanged sources re-parses nothing", async () => {
+    const first = await generateBundle(dir, true, { cache: cacheFile });
+    parseSpy.mockClear();
+
+    const second = await generateBundle(dir, true, { cache: cacheFile });
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(Array.from(second.allComponentsForTypes.keys()).sort()).toEqual(
+      Array.from(first.allComponentsForTypes.keys()).sort(),
+    );
+    expect(second.allComponentsForTypes.get("Button")?.props.map((p) => p.name)).toEqual(
+      first.allComponentsForTypes.get("Button")?.props.map((p) => p.name),
+    );
+  });
+
+  test("editing one component only re-parses that component on the next run", async () => {
+    await generateBundle(dir, true, { cache: cacheFile });
+    parseSpy.mockClear();
+
+    writeFileSync(join(dir, "Standalone.svelte"), STANDALONE.replace('"standalone"', '"changed"'));
+    const result = await generateBundle(dir, true, { cache: cacheFile });
+
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(result.allComponentsForTypes.get("Standalone")?.props.find((p) => p.name === "label")?.value).toBe(
+      '"changed"',
+    );
+  });
+
+  test("editing an @extendProps target also invalidates its dependent, even though the dependent's own content is unchanged", async () => {
+    await generateBundle(dir, true, { cache: cacheFile });
+    parseSpy.mockClear();
+
+    writeFileSync(join(dir, "Button.svelte"), BUTTON.replace("primary = false", "primary = true"));
+    await generateBundle(dir, true, { cache: cacheFile });
+
+    const calls = parseSpy.mock.calls as unknown as Array<[string, { filePath: string }]>;
+    const reparsedPaths = calls.map(([, diagnostics]) => diagnostics.filePath);
+    expect(reparsedPaths.sort()).toEqual(["./Button.svelte", "./SecondaryButton.svelte"].sort());
+  });
+
+  test("a stale cache from an unrelated project root doesn't leak into a new one", async () => {
+    const otherDir = mkdtempSync(join(tmpdir(), "sveld-parse-cache-other-"));
+    writeFileSync(join(otherDir, "Standalone.svelte"), STANDALONE);
+
+    try {
+      await generateBundle(dir, true, { cache: cacheFile });
+      parseSpy.mockClear();
+
+      const result = await generateBundle(otherDir, true, { cache: cacheFile });
+
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+      expect(result.allComponentsForTypes.has("Standalone")).toBe(true);
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an opt-in `cache` option (`--cache` / `--cache=<path>` on the CLI) that persists parsed component output to disk, keyed by a content hash of each `.svelte` file.
- Unchanged files skip re-parsing entirely on the next run, including a cold CI checkout, since the cache lives on disk rather than in a live process.
- Components that reference another via `@extendProps` / `@extends` are still correctly invalidated when their target changes, even if their own content is unchanged. This reuses the reverse-dependency graph logic that watch mode already had, now extracted into `src/dependency-graph.ts` so both paths share it instead of duplicating it.
- The cache is invalidated wholesale on a sveld or Svelte version bump.

## Test plan

- [x] `bun test` (570 pass)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] New `tests/parse-cache.test.ts` spies on `ComponentParser.prototype.parseSvelteComponent` to confirm cache hits genuinely skip re-parsing, misses reparse only the changed file, and an edited `@extends` target forces its dependent to reparse too
- [x] New CLI flag-parsing tests in `tests/cli.test.ts` for `--cache`, `--cache=<path>`, `--cache=false`