### PR TITLE
fix(writer): escape generic names before building word-boundary regex

### DIFF
--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -31,6 +31,9 @@ const NEWLINE_TO_COMMENT_REGEX = /\n/g;
 const WHITESPACE_REGEX = /\s+/g;
 const SNIPPET_TYPE_REFERENCE_REGEX = /(^|[^.\w])Snippet(?:\s*<|\b)/;
 const PRESERVED_SNIPPET_IMPORT_REGEX = /import\s+type\s+[^;]*\bSnippet\b[^;]*from\s+"svelte";/;
+// Matches regex metacharacters that must be escaped before interpolating
+// a user-authored generic name into a RegExp.
+const REGEX_METACHARS = /[.*+?^${}()|[\]\\]/g;
 
 /**
  * Formats a description for use in multi-line comment blocks.
@@ -161,7 +164,8 @@ function splitTopLevel(value: string): string[] {
  * matching on word boundaries so `Value` doesn't match `ValueType`.
  */
 function referencesGeneric(propType: string, name: string): boolean {
-  return new RegExp(`\\b${name}\\b`).test(propType);
+  const escapedName = name.replace(REGEX_METACHARS, "\\$&");
+  return new RegExp(`\\b${escapedName}\\b`).test(propType);
 }
 
 /**

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -21867,3 +21867,80 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "context-generics-dollar-name/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 5
+        },
+        "end": {
+          "line": 19,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Value$Type",
+    "Value$Type extends string"
+  ],
+  "contexts": [
+    {
+      "key": "Demo",
+      "typeName": "DemoContext",
+      "properties": [
+        {
+          "name": "value",
+          "type": "Value$Type",
+          "description": "",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-generics-dollar-name/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DemoContext<Value$Type extends string> = {
+  value: Value$Type;
+};
+
+export type ContextGenericsDollarNameProps<Value$Type extends string> = {
+  children?: (this: void) => void;
+};
+
+export default class ContextGenericsDollarName<Value$Type extends string> extends SvelteComponentTyped<
+  ContextGenericsDollarNameProps<Value$Type>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;

--- a/tests/fixtures/context-generics-dollar-name/input.svelte
+++ b/tests/fixtures/context-generics-dollar-name/input.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { setContext } from "svelte";
+
+  /**
+   * "$" is a valid TypeScript identifier character but also a regex
+   * metacharacter (end-of-string anchor). Detecting whether a context
+   * property references this generic must not be thrown off by it.
+   * @template {string} Value$Type
+   */
+
+  /**
+   * @type {Value$Type}
+   */
+  const value = /** @type {any} */ (undefined);
+
+  setContext("Demo", { value });
+</script>
+
+<div><slot /></div>

--- a/tests/fixtures/context-generics-dollar-name/output.d.ts
+++ b/tests/fixtures/context-generics-dollar-name/output.d.ts
@@ -1,0 +1,15 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DemoContext<Value$Type extends string> = {
+  value: Value$Type;
+};
+
+export type ContextGenericsDollarNameProps<Value$Type extends string> = {
+  children?: (this: void) => void;
+};
+
+export default class ContextGenericsDollarName<Value$Type extends string> extends SvelteComponentTyped<
+  ContextGenericsDollarNameProps<Value$Type>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-generics-dollar-name/output.json
+++ b/tests/fixtures/context-generics-dollar-name/output.json
@@ -1,0 +1,54 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 5
+        },
+        "end": {
+          "line": 19,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Value$Type",
+    "Value$Type extends string"
+  ],
+  "contexts": [
+    {
+      "key": "Demo",
+      "typeName": "DemoContext",
+      "properties": [
+        {
+          "name": "value",
+          "type": "Value$Type",
+          "description": "",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -314,6 +314,25 @@ describe("writerTsDefinition", () => {
     ).toEqual("export type SimpleContext = {\n  count: number;\n};");
   });
 
+  test("getContextDefs with regex-metacharacter generic name", () => {
+    // A malformed `@template` name containing an unescaped regex metacharacter
+    // (here an unbalanced "(") previously threw `SyntaxError: Invalid regular
+    // expression` when building the word-boundary check. It must not throw, and
+    // must still correctly detect the reference.
+    expect(
+      getContextDefs({
+        contexts: [
+          {
+            key: "demo:Wrapper",
+            typeName: "DemoWrapperContext",
+            properties: [{ name: "value", type: "T(x)", optional: false }],
+          },
+        ],
+        generics: ["T(", "T( extends string = string"],
+      }),
+    ).toEqual("export type DemoWrapperContext<T( extends string = string> = {\n  value: T(x);\n};");
+  });
+
   test("generates function signatures from @param and @returns", () => {
     const component_api: ComponentDocApi = {
       moduleName: "TestComponent",


### PR DESCRIPTION
referencesGeneric() in writer-ts-definitions-core.ts interpolated a user-authored `@generics`/`@template` name directly into new RegExp(`\b${name}\b`) without escaping. A generic name containing regex metacharacters, plausible from a typo'd or malformed JSDoc tag, either threw SyntaxError: Invalid regular expression mid-write or silently matched the wrong thing. Since sveld is a docgen tool, it shouldn't crash on odd input like this.

The fix escapes regex metacharacters in the name before building the RegExp, mirroring the same escape pattern already used at other new RegExp( call sites in the codebase (ComponentParser.ts, resolve-alias.ts). Word-boundary matching is unchanged for normal identifiers.

Added a unit test using a generic named T( to pin down the crash that's now fixed, and a fixture test using a generic named Value$Type (a valid TS identifier that's also a regex metacharacter) to cover the "silently matches wrong" case end to end. I avoided using an invalid-identifier name like T( in the fixture itself because such names get embedded unconditionally into the component's Props<> and class signature elsewhere in the writer, which would produce invalid TypeScript in the checked-in output.d.ts and break the project-wide typecheck.

Risk is low: this only changes how a name is escaped before matching, and existing snapshots are unaffected since the escape is a no-op for names without regex metacharacters (the overwhelming majority of real generic names).