### PR TITLE
feat(diagnostics): attach source positions to diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Needs `typescript` and a `tsconfig.json`, same as `resolveTypes`. Use `--strict`
 
 #### Type inference diagnostics
 
-`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`.
+`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`. Each diagnostic carries an optional `source` range (the same `{ start: { line, column }, end: { line, column } }` shape as JSON output source ranges) whenever the parser holds a stable position for it.
 
 With `reportDiagnostics` or `strict`, the grouped summary looks like this:
 
@@ -265,16 +265,16 @@ sveld: 4 unresolved types found.
 
 Props without inferred types (1):
   ./icons/Add.svelte
-    - Prop "title" type could not be inferred; falling back to "any".
+    - Prop "title" type could not be inferred; falling back to "any". (./icons/Add.svelte:4:2)
 
 Context values typed as `any` (1):
   ./ThemeProvider.svelte
-    - Context "theme" variable "themeStore" has no type annotation; defaulted to "any".
+    - Context "theme" variable "themeStore" has no type annotation; defaulted to "any". (./ThemeProvider.svelte:8:6)
 
 @event tags with no dispatch or callback (2):
   ./Modal.svelte
-    - @event "open" has no matching dispatch or callback prop.
-    - @event "close" has no matching dispatch or callback prop.
+    - @event "open" has no matching dispatch or callback prop. (./Modal.svelte:3:5)
+    - @event "close" has no matching dispatch or callback prop. (./Modal.svelte:4:5)
 ```
 
 When `checkExamples` is also enabled, `@example` compile failures appear as a fourth group:

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -2269,6 +2269,7 @@ export default class ComponentParser {
           "prop-unknown-type",
           prop.name,
           `Prop "${prop.name}" type could not be inferred; falling back to "${prop.type ?? "any"}".`,
+          prop.source,
         );
       }
     }
@@ -2286,6 +2287,7 @@ export default class ComponentParser {
         "event-no-source",
         eventName,
         `@event "${eventName}" has no matching dispatch or callback prop.`,
+        this.ctx.jsDocEventSources.get(eventName),
       );
     }
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -551,17 +551,21 @@ async function checkComponentExamples(
       })),
     );
 
-    for (const { component } of candidates) {
+    for (const { component, sources } of candidates) {
       const found = diagnosticsByModule.get(component.moduleName);
       if (!found || found.length === 0) continue;
 
+      const sourceById = new Map(sources.map((source) => [source.id, source.source]));
+
       const diagnostics = component.diagnostics ?? [];
       for (const item of found) {
+        const source = sourceById.get(item.id);
         diagnostics.push({
           component: component.filePath,
           kind: "example-compile-error",
           name: item.name,
           message: item.message,
+          ...(source ? { source } : {}),
         });
       }
       component.diagnostics = diagnostics;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,3 +1,5 @@
+import type { SourceRange } from "./ComponentParser";
+
 /**
  * Why sveld could not pin a type during parsing.
  *
@@ -23,6 +25,8 @@ export interface SveldDiagnostic {
   name: string;
   /** What went wrong and what type sveld used. */
   message: string;
+  /** Where in the component source this diagnostic points, when the parser holds a stable position. */
+  source?: SourceRange;
 }
 
 const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
@@ -86,7 +90,10 @@ export function formatDiagnosticsSummary(diagnostics: SveldDiagnostic[]): string
     for (const [component, group] of byComponent) {
       lines.push(`  ${component}`);
       for (const diagnostic of group) {
-        lines.push(`    - ${diagnostic.message}`);
+        const location = diagnostic.source
+          ? ` (${component}:${diagnostic.source.start.line}:${diagnostic.source.start.column})`
+          : "";
+        lines.push(`    - ${diagnostic.message}${location}`);
       }
     }
   }

--- a/src/example-check.ts
+++ b/src/example-check.ts
@@ -1,4 +1,4 @@
-import type { ComponentProp, ComponentSlot, ParsedComponent } from "./ComponentParser";
+import type { ComponentProp, ComponentSlot, ParsedComponent, SourceRange } from "./ComponentParser";
 
 /**
  * One `@example` block worth type-checking, reduced to what `resolve-types.ts`
@@ -13,6 +13,8 @@ export interface ExampleCheckSource {
   type: string;
   /** The `@example` body, stripped of any surrounding code fence. */
   code: string;
+  /** Source range of the documented symbol (prop/export/slot/event), when available. */
+  source?: SourceRange;
 }
 
 const FENCE_REGEX = /^```([\w-]*)\r?\n([\s\S]*?)\r?\n?```$/;
@@ -54,6 +56,7 @@ function sourcesFromTags(
   idPrefix: string,
   name: string,
   type: string,
+  source: SourceRange | undefined,
 ): ExampleCheckSource[] {
   const examples = (tags ?? []).filter((tag) => tag.name === "example");
   const sources: ExampleCheckSource[] = [];
@@ -67,6 +70,7 @@ function sourcesFromTags(
       name: numbered ? `${name} (example ${index + 1})` : name,
       type,
       code,
+      ...(source ? { source } : {}),
     });
   });
 
@@ -87,7 +91,7 @@ export function collectExampleSources(component: ParsedComponent): ExampleCheckS
   const sources: ExampleCheckSource[] = [];
 
   for (const prop of component.props) {
-    sources.push(...sourcesFromTags(prop.tags, `prop:${prop.name}`, prop.name, typeForProp(prop)));
+    sources.push(...sourcesFromTags(prop.tags, `prop:${prop.name}`, prop.name, typeForProp(prop), prop.source));
   }
 
   for (const moduleExport of component.moduleExports) {
@@ -97,16 +101,17 @@ export function collectExampleSources(component: ParsedComponent): ExampleCheckS
         `export:${moduleExport.name}`,
         moduleExport.name,
         typeForProp(moduleExport),
+        moduleExport.source,
       ),
     );
   }
 
   for (const slot of component.slots) {
-    sources.push(...sourcesFromTags(slot.tags, `slot:${slotName(slot)}`, slotName(slot), "any"));
+    sources.push(...sourcesFromTags(slot.tags, `slot:${slotName(slot)}`, slotName(slot), "any", slot.source));
   }
 
   for (const event of component.events) {
-    sources.push(...sourcesFromTags(event.tags, `event:${event.name}`, event.name, "any"));
+    sources.push(...sourcesFromTags(event.tags, `event:${event.name}`, event.name, "any", event.source));
   }
 
   return sources;

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -150,6 +150,9 @@ export interface ParserContext {
   /** `@event` names from JSDoc, checked against dispatches at end of parse. */
   readonly jsDocEventNames: Set<string>;
 
+  /** Source range of each `@event` JSDoc tag, keyed by event name, for `event-no-source` diagnostics. */
+  readonly jsDocEventSources: Map<string, SourceRange | undefined>;
+
   // --- contexts/bindings ---
 
   /** Map of prop bindings (e.g., `bind:value`) keyed by prop name */
@@ -218,6 +221,7 @@ export function createParserContext(): ParserContext {
     eventDescriptions: new Map(),
     forwardedEvents: new Map(),
     jsDocEventNames: new Set(),
+    jsDocEventSources: new Map(),
 
     // contexts/bindings
     bindings: new Map(),

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -6,6 +6,7 @@ import type { ComponentContext, ComponentContextProp } from "../ComponentParser"
 import type { ParserContext } from "./context";
 import { recordDiagnostic } from "./diagnostics";
 import { resolveConstInitializer } from "./props";
+import { sourceRangeFromNode } from "./source-position";
 
 /** Split a `setContext` key on `-`, `_`, `.`, `:`, `/`, or whitespace for PascalCase naming. */
 const CONTEXT_KEY_SPLIT_REGEX = /[-_.:/\s]+/;
@@ -54,6 +55,7 @@ export function parseContextValue(
             "context-any-type",
             propName,
             `Context "${key}" property "${propName}" has no type annotation; defaulted to "any".`,
+            sourceRangeFromNode(ctx, prop),
           );
           if (parser.options?.verbose) {
             console.warn(`Warning: Context "${key}" property "${propName}" has no type annotation. Using "any".`);
@@ -118,6 +120,7 @@ export function parseContextValue(
       "context-any-type",
       varName,
       `Context "${key}" variable "${varName}" has no type annotation; defaulted to "any".`,
+      sourceRangeFromNode(ctx, node),
     );
     if (parser.options?.verbose) {
       console.warn(`Warning: Context "${key}" variable "${varName}" has no type annotation. Using "any".`);

--- a/src/parser/diagnostics.ts
+++ b/src/parser/diagnostics.ts
@@ -1,3 +1,4 @@
+import type { SourceRange } from "../ComponentParser";
 import type { SveldDiagnosticKind } from "../diagnostics";
 import type { ParserContext } from "./context";
 
@@ -5,11 +6,18 @@ import type { ParserContext } from "./context";
  * Appends a diagnostic (a place sveld had to guess a type) to `ctx.diagnosticRecords`,
  * tagged with the file path of the component currently being parsed.
  */
-export function recordDiagnostic(ctx: ParserContext, kind: SveldDiagnosticKind, name: string, message: string) {
+export function recordDiagnostic(
+  ctx: ParserContext,
+  kind: SveldDiagnosticKind,
+  name: string,
+  message: string,
+  source?: SourceRange,
+) {
   ctx.diagnosticRecords.push({
     component: ctx.componentFilePath,
     kind,
     name,
     message,
+    ...(source ? { source } : {}),
   });
 }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -502,6 +502,7 @@ export function parseCustomTypes(ctx: ParserContext, parser: ComponentParser) {
         });
         ctx.eventDescriptions.set(currentEventName, currentEventDescription);
         ctx.jsDocEventNames.add(currentEventName);
+        ctx.jsDocEventSources.set(currentEventName, currentEventSource);
         eventProperties.length = 0;
         currentEventName = undefined;
         currentEventType = undefined;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -211,7 +211,17 @@ exports[`fixtures (JSON) "slot-event-template-prop-reference/input.svelte" 1`] =
       "component": "slot-event-template-prop-reference/input.svelte",
       "kind": "event-no-source",
       "name": "select",
-      "message": "@event \\"select\\" has no matching dispatch or callback prop."
+      "message": "@event \\"select\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 25
+        }
+      }
     }
   ]
 }
@@ -742,13 +752,33 @@ exports[`fixtures (JSON) "module-reexport-mixed/input.svelte" 1`] = `
       "component": "module-reexport-mixed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "name",
