### PR TITLE
Add Svelte 5 runes fixture coverage and fix $host() event detection

### DIFF
--- a/playground/src/data.ts
+++ b/playground/src/data.ts
@@ -410,6 +410,47 @@ const functionWithParamsRunes: Example = {
 `,
 };
 
+const attachmentsRunes: Example = {
+  name: "Attachments",
+  moduleName: "AttachmentsRunes",
+  code: `<script lang="ts">
+  import type { Attachment } from "svelte/attachments";
+
+  let {
+    value = $bindable(""),
+    autofocus,
+  }: {
+    value?: string;
+    autofocus?: Attachment<HTMLInputElement>;
+  } = $props();
+</script>
+
+<input bind:value {@attach autofocus} />
+`,
+};
+
+const customElementEventsRunes: Example = {
+  name: "Custom element events",
+  moduleName: "CustomElementEventsRunes",
+  code: `<svelte:options customElement="my-toggle" />
+
+<script>
+  let { pressed = $bindable(false) } = $props();
+
+  function toggle() {
+    pressed = !pressed;
+    $host().dispatchEvent(
+      new CustomEvent("toggle", { detail: pressed }),
+    );
+  }
+</script>
+
+<button onclick={toggle}>
+  {pressed ? "On" : "Off"}
+</button>
+`,
+};
+
 const buttonLegacy: Example = {
   name: "Button (non-Runes)",
   moduleName: "ButtonLegacy",
@@ -758,6 +799,8 @@ export default [
   namedSnippetsRunes,
   componentCommentsRunes,
   functionWithParamsRunes,
+  attachmentsRunes,
+  customElementEventsRunes,
   buttonLegacy,
   typeScriptPropsLegacy,
   dispatchedEventsLegacy,

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -16,14 +16,14 @@ import type {
 import type { Node } from "estree-walker";
 import { walk } from "estree-walker";
 import { compile, parse } from "svelte/compiler";
-import { isCallExpressionNamed, isIdentifier, isLiteral } from "./ast-guards";
+import { isCallExpressionNamed, isIdentifier, isLiteral, isMemberExpression } from "./ast-guards";
 import type { SveldDiagnostic } from "./diagnostics";
 import { getElementByTag } from "./element-tag-map";
 import { resolveMemberExpressionType } from "./parser/bindings";
 import { createParserContext, type ParserContext } from "./parser/context";
 import { parseSetContextCall } from "./parser/contexts";
 import { recordDiagnostic } from "./parser/diagnostics";
-import { addDispatchedEvent } from "./parser/events";
+import { addDispatchedEvent, literalDetailToTypeText, parseHostDispatchEventCall } from "./parser/events";
 import { getCommentTags, parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
 import { addProp, processInitializer } from "./parser/props";
 import { maybeSetRestProps } from "./parser/rest-props";
@@ -445,8 +445,9 @@ export interface ForwardedEvent {
 /**
  * Event that is dispatched by the component.
  *
- * Dispatched events are those created with `createEventDispatcher()`
- * and dispatched via `dispatch("eventname", detail)`.
+ * Dispatched events are those created with `createEventDispatcher()` and
+ * dispatched via `dispatch("eventname", detail)`, or dispatched from a custom
+ * element via `$host().dispatchEvent(new CustomEvent("eventname", { detail }))`.
  */
 export interface DispatchedEvent {
   /** Always "dispatched" for dispatched events */
@@ -1482,6 +1483,8 @@ export default class ComponentParser {
     }
 
     let dispatcher_name: undefined | string;
+    const hostLocalNames = new Set<string>();
+    const hostDispatchedEventNames = new Set<string>();
     const callees: { name: string; arguments: Array<Expression | unknown>; source?: SourceRange }[] = [];
     const componentRoot = {
       type: "ComponentRoot",
@@ -1527,6 +1530,19 @@ export default class ComponentParser {
             }
           }
 
+          if (calleeName === "$host") {
+            if (
+              parent &&
+              typeof parent === "object" &&
+              "id" in parent &&
+              parent.id &&
+              typeof parent.id === "object" &&
+              "name" in parent.id
+            ) {
+              hostLocalNames.add((parent.id as Identifier).name);
+            }
+          }
+
           if (calleeName === "setContext") {
             parseSetContextCall(this.ctx, this, node, parent ?? undefined);
           }
@@ -1537,6 +1553,19 @@ export default class ComponentParser {
               arguments: callExpr.arguments,
               source: sourceRangeFromNode(this.ctx, callExpr),
             });
+          }
+
+          if (
+            isMemberExpression(callExpr.callee) &&
+            isIdentifier(callExpr.callee.property) &&
+            callExpr.callee.property.name === "dispatchEvent" &&
+            (isCallExpressionNamed(callExpr.callee.object, "$host") ||
+              (isIdentifier(callExpr.callee.object) && hostLocalNames.has(callExpr.callee.object.name)))
+          ) {
+            const hostDispatchedEventName = parseHostDispatchEventCall(this.ctx, callExpr);
+            if (hostDispatchedEventName) {
+              hostDispatchedEventNames.add(hostDispatchedEventName);
+            }
           }
         }
 
@@ -2057,7 +2086,7 @@ export default class ComponentParser {
           if (event_name != null) {
             addDispatchedEvent(this.ctx, {
               name: String(event_name),
-              detail: event_detail == null ? "" : String(event_detail),
+              detail: event_detail == null ? "" : literalDetailToTypeText(event_detail),
               has_argument: Boolean(event_argument),
               source: callee.source,
             });
@@ -2074,7 +2103,7 @@ export default class ComponentParser {
      * forwarded via `on:eventname` syntax rather than dispatched. We need to check
      * which events are actually dispatched and convert the rest to forwarded events.
      */
-    const actuallyDispatchedEvents = new Set<string>();
+    const actuallyDispatchedEvents = new Set<string>(hostDispatchedEventNames);
     if (dispatcher_name !== undefined) {
       for (const callee of callees) {
         if (callee.name === dispatcher_name) {

--- a/src/ast-guards.ts
+++ b/src/ast-guards.ts
@@ -6,6 +6,7 @@ import type {
   Identifier,
   Literal,
   MemberExpression,
+  NewExpression,
   ObjectExpression,
   VariableDeclaration,
 } from "estree";
@@ -40,6 +41,18 @@ export function isCallExpression(node: unknown): node is CallExpression {
 
 export function isCallExpressionNamed(node: unknown, calleeName: string): node is CallExpression {
   if (!isCallExpression(node)) {
+    return false;
+  }
+
+  return !!node.callee && isObject(node.callee) && node.callee.type === "Identifier" && node.callee.name === calleeName;
+}
+
+export function isNewExpression(node: unknown): node is NewExpression {
+  return isObject(node) && node.type === "NewExpression";
+}
+
+export function isNewExpressionNamed(node: unknown, calleeName: string): node is NewExpression {
+  if (!isNewExpression(node)) {
     return false;
   }
 

--- a/src/parser/events.ts
+++ b/src/parser/events.ts
@@ -1,9 +1,17 @@
+import type { CallExpression } from "estree";
+import { isIdentifier, isLiteral, isNewExpressionNamed, isObjectExpression } from "../ast-guards";
 import type { DispatchedEvent } from "../ComponentParser";
 import type { ParserContext } from "./context";
+import { sourceRangeFromNode } from "./source-position";
 
 /** Returns `value`, or `undefined` when it's `undefined` or the empty string. */
 function assignValueOrUndefined(value?: "" | string) {
   return value === undefined || value === "" ? undefined : value;
+}
+
+/** Render a literal event-detail value (from a `dispatch()`/`CustomEvent` argument) as TS type text, quoting strings. */
+export function literalDetailToTypeText(value: unknown): string {
+  return typeof value === "string" ? JSON.stringify(value) : String(value);
 }
 
 /** Merge or add a dispatched event. Detail defaults to `null` when the dispatch has no argument and no `@event` detail. */
@@ -48,6 +56,42 @@ export function addDispatchedEvent(
       source,
     });
   }
+}
+
+/**
+ * Detect `$host().dispatchEvent(new CustomEvent("name", { detail }))` (or `new Event(...)`) and
+ * record it as a dispatched event, mirroring `createEventDispatcher()` detection.
+ */
+export function parseHostDispatchEventCall(ctx: ParserContext, dispatchEventCall: CallExpression): string | undefined {
+  const eventArg = dispatchEventCall.arguments[0];
+  const isCustomEvent = isNewExpressionNamed(eventArg, "CustomEvent");
+  if (!isCustomEvent && !isNewExpressionNamed(eventArg, "Event")) return undefined;
+
+  const nameArg = eventArg.arguments[0];
+  const eventName = isLiteral(nameArg) ? nameArg.value : undefined;
+  if (eventName == null) return undefined;
+
+  const optionsArg = isCustomEvent ? eventArg.arguments[1] : undefined;
+  let hasArgument = false;
+  let detailValue: unknown;
+  if (isObjectExpression(optionsArg)) {
+    const detailProperty = optionsArg.properties.find(
+      (property) => property.type === "Property" && isIdentifier(property.key) && property.key.name === "detail",
+    );
+    if (detailProperty?.type === "Property") {
+      hasArgument = true;
+      detailValue = isLiteral(detailProperty.value) ? detailProperty.value.value : undefined;
+    }
+  }
+
+  addDispatchedEvent(ctx, {
+    name: String(eventName),
+    detail: detailValue == null ? "" : literalDetailToTypeText(detailValue),
+    has_argument: hasArgument,
+    source: sourceRangeFromNode(ctx, dispatchEventCall),
+  });
+
+  return String(eventName);
 }
 
 /** Build an inline object type (with optional JSDoc per property) for event details or typedefs. */

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -2419,6 +2419,61 @@ exports[`fixtures (JSON) "template-tag-multiple/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-uncontrolled-state-prop/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "count",
+      "localName": "initialCount",
+      "kind": "let",
+      "type": "number",
+      "typeSource": "default",
+      "value": "0",
+      "defaultValue": {
+        "raw": "0",
+        "kind": "literal",
+        "value": 0
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 31
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-props-intersection/input.svelte" 1`] = `
 "{
   "source": {
@@ -5441,6 +5496,65 @@ exports[`fixtures (JSON) "slot-jsdoc-inheritdoc-before-slot/input.svelte" 1`] = 
 "
 `;
 
+exports[`fixtures (JSON) "runes-derived-prop-default/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "typeSource": "unknown",
+      "value": "$derived(now.toISOString())",
+      "defaultValue": {
+        "raw": "$derived(now.toISOString())",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-derived-prop-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "label",
+      "message": "Prop \\"label\\" type could not be inferred; falling back to \\"any\\"."
+    }
+  ]
+}
+"
+`;
+
 exports[`fixtures (JSON) "unary-expression-defaults/input.svelte" 1`] = `
 "{
   "source": {
@@ -6939,6 +7053,86 @@ exports[`fixtures (JSON) "context-typedef/input.svelte" 1`] = `
     }
   ],
   "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-internal-noleak/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 21,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    },
+    {
+      "name": "onchange",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-internal-noleak/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "value",
+      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\"."
+    },
+    {
+      "component": "runes-internal-noleak/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "onchange",
+      "message": "Prop \\"onchange\\" type could not be inferred; falling back to \\"any\\"."
+    }
+  ]
 }
 "
 `;
@@ -14126,6 +14320,60 @@ exports[`fixtures (JSON) "anchor-props/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-host-custom-element/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-host-custom-element/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "value",
+      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\"."
+    }
+  ]
+}
+"
+`;
+
 exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
 "{
   "source": {
@@ -14174,6 +14422,60 @@ exports[`fixtures (JSON) "component-comment-multi/input.svelte" 1`] = `
   },
   "contexts": [],
   "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-props-id-default/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-props-id-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "label",
+      "message": "Prop \\"label\\" type could not be inferred; falling back to \\"any\\"."
+    }
+  ]
 }
 "
 `;
@@ -17006,6 +17308,24 @@ export default class TemplateTagMultiple<
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-uncontrolled-state-prop/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesUncontrolledStatePropProps = {
+  /**
+   * @default 0
+   */
+  count?: number;
+};
+
+export default class RunesUncontrolledStateProp extends SvelteComponentTyped<
+  RunesUncontrolledStatePropProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-props-intersection/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -17863,6 +18183,24 @@ export default class SlotJsdocInheritdocBeforeSlot extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-derived-prop-default/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesDerivedPropDefaultProps = {
+  /**
+   * @default $derived(now.toISOString())
+   */
+  label?: undefined;
+};
+
+export default class RunesDerivedPropDefault extends SvelteComponentTyped<
+  RunesDerivedPropDefaultProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "unary-expression-defaults/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -18324,6 +18662,29 @@ export default class ContextTypedef extends SvelteComponentTyped<
   ContextTypedefProps,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-internal-noleak/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesInternalNoleakProps = {
+  /**
+   * @default undefined
+   */
+  value: undefined;
+
+  /**
+   * @default undefined
+   */
+  onchange: undefined;
+};
+
+export default class RunesInternalNoleak extends SvelteComponentTyped<
+  RunesInternalNoleakProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;
@@ -20407,6 +20768,24 @@ export default class AnchorProps extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-host-custom-element/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesHostCustomElementProps = {
+  /**
+   * @default undefined
+   */
+  value: undefined;
+};
+
+export default class RunesHostCustomElement extends SvelteComponentTyped<
+  RunesHostCustomElementProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "component-comment-multi/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -20424,6 +20803,24 @@ export default class ComponentCommentMulti extends SvelteComponentTyped<
   ComponentCommentMultiProps,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-props-id-default/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesPropsIdDefaultProps = {
+  /**
+   * @default undefined
+   */
+  label: undefined;
+};
+
+export default class RunesPropsIdDefault extends SvelteComponentTyped<
+  RunesPropsIdDefaultProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -9408,6 +9408,48 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "dispatched-events-string-literal-detail/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "status",
+      "detail": "\\"done\\"",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 4
+        },
+        "end": {
+          "line": 7,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "context-imported-type/input.svelte" 1`] = `
 "{
   "source": {
@@ -14437,7 +14479,7 @@ exports[`fixtures (JSON) "runes-host-custom-element/input.svelte" 1`] = `
       "column": 0
     },
     "end": {
-      "line": 12,
+      "line": 24,
       "column": 0
     }
   },
@@ -14467,7 +14509,52 @@ exports[`fixtures (JSON) "runes-host-custom-element/input.svelte" 1`] = `
   ],
   "moduleExports": [],
   "slots": [],
-  "events": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "close",
+      "detail": "null",
+      "source": {
+        "start": {
+          "line": 17,
+          "column": 4
+        },
+        "end": {
+          "line": 17,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "notify",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 68
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "ready",
+      "detail": "\\"loaded\\"",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 4
+        },
+        "end": {
+          "line": 13,
+          "column": 73
+        }
+      }
+    }
+  ],
   "typedefs": [],
   "generics": null,
   "contexts": [],
@@ -19420,6 +19507,19 @@ export default class Required extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "dispatched-events-string-literal-detail/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsStringLiteralDetailProps = Record<string, never>;
+
+export default class DispatchedEventsStringLiteralDetail extends SvelteComponentTyped<
+  DispatchedEventsStringLiteralDetailProps,
+  { status: CustomEvent<"done"> },
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "context-imported-type/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -20929,7 +21029,7 @@ export type RunesHostCustomElementProps = {
 
 export default class RunesHostCustomElement extends SvelteComponentTyped<
   RunesHostCustomElementProps,
-  Record<string, any>,
+  { close: CustomEvent<null>; notify: CustomEvent<any>; ready: CustomEvent<"loaded"> },
   Record<string, never>
 > {}
 "

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -4830,6 +4830,64 @@ exports[`fixtures (JSON) "runes-attachment-array/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-props-html-intersection/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "variant",
+      "kind": "let",
+      "type": "\\"primary\\" | \\"secondary\\"",
+      "typeSource": "typescript",
+      "value": "\\"primary\\"",
+      "defaultValue": {
+        "raw": "\\"primary\\"",
+        "kind": "literal",
+        "value": "primary"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "rest_props": {
+    "type": "Element",
+    "name": "button"
+  },
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-bindable/input.svelte" 1`] = `
 "{
   "source": {
@@ -12214,6 +12272,57 @@ exports[`fixtures (JSON) "slot-extends-template/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-snippet-generic-tuple/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "Row[]",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row",
+    "Row"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "html-in-template-string/input.svelte" 1`] = `
 "{
   "source": {
@@ -17998,6 +18107,27 @@ export default class RunesAttachmentArray extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-props-html-intersection/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { HTMLButtonAttributes } from "svelte/elements";
+
+type $RestProps = SvelteHTMLElements["button"];
+
+type $Props = ({ variant?: "primary" | "secondary" } & HTMLButtonAttributes) & {
+  [key: \`data-\${string}\`]: unknown;
+};
+
+export type RunesPropsHtmlIntersectionProps = Omit<$RestProps, keyof $Props> & $Props;
+
+export default class RunesPropsHtmlIntersection extends SvelteComponentTyped<
+  RunesPropsHtmlIntersectionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-bindable/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -20077,6 +20207,25 @@ export default class SlotExtendsTemplate<Icon = any> extends SvelteComponentType
     /** Optional badge overlay. */
     badge: Record<string, never>;
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-snippet-generic-tuple/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Snippet } from "svelte";
+
+type $Props<Row> = {
+  rows: Row[];
+  children: Snippet<[row: Row, index: number]>;
+};
+
+export type RunesSnippetGenericTupleProps<Row> = $Props<Row>;
+
+export default class RunesSnippetGenericTuple<Row> extends SvelteComponentTyped<
+  RunesSnippetGenericTupleProps<Row>,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -337,6 +337,178 @@ exports[`fixtures (JSON) "slots-named/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "example-check/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 51,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "formatValue",
+      "kind": "function",
+      "description": "Formats a value. Its example is valid and should compile cleanly.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`js\\n formatValue(\\"ok\\");\\n \`\`\`"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "newFormatName",
+      "kind": "function",
+      "description": "Renamed from \`oldFormatName\`; the example below was never updated and\\nstill calls the old, now-nonexistent name.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`js\\n oldFormatName(\\"ok\\");\\n \`\`\`"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 2
+        },
+        "end": {
+          "line": 27,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "tooManyArgs",
+      "kind": "function",
+      "description": "Its example calls it with more arguments than it declares.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`js\\n tooManyArgs(\\"a\\", \\"b\\", \\"c\\");\\n \`\`\`"
+        }
+      ],
+      "type": "(value: string) => string",
+      "typeSource": "jsdoc",
+      "params": [
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 38,
+          "column": 2
+        },
+        "end": {
+          "line": 40,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "widgetSlot",
+      "kind": "let",
+      "description": "Svelte example, not TS/JS. sveld skips it.",
+      "tags": [
+        {
+          "name": "example",
+          "body": " \`\`\`svelte\\n <Widget prop={doesNotExist} />\\n \`\`\`"
+        }
+      ],
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"unused\\"",
+      "defaultValue": {
+        "raw": "\\"unused\\"",
+        "kind": "literal",
+        "value": "unused"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 49,
+          "column": 2
+        },
+        "end": {
+          "line": 49,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "event-jsdoc-since/input.svelte" 1`] = `
 "{
   "source": {
@@ -3338,6 +3510,58 @@ exports[`fixtures (JSON) "forwarded-events/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-attachment-generic/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "measure",
+      "kind": "let",
+      "description": "@generics Element",
+      "type": "Attachment<Element>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 8
+        },
+        "end": {
+          "line": 8,
+          "column": 15
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Element",
+    "Element extends HTMLElement = HTMLDivElement"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "binary-expression-numeric/input.svelte" 1`] = `
 "{
   "source": {
@@ -4488,6 +4712,60 @@ exports[`fixtures (JSON) "slot-description-with-dash/input.svelte" 1`] = `
       }
     }
   ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-attachment-array/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "attachments",
+      "kind": "let",
+      "type": "Attachment[]",
+      "typeSource": "typescript",
+      "value": "[]",
+      "defaultValue": {
+        "raw": "[]",
+        "kind": "array",
+        "value": []
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 24
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
   "events": [],
   "typedefs": [],
   "generics": null,
@@ -6138,6 +6416,54 @@ exports[`fixtures (JSON) "constructor-expression-defaults/input.svelte" 1`] = `
         "end": {
           "line": 19,
           "column": 48
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-attachment-prop/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "onmount",
+      "kind": "let",
+      "type": "Attachment",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 15
         }
       }
     }
@@ -7960,6 +8286,54 @@ exports[`fixtures (JSON) "generics-with-rest-props/input.svelte" 1`] = `
     "type": "Element",
     "name": "div"
   },
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-attachment-factory/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "createTooltip",
+      "kind": "let",
+      "type": "(text: string) => Attachment",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 21
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
   "contexts": [],
   "diagnostics": []
 }
@@ -15953,6 +16327,57 @@ export default class SlotsNamed extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "example-check/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type ExampleCheckProps = {
+  /**
+   * Svelte example, not TS/JS. sveld skips it.
+   * @example
+   *  \`\`\`svelte
+   *  <Widget prop={doesNotExist} />
+   *  \`\`\`
+   * @default "unused"
+   */
+  widgetSlot?: string;
+};
+
+export default class ExampleCheck extends SvelteComponentTyped<
+  ExampleCheckProps,
+  Record<string, any>,
+  Record<string, never>
+> {
+  /**
+   * Formats a value. Its example is valid and should compile cleanly.
+   * @example
+   *  \`\`\`js
+   *  formatValue("ok");
+   *  \`\`\`
+   */
+  formatValue: (value: string) => string;
+
+  /**
+   * Renamed from \`oldFormatName\`; the example below was never updated and
+   * still calls the old, now-nonexistent name.
+   * @example
+   *  \`\`\`js
+   *  oldFormatName("ok");
+   *  \`\`\`
+   */
+  newFormatName: (value: string) => string;
+
+  /**
+   * Its example calls it with more arguments than it declares.
+   * @example
+   *  \`\`\`js
+   *  tooManyArgs("a", "b", "c");
+   *  \`\`\`
+   */
+  tooManyArgs: (value: string) => string;
+}
+"
+`;
+
 exports[`fixtures (TypeScript) "event-jsdoc-since/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -16900,6 +17325,22 @@ export default class ForwardedEvents extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-attachment-generic/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props<Element extends HTMLElement = HTMLDivElement> = { measure?: Attachment<Element> };
+
+export type RunesAttachmentGenericProps<Element extends HTMLElement = HTMLDivElement> = $Props<Element>;
+
+export default class RunesAttachmentGeneric<Element extends HTMLElement = HTMLDivElement> extends SvelteComponentTyped<
+  RunesAttachmentGenericProps<Element>,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "binary-expression-numeric/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -17217,6 +17658,22 @@ export default class SlotDescriptionWithDash extends SvelteComponentTyped<
      */
     default: { props?: { "aria-current"?: string; class: "bx--link" } };
   }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-attachment-array/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { attachments?: Attachment[] };
+
+export type RunesAttachmentArrayProps = $Props;
+
+export default class RunesAttachmentArray extends SvelteComponentTyped<
+  RunesAttachmentArrayProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;
@@ -17691,6 +18148,22 @@ export type ConstructorExpressionDefaultsProps = {
 
 export default class ConstructorExpressionDefaults extends SvelteComponentTyped<
   ConstructorExpressionDefaultsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-attachment-prop/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { onmount?: Attachment };
+
+export type RunesAttachmentPropProps = $Props;
+
+export default class RunesAttachmentProp extends SvelteComponentTyped<
+  RunesAttachmentPropProps,
   Record<string, any>,
   Record<string, never>
 > {}
@@ -18227,6 +18700,22 @@ export default class GenericsWithRestProps<Row extends DataTableRow = DataTableR
   GenericsWithRestPropsProps<Row>,
   Record<string, any>,
   { default: { headers: ReadonlyArray<DataTableHeader<Row>>; rows: ReadonlyArray<Row> } }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-attachment-factory/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { createTooltip?: (text: string) => Attachment };
+
+export type RunesAttachmentFactoryProps = $Props;
+
+export default class RunesAttachmentFactory extends SvelteComponentTyped<
+  RunesAttachmentFactoryProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;
@@ -20730,228 +21219,5 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
     item: { id: string };
   }
 > {}
-"
-`;
-
-exports[`fixtures (JSON) "example-check/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 51,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [
-    {
-      "name": "formatValue",
-      "kind": "function",
-      "description": "Formats a value. Its example is valid and should compile cleanly.",
-      "tags": [
-        {
-          "name": "example",
-          "body": " \`\`\`js\\n formatValue(\\"ok\\");\\n \`\`\`"
-        }
-      ],
-      "type": "(value: string) => string",
-      "typeSource": "jsdoc",
-      "params": [
-        {
-          "name": "value",
-          "type": "string",
-          "description": "",
-          "optional": false
-        }
-      ],
-      "returnType": "string",
-      "isFunction": true,
-      "isFunctionDeclaration": true,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 11,
-          "column": 2
-        },
-        "end": {
-          "line": 13,
-          "column": 3
-        }
-      }
-    },
-    {
-      "name": "newFormatName",
-      "kind": "function",
-      "description": "Renamed from \`oldFormatName\`; the example below was never updated and\\nstill calls the old, now-nonexistent name.",
-      "tags": [
-        {
-          "name": "example",
-          "body": " \`\`\`js\\n oldFormatName(\\"ok\\");\\n \`\`\`"
-        }
-      ],
-      "type": "(value: string) => string",
-      "typeSource": "jsdoc",
-      "params": [
-        {
-          "name": "value",
-          "type": "string",
-          "description": "",
-          "optional": false
-        }
-      ],
-      "returnType": "string",
-      "isFunction": true,
-      "isFunctionDeclaration": true,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 25,
-          "column": 2
-        },
-        "end": {
-          "line": 27,
-          "column": 3
-        }
-      }
-    },
-    {
-      "name": "tooManyArgs",
-      "kind": "function",
-      "description": "Its example calls it with more arguments than it declares.",
-      "tags": [
-        {
-          "name": "example",
-          "body": " \`\`\`js\\n tooManyArgs(\\"a\\", \\"b\\", \\"c\\");\\n \`\`\`"
-        }
-      ],
-      "type": "(value: string) => string",
-      "typeSource": "jsdoc",
-      "params": [
-        {
-          "name": "value",
-          "type": "string",
-          "description": "",
-          "optional": false
-        }
-      ],
-      "returnType": "string",
-      "isFunction": true,
-      "isFunctionDeclaration": true,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 38,
-          "column": 2
-        },
-        "end": {
-          "line": 40,
-          "column": 3
-        }
-      }
-    },
-    {
-      "name": "widgetSlot",
-      "kind": "let",
-      "description": "Svelte example, not TS/JS. sveld skips it.",
-      "tags": [
-        {
-          "name": "example",
-          "body": " \`\`\`svelte\\n <Widget prop={doesNotExist} />\\n \`\`\`"
-        }
-      ],
-      "type": "string",
-      "typeSource": "default",
-      "value": "\\"unused\\"",
-      "defaultValue": {
-        "raw": "\\"unused\\"",
-        "kind": "literal",
-        "value": "unused"
-      },
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": false,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 49,
-          "column": 2
-        },
-        "end": {
-          "line": 49,
-          "column": 35
-        }
-      }
-    }
-  ],
-  "moduleExports": [],
-  "slots": [],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "example-check/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type ExampleCheckProps = {
-  /**
-   * Svelte example, not TS/JS. sveld skips it.
-   * @example
-   *  \`\`\`svelte
-   *  <Widget prop={doesNotExist} />
-   *  \`\`\`
-   * @default "unused"
-   */
-  widgetSlot?: string;
-};
-
-export default class ExampleCheck extends SvelteComponentTyped<
-  ExampleCheckProps,
-  Record<string, any>,
-  Record<string, never>
-> {
-  /**
-   * Formats a value. Its example is valid and should compile cleanly.
-   * @example
-   *  \`\`\`js
-   *  formatValue("ok");
-   *  \`\`\`
-   */
-  formatValue: (value: string) => string;
-
-  /**
-   * Renamed from \`oldFormatName\`; the example below was never updated and
-   * still calls the old, now-nonexistent name.
-   * @example
-   *  \`\`\`js
-   *  oldFormatName("ok");
-   *  \`\`\`
-   */
-  newFormatName: (value: string) => string;
-
-  /**
-   * Its example calls it with more arguments than it declares.
-   * @example
-   *  \`\`\`js
-   *  tooManyArgs("a", "b", "c");
-   *  \`\`\`
-   */
-  tooManyArgs: (value: string) => string;
-}
 "
 `;

--- a/tests/fixtures/dispatched-events-string-literal-detail/input.svelte
+++ b/tests/fixtures/dispatched-events-string-literal-detail/input.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  function complete() {
+    dispatch("status", "done");
+  }
+</script>
+
+<button onclick={complete}>complete</button>

--- a/tests/fixtures/dispatched-events-string-literal-detail/output.d.ts
+++ b/tests/fixtures/dispatched-events-string-literal-detail/output.d.ts
@@ -1,0 +1,9 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsStringLiteralDetailProps = Record<string, never>;
+
+export default class DispatchedEventsStringLiteralDetail extends SvelteComponentTyped<
+  DispatchedEventsStringLiteralDetailProps,
+  { status: CustomEvent<"done"> },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-events-string-literal-detail/output.json
+++ b/tests/fixtures/dispatched-events-string-literal-detail/output.json
@@ -1,0 +1,38 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "status",
+      "detail": "\"done\"",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 4
+        },
+        "end": {
+          "line": 7,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-attachment-array/input.svelte
+++ b/tests/fixtures/runes-attachment-array/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Attachment } from "svelte/attachments";
+
+  let { attachments = [] }: { attachments?: Attachment[] } = $props();
+</script>
+
+<div {@attach (node) => { for (const attach of attachments) attach(node); }}>content</div>

--- a/tests/fixtures/runes-attachment-array/output.d.ts
+++ b/tests/fixtures/runes-attachment-array/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { attachments?: Attachment[] };
+
+export type RunesAttachmentArrayProps = $Props;
+
+export default class RunesAttachmentArray extends SvelteComponentTyped<
+  RunesAttachmentArrayProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-attachment-array/output.json
+++ b/tests/fixtures/runes-attachment-array/output.json
@@ -1,0 +1,50 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "attachments",
+      "kind": "let",
+      "type": "Attachment[]",
+      "typeSource": "typescript",
+      "value": "[]",
+      "defaultValue": {
+        "raw": "[]",
+        "kind": "array",
+        "value": []
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 24
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-attachment-factory/input.svelte
+++ b/tests/fixtures/runes-attachment-factory/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Attachment } from "svelte/attachments";
+
+  let { createTooltip }: { createTooltip?: (text: string) => Attachment } = $props();
+</script>
+
+<div {@attach createTooltip?.("hello")}>content</div>

--- a/tests/fixtures/runes-attachment-factory/output.d.ts
+++ b/tests/fixtures/runes-attachment-factory/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { createTooltip?: (text: string) => Attachment };
+
+export type RunesAttachmentFactoryProps = $Props;
+
+export default class RunesAttachmentFactory extends SvelteComponentTyped<
+  RunesAttachmentFactoryProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-attachment-factory/output.json
+++ b/tests/fixtures/runes-attachment-factory/output.json
@@ -1,0 +1,44 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "createTooltip",
+      "kind": "let",
+      "type": "(text: string) => Attachment",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 21
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-attachment-generic/input.svelte
+++ b/tests/fixtures/runes-attachment-generic/input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Attachment } from "svelte/attachments";
+
+  /**
+   * @generics {Element extends HTMLElement = HTMLDivElement} Element
+   */
+
+  let { measure }: { measure?: Attachment<Element> } = $props();
+</script>
+
+<div {@attach measure}>content</div>

--- a/tests/fixtures/runes-attachment-generic/output.d.ts
+++ b/tests/fixtures/runes-attachment-generic/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props<Element extends HTMLElement = HTMLDivElement> = { measure?: Attachment<Element> };
+
+export type RunesAttachmentGenericProps<Element extends HTMLElement = HTMLDivElement> = $Props<Element>;
+
+export default class RunesAttachmentGeneric<Element extends HTMLElement = HTMLDivElement> extends SvelteComponentTyped<
+  RunesAttachmentGenericProps<Element>,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-attachment-generic/output.json
+++ b/tests/fixtures/runes-attachment-generic/output.json
@@ -1,0 +1,48 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "measure",
+      "kind": "let",
+      "description": "@generics Element",
+      "type": "Attachment<Element>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 8
+        },
+        "end": {
+          "line": 8,
+          "column": 15
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Element",
+    "Element extends HTMLElement = HTMLDivElement"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-attachment-prop/input.svelte
+++ b/tests/fixtures/runes-attachment-prop/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Attachment } from "svelte/attachments";
+
+  let { onmount }: { onmount?: Attachment } = $props();
+</script>
+
+<div {@attach onmount}>content</div>

--- a/tests/fixtures/runes-attachment-prop/output.d.ts
+++ b/tests/fixtures/runes-attachment-prop/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { onmount?: Attachment };
+
+export type RunesAttachmentPropProps = $Props;
+
+export default class RunesAttachmentProp extends SvelteComponentTyped<
+  RunesAttachmentPropProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-attachment-prop/output.json
+++ b/tests/fixtures/runes-attachment-prop/output.json
@@ -1,0 +1,44 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "onmount",
+      "kind": "let",
+      "type": "Attachment",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 15
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-derived-prop-default/input.svelte
+++ b/tests/fixtures/runes-derived-prop-default/input.svelte
@@ -1,0 +1,8 @@
+<script>
+  let now = new Date();
+  let defaultLabel = $derived(now.toISOString());
+
+  let { label = defaultLabel } = $props();
+</script>
+
+<p>{label}</p>

--- a/tests/fixtures/runes-derived-prop-default/output.d.ts
+++ b/tests/fixtures/runes-derived-prop-default/output.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesDerivedPropDefaultProps = {
+  /**
+   * @default $derived(now.toISOString())
+   */
+  label?: undefined;
+};
+
+export default class RunesDerivedPropDefault extends SvelteComponentTyped<
+  RunesDerivedPropDefaultProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-derived-prop-default/output.json
+++ b/tests/fixtures/runes-derived-prop-default/output.json
@@ -1,0 +1,55 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "typeSource": "unknown",
+      "value": "$derived(now.toISOString())",
+      "defaultValue": {
+        "raw": "$derived(now.toISOString())",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-derived-prop-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "label",
+      "message": "Prop \"label\" type could not be inferred; falling back to \"any\"."
+    }
+  ]
+}

--- a/tests/fixtures/runes-host-custom-element/input.svelte
+++ b/tests/fixtures/runes-host-custom-element/input.svelte
@@ -1,0 +1,11 @@
+<svelte:options customElement="my-widget" />
+
+<script>
+  let { value } = $props();
+
+  function notify() {
+    $host().dispatchEvent(new CustomEvent("notify", { detail: value }));
+  }
+</script>
+
+<button onclick={notify}>{value}</button>

--- a/tests/fixtures/runes-host-custom-element/input.svelte
+++ b/tests/fixtures/runes-host-custom-element/input.svelte
@@ -3,9 +3,21 @@
 <script>
   let { value } = $props();
 
+  const host = $host();
+
   function notify() {
-    $host().dispatchEvent(new CustomEvent("notify", { detail: value }));
+    host.dispatchEvent(new CustomEvent("notify", { detail: value }));
+  }
+
+  function ready() {
+    $host().dispatchEvent(new CustomEvent("ready", { detail: "loaded" }));
+  }
+
+  function close() {
+    $host().dispatchEvent(new Event("close"));
   }
 </script>
 
 <button onclick={notify}>{value}</button>
+<button onclick={ready}>ready</button>
+<button onclick={close}>close</button>

--- a/tests/fixtures/runes-host-custom-element/output.d.ts
+++ b/tests/fixtures/runes-host-custom-element/output.d.ts
@@ -9,6 +9,6 @@ export type RunesHostCustomElementProps = {
 
 export default class RunesHostCustomElement extends SvelteComponentTyped<
   RunesHostCustomElementProps,
-  Record<string, any>,
+  { close: CustomEvent<null>; notify: CustomEvent<any>; ready: CustomEvent<"loaded"> },
   Record<string, never>
 > {}

--- a/tests/fixtures/runes-host-custom-element/output.d.ts
+++ b/tests/fixtures/runes-host-custom-element/output.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesHostCustomElementProps = {
+  /**
+   * @default undefined
+   */
+  value: undefined;
+};
+
+export default class RunesHostCustomElement extends SvelteComponentTyped<
+  RunesHostCustomElementProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-host-custom-element/output.json
+++ b/tests/fixtures/runes-host-custom-element/output.json
@@ -1,0 +1,50 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-host-custom-element/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "value",
+      "message": "Prop \"value\" type could not be inferred; falling back to \"any\"."
+    }
+  ]
+}

--- a/tests/fixtures/runes-host-custom-element/output.json
+++ b/tests/fixtures/runes-host-custom-element/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 12,
+      "line": 24,
       "column": 0
     }
   },
@@ -35,7 +35,52 @@
   ],
   "moduleExports": [],
   "slots": [],
-  "events": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "close",
+      "detail": "null",
+      "source": {
+        "start": {
+          "line": 17,
+          "column": 4
+        },
+        "end": {
+          "line": 17,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "notify",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 68
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "ready",
+      "detail": "\"loaded\"",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 4
+        },
+        "end": {
+          "line": 13,
+          "column": 73
+        }
+      }
+    }
+  ],
   "typedefs": [],
   "generics": null,
   "contexts": [],

--- a/tests/fixtures/runes-internal-noleak/input.svelte
+++ b/tests/fixtures/runes-internal-noleak/input.svelte
@@ -1,0 +1,20 @@
+<script>
+  let { value, onchange } = $props();
+
+  let doubled = $derived(value * 2);
+  let tripled = $derived.by(() => value * 3);
+
+  $effect(() => {
+    onchange?.(doubled);
+  });
+
+  $effect.pre(() => {
+    console.log("before update", doubled);
+  });
+
+  $inspect(doubled, tripled).with((type, ...values) => {
+    console.log(type, values);
+  });
+</script>
+
+<p>{doubled} {tripled}</p>

--- a/tests/fixtures/runes-internal-noleak/output.d.ts
+++ b/tests/fixtures/runes-internal-noleak/output.d.ts
@@ -1,0 +1,19 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesInternalNoleakProps = {
+  /**
+   * @default undefined
+   */
+  value: undefined;
+
+  /**
+   * @default undefined
+   */
+  onchange: undefined;
+};
+
+export default class RunesInternalNoleak extends SvelteComponentTyped<
+  RunesInternalNoleakProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-internal-noleak/output.json
+++ b/tests/fixtures/runes-internal-noleak/output.json
@@ -1,0 +1,76 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 21,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    },
+    {
+      "name": "onchange",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-internal-noleak/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "value",
+      "message": "Prop \"value\" type could not be inferred; falling back to \"any\"."
+    },
+    {
+      "component": "runes-internal-noleak/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "onchange",
+      "message": "Prop \"onchange\" type could not be inferred; falling back to \"any\"."
+    }
+  ]
+}

--- a/tests/fixtures/runes-props-html-intersection/input.svelte
+++ b/tests/fixtures/runes-props-html-intersection/input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { HTMLButtonAttributes } from "svelte/elements";
+
+  let { variant = "primary", ...rest }: { variant?: "primary" | "secondary" } & HTMLButtonAttributes = $props();
+</script>
+
+<button
+  class={variant}
+  {...rest}
+></button>

--- a/tests/fixtures/runes-props-html-intersection/output.d.ts
+++ b/tests/fixtures/runes-props-html-intersection/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+import type { HTMLButtonAttributes, SvelteHTMLElements } from "svelte/elements";
+
+type $RestProps = SvelteHTMLElements["button"];
+
+type $Props = ({ variant?: "primary" | "secondary" } & HTMLButtonAttributes) & {
+  [key: `data-${string}`]: unknown;
+};
+
+export type RunesPropsHtmlIntersectionProps = Omit<$RestProps, keyof $Props> & $Props;
+
+export default class RunesPropsHtmlIntersection extends SvelteComponentTyped<
+  RunesPropsHtmlIntersectionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-props-html-intersection/output.json
+++ b/tests/fixtures/runes-props-html-intersection/output.json
@@ -1,0 +1,54 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "variant",
+      "kind": "let",
+      "type": "\"primary\" | \"secondary\"",
+      "typeSource": "typescript",
+      "value": "\"primary\"",
+      "defaultValue": {
+        "raw": "\"primary\"",
+        "kind": "literal",
+        "value": "primary"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "rest_props": {
+    "type": "Element",
+    "name": "button"
+  },
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-props-id-default/input.svelte
+++ b/tests/fixtures/runes-props-id-default/input.svelte
@@ -1,0 +1,6 @@
+<script>
+  let { label } = $props();
+  let id = $props.id();
+</script>
+
+<div data-id={id}>{label}</div>

--- a/tests/fixtures/runes-props-id-default/output.d.ts
+++ b/tests/fixtures/runes-props-id-default/output.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesPropsIdDefaultProps = {
+  /**
+   * @default undefined
+   */
+  label: undefined;
+};
+
+export default class RunesPropsIdDefault extends SvelteComponentTyped<
+  RunesPropsIdDefaultProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-props-id-default/output.json
+++ b/tests/fixtures/runes-props-id-default/output.json
@@ -1,0 +1,50 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-props-id-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "label",
+      "message": "Prop \"label\" type could not be inferred; falling back to \"any\"."
+    }
+  ]
+}

--- a/tests/fixtures/runes-snippet-generic-tuple/input.svelte
+++ b/tests/fixtures/runes-snippet-generic-tuple/input.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  /**
+   * @generics {Row} Row
+   */
+
+  let {
+    rows,
+    children,
+  }: {
+    rows: Row[];
+    children: Snippet<[row: Row, index: number]>;
+  } = $props();
+</script>
+
+<ul>
+  {#each rows as row, index}
+    <li>{@render children(row, index)}</li>
+  {/each}
+</ul>

--- a/tests/fixtures/runes-snippet-generic-tuple/output.d.ts
+++ b/tests/fixtures/runes-snippet-generic-tuple/output.d.ts
@@ -1,0 +1,15 @@
+import type { Snippet } from "svelte";
+import { SvelteComponentTyped } from "svelte";
+
+type $Props<Row> = {
+  rows: Row[];
+  children: Snippet<[row: Row, index: number]>;
+};
+
+export type RunesSnippetGenericTupleProps<Row> = $Props<Row>;
+
+export default class RunesSnippetGenericTuple<Row> extends SvelteComponentTyped<
+  RunesSnippetGenericTupleProps<Row>,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-snippet-generic-tuple/output.json
+++ b/tests/fixtures/runes-snippet-generic-tuple/output.json
@@ -1,0 +1,47 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "Row[]",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row",
+    "Row"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-uncontrolled-state-prop/input.svelte
+++ b/tests/fixtures/runes-uncontrolled-state-prop/input.svelte
@@ -1,0 +1,6 @@
+<script>
+  let { count: initialCount = 0 } = $props();
+  let count = $state(initialCount);
+</script>
+
+<button onclick={() => count++}>{count}</button>

--- a/tests/fixtures/runes-uncontrolled-state-prop/output.d.ts
+++ b/tests/fixtures/runes-uncontrolled-state-prop/output.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesUncontrolledStatePropProps = {
+  /**
+   * @default 0
+   */
+  count?: number;
+};
+
+export default class RunesUncontrolledStateProp extends SvelteComponentTyped<
+  RunesUncontrolledStatePropProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-uncontrolled-state-prop/output.json
+++ b/tests/fixtures/runes-uncontrolled-state-prop/output.json
@@ -1,0 +1,51 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "count",
+      "localName": "initialCount",
+      "kind": "let",
+      "type": "number",
+      "typeSource": "default",
+      "value": "0",
+      "defaultValue": {
+        "raw": "0",
+        "kind": "literal",
+        "value": 0
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 31
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
## Summary

Expands runes fixture coverage for gaps identified in Svelte 5's public-API surface (attachments, `$props.id()`, internal-rune leakage, snippet/generics combos), and fixes a real detection gap found along the way.

## New fixture coverage

### Attachments (`svelte/attachments`)

Previously untested. Covers a basic `Attachment` prop, a generic `Attachment<T>`, an array of attachments, and a callback prop that returns an `Attachment`:

```svelte
<script lang="ts">
  import type { Attachment } from "svelte/attachments";
  let { onmount }: { onmount?: Attachment } = $props();
