### PR TITLE
fix: make type-inference diagnostics opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,58 @@ The check is narrow on purpose. It catches renamed or removed symbols and wrong 
 
 Needs `typescript` and a `tsconfig.json`, same as `resolveTypes`. Use `--strict` (or the `strict` option) to fail CI when an example breaks.
 
+#### Type inference diagnostics
+
+`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`.
+
+With `reportDiagnostics` or `strict`, the grouped summary looks like this:
+
+```
+sveld: 4 unresolved types found.
+
+Props without inferred types (1):
+  ./icons/Add.svelte
+    - Prop "title" type could not be inferred; falling back to "any".
+
+Context values typed as `any` (1):
+  ./ThemeProvider.svelte
+    - Context "theme" variable "themeStore" has no type annotation; defaulted to "any".
+
+@event tags with no dispatch or callback (2):
+  ./Modal.svelte
+    - @event "open" has no matching dispatch or callback prop.
+    - @event "close" has no matching dispatch or callback prop.
+```
+
+When `checkExamples` is also enabled, `@example` compile failures appear as a fourth group:
+
+```
+@example blocks that failed to compile (1):
+  ./Component.svelte
+    - Line 1: Cannot find name 'formatValue'.
+```
+
+By default, nothing is printed. Opt in when you are working on types or want CI output:
+
+```ts
+await sveld({ json: true, reportDiagnostics: true });
+```
+
+Use `strict: true` (or `--strict`) to exit with code `1` when diagnostics exist. `strict` implies `reportDiagnostics`, so CI always shows why the run failed.
+
+```ts
+await sveld({ json: true, strict: true });
+```
+
+CLI equivalent:
+
+```sh
+npx sveld --json --report-diagnostics
+npx sveld --json --strict
+```
+
+`--check` is separate: it diffs `COMPONENT_API.json` for API drift and semver classification, not inference warnings.
+
 ## Usage
 
 ### Installation
@@ -365,7 +417,7 @@ If no `input` is specified, `sveld` will infer the entry point based on the `pac
 import { sveld } from "sveld";
 import pkg from "./package.json" with { type: "json" };
 
-sveld({
+const { diagnostics } = await sveld({
   input: "./src/index.js",
   glob: true,
   markdown: true,
@@ -384,6 +436,8 @@ sveld({
   },
 });
 ```
