### PR TITLE
fix(entry)!: fail loudly when the Svelte entry cannot be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Generate documentation in JSON and/or Markdown formats using the following flags
 npx sveld --json --markdown
 ```
 
+If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
+
 ### CI: API-drift checks (`--check`)
 
 `--check` diffs the parsed component API against a committed `COMPONENT_API.json` snapshot, assigns a semver bump to each change, and exits `1` when it finds a breaking change.
@@ -431,7 +433,7 @@ The CLI exits non-zero on any fatal error (an unreadable entry, a config file th
 
 You can also call `sveld` from Node.js. See [Requirements](#requirements) for supported Node versions and the ESM-only constraint.
 
-If no `input` is specified, `sveld` infers the entry point based on the `package.json#svelte` field.
+If no `input` is specified, `sveld` infers the entry point based on the `package.json#svelte` field. If no entry point can be resolved, `sveld()` throws with an actionable message (previously it resolved to `{ diagnostics: [] }` and generated nothing).
 
 ```js
 import { sveld } from "sveld";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,15 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { asSvelteEntryPoint } from "./brands";
 import { type CheckResult, formatCheckReport, runCheck } from "./check";
 import { formatDiagnosticsSummary } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig } from "./load-config";
+import { normalizeSeparators } from "./path";
 import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
+
+/** Relative fallback entry used only when entry resolution otherwise fails. */
+const FALLBACK_ENTRY = "src/index.js";
 
 /** CLI options layered on top of the shared plugin options. */
 interface CliOptions extends PluginSveldOptions {
@@ -91,7 +98,21 @@ export async function cli(process: NodeJS.Process) {
   const fileConfig = await loadConfig();
   const options = mergeConfig<CliOptions>(fileConfig, cliOptions);
 
-  const input = getSvelteEntry(options.entry) || "src/index.js";
+  const resolvedEntry = getSvelteEntry(options.entry);
+  let input: string;
+
+  if (resolvedEntry !== null) {
+    input = resolvedEntry;
+  } else if (existsSync(join(process.cwd(), FALLBACK_ENTRY))) {
+    console.error(
+      `sveld: could not resolve an entry point; falling back to "${FALLBACK_ENTRY}". Set package.json#svelte (or pass --entry) to avoid relying on this fallback.`,
+    );
+    input = asSvelteEntryPoint(normalizeSeparators(FALLBACK_ENTRY));
+  } else {
+    process.exitCode = 1;
+    return;
+  }
+
   const result = await generateBundle(input, options.glob === true, toGenerateBundleOptions(options));
 
   // Read the committed snapshot before `writeOutput` can overwrite it.

--- a/src/get-svelte-entry.ts
+++ b/src/get-svelte-entry.ts
@@ -14,14 +14,16 @@ export function getSvelteEntry(entryPoint?: string): SvelteEntryPoint | null {
       return asSvelteEntryPoint(entryPoint);
     }
 
-    console.log(`Invalid entry point: ${entry_path}.`);
+    console.error(`Invalid entry point: ${entry_path}. Pass a valid --entry (or "entry" option), or unset it and`);
+    console.error('set the "svelte" field in your package.json instead.');
     return null;
   }
 
   const pkg_path = join(process.cwd(), "package.json");
 
   if (!existsSync(pkg_path)) {
-    console.log("Could not locate a package.json file.\n");
+    console.error("Could not locate a package.json file.");
+    console.error('Specify an entry point with --entry (or the "entry" option) instead.\n');
     return null;
   }
 
@@ -32,8 +34,10 @@ export function getSvelteEntry(entryPoint?: string): SvelteEntryPoint | null {
       return asSvelteEntryPoint(pkg.svelte);
     }
 
-    console.log("Could not determine an entry point.\n");
-    console.log('Specify an entry point to your Svelte code in the "svelte" field of your package.json.\n');
+    console.error("Could not determine an entry point.\n");
+    console.error(
+      'Specify an entry point to your Svelte code in the "svelte" field of your package.json, or pass --entry (or the "entry" option).\n',
+    );
     return null;
   } catch (error) {
     console.error("Error reading package.json:", error);

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -47,7 +47,11 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   const { input: inputOverride, strict, reportDiagnostics, ...runtimeOpts } = opts ?? {};
   const fileConfig = await loadConfig();
   const input = getSvelteEntry(inputOverride ?? fileConfig.entry);
-  if (input === null) return { diagnostics: [] };
+  if (input === null) {
+    throw new Error(
+      'sveld: could not resolve a Svelte entry point. Set package.json#svelte, or pass the "input" option.',
+    );
+  }
   const merged = mergeConfig<PluginSveldOptions>(fileConfig, runtimeOpts, { entry: input });
   const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));
   writeOutput(result, merged, input);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,7 @@
