### PR TITLE
feat: add `sveld --check` API-drift gate and semver classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ export default class Button extends SvelteComponentTyped<
   - [Vite](#vite)
   - [Node.js](#nodejs)
   - [CLI](#cli)
+  - [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check)
   - [Config File](#config-file)
   - [Publishing to NPM](#publishing-to-npm)
 - [Available Options](#available-options)
@@ -288,6 +289,32 @@ Generate documentation in JSON and/or Markdown formats using the following flags
 ```sh
 npx sveld --json --markdown
 ```
+
+### CI: API-drift checks (`--check`)
+
+`--check` diffs the parsed component API against a committed `COMPONENT_API.json` snapshot, assigns a semver bump to each change, and exits `1` when it finds a breaking change.
+
+1. Generate and commit the snapshot once: `npx sveld --json`, then commit `COMPONENT_API.json`.
+2. Add `npx sveld --check` to CI:
+
+```sh
+npx sveld --check
+```
+
+```
+sveld --check: 2 API changes detected against "COMPONENT_API.json".
+Suggested semver bump: major.
+
+  Button
+    [BREAKING] prop "target" added (required)
+    [BREAKING] prop "href" removed
+```
+
+Removed props, events, or slots, and props that become required, are breaking (`major`). New optional props, new events, and widened union types are additive (`minor`). Changes to generics, `@restProps`, `@extends`, or context shapes are not classified further. If any of those changed, `--check` calls it breaking.
+
+`--check` does not write the snapshot. Run `sveld --json` (or `sveld --json --check`) and commit the file when you want to update it. If there is no snapshot yet, `--check` prints a notice and exits `0`.
+
+Use `--check=<path>` to diff against a snapshot at a custom location (defaults to `jsonOptions.outFile`, or `COMPONENT_API.json`).
 
 ### Node.js
 

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,0 +1,429 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { ComponentDocApi, ComponentDocs } from "./bundle";
+import type { EntryExports } from "./parse-entry-exports";
+import {
+  buildComponentApiDocument,
+  COMPONENT_API_SCHEMA_VERSION,
+  type ComponentApiDocument,
+} from "./writer/document-model";
+
+type Prop = ComponentDocApi["props"][number];
+type Event = ComponentDocApi["events"][number];
+type Slot = ComponentDocApi["slots"][number];
+
+export type SemverBump = "major" | "minor" | "patch" | "none";
+
+/** One API diff between the committed snapshot and the current parse. */
+export interface ApiChange {
+  /** Component `moduleName` this change belongs to, or `"*"` for document-wide notices. */
+  component: string;
+  kind: "component" | "prop" | "moduleExport" | "event" | "slot" | "shape";
+  /** Prop, event, slot, or shape-field name, when applicable. */
+  name?: string;
+  bump: SemverBump;
+  message: string;
+}
+
+export interface CheckResult {
+  /** `false` when there was nothing on disk to diff against (e.g. first run). */
+  snapshotExists: boolean;
+  snapshotFile: string;
+  changes: ApiChange[];
+  /** Highest bump across all changes. */
+  bump: SemverBump;
+}
+
+const BUMP_RANK: Record<SemverBump, number> = { none: 0, patch: 1, minor: 2, major: 3 };
+
+function maxBump(a: SemverBump, b: SemverBump): SemverBump {
+  return BUMP_RANK[b] > BUMP_RANK[a] ? b : a;
+}
+
+function highestBump(changes: ApiChange[]): SemverBump {
+  return changes.reduce<SemverBump>((bump, change) => maxBump(bump, change.bump), "none");
+}
+
+/**
+ * Splits a type string on top-level `|`, ignoring `|` nested inside
+ * `<>`/`()`/`{}`/`[]` or string literals (e.g. a `"a|b"` literal member).
+ */
+function splitUnionMembers(type: string): Set<string> {
+  const members: string[] = [];
+  let depth = 0;
+  let current = "";
+  let quote: string | null = null;
+
+  for (let i = 0; i < type.length; i++) {
+    const ch = type[i];
+
+    if (quote) {
+      current += ch;
+      if (ch === "\\") {
+        i++;
+        current += type[i] ?? "";
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "<" || ch === "(" || ch === "{" || ch === "[") depth++;
+    if (ch === ">" || ch === ")" || ch === "}" || ch === "]") depth--;
+
+    if (ch === "|" && depth === 0) {
+      members.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += ch;
+  }
+  members.push(current.trim());
+
+  return new Set(members.filter((member) => member.length > 0));
+}
+
+/**
+ * Classifies a type-string change as additive (widened union), breaking
+ * (narrowed union), or unchanged. Only top-level union members count.
+ * Other structural changes (generics, object shape, function signature) are
+ * breaking, same as cargo-semver-checks' "when in doubt, call it major".
+ */
+function classifyTypeChange(oldType: string | undefined, newType: string | undefined): SemverBump {
+  if (oldType === newType) return "none";
+  if (oldType === undefined || newType === undefined) return "major";
+
+  const oldMembers = splitUnionMembers(oldType);
+  const newMembers = splitUnionMembers(newType);
+  const gainedMembers = [...newMembers].some((member) => !oldMembers.has(member));
+  const lostMembers = [...oldMembers].some((member) => !newMembers.has(member));
+
+  if (!gainedMembers && !lostMembers) return "none"; // same members, reordered
+  if (gainedMembers && !lostMembers) return "minor";
+  if (lostMembers && !gainedMembers) return "major";
+  return "major"; // both gained and lost members
+}
+
+function diffPropList(
+  component: string,
+  kind: "prop" | "moduleExport",
+  oldProps: Prop[],
+  newProps: Prop[],
+): ApiChange[] {
+  const label = kind === "prop" ? "prop" : "export";
+  const changes: ApiChange[] = [];
+  const oldByName = new Map(oldProps.map((prop) => [prop.name, prop]));
+  const newByName = new Map(newProps.map((prop) => [prop.name, prop]));
+
+  for (const [name, prop] of newByName) {
+    if (oldByName.has(name)) continue;
+    changes.push({
+      component,
+      kind,
+      name,
+      bump: prop.isRequired ? "major" : "minor",
+      message: `${label} "${name}" added${prop.isRequired ? " (required)" : ""}`,
+    });
+  }
+
+  for (const [name] of oldByName) {
+    if (newByName.has(name)) continue;
+    changes.push({ component, kind, name, bump: "major", message: `${label} "${name}" removed` });
+  }
+
+  for (const [name, oldProp] of oldByName) {
+    const newProp = newByName.get(name);
+    if (!newProp) continue;
+
+    if (oldProp.isRequired !== newProp.isRequired) {
+      changes.push({
+        component,
+        kind,
+        name,
+        bump: newProp.isRequired ? "major" : "minor",
+        message: `${label} "${name}" became ${newProp.isRequired ? "required" : "optional"}`,
+      });
+    }
+
+    const typeBump = classifyTypeChange(oldProp.type, newProp.type);
+    if (typeBump !== "none") {
+      changes.push({
+        component,
+        kind,
+        name,
+        bump: typeBump,
+        message: `${label} "${name}" type changed from \`${oldProp.type ?? "unknown"}\` to \`${newProp.type ?? "unknown"}\``,
+      });
+    }
+  }
+
+  return changes;
+}
+
+function diffEvents(component: string, oldEvents: Event[], newEvents: Event[]): ApiChange[] {
+  const changes: ApiChange[] = [];
+  const oldByName = new Map(oldEvents.map((event) => [event.name, event]));
+  const newByName = new Map(newEvents.map((event) => [event.name, event]));
+
+  for (const [name] of newByName) {
+    if (oldByName.has(name)) continue;
+    changes.push({ component, kind: "event", name, bump: "minor", message: `event "${name}" added` });
+  }
+
+  for (const [name] of oldByName) {
+    if (newByName.has(name)) continue;
+    changes.push({ component, kind: "event", name, bump: "major", message: `event "${name}" removed` });
+  }
+
+  for (const [name, oldEvent] of oldByName) {
+    const newEvent = newByName.get(name);
+    if (!newEvent) continue;
+
+    if (oldEvent.type !== newEvent.type) {
+      changes.push({
+        component,
+        kind: "event",
+        name,
+        bump: "major",
+        message: `event "${name}" changed from ${oldEvent.type} to ${newEvent.type}`,
+      });
+      continue;
+    }
+
+    const oldDetail = oldEvent.type === "dispatched" ? oldEvent.detail : undefined;
+    const newDetail = newEvent.type === "dispatched" ? newEvent.detail : undefined;
+    const detailBump = classifyTypeChange(oldDetail, newDetail);
+    if (detailBump !== "none") {
+      changes.push({
+        component,
+        kind: "event",
+        name,
+        bump: detailBump,
+        message: `event "${name}" detail changed from \`${oldDetail ?? "unknown"}\` to \`${newDetail ?? "unknown"}\``,
+      });
+    }
+  }
+
+  return changes;
+}
+
+function slotKey(slot: Slot): string {
+  return slot.name ?? "default";
+}
+
+function diffSlots(component: string, oldSlots: Slot[], newSlots: Slot[]): ApiChange[] {
+  const changes: ApiChange[] = [];
+  const oldByName = new Map(oldSlots.map((slot) => [slotKey(slot), slot]));
+  const newByName = new Map(newSlots.map((slot) => [slotKey(slot), slot]));
+
+  for (const [name] of newByName) {
+    if (oldByName.has(name)) continue;
+    changes.push({ component, kind: "slot", name, bump: "minor", message: `slot "${name}" added` });
+  }
+
+  for (const [name] of oldByName) {
+    if (newByName.has(name)) continue;
+    changes.push({ component, kind: "slot", name, bump: "major", message: `slot "${name}" removed` });
+  }
+
+  for (const [name, oldSlot] of oldByName) {
+    const newSlot = newByName.get(name);
+    if (!newSlot) continue;
+
+    const bump = classifyTypeChange(oldSlot.slot_props, newSlot.slot_props);
+    if (bump !== "none") {
+      changes.push({
+        component,
+        kind: "slot",
+        name,
+        bump,
+        message: `slot "${name}" props changed from \`${oldSlot.slot_props ?? "none"}\` to \`${newSlot.slot_props ?? "none"}\``,
+      });
+    }
+  }
+
+  return changes;
+}
+
+/** JSDoc-only fields ignored when diffing types. */
+const NON_SEMANTIC_KEYS = new Set(["description", "source", "componentCommentSource", "tags"]);
+
+function stripNonSemanticFields(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripNonSemanticFields);
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (NON_SEMANTIC_KEYS.has(key)) continue;
+      result[key] = stripNonSemanticFields(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+/** Fields not covered by `diffPropList`/`diffEvents`/`diffSlots`. Any change is breaking. */
+const SHAPE_FIELDS = ["generics", "rest_props", "extends", "contexts", "typedefs"] as const;
+
+function diffShape(component: string, oldComponent: ComponentDocApi, newComponent: ComponentDocApi): ApiChange[] {
+  const changes: ApiChange[] = [];
+
+  for (const field of SHAPE_FIELDS) {
+    const oldJson = JSON.stringify(stripNonSemanticFields(oldComponent[field]));
+    const newJson = JSON.stringify(stripNonSemanticFields(newComponent[field]));
+    if (oldJson !== newJson) {
+      changes.push({
+        component,
+        kind: "shape",
+        name: field,
+        bump: "major",
+        message: `"${field}" changed (breaking)`,
+      });
+    }
+  }
+
+  return changes;
+}
+
+function diffComponent(oldComponent: ComponentDocApi, newComponent: ComponentDocApi): ApiChange[] {
+  const name = newComponent.moduleName;
+  return [
+    ...diffPropList(name, "prop", oldComponent.props, newComponent.props),
+    ...diffPropList(name, "moduleExport", oldComponent.moduleExports, newComponent.moduleExports),
+    ...diffEvents(name, oldComponent.events, newComponent.events),
+    ...diffSlots(name, oldComponent.slots, newComponent.slots),
+    ...diffShape(name, oldComponent, newComponent),
+  ];
+}
+
+/** Diffs two `COMPONENT_API.json` documents and assigns a semver bump to each change. */
+export function diffApiDocuments(previous: ComponentApiDocument, next: ComponentApiDocument): ApiChange[] {
+  const changes: ApiChange[] = [];
+  const oldByName = new Map(previous.components.map((component) => [component.moduleName, component]));
+  const newByName = new Map(next.components.map((component) => [component.moduleName, component]));
+
+  for (const [name] of newByName) {
+    if (oldByName.has(name)) continue;
+    changes.push({ component: name, kind: "component", bump: "minor", message: `component "${name}" added` });
+  }
+
+  for (const [name] of oldByName) {
+    if (newByName.has(name)) continue;
+    changes.push({ component: name, kind: "component", bump: "major", message: `component "${name}" removed` });
+  }
+
+  for (const [name, oldComponent] of oldByName) {
+    const newComponent = newByName.get(name);
+    if (!newComponent) continue;
+    changes.push(...diffComponent(oldComponent, newComponent));
+  }
+
+  return changes;
+}
+
+async function readSnapshot(snapshotFile: string): Promise<ComponentApiDocument | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path.resolve(snapshotFile), "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+
+  try {
+    return JSON.parse(raw) as ComponentApiDocument;
+  } catch {
+    throw new Error(`sveld: could not parse "${snapshotFile}" as JSON. Is it a sveld COMPONENT_API.json snapshot?`);
+  }
+}
+
+export interface RunCheckOptions {
+  /** Entry-barrel exports when `documentExports` is on. */
+  entryExports?: EntryExports;
+}
+
+/**
+ * Diffs the current component set against a committed `COMPONENT_API.json`
+ * snapshot and assigns a semver bump to each change. Returns
+ * `snapshotExists: false` when no snapshot file exists yet, so the first
+ * run does not fail CI.
+ */
+export async function runCheck(
+  components: ComponentDocs,
+  snapshotFile: string,
+  options: RunCheckOptions = {},
+): Promise<CheckResult> {
+  const previous = await readSnapshot(snapshotFile);
+  if (previous === null) {
+    return { snapshotExists: false, snapshotFile, changes: [], bump: "none" };
+  }
+
+  if (previous.schemaVersion !== COMPONENT_API_SCHEMA_VERSION) {
+    return {
+      snapshotExists: true,
+      snapshotFile,
+      changes: [
+        {
+          component: "*",
+          kind: "shape",
+          bump: "none",
+          message: `snapshot schemaVersion ${previous.schemaVersion} does not match the current schemaVersion ${COMPONENT_API_SCHEMA_VERSION}; skipping diff`,
+        },
+      ],
+      bump: "none",
+    };
+  }
+
+  const next = buildComponentApiDocument(components, { entryExports: options.entryExports });
+  const changes = diffApiDocuments(previous, next);
+
+  return { snapshotExists: true, snapshotFile, changes, bump: highestBump(changes) };
+}
+
+const BUMP_LABELS: Record<SemverBump, string> = {
+  major: "BREAKING",
+  minor: "additive",
+  patch: "patch",
+  none: "no change",
+};
+
+/** Groups changes by component for CLI output. */
+export function formatCheckReport(result: CheckResult): string {
+  if (!result.snapshotExists) {
+    return `sveld --check: no snapshot found at "${result.snapshotFile}". Run \`sveld --json\` and commit the output first.`;
+  }
+
+  if (result.changes.length === 0) {
+    return `sveld --check: no API changes detected against "${result.snapshotFile}".`;
+  }
+
+  const lines: string[] = [];
+  const total = result.changes.length;
+  lines.push(`sveld --check: ${total} API change${total === 1 ? "" : "s"} detected against "${result.snapshotFile}".`);
+  lines.push(`Suggested semver bump: ${result.bump}.`);
+
+  const byComponent = new Map<string, ApiChange[]>();
+  for (const change of result.changes) {
+    const group = byComponent.get(change.component) ?? [];
+    group.push(change);
+    byComponent.set(change.component, group);
+  }
+
+  for (const [component, changes] of byComponent) {
+    lines.push("");
+    lines.push(`  ${component}`);
+    for (const change of changes) {
+      lines.push(`    [${BUMP_LABELS[change.bump]}] ${change.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import resolve from "@rollup/plugin-node-resolve";
 import { rollup } from "rollup";
 import svelte from "rollup-plugin-svelte";
+import { type CheckResult, formatCheckReport, runCheck } from "./check";
 import { formatDiagnosticsSummary } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig } from "./load-config";
@@ -10,6 +11,13 @@ import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, write
 interface CliOptions extends PluginSveldOptions {
   /** Set exit code 1 when diagnostics are present. */
   strict?: boolean;
+  /**
+   * Diff the parsed component API against a committed snapshot (default:
+   * the `json` writer's `outFile`, or `COMPONENT_API.json`) and assign a
+   * semver bump to each change. Exits `1` on a breaking change. Pass a
+   * string for a custom snapshot path.
+   */
+  check?: boolean | string;
 }
 
 function parseCliFlag(arg: string): Partial<CliOptions> {
@@ -38,9 +46,20 @@ function parseCliFlag(arg: string): Partial<CliOptions> {
       // overrides it; `--cache=false` disables it.
       if (value === "false") return { cache: false };
       return { cache: typeof value === "string" ? value : true };
+    case "check":
+      // Bare `--check` diffs against the default snapshot path;
+      // `--check=<path>` overrides it; `--check=false` disables it.
+      if (value === "false") return { check: false };
+      return { check: typeof value === "string" ? value : true };
     default:
       return {};
   }
+}
+
+/** Default snapshot path mirrors the `json` writer's default `outFile`. */
+function resolveCheckSnapshotFile(options: CliOptions): string {
+  if (typeof options.check === "string") return options.check;
+  return options.jsonOptions?.outFile ?? "COMPONENT_API.json";
 }
 
 export function parseCliOptions(argv: string[]): CliOptions {
@@ -78,10 +97,25 @@ export async function cli(process: NodeJS.Process) {
 
   const result = await generateBundle(input, options.glob === true, toGenerateBundleOptions(options));
 
+  // Read the committed snapshot before `writeOutput` can overwrite it.
+  let checkResult: CheckResult | undefined;
+  if (options.check) {
+    checkResult = await runCheck(result.components, resolveCheckSnapshotFile(options), {
+      entryExports: result.entryExports,
+    });
+  }
+
   writeOutput(result, options, input);
 
   const { diagnostics } = result;
   console.log(formatDiagnosticsSummary(diagnostics));
+
+  if (checkResult) {
+    console.log(formatCheckReport(checkResult));
+    if (checkResult.bump === "major") {
+      process.exitCode = 1;
+    }
+  }
 
   if (options.strict && diagnostics.length > 0) {
     process.exitCode = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
 export { default as ComponentParser, type SerializedComponentEvent } from "./ComponentParser";
+export {
+  type ApiChange,
+  type CheckResult,
+  diffApiDocuments,
+  formatCheckReport,
+  runCheck,
+  type SemverBump,
+} from "./check";
 export { cli } from "./cli";
 export type { SveldDiagnostic, SveldDiagnosticKind } from "./diagnostics";
 export type { SvelteEntryPoint } from "./get-svelte-entry";

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,0 +1,363 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
+import { version as svelteVersion } from "svelte/package.json";
+import { name as packageName, version as packageVersion } from "../package.json";
+import { diffApiDocuments, formatCheckReport, runCheck } from "../src/check";
+import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
+import type { ComponentApiDocument } from "../src/writer/document-model";
+import { mockComponentDocApi } from "./test-brands";
+
+function makeProp(
+  name: string,
+  overrides?: Partial<ComponentDocApi["props"][number]>,
+): ComponentDocApi["props"][number] {
+  return {
+    name,
+    kind: "let",
+    constant: false,
+    isFunction: false,
+    isFunctionDeclaration: false,
+    isRequired: false,
+    reactive: false,
+    ...overrides,
+  };
+}
+
+function document(components: ComponentDocApi[]): ComponentApiDocument {
+  return {
+    schemaVersion: 1,
+    generator: { name: packageName, version: packageVersion, svelteVersion },
+    total: components.length,
+    components,
+  };
+}
+
+describe("diffApiDocuments", () => {
+  test("no changes when both documents are identical", () => {
+    const button = mockComponentDocApi("Button", "Button.svelte", { props: [makeProp("label", { type: "string" })] });
+    expect(diffApiDocuments(document([button]), document([button]))).toEqual([]);
+  });
+
+  test("flags an added component as additive", () => {
+    const button = mockComponentDocApi("Button", "Button.svelte");
+    const changes = diffApiDocuments(document([]), document([button]));
+
+    expect(changes).toEqual([
+      { component: "Button", kind: "component", bump: "minor", message: 'component "Button" added' },
+    ]);
+  });
+
+  test("flags a removed component as breaking", () => {
+    const button = mockComponentDocApi("Button", "Button.svelte");
+    const changes = diffApiDocuments(document([button]), document([]));
+
+    expect(changes).toEqual([
+      { component: "Button", kind: "component", bump: "major", message: 'component "Button" removed' },
+    ]);
+  });
+
+  describe("props", () => {
+    test("an added optional prop is additive", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", { props: [] });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("icon", { isRequired: false })],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toEqual([
+        { component: "Button", kind: "prop", name: "icon", bump: "minor", message: 'prop "icon" added' },
+      ]);
+    });
+
+    test("an added required prop is breaking", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", { props: [] });
+      const after = mockComponentDocApi("Button", "Button.svelte", { props: [makeProp("href", { isRequired: true })] });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toEqual([
+        { component: "Button", kind: "prop", name: "href", bump: "major", message: 'prop "href" added (required)' },
+      ]);
+    });
+
+    test("a removed prop is breaking", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", { props: [makeProp("legacy")] });
+      const after = mockComponentDocApi("Button", "Button.svelte", { props: [] });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toEqual([
+        { component: "Button", kind: "prop", name: "legacy", bump: "major", message: 'prop "legacy" removed' },
+      ]);
+    });
+
+    test("a prop becoming required is breaking; becoming optional is additive", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("href", { isRequired: false }), makeProp("target", { isRequired: true })],
+      });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("href", { isRequired: true }), makeProp("target", { isRequired: false })],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toContainEqual({
+        component: "Button",
+        kind: "prop",
+        name: "href",
+        bump: "major",
+        message: 'prop "href" became required',
+      });
+      expect(changes).toContainEqual({
+        component: "Button",
+        kind: "prop",
+        name: "target",
+        bump: "minor",
+        message: 'prop "target" became optional',
+      });
+    });
+
+    test("widening a union type is additive", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("variant", { type: '"primary"' })],
+      });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("variant", { type: '"primary" | "secondary"' })],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toEqual([
+        {
+          component: "Button",
+          kind: "prop",
+          name: "variant",
+          bump: "minor",
+          message: 'prop "variant" type changed from `"primary"` to `"primary" | "secondary"`',
+        },
+      ]);
+    });
+
+    test("narrowing a union type is breaking", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("variant", { type: '"primary" | "secondary"' })],
+      });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("variant", { type: '"primary"' })],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes[0]).toMatchObject({ bump: "major" });
+    });
+
+    test("an unrelated type change is breaking", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", { props: [makeProp("value", { type: "string" })] });
+      const after = mockComponentDocApi("Button", "Button.svelte", { props: [makeProp("value", { type: "number" })] });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes[0]).toMatchObject({ bump: "major" });
+    });
+
+    test("a description-only change is not reported", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("value", { type: "string", description: "old" })],
+      });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        props: [makeProp("value", { type: "string", description: "new" })],
+      });
+
+      expect(diffApiDocuments(document([before]), document([after]))).toEqual([]);
+    });
+  });
+
+  describe("events", () => {
+    test("added/removed events are additive/breaking", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", {
+        events: [{ type: "dispatched", name: "close", detail: "null" }],
+      });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        events: [{ type: "dispatched", name: "open", detail: "null" }],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toContainEqual({
+        component: "Button",
+        kind: "event",
+        name: "open",
+        bump: "minor",
+        message: 'event "open" added',
+      });
+      expect(changes).toContainEqual({
+        component: "Button",
+        kind: "event",
+        name: "close",
+        bump: "major",
+        message: 'event "close" removed',
+      });
+    });
+
+    test("a narrowed dispatched detail type is breaking", () => {
+      const before = mockComponentDocApi("Button", "Button.svelte", {
+        events: [{ type: "dispatched", name: "change", detail: "string | number" }],
+      });
+      const after = mockComponentDocApi("Button", "Button.svelte", {
+        events: [{ type: "dispatched", name: "change", detail: "string" }],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes[0]).toMatchObject({ kind: "event", name: "change", bump: "major" });
+    });
+  });
+
+  describe("slots", () => {
+    test("added/removed slots are additive/breaking", () => {
+      const before = mockComponentDocApi("Card", "Card.svelte", { slots: [{ name: "header", default: false }] });
+      const after = mockComponentDocApi("Card", "Card.svelte", { slots: [{ name: "footer", default: false }] });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toContainEqual({
+        component: "Card",
+        kind: "slot",
+        name: "footer",
+        bump: "minor",
+        message: 'slot "footer" added',
+      });
+      expect(changes).toContainEqual({
+        component: "Card",
+        kind: "slot",
+        name: "header",
+        bump: "major",
+        message: 'slot "header" removed',
+      });
+    });
+
+    test("a narrowed slot_props type is breaking", () => {
+      const before = mockComponentDocApi("Card", "Card.svelte", {
+        slots: [{ name: null, default: true, slot_props: "{ title: string; subtitle: string }" }],
+      });
+      const after = mockComponentDocApi("Card", "Card.svelte", {
+        slots: [{ name: null, default: true, slot_props: "{ title: string }" }],
+      });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes[0]).toMatchObject({ kind: "slot", name: "default", bump: "major" });
+    });
+  });
+
+  describe("shape fields", () => {
+    test("a generics change is breaking", () => {
+      const before = mockComponentDocApi("List", "List.svelte", { generics: ["T", "string"] });
+      const after = mockComponentDocApi("List", "List.svelte", { generics: ["T", "number"] });
+
+      const changes = diffApiDocuments(document([before]), document([after]));
+      expect(changes).toEqual([
+        {
+          component: "List",
+          kind: "shape",
+          name: "generics",
+          bump: "major",
+          message: '"generics" changed (breaking)',
+        },
+      ]);
+    });
+
+    test("a description-only context change is not reported", () => {
+      const before = mockComponentDocApi("Tabs", "Tabs.svelte", {
+        contexts: [{ key: "tabs", typeName: "TabsContext", description: "old", properties: [] }],
+      });
+      const after = mockComponentDocApi("Tabs", "Tabs.svelte", {
+        contexts: [{ key: "tabs", typeName: "TabsContext", description: "new", properties: [] }],
+      });
+
+      expect(diffApiDocuments(document([before]), document([after]))).toEqual([]);
+    });
+  });
+});
+
+describe("runCheck", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-check-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("snapshotExists is false when there is no snapshot file yet", async () => {
+    const snapshotFile = path.join(tempDir, "COMPONENT_API.json");
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    const result = await runCheck(components, snapshotFile);
+
+    expect(result).toEqual({ snapshotExists: false, snapshotFile, changes: [], bump: "none" });
+  });
+
+  test("diffs parsed components against a snapshot on disk", async () => {
+    const snapshotFile = path.join(tempDir, "COMPONENT_API.json");
+    const before = mockComponentDocApi("Button", "Button.svelte", { props: [makeProp("href", { isRequired: true })] });
+    writeFileSync(snapshotFile, JSON.stringify(document([before])));
+
+    const after = mockComponentDocApi("Button", "Button.svelte", { props: [] });
+    const components: ComponentDocs = new Map([["Button", after]]);
+
+    const result = await runCheck(components, snapshotFile);
+
+    expect(result.snapshotExists).toBe(true);
+    expect(result.bump).toBe("major");
+    expect(result.changes).toContainEqual(
+      expect.objectContaining({ component: "Button", kind: "prop", name: "href", bump: "major" }),
+    );
+  });
+
+  test("skips diffing when the snapshot schemaVersion does not match", async () => {
+    const snapshotFile = path.join(tempDir, "COMPONENT_API.json");
+    writeFileSync(snapshotFile, JSON.stringify({ ...document([]), schemaVersion: 99 }));
+
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+    const result = await runCheck(components, snapshotFile);
+
+    expect(result.snapshotExists).toBe(true);
+    expect(result.bump).toBe("none");
+    expect(result.changes[0].message).toContain("schemaVersion");
+  });
+});
+
+describe("formatCheckReport", () => {
+  test("reports when no snapshot exists", () => {
+    const report = formatCheckReport({
+      snapshotExists: false,
+      snapshotFile: "COMPONENT_API.json",
+      changes: [],
+      bump: "none",
+    });
+    expect(report).toContain("no snapshot found");
+  });
+
+  test("reports a clean run", () => {
+    const report = formatCheckReport({
+      snapshotExists: true,
+      snapshotFile: "COMPONENT_API.json",
+      changes: [],
+      bump: "none",
+    });
+    expect(report).toContain("no API changes detected");
+  });
+
+  test("groups changes by component and prints the suggested bump", () => {
+    const report = formatCheckReport({
+      snapshotExists: true,
+      snapshotFile: "COMPONENT_API.json",
+      bump: "major",
+      changes: [
+        { component: "Button", kind: "prop", name: "href", bump: "major", message: 'prop "href" removed' },
+        { component: "Card", kind: "component", bump: "minor", message: 'component "Card" added' },
+      ],
+    });
+
+    expect(report).toContain("2 API changes detected");
+    expect(report).toContain("Suggested semver bump: major.");
+    expect(report).toContain("Button");
+    expect(report).toContain('[BREAKING] prop "href" removed');
+    expect(report).toContain("Card");
+    expect(report).toContain('[additive] component "Card" added');
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -24,4 +24,16 @@ describe("parseCliOptions", () => {
   test("--cache=false disables the cache", () => {
     expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
   });
+
+  test("--check enables the default snapshot check", () => {
+    expect(parseCliOptions(["--check"])).toEqual({ check: true });
+  });
+
+  test("--check=<path> sets a custom snapshot location", () => {
+    expect(parseCliOptions(["--check=api-snapshot.json"])).toEqual({ check: "api-snapshot.json" });
+  });
+
+  test("--check=false disables the check", () => {
+    expect(parseCliOptions(["--check=false"])).toEqual({ check: false });
+  });
 });


### PR DESCRIPTION
## Summary

`sveld --check` compares the freshly-parsed component API against a committed `COMPONENT_API.json` snapshot and classifies every difference as a semver bump (major/minor/patch). It fails the run (exit code 1) when a breaking change is detected, turning sveld into a CI release guardrail rather than just a docs generator.

Classification rules:

- Component, prop, event, or slot removed, or a prop becoming required: `major`
- Component, prop, event, or slot added (non-required), or a prop becoming optional: `minor`
- Union type widened (gained members only): `minor`; narrowed or otherwise changed: `major`
- Generics, `@restProps`, `@extends`, contexts, `@typedef`s: compared structurally (JSDoc-only fields like descriptions ignored) and, if changed at all, conservatively treated as `major`

`--check` reads the snapshot from disk before `writeOutput` runs, so combining it with `--json` in one invocation still diffs against the prior committed state rather than a self-comparison. A missing snapshot (first run) reports and exits `0` instead of failing CI. `--check=<path>` overrides the snapshot location (defaults to `jsonOptions.outFile`, or `COMPONENT_API.json`).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test --parallel` (596 pass)
- [x] Manual smoke test: generated a snapshot, introduced a breaking prop swap, confirmed `--check` reports `major` and exits `1`; confirmed an additive optional prop reports `minor` and exits `0`; confirmed `--check` alone never overwrites the snapshot