### PR TITLE
fix(cli): exit non-zero when the CLI crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Removed props, events, or slots, and props that become required, are breaking (`
 
 Use `--check=<path>` to diff against a snapshot at a custom location (defaults to `jsonOptions.outFile`, or `COMPONENT_API.json`).
 
+The CLI exits non-zero on any fatal error (an unreadable entry, a config file that throws, etc.), not just on `--strict`/`--check` findings, so it's safe to use either flag as a CI gate.
+
 ### Node.js
 
 You can also call `sveld` from Node.js. The package is **ESM-only**; `require("sveld")` does not work. Use `import` or dynamic `import()`.

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,8 @@
       "!!**/.svelte-kit/**/*",
       "!!**/tests/e2e/**/*.svelte",
       "!!**/tests/e2e/**/*.d.ts",
-      "!!**/tests/e2e/**/*.json"
+      "!!**/tests/e2e/**/*.json",
+      "!!**/tests/e2e/cli-crash/**/*"
     ]
   },
   "formatter": {

--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-import("./lib/index.js").then(({ cli }) => cli(process)).catch(console.error);
+import("./lib/index.js")
+  .then(({ cli }) => cli(process))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/tests/e2e/cli-crash/sveld.config.js
+++ b/tests/e2e/cli-crash/sveld.config.js
@@ -1,0 +1,2 @@
+export default {
+  glob: true,

--- a/tests/test-e2e.ts
+++ b/tests/test-e2e.ts
@@ -23,6 +23,22 @@ for await (const dir of $`find tests/e2e -maxdepth 1`.lines()) {
   }
 }
 
+// Smoke-test the published bin shim: a config file that throws while
+// loading must exit non-zero (see cli.js's rejection handler), otherwise
+// CI gates using --strict or --check would pass silently on a crash.
+const cliPath = `${import.meta.dir}/../cli.js`;
+const crashResult = Bun.spawnSync(["node", cliPath], {
+  cwd: `${import.meta.dir}/e2e/cli-crash`,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+const crashStderr = crashResult.stderr.toString();
+
+if (crashResult.exitCode !== 1 || !crashStderr.includes("sveld.config.js")) {
+  console.error("CLI crash smoke test failed. exitCode:", crashResult.exitCode, "stderr:", crashStderr);
+  hasError = true;
+}
+
 if (hasError) {
   process.exit(1);
 }


### PR DESCRIPTION
The published bin shim (cli.js) caught any rejection from cli() with .catch(console.error), which printed the error but left the process exit code at 0. A config file that throws while loading, an unreadable entry, or a --fail-fast parse failure would all print to stderr and still exit clean, so any CI pipeline gating on sveld --strict or sveld --check would pass silently on a crash.

This sets process.exitCode = 1 in the shim's rejection handler (not process.exit, so pending stream writes still flush) and keeps the file minimal and dependency-free as before. I also audited cli() in src/cli.ts and loadConfig in src/load-config.ts to confirm no internal path swallows an error without setting the exit code; everything either propagates uncaught or explicitly sets process.exitCode already.

Coverage lives in the e2e harness since it already builds before running: tests/test-e2e.ts now spawns the built cli.js against a new fixture, tests/e2e/cli-crash/sveld.config.js, which has a deliberate syntax error, and asserts the process exits 1 with stderr mentioning the config file. Also added a line to the README noting the CLI's non-zero exit guarantee for CI gates.

Risk is low and localized to the bin shim and test harness; the only behavior change is that fatal errors now produce exit code 1 instead of 0, which is the intended fix rather than a regression risk for any caller that was already checking cli.js's exit code correctly.