-      "message": "Prop \\"name\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"name\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 27,
+          "column": 2
+        },
+        "end": {
+          "line": 27,
+          "column": 18
+        }
+      }
     },
     {
       "component": "module-reexport-mixed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 30,
+          "column": 2
+        },
+        "end": {
+          "line": 30,
+          "column": 26
+        }
+      }
     }
   ]
 }
@@ -1147,13 +1177,33 @@ exports[`fixtures (JSON) "runes-dispatched-events/input.svelte" 1`] = `
       "component": "runes-dispatched-events/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     },
     {
       "component": "runes-dispatched-events/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onchange",
-      "message": "Prop \\"onchange\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"onchange\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
     }
   ]
 }
@@ -1258,7 +1308,17 @@ exports[`fixtures (JSON) "module-reexport/input.svelte" 1`] = `
       "component": "module-reexport/input.svelte",
       "kind": "prop-unknown-type",
       "name": "data",
-      "message": "Prop \\"data\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"data\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 2
+        },
+        "end": {
+          "line": 12,
+          "column": 25
+        }
+      }
     }
   ]
 }
@@ -1374,7 +1434,17 @@ exports[`fixtures (JSON) "resolve-default-chained/input.svelte" 1`] = `
       "component": "resolve-default-chained/input.svelte",
       "kind": "prop-unknown-type",
       "name": "deep6",
-      "message": "Prop \\"deep6\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"deep6\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 2
+        },
+        "end": {
+          "line": 25,
+          "column": 28
+        }
+      }
     }
   ]
 }
@@ -2290,13 +2360,33 @@ exports[`fixtures (JSON) "prop-metadata-consolidated/input.svelte" 1`] = `
       "component": "prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "callDefault",
