### PR TITLE
refactor(writer): unify writer output via shared document model + registry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,5 @@ export type { SvelteEntryPoint } from "./get-svelte-entry";
 export { defineConfig, type SveldConfig } from "./load-config";
 export { default } from "./plugin";
 export { sveld } from "./sveld";
+export { buildComponentApiDocument, type ComponentApiDocument } from "./writer/document-model";
+export { getWriter, listWriters, type OutputWriter, registerWriter } from "./writer/registry";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,6 @@
 import { dirname } from "node:path";
 import {
+  type ComponentDocs,
   type GenerateBundleOptions,
   type GenerateBundleResult,
   generateBundle,
@@ -7,9 +8,12 @@ import {
 } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { createSveldBundle, type SveldBundle } from "./watch";
-import writeJson, { type WriteJsonOptions } from "./writer/writer-json";
-import writeMarkdown, { type WriteMarkdownOptions } from "./writer/writer-markdown";
-import writeTsDefinitions, { type WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
+// Side-effect import: registers the built-in "json"/"markdown"/"types" writers.
+import "./writer/built-in-writers";
+import { getWriter } from "./writer/registry";
+import type { WriteJsonOptions } from "./writer/writer-json";
+import type { WriteMarkdownOptions } from "./writer/writer-markdown";
+import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 
 export type {
   CollectedComponents,
@@ -45,6 +49,12 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
   jsonOptions?: Partial<Omit<WriteJsonOptions, "inputDir">>;
   markdown?: boolean;
   markdownOptions?: Partial<WriteMarkdownOptions>;
+  /**
+   * Run additional, userland-registered writers (via `registerWriter` from
+   * "sveld") beyond the built-in `json`/`markdown`/`types` outputs. Keyed by
+   * the writer's registered `name`, valued by that writer's options.
+   */
+  additionalWriters?: Record<string, unknown>;
   /**
    * Abort the entire run when a single component fails to parse.
    * When `false` (the default), parse failures are collected as diagnostics
@@ -148,6 +158,13 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
   };
 }
 
+/** Looks up a built-in writer by name; throws if `built-in-writers` never registered it. */
+function runBuiltInWriter(name: "types" | "json" | "markdown", components: ComponentDocs, options: unknown) {
+  const writer = getWriter(name);
+  if (!writer) throw new Error(`sveld: built-in writer "${name}" is not registered.`);
+  return writer.write(components, options);
+}
+
 /**
  * Writes output files based on plugin options.
  *
@@ -178,13 +195,13 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
      * This ensures TypeScript definitions are available for all components,
      * not just exported ones, which is useful for type checking.
      */
-    writeTsDefinitions(result.allComponentsForTypes, {
+    runBuiltInWriter("types", result.allComponentsForTypes, {
       outDir: "types",
       preamble: "",
       ...opts?.typesOptions,
       exports: result.exports,
       inputDir,
-    });
+    } satisfies WriteTsDefinitionsOptions);
   }
 
   if (opts?.json) {
@@ -193,13 +210,13 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
      * JSON output should only include components that are actually exported,
      * matching the public API surface.
      */
-    writeJson(result.components, {
+    runBuiltInWriter("json", result.components, {
       outFile: "COMPONENT_API.json",
       ...opts?.jsonOptions,
       input,
       inputDir,
       entryExports: result.entryExports,
-    });
+    } satisfies WriteJsonOptions);
   }
 
   if (opts?.markdown) {
@@ -208,10 +225,20 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
      * Documentation should only include exported components that are
      * part of the public API.
      */
-    writeMarkdown(result.components, {
+    runBuiltInWriter("markdown", result.components, {
       outFile: "COMPONENT_INDEX.md",
       ...opts?.markdownOptions,
       entryExports: result.entryExports,
-    });
+    } satisfies WriteMarkdownOptions);
+  }
+
+  for (const [name, writerOptions] of Object.entries(opts?.additionalWriters ?? {})) {
+    const writer = getWriter(name);
+    if (!writer) {
+      console.warn(`sveld: no writer registered with name "${name}"; skipping.`);
+      continue;
+    }
+    const components = writer.componentSet === "all" ? result.allComponentsForTypes : result.components;
+    writer.write(components, writerOptions);
   }
 }

--- a/src/writer/built-in-writers.ts
+++ b/src/writer/built-in-writers.ts
@@ -1,0 +1,8 @@
+import { registerWriter } from "./registry";
+import writeJson from "./writer-json";
+import writeMarkdown from "./writer-markdown";
+import writeTsDefinitions from "./writer-ts-definitions";
+
+registerWriter({ name: "json", componentSet: "exported", write: writeJson });
+registerWriter({ name: "markdown", componentSet: "exported", write: writeMarkdown });
+registerWriter({ name: "types", componentSet: "all", write: writeTsDefinitions });

--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -1,0 +1,67 @@
+import { version as svelteVersion } from "svelte/package.json";
+import { name as packageName, version as packageVersion } from "../../package.json";
+import type { EntryExports } from "../parse-entry-exports";
+import type { ComponentDocApi, ComponentDocs } from "../plugin";
+
+export const COMPONENT_API_SCHEMA_VERSION = 1;
+
+/**
+ * Canonical, renderer-agnostic representation of a component collection.
+ *
+ * Every writer (JSON, Markdown, TypeScript definitions) builds this document
+ * via `buildComponentApiDocument` instead of independently sorting/filtering
+ * the raw `ComponentDocs` map, so sort order and field stripping can't drift
+ * between output formats.
+ */
+export interface ComponentApiDocument {
+  schemaVersion: 1;
+  generator: {
+    name: string;
+    version: string;
+    svelteVersion: string;
+  };
+  total: number;
+  components: ComponentDocApi[];
+  /** Only when `documentExports` is on. */
+  totalExports?: number;
+  exports?: EntryExports;
+}
+
+export interface BuildComponentApiDocumentOptions {
+  /** Entry-barrel exports when `documentExports` is on. */
+  entryExports?: EntryExports;
+}
+
+/**
+ * Builds the canonical document for a component collection: components
+ * sorted alphabetically by `moduleName`, with the Node-only `diagnostics`
+ * field stripped.
+ */
+export function buildComponentApiDocument(
+  components: ComponentDocs,
+  options: BuildComponentApiDocumentOptions = {},
+): ComponentApiDocument {
+  const sorted = Array.from(components, ([, component]) => {
+    // `diagnostics` is for the Node API only; rendered output skips it.
+    const { diagnostics: _diagnostics, ...rest } = component;
+    return rest as ComponentDocApi;
+  }).sort((a, b) => a.moduleName.localeCompare(b.moduleName));
+
+  const document: ComponentApiDocument = {
+    schemaVersion: COMPONENT_API_SCHEMA_VERSION,
+    generator: {
+      name: packageName,
+      version: packageVersion,
+      svelteVersion,
+    },
+    total: sorted.length,
+    components: sorted,
+  };
+
+  if (options.entryExports && options.entryExports.length > 0) {
+    document.totalExports = options.entryExports.length;
+    document.exports = options.entryExports;
+  }
+
+  return document;
+}

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -1,5 +1,6 @@
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { buildComponentApiDocument } from "./document-model";
 import type { AppendType } from "./MarkdownWriterBase";
 import {
   EVENT_TABLE_HEADER,
@@ -38,12 +39,9 @@ export function renderComponentsToMarkdown(
     renderExports(document, entryExports);
   }
 
-  const keys = Array.from(components.keys()).sort();
+  const apiDocument = buildComponentApiDocument(components);
 
-  for (const key of keys) {
-    const component = components.get(key);
-    if (!component) continue;
-
+  for (const component of apiDocument.components) {
     renderComponent(document, component);
   }
 }

--- a/src/writer/registry.ts
+++ b/src/writer/registry.ts
@@ -1,0 +1,30 @@
+import type { ComponentDocs } from "../plugin";
+
+/** Which component set a writer expects: exported-only, or every discovered component. */
+export type WriterComponentSet = "exported" | "all";
+
+/**
+ * A pluggable output format. Built-in writers (`json`, `markdown`, `types`)
+ * register themselves under these names; third parties can `registerWriter`
+ * their own to add new output formats without a core PR.
+ */
+export interface OutputWriter<TOptions = unknown> {
+  name: string;
+  /** Which component set this writer expects. @default "exported" */
+  componentSet?: WriterComponentSet;
+  write(components: ComponentDocs, options: TOptions): Promise<unknown> | unknown;
+}
+
+const writers = new Map<string, OutputWriter<unknown>>();
+
+export function registerWriter<TOptions = unknown>(writer: OutputWriter<TOptions>): void {
+  writers.set(writer.name, writer as OutputWriter<unknown>);
+}
+
+export function getWriter(name: string): OutputWriter<unknown> | undefined {
+  return writers.get(name);
+}
+
+export function listWriters(): OutputWriter<unknown>[] {
+  return Array.from(writers.values());
+}

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,9 +1,8 @@
 import path from "node:path";
-import { version as svelteVersion } from "svelte/package.json";
-import { name as packageName, version as packageVersion } from "../../package.json";
 import type { EntryExports } from "../parse-entry-exports";
 import { normalizeSeparators } from "../path";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { buildComponentApiDocument, type ComponentApiDocument } from "./document-model";
 import { createJsonWriter } from "./Writer";
 
 export interface WriteJsonOptions {
@@ -16,59 +15,18 @@ export interface WriteJsonOptions {
 }
 
 /**
- * JSON output structure for component documentation.
+ * Normalizes each component's `filePath` to be resolvable from `cwd`.
  *
- * Contains the total count of components and an array of all
- * component documentation objects.
+ * This is JSON-output-specific: it makes `COMPONENT_API.json` self-describing.
+ * Other writers (e.g. `.d.ts`) need the original relative `filePath` to
+ * compute their own output locations, so this must not live in the shared
+ * document model.
  */
-interface JsonOutput {
-  schemaVersion: 1;
-  generator: {
-    name: string;
-    version: string;
-    svelteVersion: string;
-  };
-  total: number;
-  components: ComponentDocApi[];
-  /** Only when `documentExports` is on. */
-  totalExports?: number;
-  exports?: EntryExports;
-}
-
-const JSON_SCHEMA_VERSION = 1;
-
-function createGeneratorMetadata(): JsonOutput["generator"] {
-  return {
-    name: packageName,
-    version: packageVersion,
-    svelteVersion,
-  };
-}
-
-/**
- * Transforms and sorts component documentation for JSON output.
- *
- * Normalizes file paths and sorts components alphabetically by module name.
- *
- * @param components - Map of component documentation
- * @param inputDir - The input directory for normalizing paths
- * @returns Sorted array of component documentation with normalized paths
- *
- * @example
- * ```ts
- * // Input: components with relative paths
- * // Output: components with normalized absolute paths, sorted by name
- * ```
- */
-function transformAndSortComponents(components: ComponentDocs, inputDir: string): ComponentDocApi[] {
-  return Array.from(components, ([_moduleName, component]) => {
-    // `diagnostics` is for the Node API only; COMPONENT_API.json skips it.
-    const { diagnostics: _diagnostics, ...rest } = component;
-    return {
-      ...rest,
-      filePath: normalizeSeparators(path.join(inputDir, path.normalize(component.filePath))),
-    } as ComponentDocApi;
-  }).sort((a, b) => a.moduleName.localeCompare(b.moduleName));
+function withNormalizedFilePaths(components: ComponentDocApi[], inputDir: string): ComponentDocApi[] {
+  return components.map((component) => ({
+    ...component,
+    filePath: normalizeSeparators(path.join(inputDir, path.normalize(component.filePath))),
+  }));
 }
 
 /**
@@ -90,7 +48,8 @@ function transformAndSortComponents(components: ComponentDocs, inputDir: string)
  * ```
  */
 async function writeJsonComponents(components: ComponentDocs, options: WriteJsonOptions) {
-  const output = transformAndSortComponents(components, options.inputDir);
+  const document = buildComponentApiDocument(components);
+  const output = withNormalizedFilePaths(document.components, options.inputDir);
 
   await Promise.all(
     output.map((c) => {
@@ -121,17 +80,11 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
  * ```
  */
 async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptions) {
-  const output: JsonOutput = {
-    schemaVersion: JSON_SCHEMA_VERSION,
-    generator: createGeneratorMetadata(),
-    total: components.size,
-    components: transformAndSortComponents(components, options.inputDir),
+  const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
+  const output: ComponentApiDocument = {
+    ...document,
+    components: withNormalizedFilePaths(document.components, options.inputDir),
   };
-
-  if (options.entryExports && options.entryExports.length > 0) {
-    output.totalExports = options.entryExports.length;
-    output.exports = options.entryExports;
-  }
 
   const output_path = path.join(process.cwd(), options.outFile);
   const writer = createJsonWriter();

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { convertSvelteExt, createExports } from "../create-exports";
 import type { ParsedExports } from "../parse-exports";
 import type { ComponentDocs } from "../plugin";
+import { buildComponentApiDocument } from "./document-model";
 import { createTypeScriptWriter } from "./Writer";
 import { writeTsDefinition } from "./writer-ts-definitions-core";
 
@@ -83,7 +84,8 @@ export default async function writeTsDefinitions(components: ComponentDocs, opti
   const writer = createTypeScriptWriter(options.printWidth);
   const indexDTs = options.preamble + createExports(options.exports);
 
-  const writePromises = Array.from(components).map(async ([_moduleName, component]) => {
+  const document = buildComponentApiDocument(components);
+  const writePromises = document.components.map(async (component) => {
     const ts_filepath = convertSvelteExt(join(options.outDir, component.filePath));
     await writer.write(ts_filepath, writeTsDefinition(component));
   });


### PR DESCRIPTION
## Summary
- `writer-json.ts`, `markdown-render-utils.ts`, and `writer-ts-definitions.ts` each independently sorted components and stripped fields, which could drift without anyone noticing. They now all build from a single `buildComponentApiDocument()` in `src/writer/document-model.ts`.
- Adds a small `OutputWriter` registry (`src/writer/registry.ts`) that the built-in `json`/`markdown`/`types` writers register into, plus a new `additionalWriters` plugin option so third-party output formats (e.g. a Storybook `argTypes` bridge) can be added without a core PR.
- The `.d.ts` writer still receives `allComponentsForTypes` (glob-discovered) while JSON/Markdown receive `components` (exported-only) — that distinction is intentional and preserved, not a bug being fixed.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (562 tests, no snapshot drift)
- [x] Manually verified a scratch third-party writer registered via `registerWriter` and invoked via `additionalWriters` receives the correct component set and options end-to-end