-import { parseCliOptions } from "../src/cli";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cli, parseCliOptions } from "../src/cli";
 
 describe("parseCliOptions", () => {
   test("--fail-fast enables failFast", () => {
@@ -51,5 +54,51 @@ describe("parseCliOptions", () => {
 
   test("--strict enables strict", () => {
     expect(parseCliOptions(["--strict"])).toEqual({ strict: true });
+  });
+});
+
+describe("cli() entry resolution failures", () => {
+  // `process.exitCode = undefined` does not clear a previously-set numeric
+  // exit code (Node/Bun ignore the assignment), so `0` is used as the
+  // neutral baseline instead of relying on the initial `undefined` state.
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    process.argv = ["bun", "cli.js"];
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-entry-"));
+    process.chdir(dir);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("sets exitCode 1 and writes nothing when no entry and no src/index.js fallback exist", async () => {
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(dir, "types"))).toBe(false);
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+  });
+
+  test("falls back to src/index.js with a stderr note when resolution fails but the fallback exists", async () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.js"), "export {};\n");
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('falling back to "src/index.js"'));
   });
 });

--- a/tests/get-svelte-entry.test.ts
+++ b/tests/get-svelte-entry.test.ts
@@ -40,7 +40,8 @@ describe("getSvelteEntry", () => {
     const result = getSvelteEntry("src/NonExistent.svelte");
 
     expect(result).toBeNull();
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Invalid entry point"));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Invalid entry point"));
+    expect(console.log).not.toHaveBeenCalled();
   });
 
   test("returns svelte field from package.json if no entry point provided", () => {
@@ -60,7 +61,8 @@ describe("getSvelteEntry", () => {
     const result = getSvelteEntry();
 
     expect(result).toBeNull();
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Could not determine an entry point"));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Could not determine an entry point"));
+    expect(console.log).not.toHaveBeenCalled();
   });
 
   test("returns null if package.json does not exist", () => {
@@ -69,7 +71,8 @@ describe("getSvelteEntry", () => {
     const result = getSvelteEntry();
 
     expect(result).toBeNull();
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Could not locate a package.json file"));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Could not locate a package.json file"));
+    expect(console.log).not.toHaveBeenCalled();
   });
 
   test("handles malformed package.json", () => {
@@ -84,7 +87,7 @@ describe("getSvelteEntry", () => {
     const result = getSvelteEntry("");
 
     expect(result).toBeNull();
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Could not locate a package.json file."));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Could not locate a package.json file."));
   });
 
   test("handles undefined svelte field in package.json", () => {
@@ -93,6 +96,6 @@ describe("getSvelteEntry", () => {
 
     const result = getSvelteEntry();
     expect(result).toBeNull();
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Could not determine an entry point"));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Could not determine an entry point"));
   });
 });

--- a/tests/sveld.test.ts
+++ b/tests/sveld.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sveld } from "../src/sveld";
+
+const ENTRY_ERROR = /entry/i;
+
+describe("sveld() entry resolution failures", () => {
+  let dir: string;
+  let previousCwd: string;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), "sveld-entry-"));
+    process.chdir(dir);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("throws when the given input does not resolve", async () => {
+    await expect(sveld({ input: "does-not-exist/" })).rejects.toThrow(ENTRY_ERROR);
+  });
+
+  test("throws when no input is given and package.json#svelte is absent", async () => {
+    await expect(sveld()).rejects.toThrow(ENTRY_ERROR);
+  });
+});


### PR DESCRIPTION
Entry-resolution failures used to look like success. get-svelte-entry.ts logged with console.log instead of console.error, sveld() returned an empty { diagnostics: [] } result when it couldn't find an entry, and the CLI silently fell back to a guessed src/index.js path that usually doesn't exist either, producing no output with exit code 0.

This changes the behavior so failures are surfaced: the three resolution failure messages now go to stderr and mention --entry/the entry option as an alternative to package.json#svelte. sveld() now throws an actionable error instead of returning an empty result. The CLI only falls back to src/index.js when that file actually exists relative to cwd, printing a stderr note when it does, and otherwise sets a non-zero exit code and returns without generating anything. Path handling for the fallback goes through the existing normalizeSeparators/asSvelteEntryPoint helpers for Windows compatibility.

This is a breaking change for programmatic callers relying on sveld() resolving to { diagnostics: [] } on a missing entry. It's called out in the README's Node.js and CLI sections. Tests cover both get-svelte-entry's stderr behavior and the CLI's exit-1 and fallback-with-warning paths.