-      "message": "Prop \\"callDefault\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"callDefault\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 2
+        },
+        "end": {
+          "line": 21,
+          "column": 41
+        }
+      }
     },
     {
       "component": "prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "unknown",
-      "message": "Prop \\"unknown\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"unknown\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 29,
+          "column": 2
+        },
+        "end": {
+          "line": 29,
+          "column": 21
+        }
+      }
     }
   ]
 }
@@ -2686,7 +2776,17 @@ exports[`fixtures (JSON) "legacy-bind-component-ref-forward/input.svelte" 1`] = 
       "component": "legacy-bind-component-ref-forward/input.svelte",
       "kind": "prop-unknown-type",
       "name": "listRef",
-      "message": "Prop \\"listRef\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"listRef\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 28
+        }
+      }
     }
   ]
 }
@@ -2735,7 +2835,17 @@ exports[`fixtures (JSON) "dispatched-events-dynamic/input.svelte" 1`] = `
       "component": "dispatched-events-dynamic/input.svelte",
       "kind": "event-no-source",
       "name": "KEY",
-      "message": "@event \\"KEY\\" has no matching dispatch or callback prop."
+      "message": "@event \\"KEY\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 32
+        }
+      }
     }
   ]
 }
@@ -4206,25 +4316,65 @@ exports[`fixtures (JSON) "typedef-event-shared-block/input.svelte" 1`] = `
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "resize",
-      "message": "@event \\"resize\\" has no matching dispatch or callback prop."
+      "message": "@event \\"resize\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 20,
+          "column": 6
+        },
+        "end": {
+          "line": 20,
+          "column": 19
+        }
+      }
     },
     {
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "scroll",
-      "message": "@event \\"scroll\\" has no matching dispatch or callback prop."
+      "message": "@event \\"scroll\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 20,
+          "column": 7
+        },
+        "end": {
+          "line": 20,
+          "column": 20
+        }
+      }
     },
     {
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "queue",
-      "message": "@event \\"queue\\" has no matching dispatch or callback prop."
+      "message": "@event \\"queue\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 31,
+          "column": 7
+        },
+        "end": {
+          "line": 32,
+          "column": 12
+        }
+      }
     },
     {
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "dequeue",
-      "message": "@event \\"dequeue\\" has no matching dispatch or callback prop."
+      "message": "@event \\"dequeue\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 31,
+          "column": 9
+        },
+        "end": {
+          "line": 32,
+          "column": 1
+        }
+      }
     }
   ]
 }
