### PR TITLE
feat(diagnostics): report skipped {`@render`} syntax, remove dead verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,12 +256,12 @@ Needs `typescript` and a `tsconfig.json`, same as `resolveTypes`. Use `--strict`
 
 #### Type inference diagnostics
 
-`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`. Each diagnostic carries an optional `source` range (the same `{ start: { line, column }, end: { line, column } }` shape as JSON output source ranges) whenever the parser holds a stable position for it.
+`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, `$props()`/`{@render}` syntax sveld can't model, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`. Each diagnostic carries an optional `source` range (the same `{ start: { line, column }, end: { line, column } }` shape as JSON output source ranges) whenever the parser holds a stable position for it.
 
 With `reportDiagnostics` or `strict`, the grouped summary looks like this:
 
 ```
-sveld: 4 unresolved types found.
+sveld: 5 unresolved types found.
 
 Props without inferred types (1):
   ./icons/Add.svelte
@@ -275,9 +275,13 @@ Context values typed as `any` (1):
   ./Modal.svelte
     - @event "open" has no matching dispatch or callback prop. (./Modal.svelte:3:5)
     - @event "close" has no matching dispatch or callback prop. (./Modal.svelte:4:5)
+
+Component syntax sveld skipped (1):
+  ./Tabs.svelte
+    - {@render tabs(getTabProps())} argument is not a plain object literal; the render call was not mapped to slot metadata. (./Tabs.svelte:6:4)
 ```
 
-When `checkExamples` is also enabled, `@example` compile failures appear as a fourth group:
+When `checkExamples` is also enabled, `@example` compile failures appear as a fifth group:
 
 ```
 @example blocks that failed to compile (1):

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -252,14 +252,6 @@ interface ComponentParserDiagnostics {
   filePath: string;
 }
 
-/**
- * Options for configuring the ComponentParser behavior.
- */
-interface ComponentParserOptions {
-  /** Enable verbose logging for debugging parsing issues */
-  verbose?: boolean;
-}
-
 export type ComponentPropBinding = "readonly" | "writable";
 
 /**
@@ -678,19 +670,12 @@ export interface ParsedComponent {
 }
 
 export default class ComponentParser {
-  /** Parser configuration options (e.g., verbose logging) */
-  options?: ComponentParserOptions;
-
   /**
    * All per-parse mutable state (props, slots, events, scopes, source, etc.).
    * See {@link ParserContext} for field-by-field documentation. Replaced
    * wholesale by `cleanup()` between parses.
    */
   private ctx: ParserContext = createParserContext();
-
-  constructor(options?: ComponentParserOptions) {
-    this.options = options;
-  }
 
   private static mapToArray<T>(map: Map<string, T> | Map<string | null, T>) {
     return Array.from(map, ([_key, value]) => value);
@@ -766,18 +751,6 @@ export default class ComponentParser {
     }
 
     return undefined;
-  }
-
-  logUnsupportedRunesPattern(message: string) {
-    if (this.options?.verbose && this.ctx.syntaxMode === "runes") {
-      console.warn(`Warning: ${message}`);
-    }
-  }
-
-  logParserWarning(message: string) {
-    if (this.options?.verbose) {
-      console.warn(`Warning: ${message}`);
-    }
   }
 
   /**
@@ -1007,7 +980,7 @@ export default class ComponentParser {
              * Store in cache for later lookup.
              */
             const parsed = parseComment(commentBlock, { spacing: "preserve" });
-            const { type: typeTag, description } = getCommentTags(this, parsed);
+            const { type: typeTag, description } = getCommentTags(parsed);
             if (typeTag) {
               this.ctx.variableInfoCache.set(varName, {
                 type: this.aliasType(typeTag.type),
@@ -1157,7 +1130,7 @@ export default class ComponentParser {
              * Parse the JSDoc to extract `@type` tag and description.
              */
             const parsed = parseComment(commentBlock, { spacing: "preserve" });
-            const { type: typeTag, description } = getCommentTags(this, parsed);
+            const { type: typeTag, description } = getCommentTags(parsed);
             if (typeTag) {
               return {
                 type: this.aliasType(typeTag.type),
@@ -1301,10 +1274,6 @@ export default class ComponentParser {
    * ```
    */
   public parseSvelteComponent(source: string, diagnostics: ComponentParserDiagnostics): ParsedComponent {
-    if (this.options?.verbose) {
-      console.log(`[parsing] "${diagnostics.moduleName}" ${diagnostics.filePath}`);
-    }
-
     this.cleanup();
     this.ctx.componentFilePath = diagnostics.filePath;
     /**
@@ -1919,9 +1888,18 @@ export default class ComponentParser {
                 null,
                 2,
               );
-            } else {
-              this.logUnsupportedRunesPattern(
-                `Skipping unsupported {@render ...} argument for snippet prop "${renderInfo.publicName}".`,
+            } else if (renderInfo.arguments.length === 1) {
+              /**
+               * Multiple positional arguments (e.g. `{@render row(item, index)}`) are a
+               * supported pattern typed via `Snippet<[...]>` and intentionally left unmodeled
+               * here; only a single non-object argument loses information sveld can't recover.
+               */
+              recordDiagnostic(
+                this.ctx,
+                "syntax-skipped",
+                renderInfo.publicName,
+                `{@render ${renderInfo.publicName}(...)} argument is not a plain object literal; the render call was not mapped to slot metadata.`,
+                sourceRangeFromNode(this.ctx, node),
               );
             }
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -7,12 +7,14 @@ import type { SourceRange } from "./ComponentParser";
  * - `context-any-type`: `setContext` value inferred as `any`.
  * - `event-no-source`: `@event` with no dispatch, forward, or callback prop.
  * - `example-compile-error`: an `@example` block failed to type-check (opt-in, `checkExamples`).