</script>
<div {@attach onmount}>content</div>
```

### Internal runes and prop defaults

- `$props.id()` used alongside real props
- The "uncontrolled prop mirrored into `$state`" idiom:
  ```js
  let { count: initialCount = 0 } = $props();
  let count = $state(initialCount);
  ```
- A prop default referencing a `$derived` local
- `$derived`, `$derived.by`, `$effect`, `$effect.pre`, and `$inspect().with(...)` mixed with real props, confirming none of it leaks into the public props/events API

### Combinations

- `Snippet<[Row, index]>` tuple type paired with `@generics`
- The common `{ variant } & HTMLButtonAttributes` rest-props wrapper pattern

## Fix: `$host().dispatchEvent(...)` not recognized as an event

Custom-element components that dispatch real DOM events via `$host()` previously produced no event entries at all:

```svelte
<svelte:options customElement="my-widget" />
<script>
  function notify() {
    $host().dispatchEvent(new CustomEvent("notify", { detail: value }));
  }
</script>
```

This now detects the event the same way `createEventDispatcher()` dispatches are detected, both inline (`$host().dispatchEvent(...)`) and via a local variable (`const host = $host(); host.dispatchEvent(...)`).

Fixing this surfaced a shared bug: a string-literal dispatch detail (e.g. `dispatch("status", "done")`) rendered as an unquoted, invalid type reference (`CustomEvent<done>`) instead of a quoted string-literal type (`CustomEvent<"done">`). Fixed for both the `createEventDispatcher()` and `$host()` paths, with a dedicated regression fixture.

## Test plan

- [x] `bun test` (629 tests pass)
- [x] `bun run test:fixtures-types` (generated `.d.ts` type-checks)
- [x] `bun run lint`
- [x] `bun run typecheck`