@@ -4505,7 +4655,17 @@ exports[`fixtures (JSON) "theme-component/input.svelte" 1`] = `
       "component": "theme-component/input.svelte",
       "kind": "event-no-source",
       "name": "update",
-      "message": "@event \\"update\\" has no matching dispatch or callback prop."
+      "message": "@event \\"update\\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 26,
+          "column": 8
+        },
+        "end": {
+          "line": 26,
+          "column": 21
+        }
+      }
     }
   ]
 }
@@ -5307,13 +5467,33 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
       "component": "infer-basic/input.svelte",
       "kind": "prop-unknown-type",
       "name": "ref",
-      "message": "Prop \\"ref\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"ref\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      }
     },
     {
       "component": "infer-basic/input.svelte",
       "kind": "prop-unknown-type",
       "name": "name",
-      "message": "Prop \\"name\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"name\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 18
+        }
+      }
     }
   ]
 }
@@ -5498,7 +5678,17 @@ exports[`fixtures (JSON) "runes-props-basic/input.svelte" 1`] = `
       "component": "runes-props-basic/input.svelte",
       "kind": "prop-unknown-type",
       "name": "title",
-      "message": "Prop \\"title\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"title\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     }
   ]
 }
@@ -5606,7 +5796,17 @@ exports[`fixtures (JSON) "runes-derived-prop-default/input.svelte" 1`] = `
       "component": "runes-derived-prop-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "label",
-      "message": "Prop \\"label\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"label\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 28
+        }
+      }
     }
   ]
 }
@@ -5912,7 +6112,17 @@ exports[`fixtures (JSON) "module-reexport-direct/input.svelte" 1`] = `
       "component": "module-reexport-direct/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onReady",
-      "message": "Prop \\"onReady\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"onReady\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 21
+        }
+      }
     }
   ]
 }
@@ -6171,7 +6381,17 @@ exports[`fixtures (JSON) "runes-snippets-named/input.svelte" 1`] = `
       "component": "runes-snippets-named/input.svelte",
       "kind": "prop-unknown-type",
       "name": "item",
-      "message": "Prop \\"item\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"item\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 12
+        }
+      }
     }
   ]
 }
@@ -6907,13 +7127,33 @@ exports[`fixtures (JSON) "runes-snippet-description-hyphens/input.svelte" 1`] = 
       "component": "runes-snippet-description-hyphens/input.svelte",
       "kind": "prop-unknown-type",
       "name": "row",
-      "message": "Prop \\"row\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"row\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 8
+        },
+        "end": {
+          "line": 7,
+          "column": 11
+        }
+      }
     },
     {
       "component": "runes-snippet-description-hyphens/input.svelte",
       "kind": "prop-unknown-type",
       "name": "col",
-      "message": "Prop \\"col\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"col\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 13
+        },
+        "end": {
+          "line": 7,
+          "column": 16
+        }
+      }
     }
   ]
 }
@@ -7182,13 +7422,33 @@ exports[`fixtures (JSON) "runes-internal-noleak/input.svelte" 1`] = `
       "component": "runes-internal-noleak/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     },
     {
       "component": "runes-internal-noleak/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onchange",
-      "message": "Prop \\"onchange\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"onchange\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
     }
   ]
 }
@@ -8089,19 +8349,49 @@ exports[`fixtures (JSON) "runes-prop-metadata-consolidated/input.svelte" 1`] = `
       "component": "runes-prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "open",
-      "message": "Prop \\"open\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"open\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 22
+        }
+      }
     },
     {
       "component": "runes-prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "computed",
-      "message": "Prop \\"computed\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"computed\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 4
+        },
+        "end": {
+          "line": 13,
+          "column": 30
+        }
+      }
     },
     {
       "component": "runes-prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "bare",
-      "message": "Prop \\"bare\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"bare\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 8
+        }
+      }
     }
   ]
 }
@@ -9401,7 +9691,17 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
       "component": "required/input.svelte",
       "kind": "prop-unknown-type",
       "name": "prop2",
-      "message": "Prop \\"prop2\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"prop2\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 2
+        },
+        "end": {
+          "line": 14,
+          "column": 19
+        }
+      }
     }
   ]
 }
@@ -10580,7 +10880,17 @@ exports[`fixtures (JSON) "bindable-direction-legacy/input.svelte" 1`] = `
       "component": "bindable-direction-legacy/input.svelte",
       "kind": "prop-unknown-type",
       "name": "size",
