### PR TITLE
feat(writer)!: make prettier an optional peer dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ A change to props, events, slots, or context handling should be exercised across
 
 ## Build
 
-[`scripts/build.ts`](scripts/build.ts) (`bun run build`) removes `lib/`, bundles `src/index.ts` with `Bun.build` (minified ESM, Node target), then runs `tsc --project tsconfig.build.json` to emit declarations. Dependencies are bundled into `lib/` _except_ `prettier` (kept external — it uses `createRequire` for its data files). `lib/` is gitignored and is never committed. `bun run build -w` rebuilds on changes under `src/`.
+[`scripts/build.ts`](scripts/build.ts) (`bun run build`) removes `lib/`, bundles `src/index.ts` with `Bun.build` (minified ESM, Node target), then runs `tsc --project tsconfig.build.json` to emit declarations. Dependencies are bundled into `lib/` _except_ `prettier` (kept external — it's an optional peer dependency, dynamically imported at runtime, and uses `createRequire` for its data files). `lib/` is gitignored and is never committed. `bun run build -w` rebuilds on changes under `src/`.
 
 The published binary is [`cli.js`](cli.js), which dynamically imports the built `lib/index.js` and calls `cli`.
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ bun i -D sveld
 yarn add -D sveld
 ```
 
+`prettier` is an optional peer dependency, used only to format emitted `.d.ts` and Markdown output. Install it alongside `sveld` for formatted output; without it, output is still valid but unformatted.
+
 ### Vite
 
 Import and add `sveld` as a plugin to your `vite.config.ts`. The plugin only runs during `vite build`, unless `watch: true` is set, in which case it also regenerates output during `vite dev`.

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "sveld",
-      "dependencies": {
-        "prettier": "^3.8.4",
-      },
       "devDependencies": {
         "@biomejs/biome": "2.5.2",
         "@types/bun": "^1.3.14",
@@ -15,10 +12,17 @@
         "comment-parser": "^1.4.1",
         "culls": "^0.2.0",
         "estree-walker": "^3.0.3",
+        "prettier": "^3.8.4",
         "svelte": "^5.56.3",
         "tinyglobby": "^0.2.17",
         "typescript": "rc",
       },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+      },
+      "optionalPeers": [
+        "prettier",
+      ],
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "build": "bun scripts/build.ts",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "prettier": "^3.8.4"
-  },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@types/bun": "^1.3.14",
@@ -34,9 +31,18 @@
     "comment-parser": "^1.4.1",
     "culls": "^0.2.0",
     "estree-walker": "^3.0.3",
+    "prettier": "^3.8.4",
     "svelte": "^5.56.3",
     "tinyglobby": "^0.2.17",
     "typescript": "rc"
+  },
+  "peerDependencies": {
+    "prettier": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "bin": {
     "sveld": "cli.js"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -27,7 +27,7 @@ async function buildProject() {
     // them so `svelte/compiler` (and `estree-walker`) ship inside `lib`.
     packages: "bundle",
     external: [
-      // Runtime dependency; avoids bundling css-tree/mdn-data which use
+      // Optional peer dependency; avoids bundling css-tree/mdn-data which use
       // createRequire with relative paths for JSON data files.
       "prettier",
     ],

--- a/src/writer/Writer.ts
+++ b/src/writer/Writer.ts
@@ -1,8 +1,42 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { parse } from "node:path";
-import { format, type ParserOptions } from "prettier";
+import type { ParserOptions } from "prettier";
 
 export const DEFAULT_TYPESCRIPT_PRINT_WIDTH = 80;
+
+// undefined = not yet attempted, null = confirmed unavailable
+let prettierModule: typeof import("prettier") | null | undefined;
+
+/**
+ * Exposed so tests can simulate prettier being unavailable by stubbing
+ * `prettierLoader.load` directly, instead of fighting the module registry to
+ * make a real, installed dependency appear missing.
+ *
+ * @internal
+ */
+export const prettierLoader = {
+  load: (): Promise<typeof import("prettier")> => import("prettier"),
+};
+
+/** @internal exposed for tests to reset the module-scope cache between cases */
+export function __resetPrettierCacheForTesting(): void {
+  prettierModule = undefined;
+}
+
+async function loadPrettier(): Promise<typeof import("prettier") | null> {
+  if (prettierModule !== undefined) {
+    return prettierModule;
+  }
+
+  try {
+    prettierModule = await prettierLoader.load();
+  } catch {
+    prettierModule = null;
+    console.warn("prettier is not installed; emitting unformatted output. Install prettier for formatted files.");
+  }
+
+  return prettierModule;
+}
 
 /**
  * Options for configuring a Writer instance.
@@ -43,6 +77,7 @@ export default class Writer {
    * Returns the original content if formatting fails.
    *
    * @param raw - The raw content to format
+   * @param filePath - Optional file path, included in the error message if formatting fails
    * @returns Formatted content, or original content if formatting fails
    *
    * @example
@@ -51,12 +86,18 @@ export default class Writer {
    * // Returns: "export type Props = {};\n"
    * ```
    */
-  public async format(raw: string) {
+  public async format(raw: string, filePath?: string) {
+    const prettier = await loadPrettier();
+
+    if (!prettier) {
+      return raw;
+    }
+
     try {
-      const result = await format(raw, this.options);
+      const result = await prettier.format(raw, this.options);
       return result;
     } catch (error) {
-      console.error(error);
+      console.error(filePath ? `Failed to format ${filePath}:` : "Failed to format:", error);
       return raw;
     }
   }
@@ -78,7 +119,7 @@ export default class Writer {
    */
   public async write(filePath: string, raw: string) {
     await mkdir(parse(filePath).dir, { recursive: true });
-    await writeFile(filePath, await this.format(raw));
+    await writeFile(filePath, await this.format(raw, filePath));
   }
 }
 

--- a/tests/Writer.test.ts
+++ b/tests/Writer.test.ts
@@ -1,4 +1,4 @@
-import Writer, { createTypeScriptWriter } from "../src/writer/Writer";
+import Writer, { __resetPrettierCacheForTesting, createTypeScriptWriter, prettierLoader } from "../src/writer/Writer";
 
 describe("Writer", () => {
   beforeEach(() => {
@@ -60,5 +60,28 @@ describe("Writer", () => {
     expect(await writer.format(null)).toEqual(null);
     // @ts-expect-error
     expect(await writer.format(undefined)).toEqual(undefined);
+  });
+
+  describe("when prettier is unavailable", () => {
+    const originalLoad = prettierLoader.load;
+
+    beforeEach(() => {
+      __resetPrettierCacheForTesting();
+      prettierLoader.load = () => Promise.reject(new Error("Cannot find module 'prettier'"));
+    });
+
+    afterEach(() => {
+      prettierLoader.load = originalLoad;
+      __resetPrettierCacheForTesting();
+    });
+
+    test("returns raw input and warns exactly once across multiple calls", async () => {
+      const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const writer = new Writer({ parser: "json", printWidth: 80 });
+
+      expect(await writer.format("{a:null}")).toBe("{a:null}");
+      expect(await writer.format("{b:null}")).toBe("{b:null}");
+      expect(consoleWarn).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
Prettier was sveld's only runtime dependency, pulled in solely by Writer.format() to prettify emitted .d.ts, JSON, and Markdown output. Writer.format() already fell back to raw output on any formatting failure, so the change makes that fallback cover a missing install too. It replaces the static prettier import with a lazy, cached dynamic import, warns once via console.warn if the module can't be loaded, and returns the raw content unchanged in that case. package.json drops prettier from dependencies, adds it as an optional peerDependency, and keeps it in devDependencies so the project's own build and tests still format output. scripts/build.ts keeps prettier external in the bundle for the same createRequire reason as before, just with an updated comment.

Risk is limited mostly to consumers who relied on sveld transitively installing prettier without declaring it themselves: emitted output will now be valid but unformatted for anyone who doesn't have prettier in their own project, which is the intended and documented breaking change. Console.error on format failures now includes the target file path where available, changing log output slightly but not behavior. Added a unit test that stubs the loader to simulate a missing prettier and asserts the warning fires exactly once across repeated calls, and manually verified in an isolated temp directory (no prettier installed) that the CLI still runs end to end and produces valid output.