### PR TITLE
feat: add opt-in `checkExamples` to type-check `@example` blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,45 @@ await sveld({ json: true, cache: true });
 
 If a component [`@extendProps`](#extendprops) / [`@extends`](#extendprops) another file, it is re-parsed when that dependency changes, same as in [`watch`](#available-options) mode. Bumping the `sveld` or Svelte version clears the cache.
 
+#### Compile-checked `@example` blocks (`checkExamples`)
+
+`@example` blocks are just text. Rename a prop and the sample code can sit there broken for months. Set `checkExamples: true` to run plain TS/JS `@example` blocks through the TypeScript program. Broken examples show up as `example-compile-error` diagnostics.
+
+```ts
+await sveld({ json: true, checkExamples: true });
+```
+
+```svelte
+<script>
+  /**
+   * Formats a value.
+   * @param {string} value
+   * @returns {string}
+   * @example
+   * ```js
+   * formatValue("ok");
+   * ```
+   */
+  export function formatValue(value) {
+    return value;
+  }
+</script>
+```
+
+If `formatValue` is later renamed and the example is never updated, `checkExamples` reports it:
+
+```
+@example blocks that failed to compile (1):
+  ./Component.svelte
+    - Line 1: Cannot find name 'formatValue'.
+```
+
+Plain TS/JS only. Examples fenced as `svelte` or `html`, or bare markup like `<Button />`, are skipped. Checking those needs `svelte2tsx` or similar, and sveld stays AST-only.
+
+The check is narrow on purpose. It catches renamed or removed symbols and wrong argument counts. It is not full type checking and never pulls in types sveld cannot see.
+
+Needs `typescript` and a `tsconfig.json`, same as `resolveTypes`. Use `--strict` (or the `strict` option) to fail CI when an example breaks.
+
 ## Usage
 
 ### Installation
@@ -420,7 +459,9 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 - **`markdownOptions`** (object, optional): Options for Markdown output.
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
+- **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
 - **`cache`** (boolean | string, optional, default: `false`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path. Also available as `--cache` / `--cache=<path>`. See [Persistent parse cache](#persistent-parse-cache-cache).
+- **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 
 By default, only TypeScript definitions are generated.
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -376,7 +376,7 @@ interface ComponentPropParam {
  * its type, default value, description, and metadata about whether it's
  * required, reactive, or a function.
  */
-interface ComponentProp {
+export interface ComponentProp {
   /** The prop name as declared in the component */
   name: string;
   /** The declaration kind: "let" (required), "const" (optional with default), or "function" */
@@ -529,7 +529,7 @@ const NEWLINE_CR_REGEX = /[\r\n]+/g;
  * Represents a slot that can be used to pass content into the component.
  * Includes information about slot props, fallback content, and descriptions.
  */
-interface ComponentSlot {
+export interface ComponentSlot {
   /** The slot name (null or undefined for default slot) */
   name?: string | null;
   /** Whether this is the default slot */

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -11,6 +11,7 @@ import ComponentParser, {
 } from "./ComponentParser";
 import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
+import { collectExampleSources } from "./example-check";
 import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
@@ -68,16 +69,24 @@ export interface GenerateBundleOptions {
    * string sets a custom path. Off by default.
    */
   cache?: boolean | string;
+  /**
+   * Run plain TS/JS `@example` blocks on props, module exports, slots, and
+   * events through the TypeScript program. Broken examples become
+   * `example-compile-error` diagnostics. Svelte/HTML markup is skipped.
+   * Off by default. Requires `typescript`.
+   */
+  checkExamples?: boolean;
 }
 
 export function toGenerateBundleOptions(
-  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes" | "documentExports" | "cache">,
+  opts?: Pick<GenerateBundleOptions, "failFast" | "resolveTypes" | "documentExports" | "cache" | "checkExamples">,
 ): GenerateBundleOptions {
   return {
     failFast: opts?.failFast,
     resolveTypes: opts?.resolveTypes === true,
     documentExports: opts?.documentExports === true,
     cache: opts?.cache,
+    checkExamples: opts?.checkExamples === true,
   };
 }
 
@@ -452,6 +461,13 @@ export async function generateBundle(
 
   cache?.save();
 
+  if (options.checkExamples) {
+    // Runs over allComponentsForTypes (not just exports): that's the map the
+    // diagnostics summary below is built from, so every discovered component's
+    // examples get checked and surfaced, not just the public barrel.
+    await checkComponentExamples(allComponentsForTypes, rootDir, resolveComponentFilePath);
+  }
+
   // Same file can land in both export and all-components passes; dedupe before returning.
   const diagnostics = dedupeDiagnostics(
     Array.from(allComponentsForTypes.values()).flatMap((component) => component.diagnostics ?? []),
@@ -501,6 +517,54 @@ async function resolveImportedPropTypes(
     for (const { component } of candidates) {
       const resolved = resolvedByModule.get(component.moduleName);
       if (resolved) applyResolvedProps(component, resolved);
+    }
+  } finally {
+    await resolver.dispose();
+  }
+}
+
+async function checkComponentExamples(
+  components: ComponentDocs,
+  rootDir: string,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Promise<void> {
+  const candidates: Array<{ component: ComponentDocApi; sources: ReturnType<typeof collectExampleSources> }> = [];
+
+  for (const component of components.values()) {
+    const sources = collectExampleSources(component);
+    if (sources.length === 0) continue;
+    candidates.push({ component, sources });
+  }
+
+  if (candidates.length === 0) return;
+
+  const { TypeResolver } = await import("./resolve-types");
+  const resolver = await TypeResolver.create(rootDir);
+  if (!resolver) return;
+
+  try {
+    const diagnosticsByModule = await resolver.checkExamples(
+      candidates.map(({ component, sources }) => ({
+        moduleName: component.moduleName,
+        filePath: resolveComponentFilePath(component.filePath),
+        sources,
+      })),
+    );
+
+    for (const { component } of candidates) {
+      const found = diagnosticsByModule.get(component.moduleName);
+      if (!found || found.length === 0) continue;
+
+      const diagnostics = component.diagnostics ?? [];
+      for (const item of found) {
+        diagnostics.push({
+          component: component.filePath,
+          kind: "example-compile-error",
+          name: item.name,
+          message: item.message,
+        });
+      }
+      component.diagnostics = diagnostics;
     }
   } finally {
     await resolver.dispose();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ function parseCliFlag(arg: string): Partial<CliOptions> {
     case "markdown":
     case "strict":
     case "resolveTypes":
+    case "checkExamples":
       return { [flag]: value === true || value === "true" };
     case "fail-fast":
       return { failFast: value === true || value === "true" };

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -4,8 +4,13 @@
  * - `prop-unknown-type`: prop `typeSource` is `"unknown"`.
  * - `context-any-type`: `setContext` value inferred as `any`.
  * - `event-no-source`: `@event` with no dispatch, forward, or callback prop.
+ * - `example-compile-error`: an `@example` block failed to type-check (opt-in, `checkExamples`).
  */
-export type SveldDiagnosticKind = "prop-unknown-type" | "context-any-type" | "event-no-source";
+export type SveldDiagnosticKind =
+  | "prop-unknown-type"
+  | "context-any-type"
+  | "event-no-source"
+  | "example-compile-error";
 
 /**
  * One place sveld had to guess a type instead of inferring it.
@@ -24,9 +29,15 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "prop-unknown-type": "Props without inferred types",
   "context-any-type": "Context values typed as `any`",
   "event-no-source": "@event tags with no dispatch or callback",
+  "example-compile-error": "@example blocks that failed to compile",
 };
 
-const KIND_ORDER: SveldDiagnosticKind[] = ["prop-unknown-type", "context-any-type", "event-no-source"];
+const KIND_ORDER: SveldDiagnosticKind[] = [
+  "prop-unknown-type",
+  "context-any-type",
+  "event-no-source",
+  "example-compile-error",
+];
 
 /**
  * Drop duplicates (same component, kind, and name). Each file is parsed twice

--- a/src/example-check.ts
+++ b/src/example-check.ts
@@ -1,0 +1,113 @@
+import type { ComponentProp, ComponentSlot, ParsedComponent } from "./ComponentParser";
+
+/**
+ * One `@example` block worth type-checking, reduced to what `resolve-types.ts`
+ * needs: a declaration for the documented symbol and the example body itself.
+ */
+export interface ExampleCheckSource {
+  /** Stable id for diagnostics, e.g. `"prop:variant"` or `"prop:variant#1"` for a second example. */
+  id: string;
+  /** Human-readable name shown in diagnostics, e.g. `"variant"` or `"variant (example 2)"`. */
+  name: string;
+  /** TypeScript type to bind the documented symbol to before running `code`. */
+  type: string;
+  /** The `@example` body, stripped of any surrounding code fence. */
+  code: string;
+}
+
+const FENCE_REGEX = /^```([\w-]*)\r?\n([\s\S]*?)\r?\n?```$/;
+
+/** Languages sveld can type-check with `tsc`. Anything else (svelte, html, ...) is markup and skipped. */
+const CHECKABLE_FENCE_LANGS = new Set(["", "js", "jsx", "ts", "tsx", "javascript", "typescript"]);
+
+/**
+ * Extracts plain TS/JS code from an `@example` body, or `null` when the
+ * example is Svelte/HTML markup (or another language sveld can't type-check
+ * without `svelte2tsx` or similar).
+ */
+function extractCheckableCode(body: string): string | null {
+  const trimmed = body.trim();
+  if (trimmed === "") return null;
+
+  const fenceMatch = trimmed.match(FENCE_REGEX);
+  if (fenceMatch) {
+    const lang = fenceMatch[1].toLowerCase();
+    if (!CHECKABLE_FENCE_LANGS.has(lang)) return null;
+    const inner = fenceMatch[2].trim();
+    return inner === "" ? null : inner;
+  }
+
+  // No fence: skip bare markup like `<Disclosure open />`.
+  if (trimmed.startsWith("<")) return null;
+  return trimmed;
+}
+
+/** The type sveld declares the documented symbol as before running its examples. */
+function typeForProp(prop: ComponentProp): string {
+  if (!prop.isFunction) return "any";
+  const params = (prop.params ?? []).map((param) => `${param.name}${param.optional ? "?" : ""}: any`).join(", ");
+  return `(${params}) => any`;
+}
+
+function sourcesFromTags(
+  tags: Array<{ name: string; body: string }> | undefined,
+  idPrefix: string,
+  name: string,
+  type: string,
+): ExampleCheckSource[] {
+  const examples = (tags ?? []).filter((tag) => tag.name === "example");
+  const sources: ExampleCheckSource[] = [];
+
+  examples.forEach((tag, index) => {
+    const code = extractCheckableCode(tag.body);
+    if (code === null) return;
+    const numbered = examples.length > 1;
+    sources.push({
+      id: numbered ? `${idPrefix}#${index}` : idPrefix,
+      name: numbered ? `${name} (example ${index + 1})` : name,
+      type,
+      code,
+    });
+  });
+
+  return sources;
+}
+
+function slotName(slot: ComponentSlot): string {
+  return slot.name ?? "default";
+}
+
+/**
+ * Collects every `@example` block sveld can type-check for a parsed component:
+ * plain TS/JS bodies on props, module exports, slots, and events. Svelte/HTML
+ * markup examples (most slot/event examples, many prop examples) are skipped.
+ * Checking those needs `svelte2tsx` or similar; sveld stays AST-only.
+ */
+export function collectExampleSources(component: ParsedComponent): ExampleCheckSource[] {
+  const sources: ExampleCheckSource[] = [];
+
+  for (const prop of component.props) {
+    sources.push(...sourcesFromTags(prop.tags, `prop:${prop.name}`, prop.name, typeForProp(prop)));
+  }
+
+  for (const moduleExport of component.moduleExports) {
+    sources.push(
+      ...sourcesFromTags(
+        moduleExport.tags,
+        `export:${moduleExport.name}`,
+        moduleExport.name,
+        typeForProp(moduleExport),
+      ),
+    );
+  }
+
+  for (const slot of component.slots) {
+    sources.push(...sourcesFromTags(slot.tags, `slot:${slotName(slot)}`, slotName(slot), "any"));
+  }
+
+  for (const event of component.events) {
+    sources.push(...sourcesFromTags(event.tags, `event:${event.name}`, event.name, "any"));
+  }
+
+  return sources;
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,7 +34,7 @@ export {
   toGenerateBundleOptions,
 } from "./bundle";
 
-export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolveTypes" | "cache"> {
+export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolveTypes" | "cache" | "checkExamples"> {
   /**
    * Specify the entry point to uncompiled Svelte source.
    * If not provided, sveld will use the "svelte" field from package.json.

--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -1,12 +1,26 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import type { ParsedComponentTypeScriptMetadata, ResolvedComponentProp } from "./ComponentParser";
+import type { ExampleCheckSource } from "./example-check";
 import { normalizeSeparators } from "./path";
 
 export interface ResolveTarget {
   moduleName: string;
   filePath: string;
   metadata: ParsedComponentTypeScriptMetadata;
+}
+
+export interface ExampleCheckTarget {
+  moduleName: string;
+  filePath: string;
+  sources: ExampleCheckSource[];
+}
+
+/** One `@example` block that failed to type-check. */
+export interface ExampleCheckDiagnostic {
+  id: string;
+  name: string;
+  message: string;
 }
 
 // The opt-in resolution path talks to the TypeScript 7 native preview through
@@ -18,6 +32,11 @@ type TS = any;
 const VIRTUAL_PROPS_BINDING = "__sveld_resolved_props__";
 const VIRTUAL_PROPS_TYPE = "__SveldResolvedProps__";
 const TRAILING_UNDEFINED = / \| undefined$/;
+const NON_FILENAME_CHAR_REGEX = /[^A-Za-z0-9_-]/g;
+const NON_IDENTIFIER_CHAR_REGEX = /[^A-Za-z0-9_$]/g;
+const LEADING_DIGIT_REGEX = /^[0-9]/;
+/** Line 1 of an example virtual file is always the declaration; the example body starts on line 2. */
+const EXAMPLE_CODE_START_LINE = 2;
 
 /**
  * Expands opaque imported `$props()` types using the project's TypeScript program.
@@ -104,6 +123,67 @@ export class TypeResolver {
     return results;
   }
 
+  /**
+   * Type-checks every `@example` block in one program snapshot.
+   *
+   * Each example gets its own virtual file: a `declare`-style binding for the
+   * documented symbol (typed as `any` end-to-end, so types sveld can't see
+   * never cause a false positive), then the example body. Catches renamed
+   * or removed symbols and wrong arity. Not full type checking; it does not
+   * depend on the rest of the component's types.
+   */
+  async checkExamples(targets: ExampleCheckTarget[]): Promise<Map<string, ExampleCheckDiagnostic[]>> {
+    const results = new Map<string, ExampleCheckDiagnostic[]>();
+    if (targets.length === 0) return results;
+
+    const examples: Array<{ moduleName: string; source: ExampleCheckSource; file: string }> = [];
+    for (const target of targets) {
+      for (const source of target.sources) {
+        const file = this.exampleFileName(target.filePath, target.moduleName, source.id);
+        this.overlay.set(file, buildExampleModule(source));
+        examples.push({ moduleName: target.moduleName, source, file });
+      }
+    }
+
+    if (examples.length === 0) return results;
+
+    const snapshot = await this.api.updateSnapshot({
+      openProject: this.tsconfigPath,
+      fileChanges: { created: examples.map((example) => example.file) },
+    });
+
+    try {
+      await Promise.all(
+        examples.map(async ({ moduleName, source, file }) => {
+          const project = await snapshot.getDefaultProjectForFile(file);
+          if (!project) return;
+
+          const [syntactic, semantic]: [TS[], TS[]] = await Promise.all([
+            project.program.getSyntacticDiagnostics(file),
+            project.program.getSemanticDiagnostics(file),
+          ]);
+          const diagnostics = [...syntactic, ...semantic];
+          if (diagnostics.length === 0) return;
+
+          const content = this.overlay.get(file) ?? "";
+          const message = diagnostics
+            .map((diagnostic: TS) => formatExampleDiagnostic(diagnostic, content))
+            .sort((a, b) => a.line - b.line)
+            .map((entry) => `Line ${entry.line}: ${entry.text}`)
+            .join("\n");
+
+          const list = results.get(moduleName) ?? [];
+          list.push({ id: source.id, name: source.name, message });
+          results.set(moduleName, list);
+        }),
+      );
+    } finally {
+      await snapshot.dispose?.();
+    }
+
+    return results;
+  }
+
   /** Closes the TypeScript server process. */
   async dispose(): Promise<void> {
     this.overlay.clear();
@@ -182,6 +262,12 @@ export class TypeResolver {
     const dir = path.dirname(path.resolve(componentFilePath));
     return normalizeSeparators(path.join(dir, `__sveld_resolved_${moduleName}.ts`));
   }
+
+  private exampleFileName(componentFilePath: string, moduleName: string, exampleId: string) {
+    const dir = path.dirname(path.resolve(componentFilePath));
+    const safeId = exampleId.replace(NON_FILENAME_CHAR_REGEX, "_");
+    return normalizeSeparators(path.join(dir, `__sveld_example_${moduleName}_${safeId}.ts`));
+  }
 }
 
 function buildVirtualModule(metadata: ParsedComponentTypeScriptMetadata): string {
@@ -191,6 +277,27 @@ function buildVirtualModule(metadata: ParsedComponentTypeScriptMetadata): string
     `type ${VIRTUAL_PROPS_TYPE} = ${metadata.canonicalPropsType};`,
     `declare const ${VIRTUAL_PROPS_BINDING}: ${VIRTUAL_PROPS_TYPE};`,
   ].join("\n");
+}
+
+/** Sanitizes a documented symbol's name into a valid binding identifier (e.g. a slot named `"header-icon"`). */
+function declarationIdentifier(name: string): string {
+  const sanitized = name.replace(NON_IDENTIFIER_CHAR_REGEX, "_");
+  if (sanitized === "" || LEADING_DIGIT_REGEX.test(sanitized)) return `_${sanitized}`;
+  return sanitized;
+}
+
+/** One example, in its own virtual file: a typed binding for the symbol, then the example body. */
+function buildExampleModule(source: ExampleCheckSource): string {
+  const binding = declarationIdentifier(source.name);
+  return `const ${binding} = null as unknown as (${source.type});\n${source.code}\n`;
+}
+
+/** Converts a diagnostic's character offset into a line number relative to the example body. */
+function formatExampleDiagnostic(diagnostic: TS, content: string): { line: number; text: string } {
+  const pos: number = diagnostic.pos ?? 0;
+  const virtualLine = content.slice(0, pos).split("\n").length;
+  const line = Math.max(1, virtualLine - EXAMPLE_CODE_START_LINE + 1);
+  return { line, text: String(diagnostic.text ?? "").trim() };
 }
 
 /** Offset of the props binding identifier on the trailing `declare const` line. */

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -20732,3 +20732,226 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "example-check/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 51,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "formatValue",
+      "kind": "function",
+      "description": "Formats a value. Its example is valid and should compile cleanly.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`js\\n formatValue(\\"ok\\");\\n \`\`\`"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "newFormatName",
+      "kind": "function",
+      "description": "Renamed from \`oldFormatName\`; the example below was never updated and\\nstill calls the old, now-nonexistent name.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`js\\n oldFormatName(\\"ok\\");\\n \`\`\`"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 2
+        },
+        "end": {
+          "line": 27,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "tooManyArgs",
+      "kind": "function",
+      "description": "Its example calls it with more arguments than it declares.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`js\\n tooManyArgs(\\"a\\", \\"b\\", \\"c\\");\\n \`\`\`"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 38,
+          "column": 2
+        },
+        "end": {
+          "line": 40,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "widgetSlot",
+      "kind": "let",
+      "description": "Svelte example, not TS/JS. sveld skips it.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`svelte\\n <Widget prop={doesNotExist} />\\n \`\`\`"
+        }
+      ],
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"unused\\"",
+      "defaultValue": {
+        "raw": "\\"unused\\"",
+        "kind": "literal",
+        "value": "unused"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 49,
+          "column": 2
+        },
+        "end": {
+          "line": 49,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "example-check/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type ExampleCheckProps = {
+  /**
+   * Svelte example, not TS/JS. sveld skips it.
+   * @example
+   *  \`\`\`svelte
+   *  <Widget prop={doesNotExist} />
+   *  \`\`\`
+   * @default "unused"
+   */
+  widgetSlot?: string;
+};
+
+export default class ExampleCheck extends SvelteComponentTyped<
+  ExampleCheckProps,
+  Record<string, any>,
+  Record<string, never>
+> {
+  /**
+   * Formats a value. Its example is valid and should compile cleanly.
+   * @example
+   *  \`\`\`js
+   *  formatValue("ok");
+   *  \`\`\`
+   */
+  formatValue: (value: string) => string;
+
+  /**
+   * Renamed from \`oldFormatName\`; the example below was never updated and
+   * still calls the old, now-nonexistent name.
+   * @example
+   *  \`\`\`js
+   *  oldFormatName("ok");
+   *  \`\`\`
+   */
+  newFormatName: (value: string) => string;
+
+  /**
+   * Its example calls it with more arguments than it declares.
+   * @example
+   *  \`\`\`js
+   *  tooManyArgs("a", "b", "c");
+   *  \`\`\`
+   */
+  tooManyArgs: (value: string) => string;
+}
+"
+`;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -25,9 +25,9 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
   });
 
-  test("--check enables the default snapshot check", () => {
-    expect(parseCliOptions(["--check"])).toEqual({ check: true });
-  });
+<<<<<<< HEAD
+  test("--check enables the default snapshot check", () => 
+    expect(parseCliOptions(["--check"])).toEqual({ check: true }););
 
   test("--check=<path> sets a custom snapshot location", () => {
     expect(parseCliOptions(["--check=api-snapshot.json"])).toEqual({ check: "api-snapshot.json" });
@@ -35,5 +35,8 @@ describe("parseCliOptions", () => {
 
   test("--check=false disables the check", () => {
     expect(parseCliOptions(["--check=false"])).toEqual({ check: false });
-  });
+=======
+  test("--checkExamples enables checkExamples", () => 
+    expect(parseCliOptions(["--checkExamples"])).toEqual({ checkExamples: true });
+>>>>>>> fdd2a46 (feat: add opt-in `checkExamples` to type-check `@example` blocks));
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -25,6 +25,7 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
   });
 
+<<<<<<< HEAD
   test("--check enables the default snapshot check", () => {
     expect(parseCliOptions(["--check"])).toEqual({ check: true });
   });
@@ -35,5 +36,9 @@ describe("parseCliOptions", () => {
 
   test("--check=false disables the check", () => {
     expect(parseCliOptions(["--check=false"])).toEqual({ check: false });
+=======
+  test("--checkExamples enables checkExamples", () => {
+    expect(parseCliOptions(["--checkExamples"])).toEqual({ checkExamples: true });
+>>>>>>> fdd2a46 (feat: add opt-in `checkExamples` to type-check `@example` blocks)
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -25,7 +25,6 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
   });
 
-<<<<<<< HEAD
   test("--check enables the default snapshot check", () => {
     expect(parseCliOptions(["--check"])).toEqual({ check: true });
   });
@@ -36,10 +35,6 @@ describe("parseCliOptions", () => {
 
   test("--check=false disables the check", () => {
     expect(parseCliOptions(["--check=false"])).toEqual({ check: false });
-=======
-  test("--checkExamples enables checkExamples", () => {
-    expect(parseCliOptions(["--checkExamples"])).toEqual({ checkExamples: true });
->>>>>>> fdd2a46 (feat: add opt-in `checkExamples` to type-check `@example` blocks)
   });
 
   test("--checkExamples enables checkExamples", () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -25,9 +25,9 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
   });
 
-<<<<<<< HEAD
-  test("--check enables the default snapshot check", () => 
-    expect(parseCliOptions(["--check"])).toEqual({ check: true }););
+  test("--check enables the default snapshot check", () => {
+    expect(parseCliOptions(["--check"])).toEqual({ check: true });
+  });
 
   test("--check=<path> sets a custom snapshot location", () => {
     expect(parseCliOptions(["--check=api-snapshot.json"])).toEqual({ check: "api-snapshot.json" });
@@ -35,8 +35,9 @@ describe("parseCliOptions", () => {
 
   test("--check=false disables the check", () => {
     expect(parseCliOptions(["--check=false"])).toEqual({ check: false });
-=======
-  test("--checkExamples enables checkExamples", () => 
+  });
+
+  test("--checkExamples enables checkExamples", () => {
     expect(parseCliOptions(["--checkExamples"])).toEqual({ checkExamples: true });
->>>>>>> fdd2a46 (feat: add opt-in `checkExamples` to type-check `@example` blocks));
+  });
 });

--- a/tests/example-check.test.ts
+++ b/tests/example-check.test.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import { asNormalizedPath } from "../src/brands";
+import ComponentParser from "../src/ComponentParser";
+import { collectExampleSources } from "../src/example-check";
+import { TypeResolver } from "../src/resolve-types";
+
+const FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "example-check");
+const COMPONENT_PATH = path.join(FIXTURE_DIR, "input.svelte");
+const ARGUMENT_REGEX = /argument/i;
+
+async function parseFixture() {
+  const source = await Bun.file(COMPONENT_PATH).text();
+  const parser = new ComponentParser();
+  return parser.parseSvelteComponent(source, {
+    moduleName: "ExampleCheck",
+    filePath: asNormalizedPath(COMPONENT_PATH),
+  });
+}
+
+describe("collectExampleSources", () => {
+  test("collects plain TS/JS examples and skips markup examples", async () => {
+    const parsed = await parseFixture();
+    const sources = collectExampleSources(parsed);
+    const byId = Object.fromEntries(sources.map((source) => [source.id, source]));
+
+    expect(Object.keys(byId).sort()).toEqual(["prop:formatValue", "prop:newFormatName", "prop:tooManyArgs"]);
+    expect(byId["prop:formatValue"]).toMatchObject({ name: "formatValue", type: "(value: any) => any" });
+    expect(byId["prop:formatValue"].code).toBe('formatValue("ok");');
+  });
+});
+
+describe("opt-in @example compile checking", () => {
+  test("flags a renamed symbol and a wrong-arity call, leaves a valid example untouched", async () => {
+    const parsed = await parseFixture();
+    const sources = collectExampleSources(parsed);
+
+    const resolver = await TypeResolver.create(FIXTURE_DIR);
+    expect(resolver).not.toBeNull();
+    if (!resolver) return;
+
+    try {
+      const diagnosticsByModule = await resolver.checkExamples([
+        { moduleName: "ExampleCheck", filePath: COMPONENT_PATH, sources },
+      ]);
+
+      const diagnostics = diagnosticsByModule.get("ExampleCheck") ?? [];
+      const byId = Object.fromEntries(diagnostics.map((d) => [d.id, d]));
+
+      expect(byId["prop:formatValue"]).toBeUndefined();
+
+      expect(byId["prop:newFormatName"]?.message).toContain("oldFormatName");
+      expect(byId["prop:tooManyArgs"]?.message).toMatch(ARGUMENT_REGEX);
+    } finally {
+      await resolver.dispose();
+    }
+  }, 30_000);
+});

--- a/tests/fixtures/example-check/input.svelte
+++ b/tests/fixtures/example-check/input.svelte
@@ -1,0 +1,50 @@
+<script>
+  /**
+   * Formats a value. Its example is valid and should compile cleanly.
+   * @param {string} value
+   * @returns {string}
+   * @example
+   * ```js
+   * formatValue("ok");
+   * ```
+   */
+  export function formatValue(value) {
+    return value;
+  }
+
+  /**
+   * Renamed from `oldFormatName`; the example below was never updated and
+   * still calls the old, now-nonexistent name.
+   * @param {string} value
+   * @returns {string}
+   * @example
+   * ```js
+   * oldFormatName("ok");
+   * ```
+   */
+  export function newFormatName(value) {
+    return value;
+  }
+
+  /**
+   * Its example calls it with more arguments than it declares.
+   * @param {string} value
+   * @returns {string}
+   * @example
+   * ```js
+   * tooManyArgs("a", "b", "c");
+   * ```
+   */
+  export function tooManyArgs(value) {
+    return value;
+  }
+
+  /**
+   * Svelte example, not TS/JS. sveld skips it.
+   * @example
+   * ```svelte
+   * <Widget prop={doesNotExist} />
+   * ```
+   */
+  export let widgetSlot = "unused";
+</script>

--- a/tests/fixtures/example-check/output.d.ts
+++ b/tests/fixtures/example-check/output.d.ts
@@ -1,0 +1,47 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type ExampleCheckProps = {
+  /**
+   * Svelte example, not TS/JS. sveld skips it.
+   * @example
+   *  ```svelte
+   *  <Widget prop={doesNotExist} />
+   *  ```
+   * @default "unused"
+   */
+  widgetSlot?: string;
+};
+
+export default class ExampleCheck extends SvelteComponentTyped<
+  ExampleCheckProps,
+  Record<string, any>,
+  Record<string, never>
+> {
+  /**
+   * Formats a value. Its example is valid and should compile cleanly.
+   * @example
+   *  ```js
+   *  formatValue("ok");
+   *  ```
+   */
+  formatValue: (value: string) => string;
+
+  /**
+   * Renamed from `oldFormatName`; the example below was never updated and
+   * still calls the old, now-nonexistent name.
+   * @example
+   *  ```js
+   *  oldFormatName("ok");
+   *  ```
+   */
+  newFormatName: (value: string) => string;
+
+  /**
+   * Its example calls it with more arguments than it declares.
+   * @example
+   *  ```js
+   *  tooManyArgs("a", "b", "c");
+   *  ```
+   */
+  tooManyArgs: (value: string) => string;
+}

--- a/tests/fixtures/example-check/output.json
+++ b/tests/fixtures/example-check/output.json
@@ -1,0 +1,168 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 51,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "formatValue",
+      "kind": "function",
+      "description": "Formats a value. Its example is valid and should compile cleanly.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```js\n formatValue(\"ok\");\n ```"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "newFormatName",
+      "kind": "function",
+      "description": "Renamed from `oldFormatName`; the example below was never updated and\nstill calls the old, now-nonexistent name.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```js\n oldFormatName(\"ok\");\n ```"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 2
+        },
+        "end": {
+          "line": 27,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "tooManyArgs",
+      "kind": "function",
+      "description": "Its example calls it with more arguments than it declares.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```js\n tooManyArgs(\"a\", \"b\", \"c\");\n ```"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 38,
+          "column": 2
+        },
+        "end": {
+          "line": 40,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "widgetSlot",
+      "kind": "let",
+      "description": "Svelte example, not TS/JS. sveld skips it.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " ```svelte\n <Widget prop={doesNotExist} />\n ```"
+        }
+      ],
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"unused\"",
+      "defaultValue": {
+        "raw": "\"unused\"",
+        "kind": "literal",
+        "value": "unused"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 49,
+          "column": 2
+        },
+        "end": {
+          "line": 49,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
## Summary

- Adds a `checkExamples` opt-in option (CLI `--checkExamples`, config, plugin) that type-checks plain TS/JS `@example` blocks against the TypeScript program.
- Reports a new `example-compile-error` diagnostic when an example references a renamed/removed symbol or calls a function with the wrong number of arguments.
- Svelte/HTML markup examples (the majority of slot/event examples) are intentionally skipped: verifying rendered markup would need a template-aware transform like svelte2tsx, which is out of scope for sveld's static, AST-only analysis. The check itself only proves symbol existence and call arity, not full type soundness, so it never depends on types sveld can't resolve.
- Mirrors the existing `resolveTypes` wiring end to end and reuses the same TypeScript native-preview API.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (567 tests, 0 failures)
- [x] New fixture and tests in `tests/example-check.test.ts` cover a valid example, a renamed-symbol example, a wrong-arity example, and markup-example skipping.