-      "message": "Prop \\"size\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"size\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 30
+        }
+      }
     }
   ]
 }
@@ -11031,7 +11341,17 @@ exports[`fixtures (JSON) "runes-callback-props/input.svelte" 1`] = `
       "component": "runes-callback-props/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onclick",
-      "message": "Prop \\"onclick\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"onclick\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
+      }
     }
   ]
 }
@@ -11557,7 +11877,17 @@ exports[`fixtures (JSON) "non-literal-defaults/input.svelte" 1`] = `
       "component": "non-literal-defaults/input.svelte",
       "kind": "prop-unknown-type",
       "name": "handler",
-      "message": "Prop \\"handler\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"handler\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 64,
+          "column": 2
+        },
+        "end": {
+          "line": 64,
+          "column": 33
+        }
+      }
     }
   ]
 }
@@ -11766,7 +12096,17 @@ exports[`fixtures (JSON) "runes-props-renamed/input.svelte" 1`] = `
       "component": "runes-props-renamed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "class",
-      "message": "Prop \\"class\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"class\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 20
+        }
+      }
     }
   ]
 }
@@ -11934,7 +12274,17 @@ exports[`fixtures (JSON) "runes-snippets-default/input.svelte" 1`] = `
       "component": "runes-snippets-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "item",
-      "message": "Prop \\"item\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"item\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 12
+        }
+      }
     }
   ]
 }
@@ -13887,7 +14237,17 @@ exports[`fixtures (JSON) "bindable-direction-runes/input.svelte" 1`] = `
       "component": "bindable-direction-runes/input.svelte",
       "kind": "prop-unknown-type",
       "name": "size",
-      "message": "Prop \\"size\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"size\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 4
+        },
+        "end": {
+          "line": 7,
+          "column": 20
+        }
+      }
     }
   ]
 }
@@ -14563,7 +14923,17 @@ exports[`fixtures (JSON) "runes-host-custom-element/input.svelte" 1`] = `
       "component": "runes-host-custom-element/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"value\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
     }
   ]
 }
@@ -14669,7 +15039,17 @@ exports[`fixtures (JSON) "runes-props-id-default/input.svelte" 1`] = `
       "component": "runes-props-id-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "label",
-      "message": "Prop \\"label\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"label\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     }
   ]
 }
@@ -14727,7 +15107,17 @@ exports[`fixtures (JSON) "runes-rest-props/input.svelte" 1`] = `
       "component": "runes-rest-props/input.svelte",
       "kind": "prop-unknown-type",
       "name": "variant",
-      "message": "Prop \\"variant\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"variant\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
+      }
     }
   ]
 }
@@ -15110,7 +15500,17 @@ exports[`fixtures (JSON) "legacy-bind-component-ref/input.svelte" 1`] = `
       "component": "legacy-bind-component-ref/input.svelte",
       "kind": "prop-unknown-type",
       "name": "ref",
-      "message": "Prop \\"ref\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"ref\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      }
     }
   ]
 }
@@ -16356,7 +16756,17 @@ exports[`fixtures (JSON) "typed-props/input.svelte" 1`] = `
       "component": "typed-props/input.svelte",
       "kind": "prop-unknown-type",
       "name": "prop2",
-      "message": "Prop \\"prop2\\" type could not be inferred; falling back to \\"any\\"."
+      "message": "Prop \\"prop2\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 26
+        }
+      }
     }
   ]
 }

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -38,6 +38,7 @@ describe("ComponentParser diagnostics", () => {
       name: "value",
     });
     expect(typeof propDiagnostic?.message).toBe("string");
+    expect(propDiagnostic?.source?.start.line).toBe(3);
   });
 
   test("flags setContext values that default to any", () => {
@@ -112,6 +113,15 @@ describe("diagnostics helpers", () => {
     expect(deduped.map((d) => d.name)).toEqual(["value", "other"]);
   });
 
+  test("dedupeDiagnostics collapses records that differ only in source", () => {
+    const withSource = make({ source: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } } });
+    const withoutSource = make({});
+
+    const deduped = dedupeDiagnostics([withSource, withoutSource]);
+
+    expect(deduped).toHaveLength(1);
+  });
+
   test("formatDiagnosticsSummary reports a clean run", () => {
     expect(formatDiagnosticsSummary([])).toBe("sveld: all types resolved.");
   });