+
+`diagnostics` is always populated; printing is opt-in via `reportDiagnostics` or `strict` (see [Type inference diagnostics](#type-inference-diagnostics)).
 
 #### `jsonOptions.outDir`
 
@@ -462,6 +516,8 @@ TypeScript definitions land in the `types` folder by default. Include that folde
 - **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
 - **`cache`** (boolean | string, optional, default: `false`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path. Also available as `--cache` / `--cache=<path>`. See [Persistent parse cache](#persistent-parse-cache-cache).
 - **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
+- **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
+- **`strict`** (boolean, optional, default: `false`): Exit with code `1` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).
 
 By default, only TypeScript definitions are generated.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,9 @@ import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, write
 
 /** CLI options layered on top of the shared plugin options. */
 interface CliOptions extends PluginSveldOptions {
-  /** Set exit code 1 when diagnostics are present. */
+  /** Print unresolved-type diagnostics to stderr. */
+  reportDiagnostics?: boolean;
+  /** Set exit code 1 when diagnostics are present. Implies `reportDiagnostics`. */
   strict?: boolean;
   /**
    * Diff the parsed component API against a committed snapshot (default:
@@ -34,7 +36,11 @@ function parseCliFlag(arg: string): Partial<CliOptions> {
     case "types":
     case "json":
     case "markdown":
+      return { [flag]: value === true || value === "true" };
     case "strict":
+      return { strict: value === true || value === "true" };
+    case "report-diagnostics":
+      return { reportDiagnostics: value === true || value === "true" };
     case "resolveTypes":
     case "checkExamples":
       return { [flag]: value === true || value === "true" };
@@ -109,7 +115,11 @@ export async function cli(process: NodeJS.Process) {
   writeOutput(result, options, input);
 
   const { diagnostics } = result;
-  console.log(formatDiagnosticsSummary(diagnostics));
+  const shouldReport = options.reportDiagnostics || options.strict;
+
+  if (shouldReport && diagnostics.length > 0) {
+    console.error(formatDiagnosticsSummary(diagnostics));
+  }
 
   if (checkResult) {
     console.log(formatCheckReport(checkResult));

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -11,7 +11,12 @@ interface SveldOptions extends Omit<PluginSveldOptions, "entry"> {
    */
   input?: string;
   /**
-   * Exit with code 1 when diagnostics are present. Default `false`.
+   * Print unresolved-type diagnostics to stderr. Default `false`.
+   */
+  reportDiagnostics?: boolean;
+  /**
+   * Exit with code 1 when diagnostics are present. Implies `reportDiagnostics`.
+   * Default `false`.
    */
   strict?: boolean;
 }
@@ -39,7 +44,7 @@ interface SveldResult {
  * ```
  */
 export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
-  const { input: inputOverride, strict, ...runtimeOpts } = opts ?? {};
+  const { input: inputOverride, strict, reportDiagnostics, ...runtimeOpts } = opts ?? {};
   const fileConfig = await loadConfig();
   const input = getSvelteEntry(inputOverride ?? fileConfig.entry);
   if (input === null) return { diagnostics: [] };
@@ -48,12 +53,14 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   writeOutput(result, merged, input);
 
   const { diagnostics } = result;
-  if (diagnostics.length > 0) {
-    console.warn(formatDiagnosticsSummary(diagnostics));
+  const shouldReport = reportDiagnostics || strict;
 
-    if (strict) {
-      process.exitCode = 1;
-    }
+  if (shouldReport && diagnostics.length > 0) {
+    console.warn(formatDiagnosticsSummary(diagnostics));
+  }
+
+  if (strict && diagnostics.length > 0) {
+    process.exitCode = 1;
   }
 
   return { diagnostics };

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -40,4 +40,16 @@ describe("parseCliOptions", () => {
   test("--checkExamples enables checkExamples", () => {
     expect(parseCliOptions(["--checkExamples"])).toEqual({ checkExamples: true });
   });
+
+  test("--report-diagnostics enables reportDiagnostics", () => {
+    expect(parseCliOptions(["--report-diagnostics"])).toEqual({ reportDiagnostics: true });
+  });
+
+  test("--report-diagnostics=false disables reportDiagnostics", () => {
+    expect(parseCliOptions(["--report-diagnostics=false"])).toEqual({ reportDiagnostics: false });
+  });
+
+  test("--strict enables strict", () => {
+    expect(parseCliOptions(["--strict"])).toEqual({ strict: true });
+  });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -163,7 +163,14 @@ describe("sveld() strict mode", () => {
 
     expect(diagnostics.some((d) => d.kind === "event-no-source" && d.name === "phantom")).toBe(true);
     expect(process.exitCode).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("reportDiagnostics: true prints the summary", async () => {
+    await sveld({ input: relativeDir, glob: true, types: false, reportDiagnostics: true });
+
     expect(warnSpy).toHaveBeenCalled();
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("unresolved types found");
   });
 
   test("strict: true sets a non-zero exit code when diagnostics exist", async () => {
@@ -171,5 +178,6 @@ describe("sveld() strict mode", () => {
 
     expect(diagnostics.length).toBeGreaterThan(0);
     expect(process.exitCode).toBe(1);
+    expect(warnSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
0.34.0 printed unresolved-type summaries on every run, which drowned routine docgen in noise for large libraries. Gate printing behind `reportDiagnostics` / `--report-diagnostics`; `strict` still fails CI and implies reporting so failures stay visible.