+ * - `syntax-skipped`: `$props()`/`{@render}` syntax the parser can't model; omitted from output.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
   | "context-any-type"
   | "event-no-source"
-  | "example-compile-error";
+  | "example-compile-error"
+  | "syntax-skipped";
 
 /**
  * One place sveld had to guess a type instead of inferring it.
@@ -34,6 +36,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "context-any-type": "Context values typed as `any`",
   "event-no-source": "@event tags with no dispatch or callback",
   "example-compile-error": "@example blocks that failed to compile",
+  "syntax-skipped": "Component syntax sveld skipped",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -41,6 +44,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "context-any-type",
   "event-no-source",
   "example-compile-error",
+  "syntax-skipped",
 ];
 
 /**

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -57,9 +57,6 @@ export function parseContextValue(
             `Context "${key}" property "${propName}" has no type annotation; defaulted to "any".`,
             sourceRangeFromNode(ctx, prop),
           );
-          if (parser.options?.verbose) {
-            console.warn(`Warning: Context "${key}" property "${propName}" has no type annotation. Using "any".`);
-          }
         }
       } else if (
         prop.value &&
@@ -122,9 +119,6 @@ export function parseContextValue(
       `Context "${key}" variable "${varName}" has no type annotation; defaulted to "any".`,
       sourceRangeFromNode(ctx, node),
     );
-    if (parser.options?.verbose) {
-      console.warn(`Warning: Context "${key}" variable "${varName}" has no type annotation. Using "any".`);
-    }
 
     return {
       key,
@@ -241,13 +235,7 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
   if (!valueArg) return;
 
   const contextInfo = parseContextValue(ctx, parser, valueArg, contextKey);
-  if (contextInfo) {
-    if (ctx.contexts.has(contextKey)) {
-      if (parser.options?.verbose) {
-        console.warn(`Warning: Multiple setContext calls with key "${contextKey}". Using first occurrence.`);
-      }
-    } else {
-      ctx.contexts.set(contextKey, contextInfo);
-    }
+  if (contextInfo && !ctx.contexts.has(contextKey)) {
+    ctx.contexts.set(contextKey, contextInfo);
   }
 }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -131,7 +131,7 @@ export function formatComment(comment: string) {
 }
 
 /** Split JSDoc tags into type/param/returns/passthrough buckets. */