@@ -127,6 +137,24 @@ describe("diagnostics helpers", () => {
     expect(summary).toContain("@event tags with no dispatch or callback (1):");
     expect(summary).toContain("prop fallback");
     expect(summary).toContain("event fallback");
+  });
+
+  test("formatDiagnosticsSummary appends the position when source is present", () => {
+    const summary = formatDiagnosticsSummary([
+      make({
+        message: "prop fallback",
+        source: { start: { line: 4, column: 2 }, end: { line: 4, column: 10 } },
+      }),
+    ]);
+
+    expect(summary).toContain("prop fallback (./A.svelte:4:2)");
+  });
+
+  test("formatDiagnosticsSummary omits the position when source is absent", () => {
+    const summary = formatDiagnosticsSummary([make({ message: "prop fallback" })]);
+
+    expect(summary).toContain("- prop fallback");
+    expect(summary).not.toContain("prop fallback (");
   });
 });
 

--- a/tests/fixtures/bindable-direction-legacy/output.json
+++ b/tests/fixtures/bindable-direction-legacy/output.json
@@ -108,7 +108,17 @@
       "component": "bindable-direction-legacy/input.svelte",
       "kind": "prop-unknown-type",
       "name": "size",
-      "message": "Prop \"size\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"size\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 30
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/bindable-direction-runes/output.json
+++ b/tests/fixtures/bindable-direction-runes/output.json
@@ -109,7 +109,17 @@
       "component": "bindable-direction-runes/input.svelte",
       "kind": "prop-unknown-type",
       "name": "size",
-      "message": "Prop \"size\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"size\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 4
+        },
+        "end": {
+          "line": 7,
+          "column": 20
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/dispatched-events-dynamic/output.json
+++ b/tests/fixtures/dispatched-events-dynamic/output.json
@@ -39,7 +39,17 @@
       "component": "dispatched-events-dynamic/input.svelte",
       "kind": "event-no-source",
       "name": "KEY",
-      "message": "@event \"KEY\" has no matching dispatch or callback prop."
+      "message": "@event \"KEY\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 32
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -217,13 +217,33 @@
       "component": "infer-basic/input.svelte",
       "kind": "prop-unknown-type",
       "name": "ref",
-      "message": "Prop \"ref\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"ref\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      }
     },
     {
       "component": "infer-basic/input.svelte",
       "kind": "prop-unknown-type",
       "name": "name",
-      "message": "Prop \"name\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"name\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 18
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/legacy-bind-component-ref-forward/output.json
+++ b/tests/fixtures/legacy-bind-component-ref-forward/output.json
@@ -50,7 +50,17 @@
       "component": "legacy-bind-component-ref-forward/input.svelte",
       "kind": "prop-unknown-type",
       "name": "listRef",
-      "message": "Prop \"listRef\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"listRef\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 28
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/legacy-bind-component-ref/output.json
+++ b/tests/fixtures/legacy-bind-component-ref/output.json
@@ -50,7 +50,17 @@
       "component": "legacy-bind-component-ref/input.svelte",
       "kind": "prop-unknown-type",
       "name": "ref",
-      "message": "Prop \"ref\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"ref\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/module-reexport-direct/output.json
+++ b/tests/fixtures/module-reexport-direct/output.json
@@ -106,7 +106,17 @@
       "component": "module-reexport-direct/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onReady",
-      "message": "Prop \"onReady\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"onReady\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 21
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/module-reexport-mixed/output.json
+++ b/tests/fixtures/module-reexport-mixed/output.json
@@ -149,13 +149,33 @@
       "component": "module-reexport-mixed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "name",
-      "message": "Prop \"name\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"name\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 27,
+          "column": 2
+        },
+        "end": {
+          "line": 27,
+          "column": 18
+        }
+      }
     },
     {
       "component": "module-reexport-mixed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \"value\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"value\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 30,
+          "column": 2
+        },
+        "end": {
+          "line": 30,
+          "column": 26
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/module-reexport/output.json
+++ b/tests/fixtures/module-reexport/output.json
@@ -95,7 +95,17 @@
       "component": "module-reexport/input.svelte",
       "kind": "prop-unknown-type",
       "name": "data",
-      "message": "Prop \"data\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"data\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 2
+        },
+        "end": {
+          "line": 12,
+          "column": 25
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/non-literal-defaults/output.json
+++ b/tests/fixtures/non-literal-defaults/output.json
@@ -355,7 +355,17 @@
       "component": "non-literal-defaults/input.svelte",
       "kind": "prop-unknown-type",
       "name": "handler",
-      "message": "Prop \"handler\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"handler\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 64,
+          "column": 2
+        },
+        "end": {
+          "line": 64,
+          "column": 33
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/prop-metadata-consolidated/output.json
+++ b/tests/fixtures/prop-metadata-consolidated/output.json
@@ -310,13 +310,33 @@
       "component": "prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "callDefault",
-      "message": "Prop \"callDefault\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"callDefault\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 2
+        },
+        "end": {
+          "line": 21,
+          "column": 41
+        }
+      }
     },
     {
       "component": "prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "unknown",
-      "message": "Prop \"unknown\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"unknown\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 29,
+          "column": 2
+        },
+        "end": {
+          "line": 29,
+          "column": 21
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/required/output.json
+++ b/tests/fixtures/required/output.json
@@ -137,7 +137,17 @@
       "component": "required/input.svelte",
       "kind": "prop-unknown-type",
       "name": "prop2",
-      "message": "Prop \"prop2\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"prop2\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 2
+        },
+        "end": {
+          "line": 14,
+          "column": 19
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/resolve-default-chained/output.json
+++ b/tests/fixtures/resolve-default-chained/output.json
@@ -106,7 +106,17 @@
       "component": "resolve-default-chained/input.svelte",
       "kind": "prop-unknown-type",
       "name": "deep6",
-      "message": "Prop \"deep6\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"deep6\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 25,
+          "column": 2
+        },
+        "end": {
+          "line": 25,
+          "column": 28
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-callback-props/output.json
+++ b/tests/fixtures/runes-callback-props/output.json
@@ -44,7 +44,17 @@
       "component": "runes-callback-props/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onclick",
-      "message": "Prop \"onclick\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"onclick\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-derived-prop-default/output.json
+++ b/tests/fixtures/runes-derived-prop-default/output.json
@@ -49,7 +49,17 @@
       "component": "runes-derived-prop-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "label",
-      "message": "Prop \"label\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"label\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 28
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-dispatched-events/output.json
+++ b/tests/fixtures/runes-dispatched-events/output.json
@@ -64,13 +64,33 @@
       "component": "runes-dispatched-events/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \"value\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"value\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     },
     {
       "component": "runes-dispatched-events/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onchange",
-      "message": "Prop \"onchange\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"onchange\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-host-custom-element/output.json
+++ b/tests/fixtures/runes-host-custom-element/output.json
@@ -89,7 +89,17 @@
       "component": "runes-host-custom-element/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \"value\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"value\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-internal-noleak/output.json
+++ b/tests/fixtures/runes-internal-noleak/output.json
@@ -64,13 +64,33 @@
       "component": "runes-internal-noleak/input.svelte",
       "kind": "prop-unknown-type",
       "name": "value",
-      "message": "Prop \"value\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"value\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     },
     {
       "component": "runes-internal-noleak/input.svelte",
       "kind": "prop-unknown-type",
       "name": "onchange",
-      "message": "Prop \"onchange\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"onchange\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-prop-metadata-consolidated/output.json
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output.json
@@ -230,19 +230,49 @@
       "component": "runes-prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "open",
-      "message": "Prop \"open\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"open\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 22
+        }
+      }
     },
     {
       "component": "runes-prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "computed",
-      "message": "Prop \"computed\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"computed\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 4
+        },
+        "end": {
+          "line": 13,
+          "column": 30
+        }
+      }
     },
     {
       "component": "runes-prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",
       "name": "bare",
-      "message": "Prop \"bare\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"bare\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 8
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-props-basic/output.json
+++ b/tests/fixtures/runes-props-basic/output.json
@@ -71,7 +71,17 @@
       "component": "runes-props-basic/input.svelte",
       "kind": "prop-unknown-type",
       "name": "title",
-      "message": "Prop \"title\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"title\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-props-id-default/output.json
+++ b/tests/fixtures/runes-props-id-default/output.json
@@ -44,7 +44,17 @@
       "component": "runes-props-id-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "label",
-      "message": "Prop \"label\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"label\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-props-renamed/output.json
+++ b/tests/fixtures/runes-props-renamed/output.json
@@ -45,7 +45,17 @@
       "component": "runes-props-renamed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "class",
-      "message": "Prop \"class\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"class\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 20
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-rest-props/output.json
+++ b/tests/fixtures/runes-rest-props/output.json
@@ -48,7 +48,17 @@
       "component": "runes-rest-props/input.svelte",
       "kind": "prop-unknown-type",
       "name": "variant",
-      "message": "Prop \"variant\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"variant\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-snippet-description-hyphens/output.json
+++ b/tests/fixtures/runes-snippet-description-hyphens/output.json
@@ -81,13 +81,33 @@
       "component": "runes-snippet-description-hyphens/input.svelte",
       "kind": "prop-unknown-type",
       "name": "row",
-      "message": "Prop \"row\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"row\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 8
+        },
+        "end": {
+          "line": 7,
+          "column": 11
+        }
+      }
     },
     {
       "component": "runes-snippet-description-hyphens/input.svelte",
       "kind": "prop-unknown-type",
       "name": "col",
-      "message": "Prop \"col\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"col\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 13
+        },
+        "end": {
+          "line": 7,
+          "column": 16
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-snippets-default/output.json
+++ b/tests/fixtures/runes-snippets-default/output.json
@@ -60,7 +60,17 @@
       "component": "runes-snippets-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "item",
-      "message": "Prop \"item\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"item\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 12
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/runes-snippets-named/output.json
+++ b/tests/fixtures/runes-snippets-named/output.json
@@ -60,7 +60,17 @@
       "component": "runes-snippets-named/input.svelte",
       "kind": "prop-unknown-type",
       "name": "item",
-      "message": "Prop \"item\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"item\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 12
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/slot-event-template-prop-reference/output.json
+++ b/tests/fixtures/slot-event-template-prop-reference/output.json
@@ -86,7 +86,17 @@
       "component": "slot-event-template-prop-reference/input.svelte",
       "kind": "event-no-source",
       "name": "select",
-      "message": "@event \"select\" has no matching dispatch or callback prop."
+      "message": "@event \"select\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 25
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/theme-component/output.json
+++ b/tests/fixtures/theme-component/output.json
@@ -208,7 +208,17 @@
       "component": "theme-component/input.svelte",
       "kind": "event-no-source",
       "name": "update",
-      "message": "@event \"update\" has no matching dispatch or callback prop."
+      "message": "@event \"update\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 26,
+          "column": 8
+        },
+        "end": {
+          "line": 26,
+          "column": 21
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/typed-props/output.json
+++ b/tests/fixtures/typed-props/output.json
@@ -127,7 +127,17 @@
       "component": "typed-props/input.svelte",
       "kind": "prop-unknown-type",
       "name": "prop2",
-      "message": "Prop \"prop2\" type could not be inferred; falling back to \"any\"."
+      "message": "Prop \"prop2\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 26
+        }
+      }
     }
   ]
 }