-export function getCommentTags(parser: ComponentParser, parsed: ReturnType<typeof parseComment>) {
+export function getCommentTags(parsed: ReturnType<typeof parseComment>) {
   const tags = parsed[0]?.tags ?? [];
   const excludedTags = new Set([
     "type",
@@ -171,15 +171,12 @@ export function getCommentTags(parser: ComponentParser, parsed: ReturnType<typeo
       passthroughTags.push(tag);
     } else if (tag.tag === "bindable") {
       if (tag.type) {
-        parser.logParserWarning(`Ignoring invalid @bindable value "${tag.type} ${tag.name}".`);
         continue;
       }
 
       const value = `${tag.name}${tag.description ? ` ${tag.description}` : ""}`.trim();
       if (value === "readonly" || value === "writable") {
         binding ??= value;
-      } else {
-        parser.logParserWarning(`Ignoring invalid @bindable value "${value}".`);
       }
     } else if (!excludedTags.has(tag.tag)) {
       additionalTags.push(tag);
@@ -293,7 +290,7 @@ export function processJSDocComment(
     additional: additionalTags,
     passthrough: passthroughTags,
     description: commentDescription,
-  } = getCommentTags(parser, comment);
+  } = getCommentTags(comment);
 
   let type: string | undefined;
   let params: ComponentPropParam[] | undefined;

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -1,4 +1,4 @@
-import type { Property, VariableDeclaration, VariableDeclarator } from "estree";
+import type { AssignmentPattern, Identifier, Property, VariableDeclaration, VariableDeclarator } from "estree";
 import { parse } from "svelte/compiler";
 import { isCallExpressionNamed } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
@@ -326,7 +326,6 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
     }
 
     if (declarator.id.type !== "ObjectPattern") {
-      parser.logUnsupportedRunesPattern("Skipping unsupported $props() declaration pattern.");
       continue;
     }
 
@@ -344,20 +343,14 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
       if (property.type === "RestElement") {
         if (property.argument.type === "Identifier") {
           ctx.restPropLocals.add(property.argument.name);
-        } else {
-          parser.logUnsupportedRunesPattern("Skipping unsupported rest element in $props() destructuring.");
         }
         continue;
       }
 
-      if (property.computed) {
-        parser.logUnsupportedRunesPattern("Skipping computed property in $props() destructuring.");
-        continue;
-      }
-
+      // Svelte's own `$props()` analysis (VariableDeclarator.js) already rejects computed keys
+      // and non-Identifier destructuring targets as a compile error, so neither can reach here.
       const propName = parser.getPropertyName(property.key);
       if (!propName) {
-        parser.logUnsupportedRunesPattern("Skipping unsupported property name in $props() destructuring.");
         continue;
       }
 
@@ -366,19 +359,10 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
 
       if (property.value.type === "Identifier") {
         localName = property.value.name;
-      } else if (property.value.type === "AssignmentPattern") {
-        if (property.value.left.type !== "Identifier") {
-          parser.logUnsupportedRunesPattern(
-            `Skipping nested pattern for prop "${propName}" in $props() destructuring.`,
-          );
-          continue;
-        }
-
-        localName = property.value.left.name;
-        init = property.value.right;
       } else {
-        parser.logUnsupportedRunesPattern(`Skipping nested pattern for prop "${propName}" in $props() destructuring.`);
-        continue;
+        const assignmentPattern = property.value as AssignmentPattern & { left: Identifier };
+        localName = assignmentPattern.left.name;
+        init = assignmentPattern.right;
       }
 
       if (!localName) continue;

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -125,9 +125,7 @@ describe("ComponentParser", () => {
   });
 
   test("parses @bindable JSDoc metadata and ignores invalid values", () => {
-    const log = jest.spyOn(console, "log").mockImplementation(() => undefined);
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    const parser = new ComponentParser({ verbose: true });
+    const parser = new ComponentParser();
     const source = `
       <script>
         /**
@@ -149,10 +147,6 @@ describe("ComponentParser", () => {
     expect(result.props.find((p) => p.name === "size")?.binding).toBe("readonly");
     expect(result.props.find((p) => p.name === "size")?.description).toBe("Current value.");
     expect(result.props.find((p) => p.name === "invalid")?.binding).toBeUndefined();
-    expect(warn).toHaveBeenCalledWith('Warning: Ignoring invalid @bindable value "sideways".');
-
-    warn.mockRestore();
-    log.mockRestore();
   });
 
   test("preserves JSDoc when @ts-ignore is present", () => {

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -22354,3 +22354,101 @@ export default class ContextGenericsDollarName<Value$Type extends string> extend
 > {}
 "
 `;
+
+exports[`fixtures (JSON) "runes-render-skipped-argument/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "title",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-render-skipped-argument/input.svelte",
+      "kind": "syntax-skipped",
+      "name": "children",
+      "message": "{@render children(...)} argument is not a plain object literal; the render call was not mapped to slot metadata.",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 12
+        },
+        "end": {
+          "line": 9,
+          "column": 42
+        }
+      }
+    },
+    {
+      "component": "runes-render-skipped-argument/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "title",
+      "message": "Prop \\"title\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ]
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-render-skipped-argument/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesRenderSkippedArgumentProps = {
+  /**
+   * @default undefined
+   */
+  title: undefined;
+};
+
+export default class RunesRenderSkippedArgument extends SvelteComponentTyped<
+  RunesRenderSkippedArgumentProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -95,6 +95,24 @@ describe("ComponentParser diagnostics", () => {
 
     expect(diagnostics?.some((d) => d.kind === "event-no-source")).toBe(false);
   });
+
+  test("flags a non-trivial {@render} argument as syntax-skipped", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        let { children, title } = $props();
+      </script>
+      <div>{title}{@render children(getProps())}</div>
+    `;
+
+    const { diagnostics, props } = parser.parseSvelteComponent(source, parseContext);
+    const syntaxDiagnostic = diagnostics?.find((d) => d.kind === "syntax-skipped");
+
+    expect(syntaxDiagnostic).toMatchObject({ kind: "syntax-skipped", name: "children" });
+    expect(typeof syntaxDiagnostic?.message).toBe("string");
+    expect(syntaxDiagnostic?.source).toBeDefined();
+    expect(props.map((p) => p.name)).toContain("title");
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/fixtures/runes-render-skipped-argument/input.svelte
+++ b/tests/fixtures/runes-render-skipped-argument/input.svelte
@@ -1,0 +1,9 @@
+<script>
+  let { title, children } = $props();
+
+  function getProps() {
+    return { title };
+  }
+</script>
+
+<div>{title}{@render children(getProps())}</div>

--- a/tests/fixtures/runes-render-skipped-argument/output.d.ts
+++ b/tests/fixtures/runes-render-skipped-argument/output.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesRenderSkippedArgumentProps = {
+  /**
+   * @default undefined
+   */
+  title: undefined;
+};
+
+export default class RunesRenderSkippedArgument extends SvelteComponentTyped<
+  RunesRenderSkippedArgumentProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-render-skipped-argument/output.json
+++ b/tests/fixtures/runes-render-skipped-argument/output.json
@@ -1,0 +1,76 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "title",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-render-skipped-argument/input.svelte",
+      "kind": "syntax-skipped",
+      "name": "children",
+      "message": "{@render children(...)} argument is not a plain object literal; the render call was not mapped to slot metadata.",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 12
+        },
+        "end": {
+          "line": 9,
+          "column": 42
+        }
+      }
+    },
+    {
+      "component": "runes-render-skipped-argument/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "title",
+      "message": "Prop \"title\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Non-trivial {`@render`} arguments (anything other than zero args or a single object literal) were silently dropped from output, and the warning that covered it was gated behind a parser verbose option that nothing in bundle, plugin, or CLI ever set. This replaces that dead warning with a syntax-skipped diagnostic kind (with source positions) so --report-diagnostics and --strict surface render calls sveld couldn't map to slot metadata. Multi-argument positional render calls (e.g. children(item, index), typed via Snippet<[...]>) are left unflagged since they're a supported pattern with no information loss, not a skip.

While wiring this up I found the two other warnings this prompt targeted, computed keys and nested destructuring in $props(), are unreachable in practice: Svelte's own compiler already rejects that syntax as a hard compile error before sveld's AST walk ever runs. Rather than instrument dead code, those branches are deleted and the destructure walk now trusts that invariant directly.

Since verbose is gone, this also removes every console.* call it gated across ComponentParser, contexts.ts, and jsdoc.ts, along with the option itself and the two logging helper methods. One existing test that asserted on a console.warn call from an invalid `@bindable` value was updated to drop that assertion.

Risk is low and localized to diagnostic emission and dead-code removal; behavior for valid components is unchanged except that a previously-silent {`@render`} case now surfaces a diagnostic. Existing fixture snapshots are unaffected; a new fixture pins the {`@render`} skip behavior.