--- a/tests/fixtures/typedef-event-shared-block/output.json
+++ b/tests/fixtures/typedef-event-shared-block/output.json
@@ -239,25 +239,65 @@
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "resize",
-      "message": "@event \"resize\" has no matching dispatch or callback prop."
+      "message": "@event \"resize\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 20,
+          "column": 6
+        },
+        "end": {
+          "line": 20,
+          "column": 19
+        }
+      }
     },
     {
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "scroll",
-      "message": "@event \"scroll\" has no matching dispatch or callback prop."
+      "message": "@event \"scroll\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 20,
+          "column": 7
+        },
+        "end": {
+          "line": 20,
+          "column": 20
+        }
+      }
     },
     {
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "queue",
-      "message": "@event \"queue\" has no matching dispatch or callback prop."
+      "message": "@event \"queue\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 31,
+          "column": 7
+        },
+        "end": {
+          "line": 32,
+          "column": 12
+        }
+      }
     },
     {
       "component": "typedef-event-shared-block/input.svelte",
       "kind": "event-no-source",
       "name": "dequeue",
-      "message": "@event \"dequeue\" has no matching dispatch or callback prop."
+      "message": "@event \"dequeue\" has no matching dispatch or callback prop.",
+      "source": {
+        "start": {
+          "line": 31,
+          "column": 9
+        },
+        "end": {
+          "line": 32,
+          "column": 1
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds an optional source range to SveldDiagnostic, reusing the same 1-based-line/0-based-column SourceRange shape the JSON writer already uses for props, slots, events, and contexts.

The parser threads a position through wherever it already has one: prop-unknown-type gets the prop's own source range, context-any-type gets the setContext property or variable's range, event-no-source gets the `@event` JSDoc tag's range, and example-compile-error gets the documented symbol's range when cheap to attach. formatDiagnosticsSummary now appends a (component:line:column) suffix to each line when a source is present, and omits it otherwise. Dedup identity (component+kind+name) is unchanged, so records that differ only in source still collapse.

Establishing this shape now avoids a breaking change to SveldDiagnostic after v1, since new diagnostic kinds are expected to land afterward and should follow the same convention.

Risk is low: the field is optional and additive everywhere it's threaded through, writer-json.ts still strips diagnostics entirely so COMPONENT_API.json and its schema are unaffected. The one behavior change to watch is the CLI/summary output format, which now includes a location suffix for diagnostics that have one; existing fixture snapshots that already captured diagnostics were updated to include the new source field.