### PR TITLE
feat(writer): emit Custom Elements Manifest output

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ export default class Button extends SvelteComponentTyped<
 - [Available Options](#available-options)
 - [Documenting Entry Exports](#documenting-entry-exports)
 - [JSON Output](#json-output)
+- [Custom Elements Manifest](#custom-elements-manifest)
+  - [Consuming the manifest](#consuming-the-manifest)
 - [API Reference](#api-reference)
   - [reactive](#reactive)
   - [binding](#binding)
@@ -545,6 +547,8 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`jsonOptions`** (object, optional): Options for JSON output.
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.
 - **`markdownOptions`** (object, optional): Options for Markdown output.
+- **`customElements`** (boolean, optional): Generate a [Custom Elements Manifest](#custom-elements-manifest) (`custom-elements.json`). Also available as the `--custom-elements` CLI flag.
+- **`customElementsOptions`** (object, optional): Options for Custom Elements Manifest output, including `outFile`.
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
 - **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
@@ -649,6 +653,7 @@ interface ComponentDocApi {
   componentComment?: string;
   componentCommentSource?: SourceRange;
   contexts?: ComponentContext[];
+  customElementTag?: string;
 }
 
 interface ComponentProp {
@@ -714,6 +719,47 @@ Prop metadata is additive and keeps the older public fields:
 - `typeSource` identifies the conservative source of the emitted `type`: TypeScript annotation, JSDoc, initializer/default inference, other parser inference, or unknown fallback.
 - `value` remains the raw default expression string. `defaultValue` adds structured metadata with the same raw expression, a coarse `kind`, and a parsed `value` only for JSON-safe literals, arrays, and plain objects. `sveld` does not evaluate arbitrary code.
 - `bindable: true` is emitted only for props explicitly declared with Svelte 5 `$bindable(...)`. Missing `bindable` should be treated as false.
+
+## Custom Elements Manifest
+
+Set `customElements: true` to emit a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest) (`custom-elements.json`, `schemaVersion: "1.0.0"`). This is the interchange format the web-components ecosystem standardized on: Storybook autodocs, VS Code/JetBrains HTML data, and other CEM-aware tooling can all read it directly.
+
+```diff
+sveld({
++  customElements: true,
+})
+```
+
+- **`customElements`** (boolean, optional): Generate `custom-elements.json`.
+- **`customElementsOptions.outFile`** (string, optional, default: `"custom-elements.json"`): Override the output path.
+- Also available as the `--custom-elements` CLI flag.
+
+Each exported component becomes one `javascript-module` with a class declaration:
+
+- **Members** — every prop becomes a `ClassField` (`name`, `type.text`, `default`, `description`, `deprecated`).
+- **Attributes** — derived conservatively from props: only props with a bare primitive type (`string`, `number`, or `boolean`) become attributes, using the same default name Svelte's custom-element runtime uses (`prop.toLowerCase()`, unless the tool's own `attribute` override applies). Props whose lowercased name collides with another prop are dropped from `attributes` on both sides, since which one wins at runtime is ambiguous. Complex types (arrays, objects, unions, custom types) never become attributes.
+- **Events** — dispatched events (`createEventDispatcher()`, and `$host().dispatchEvent(...)` from inside a custom element) become `{ name, type: { text: "CustomEvent<...>" } }`. Forwarded (`on:click`) events are left out, since they aren't dispatched by the component's own class.
+- **Slots** — named and default slots, with descriptions. The default slot's `name` is `""`, matching the CEM convention.
+
+When a component sets `<svelte:options customElement="x-foo" />` (or the object form, `<svelte:options customElement={{ tag: "x-foo" }} />`), its declaration gets `tagName: "x-foo"` and `customElement: true`, and the module's `exports` include a `custom-element-definition` export alongside the plain `js` export.
+
+Components without `customElement` still emit a plain class declaration (no `tagName`/`customElement`) — useful for documenting the class shape even before it's compiled as a custom element, but the manifest is most useful for `customElement`-compiled builds, where downstream tooling can resolve `tagName`, `attributes`, and `events` for actual custom-element usage.
+
+### Consuming the manifest
+
+Most tools discover `custom-elements.json` through a `customElements` field in `package.json`, pointing at the generated file:
+
+```json
+{
+  "customElements": "custom-elements.json"
+}
+```
+
+With that in place:
+
+- The [VS Code custom elements extension](https://marketplace.visualstudio.com/items?itemName=BendingSpoons.vscode-custom-elements) and JetBrains IDEs pick it up automatically, giving tag name, attribute, and slot completion/hover in HTML and Svelte templates.
+- [Storybook](https://storybook.js.org/docs/api/doc-blocks/doc-block-argtypes#extracting-argtypes) for web components reads the manifest to auto-generate `argTypes` (controls, docs tables) for `customElement`-compiled components, once you point it at the file (e.g. `setCustomElementsManifest` from `@storybook/web-components`, or `customElements: "custom-elements.json"` in `.storybook/main.js`).
+- Any other tool built against the [Custom Elements Manifest spec](https://github.com/webcomponents/custom-elements-manifest) (API viewers, doc generators, linters) can read the file directly without sveld-specific integration.
 
 ## API Reference
 

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -11,6 +11,7 @@
     Tabs,
   } from "carbon-components-svelte";
   import Code from "carbon-icons-svelte/lib/Code.svelte";
+  import Cube from "carbon-icons-svelte/lib/Cube.svelte";
   import Json from "carbon-icons-svelte/lib/Json.svelte";
   import TextCreation from "carbon-icons-svelte/lib/TextCreation.svelte";
   import { type Component, onMount } from "svelte";
@@ -31,6 +32,7 @@
   let tabTypeScript: Component<TabProps> | undefined;
   let tabJson: Component<TabProps> | undefined;
   let tabMarkdown: Component<TabProps> | undefined;
+  let tabCustomElements: Component<TabProps> | undefined;
 
   onMount(() => {
     import("./CodeEditor.svelte").then((importee) => {
@@ -47,6 +49,10 @@
 
     import("./TabMarkdown.svelte").then((importee) => {
       tabMarkdown = importee.default;
+    });
+
+    import("./TabCustomElements.svelte").then((importee) => {
+      tabCustomElements = importee.default;
     });
   });
 
@@ -127,6 +133,10 @@
             label="Markdown"
             icon={TextCreation}
           />
+          <Tab
+            label="Custom Elements"
+            icon={Cube}
+          />
           <div
             class="tab-content-slot"
             slot="content"
@@ -160,6 +170,17 @@
               {#if tabMarkdown}
                 <svelte:component
                   this={tabMarkdown}
+                  {parsed_component}
+                  {moduleName}
+                />
+              {:else}
+                <InlineLoading style="margin: var(--cds-spacing-05)" />
+              {/if}
+            </TabContent>
+            <TabContent>
+              {#if tabCustomElements}
+                <svelte:component
+                  this={tabCustomElements}
                   {parsed_component}
                   {moduleName}
                 />

--- a/playground/src/TabCustomElements.svelte
+++ b/playground/src/TabCustomElements.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  export let parsed_component = {};
+  export let moduleName = "";
+
+  import json from "svelte-highlight/languages/json";
+  import { buildCustomElementsManifest } from "../../src/writer/writer-custom-elements-core";
+  import CodeHighlighter from "./CodeHighlighter.svelte";
+
+  let manifest = { schemaVersion: "1.0.0", modules: [] };
+
+  $: {
+    try {
+      const filePath = `${moduleName}.svelte`;
+      const components = new Map([[moduleName, { ...parsed_component, moduleName, filePath }]]);
+      manifest = buildCustomElementsManifest(components);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+</script>
+
+<CodeHighlighter
+  language={json}
+  code={JSON.stringify(manifest, null, 2)}
+/>

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -133,6 +133,10 @@
         "contexts": {
           "type": "array",
           "items": { "$ref": "#/$defs/context" }
+        },
+        "customElementTag": {
+          "type": "string",
+          "description": "Custom-element tag name from `<svelte:options customElement=\"x-foo\" />` (or the object form's `tag`), when present."
         }
       }
     },

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -660,6 +660,8 @@ export interface ParsedComponent {
   componentCommentSource?: SourceRange;
   /** Contexts created with `setContext` in the component */
   contexts?: ComponentContext[];
+  /** Custom-element tag name from `<svelte:options customElement="x-foo" />` (or the object form's `tag`), when present */
+  customElementTag?: string;
   /**
    * Type guesses from this parse (unknown props, `any` contexts, orphan `@event` tags).
    * Set on every {@link ComponentParser.parseSvelteComponent} call.
@@ -2284,6 +2286,7 @@ export default class ComponentParser {
       componentComment: this.ctx.componentComment,
       componentCommentSource: this.ctx.componentCommentSource,
       contexts: contextsArray,
+      customElementTag: this.ctx.customElementTag,
       diagnostics: this.ctx.diagnosticRecords.slice(),
     };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,8 @@ function parseCliFlag(arg: string): Partial<CliOptions> {
     case "json":
     case "markdown":
       return { [flag]: value === true || value === "true" };
+    case "custom-elements":
+      return { customElements: value === true || value === "true" };
     case "strict":
       return { strict: value === true || value === "true" };
     case "report-diagnostics":

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -56,6 +56,9 @@ export interface ParserContext {
   /** Component extension information (e.g., `extends` attribute) */
   extends?: Extends;
 
+  /** Custom-element tag name from `<svelte:options customElement="x-foo" />` (or the object form's `tag`), when present */
+  customElementTag?: string;
+
   /** Component-level description extracted from `@component` HTML comment */
   componentComment?: string;
 
@@ -183,6 +186,7 @@ export function createParserContext(): ParserContext {
     // metadata
     rest_props: undefined,
     extends: undefined,
+    customElementTag: undefined,
     componentComment: undefined,
     componentCommentSource: undefined,
     generics: null,

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -189,9 +189,11 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
       };
     };
     module?: ModernScriptNode;
+    options?: { customElement?: { tag?: string } } | null;
   };
 
   ctx.scriptLanguage = parser.resolveScriptLanguage(modernParsed);
+  ctx.customElementTag = modernParsed.options?.customElement?.tag;
   const body = modernParsed.instance?.content?.body ?? [];
 
   for (const statement of body) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,9 +8,10 @@ import {
 } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { createSveldBundle, type SveldBundle } from "./watch";
-// Side-effect import: registers the built-in "json"/"markdown"/"types" writers.
+// Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements" writers.
 import "./writer/built-in-writers";
 import { getWriter } from "./writer/registry";
+import type { WriteCustomElementsOptions } from "./writer/writer-custom-elements";
 import type { WriteJsonOptions } from "./writer/writer-json";
 import type { WriteMarkdownOptions } from "./writer/writer-markdown";
 import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
@@ -49,6 +50,9 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
   jsonOptions?: Partial<Omit<WriteJsonOptions, "inputDir">>;
   markdown?: boolean;
   markdownOptions?: Partial<WriteMarkdownOptions>;
+  /** Generate a Custom Elements Manifest (`custom-elements.json`, schemaVersion "1.0.0"). */
+  customElements?: boolean;
+  customElementsOptions?: Partial<Omit<WriteCustomElementsOptions, "inputDir">>;
   /**
    * Run additional, userland-registered writers (via `registerWriter` from
    * "sveld") beyond the built-in `json`/`markdown`/`types` outputs. Keyed by
@@ -159,7 +163,11 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
 }
 
 /** Looks up a built-in writer by name; throws if `built-in-writers` never registered it. */
-function runBuiltInWriter(name: "types" | "json" | "markdown", components: ComponentDocs, options: unknown) {
+function runBuiltInWriter(
+  name: "types" | "json" | "markdown" | "custom-elements",
+  components: ComponentDocs,
+  options: unknown,
+) {
   const writer = getWriter(name);
   if (!writer) throw new Error(`sveld: built-in writer "${name}" is not registered.`);
   return writer.write(components, options);
@@ -230,6 +238,18 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
       ...opts?.markdownOptions,
       entryExports: result.entryExports,
     } satisfies WriteMarkdownOptions);
+  }
+
+  if (opts?.customElements) {
+    /**
+     * Use components (exported only) for the Custom Elements Manifest, matching
+     * the JSON/Markdown outputs' public-API-surface convention.
+     */
+    runBuiltInWriter("custom-elements", result.components, {
+      outFile: "custom-elements.json",
+      ...opts?.customElementsOptions,
+      inputDir,
+    } satisfies WriteCustomElementsOptions);
   }
 
   for (const [name, writerOptions] of Object.entries(opts?.additionalWriters ?? {})) {

--- a/src/writer/built-in-writers.ts
+++ b/src/writer/built-in-writers.ts
@@ -1,4 +1,5 @@
 import { registerWriter } from "./registry";
+import writeCustomElements from "./writer-custom-elements";
 import writeJson from "./writer-json";
 import writeMarkdown from "./writer-markdown";
 import writeTsDefinitions from "./writer-ts-definitions";
@@ -6,3 +7,4 @@ import writeTsDefinitions from "./writer-ts-definitions";
 registerWriter({ name: "json", componentSet: "exported", write: writeJson });
 registerWriter({ name: "markdown", componentSet: "exported", write: writeMarkdown });
 registerWriter({ name: "types", componentSet: "all", write: writeTsDefinitions });
+registerWriter({ name: "custom-elements", componentSet: "exported", write: writeCustomElements });

--- a/src/writer/writer-custom-elements-core.ts
+++ b/src/writer/writer-custom-elements-core.ts
@@ -1,0 +1,229 @@
+import type { DeprecatedValue } from "../ComponentParser";
+import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { buildComponentApiDocument } from "./document-model";
+
+/**
+ * Minimal local subset of the published Custom Elements Manifest schema
+ * (schemaVersion "1.0.0") for the fields sveld can populate. See
+ * https://github.com/webcomponents/custom-elements-manifest for the full spec.
+ */
+export interface CemType {
+  text: string;
+}
+
+export interface CemClassField {
+  kind: "field";
+  name: string;
+  type?: CemType;
+  default?: string;
+  description?: string;
+  deprecated?: DeprecatedValue;
+}
+
+export interface CemAttribute {
+  name: string;
+  fieldName: string;
+  type?: CemType;
+  default?: string;
+  description?: string;
+}
+
+export interface CemEvent {
+  name: string;
+  type: CemType;
+  description?: string;
+  deprecated?: DeprecatedValue;
+}
+
+export interface CemSlot {
+  name: string;
+  description?: string;
+  deprecated?: DeprecatedValue;
+}
+
+export interface CemClassDeclaration {
+  kind: "class";
+  name: string;
+  description?: string;
+  members: CemClassField[];
+  attributes: CemAttribute[];
+  events: CemEvent[];
+  slots: CemSlot[];
+  /** Only present when the source component sets `<svelte:options customElement="..." />`. */
+  tagName?: string;
+  /** Only present when the source component sets `<svelte:options customElement="..." />`. */
+  customElement?: true;
+}
+
+export interface CemJavaScriptExport {
+  kind: "js";
+  name: string;
+  declaration: { name: string; module: string };
+}
+
+export interface CemCustomElementExport {
+  kind: "custom-element-definition";
+  name: string;
+  declaration: { name: string; module: string };
+}
+
+export type CemExport = CemJavaScriptExport | CemCustomElementExport;
+
+export interface CemModule {
+  kind: "javascript-module";
+  path: string;
+  declarations: CemClassDeclaration[];
+  exports: CemExport[];
+}
+
+export interface CustomElementsManifest {
+  schemaVersion: "1.0.0";
+  modules: CemModule[];
+}
+
+/**
+ * Attribute-compatible prop types: primitives only. Anything else (arrays,
+ * objects, unions, custom types) is skipped, since sveld doesn't attempt to
+ * infer how a complex type reflects to a DOM attribute string.
+ */
+const PRIMITIVE_ATTRIBUTE_TYPES = new Set(["string", "number", "boolean"]);
+
+function buildMembers(props: ComponentDocApi["props"]): CemClassField[] {
+  return props.map((prop) => ({
+    kind: "field",
+    name: prop.name,
+    ...(prop.type ? { type: { text: prop.type } } : {}),
+    ...(prop.value === undefined ? {} : { default: prop.value }),
+    ...(prop.description ? { description: prop.description } : {}),
+    ...(prop.deprecated === undefined ? {} : { deprecated: prop.deprecated }),
+  }));
+}
+
+/**
+ * Derives attributes from props whose name is already attribute-compatible
+ * (Svelte's custom-element runtime lowercases the prop name by default,
+ * `key.toLowerCase()`) and whose type is a bare primitive. Props that would
+ * collide on the same lowercased attribute name are dropped on both sides,
+ * since which prop wins at runtime is ambiguous.
+ */
+function buildAttributes(props: ComponentDocApi["props"]): CemAttribute[] {
+  const byAttributeName = new Map<string, ComponentDocApi["props"]>();
+
+  for (const prop of props) {
+    if (!prop.type || !PRIMITIVE_ATTRIBUTE_TYPES.has(prop.type.trim())) continue;
+
+    const attributeName = prop.name.toLowerCase();
+    const existing = byAttributeName.get(attributeName);
+    if (existing) {
+      existing.push(prop);
+    } else {
+      byAttributeName.set(attributeName, [prop]);
+    }
+  }
+
+  const attributes: CemAttribute[] = [];
+  for (const [attributeName, candidates] of byAttributeName) {
+    if (candidates.length !== 1) continue;
+    const prop = candidates[0];
+    attributes.push({
+      name: attributeName,
+      fieldName: prop.name,
+      type: { text: prop.type as string },
+      ...(prop.value === undefined ? {} : { default: prop.value }),
+      ...(prop.description ? { description: prop.description } : {}),
+    });
+  }
+
+  return attributes;
+}
+
+function buildEvents(events: ComponentDocApi["events"]): CemEvent[] {
+  return events
+    .filter((event) => event.type === "dispatched")
+    .map((event) => ({
+      name: event.name,
+      type: { text: `CustomEvent<${event.detail ?? "unknown"}>` },
+      ...(event.description ? { description: event.description } : {}),
+      ...(event.deprecated === undefined ? {} : { deprecated: event.deprecated }),
+    }));
+}
+
+function buildSlots(slots: ComponentDocApi["slots"]): CemSlot[] {
+  return slots.map((slot) => ({
+    name: slot.default ? "" : (slot.name ?? ""),
+    ...(slot.description ? { description: slot.description } : {}),
+    ...(slot.deprecated === undefined ? {} : { deprecated: slot.deprecated }),
+  }));
+}
+
+function buildDeclaration(component: ComponentDocApi): CemClassDeclaration {
+  const declaration: CemClassDeclaration = {
+    kind: "class",
+    name: component.moduleName,
+    ...(component.componentComment ? { description: component.componentComment } : {}),
+    members: buildMembers(component.props),
+    attributes: buildAttributes(component.props),
+    events: buildEvents(component.events),
+    slots: buildSlots(component.slots),
+  };
+
+  if (component.customElementTag) {
+    declaration.tagName = component.customElementTag;
+    declaration.customElement = true;
+  }
+
+  return declaration;
+}
+
+function buildExports(component: ComponentDocApi, modulePath: string): CemExport[] {
+  const exports: CemExport[] = [
+    {
+      kind: "js",
+      name: component.moduleName,
+      declaration: { name: component.moduleName, module: modulePath },
+    },
+  ];
+
+  if (component.customElementTag) {
+    exports.push({
+      kind: "custom-element-definition",
+      name: component.customElementTag,
+      declaration: { name: component.moduleName, module: modulePath },
+    });
+  }
+
+  return exports;
+}
+
+export interface BuildCustomElementsManifestOptions {
+  /** Resolves each component's manifest `path`. Defaults to the component's `filePath` as-is. */
+  resolveModulePath?: (component: ComponentDocApi) => string;
+}
+
+/**
+ * Builds a Custom Elements Manifest (schemaVersion "1.0.0") in memory, with
+ * no file-system or `node:*` dependency so it can run in the browser (e.g.
+ * the playground).
+ */
+export function buildCustomElementsManifest(
+  components: ComponentDocs,
+  options: BuildCustomElementsManifestOptions = {},
+): CustomElementsManifest {
+  const document = buildComponentApiDocument(components);
+  const resolveModulePath = options.resolveModulePath ?? ((component: ComponentDocApi) => component.filePath);
+
+  const modules: CemModule[] = document.components.map((component) => {
+    const modulePath = resolveModulePath(component);
+    return {
+      kind: "javascript-module",
+      path: modulePath,
+      declarations: [buildDeclaration(component)],
+      exports: buildExports(component, modulePath),
+    };
+  });
+
+  return {
+    schemaVersion: "1.0.0",
+    modules,
+  };
+}

--- a/src/writer/writer-custom-elements.ts
+++ b/src/writer/writer-custom-elements.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+import { normalizeSeparators } from "../path";
+import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { createJsonWriter } from "./Writer";
+import { buildCustomElementsManifest } from "./writer-custom-elements-core";
+
+export type {
+  CemAttribute,
+  CemClassDeclaration,
+  CemClassField,
+  CemCustomElementExport,
+  CemEvent,
+  CemExport,
+  CemJavaScriptExport,
+  CemModule,
+  CemSlot,
+  CemType,
+  CustomElementsManifest,
+} from "./writer-custom-elements-core";
+
+export interface WriteCustomElementsOptions {
+  inputDir: string;
+  outFile: string;
+}
+
+/**
+ * Normalizes `filePath` to be resolvable from `cwd`, matching the JSON
+ * writer's convention so `custom-elements.json` is self-describing.
+ */
+function normalizedModulePath(component: ComponentDocApi, inputDir: string): string {
+  return normalizeSeparators(path.join(inputDir, path.normalize(component.filePath)));
+}
+
+/**
+ * Writes component documentation as a Custom Elements Manifest
+ * (schemaVersion "1.0.0"). Components without a `customElementTag` (i.e. not
+ * compiled with `<svelte:options customElement="..." />`) still emit a plain
+ * class declaration; the manifest is most useful for `customElement`-compiled
+ * builds, where editors, Storybook, and other CEM-aware tooling can resolve
+ * `tagName`, `attributes`, and `events`.
+ */
+export default async function writeCustomElements(components: ComponentDocs, options: WriteCustomElementsOptions) {
+  const manifest = buildCustomElementsManifest(components, {
+    resolveModulePath: (component) => normalizedModulePath(component, options.inputDir),
+  });
+
+  const output_path = path.join(process.cwd(), options.outFile);
+  const writer = createJsonWriter();
+  await writer.write(output_path, JSON.stringify(manifest));
+
+  console.log(`created "${options.outFile}".`);
+}

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -122,6 +122,86 @@ exports[`fixtures (JSON) "svg-props/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-render-skipped-argument/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "title",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-render-skipped-argument/input.svelte",
+      "kind": "syntax-skipped",
+      "name": "children",
+      "message": "{@render children(...)} argument is not a plain object literal; the render call was not mapped to slot metadata.",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 12
+        },
+        "end": {
+          "line": 9,
+          "column": 42
+        }
+      }
+    },
+    {
+      "component": "runes-render-skipped-argument/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "title",
+      "message": "Prop \\"title\\" type could not be inferred; falling back to \\"any\\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ]
+}
+"
+`;
+
 exports[`fixtures (JSON) "slot-event-template-prop-reference/input.svelte" 1`] = `
 "{
   "source": {
@@ -2504,6 +2584,64 @@ exports[`fixtures (JSON) "template-tag-multiple/input.svelte" 1`] = `
     "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"
   ],
   "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "context-generics-dollar-name/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 5
+        },
+        "end": {
+          "line": 19,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Value$Type",
+    "Value$Type extends string"
+  ],
+  "contexts": [
+    {
+      "key": "Demo",
+      "typeName": "DemoContext",
+      "properties": [
+        {
+          "name": "value",
+          "type": "Value$Type",
+          "description": "",
+          "optional": false
+        }
+      ]
+    }
+  ],
   "diagnostics": []
 }
 "
@@ -14918,6 +15056,7 @@ exports[`fixtures (JSON) "runes-host-custom-element/input.svelte" 1`] = `
   "typedefs": [],
   "generics": null,
   "contexts": [],
+  "customElementTag": "my-widget",
   "diagnostics": [
     {
       "component": "runes-host-custom-element/input.svelte",
@@ -15610,6 +15749,78 @@ exports[`fixtures (JSON) "slot-jsdoc-template-not-passthrough/input.svelte" 1`] 
   "typedefs": [],
   "generics": null,
   "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "custom-element-options-tag/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "The badge label.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\\"\\"",
+      "defaultValue": {
+        "raw": "\\"\\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 24
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "customElementTag": "x-badge",
   "diagnostics": []
 }
 "
@@ -17185,6 +17396,24 @@ export default class SvgProps extends SvelteComponentTyped<SvgPropsProps, Record
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-render-skipped-argument/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type RunesRenderSkippedArgumentProps = {
+  /**
+   * @default undefined
+   */
+  title: undefined;
+};
+
+export default class RunesRenderSkippedArgument extends SvelteComponentTyped<
+  RunesRenderSkippedArgumentProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "slot-event-template-prop-reference/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -17910,6 +18139,25 @@ export default class TemplateTagMultiple<
   TemplateTagMultipleProps<Row, Header>,
   Record<string, any>,
   { default: { headers: ReadonlyArray<DataTableHeader<Row, Header>>; rows: ReadonlyArray<Row> } }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "context-generics-dollar-name/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DemoContext<Value$Type extends string> = {
+  value: Value$Type;
+};
+
+export type ContextGenericsDollarNameProps<Value$Type extends string> = {
+  children?: (this: void) => void;
+};
+
+export default class ContextGenericsDollarName<Value$Type extends string> extends SvelteComponentTyped<
+  ContextGenericsDollarNameProps<Value$Type>,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;
@@ -21700,6 +21948,27 @@ export default class SlotJsdocTemplateNotPassthrough extends SvelteComponentType
 "
 `;
 
+exports[`fixtures (TypeScript) "custom-element-options-tag/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type CustomElementOptionsTagProps = {
+  /**
+   * The badge label.
+   * @default ""
+   */
+  label?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class CustomElementOptionsTag extends SvelteComponentTyped<
+  CustomElementOptionsTagProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "svelte-element-dynamic/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
@@ -22274,181 +22543,6 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
     /** Row id maps to server-side UUID v4 (not v1-v3). */
     item: { id: string };
   }
-> {}
-"
-`;
-
-exports[`fixtures (JSON) "context-generics-dollar-name/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 20,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "Record<string, never>",
-      "source": {
-        "start": {
-          "line": 19,
-          "column": 5
-        },
-        "end": {
-          "line": 19,
-          "column": 13
-        }
-      }
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": [
-    "Value$Type",
-    "Value$Type extends string"
-  ],
-  "contexts": [
-    {
-      "key": "Demo",
-      "typeName": "DemoContext",
-      "properties": [
-        {
-          "name": "value",
-          "type": "Value$Type",
-          "description": "",
-          "optional": false
-        }
-      ]
-    }
-  ],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "context-generics-dollar-name/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type DemoContext<Value$Type extends string> = {
-  value: Value$Type;
-};
-
-export type ContextGenericsDollarNameProps<Value$Type extends string> = {
-  children?: (this: void) => void;
-};
-
-export default class ContextGenericsDollarName<Value$Type extends string> extends SvelteComponentTyped<
-  ContextGenericsDollarNameProps<Value$Type>,
-  Record<string, any>,
-  { default: Record<string, never> }
-> {}
-"
-`;
-
-exports[`fixtures (JSON) "runes-render-skipped-argument/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 10,
-      "column": 0
-    }
-  },
-  "syntaxMode": "runes",
-  "scriptLanguage": "js",
-  "props": [
-    {
-      "name": "title",
-      "kind": "let",
-      "typeSource": "unknown",
-      "isFunction": false,
-      "isFunctionDeclaration": false,
-      "isRequired": true,
-      "constant": false,
-      "reactive": false,
-      "source": {
-        "start": {
-          "line": 2,
-          "column": 8
-        },
-        "end": {
-          "line": 2,
-          "column": 13
-        }
-      }
-    }
-  ],
-  "moduleExports": [],
-  "slots": [],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [],
-  "diagnostics": [
-    {
-      "component": "runes-render-skipped-argument/input.svelte",
-      "kind": "syntax-skipped",
-      "name": "children",
-      "message": "{@render children(...)} argument is not a plain object literal; the render call was not mapped to slot metadata.",
-      "source": {
-        "start": {
-          "line": 9,
-          "column": 12
-        },
-        "end": {
-          "line": 9,
-          "column": 42
-        }
-      }
-    },
-    {
-      "component": "runes-render-skipped-argument/input.svelte",
-      "kind": "prop-unknown-type",
-      "name": "title",
-      "message": "Prop \\"title\\" type could not be inferred; falling back to \\"any\\".",
-      "source": {
-        "start": {
-          "line": 2,
-          "column": 8
-        },
-        "end": {
-          "line": 2,
-          "column": 13
-        }
-      }
-    }
-  ]
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "runes-render-skipped-argument/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type RunesRenderSkippedArgumentProps = {
-  /**
-   * @default undefined
-   */
-  title: undefined;
-};
-
-export default class RunesRenderSkippedArgument extends SvelteComponentTyped<
-  RunesRenderSkippedArgumentProps,
-  Record<string, any>,
-  Record<string, never>
 > {}
 "
 `;

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -81,6 +81,7 @@ describe("component API JSON schema", () => {
         "componentComment",
         "componentCommentSource",
         "contexts",
+        "customElementTag",
       ]),
     );
   });

--- a/tests/fixtures/custom-element-options-tag/input.svelte
+++ b/tests/fixtures/custom-element-options-tag/input.svelte
@@ -1,0 +1,10 @@
+<svelte:options customElement="x-badge" />
+
+<script>
+  /** The badge label. */
+  export let label = "";
+</script>
+
+<span>{label}</span>
+
+<slot />

--- a/tests/fixtures/custom-element-options-tag/output.d.ts
+++ b/tests/fixtures/custom-element-options-tag/output.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type CustomElementOptionsTagProps = {
+  /**
+   * The badge label.
+   * @default ""
+   */
+  label?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class CustomElementOptionsTag extends SvelteComponentTyped<
+  CustomElementOptionsTagProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/custom-element-options-tag/output.json
+++ b/tests/fixtures/custom-element-options-tag/output.json
@@ -1,0 +1,68 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "The badge label.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"\"",
+      "defaultValue": {
+        "raw": "\"\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 24
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "customElementTag": "x-badge",
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-host-custom-element/output.json
+++ b/tests/fixtures/runes-host-custom-element/output.json
@@ -84,6 +84,7 @@
   "typedefs": [],
   "generics": null,
   "contexts": [],
+  "customElementTag": "my-widget",
   "diagnostics": [
     {
       "component": "runes-host-custom-element/input.svelte",

--- a/tests/writer-custom-elements.test.ts
+++ b/tests/writer-custom-elements.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Manual validation step (not automated to avoid a runtime dependency on the
+ * large `custom-elements-manifest` schema package): to validate a generated
+ * `custom-elements.json` against the published schema, run
+ *
+ *   npx ajv-cli validate \
+ *     -s https://unpkg.com/custom-elements-manifest/schema.json \
+ *     -d custom-elements.json
+ *
+ * after enabling `customElements: true` in a project using sveld.
+ */
+import { readFileSync, rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
+import type { ComponentProp, ComponentSlot, SerializedComponentEvent } from "../src/ComponentParser";
+import type { ComponentDocs } from "../src/plugin";
+import type { CemModule } from "../src/writer/writer-custom-elements";
+import writeCustomElements from "../src/writer/writer-custom-elements";
+import { mockComponentDocApi } from "./test-brands";
+
+function mockProp(name: string, overrides?: Partial<ComponentProp>): ComponentProp {
+  return {
+    name,
+    kind: "let",
+    constant: false,
+    isFunction: false,
+    isFunctionDeclaration: false,
+    isRequired: true,
+    reactive: false,
+    ...overrides,
+  };
+}
+
+function mockEvent(name: string, overrides?: Partial<SerializedComponentEvent>): SerializedComponentEvent {
+  return {
+    type: "dispatched",
+    name,
+    ...overrides,
+  } as SerializedComponentEvent;
+}
+
+function mockSlot(overrides?: Partial<ComponentSlot>): ComponentSlot {
+  return {
+    default: true,
+    ...overrides,
+  };
+}
+
+async function runWriter(components: ComponentDocs): Promise<{ module: CemModule; cleanup: () => void }> {
+  const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-"));
+  const outFile = path.relative(process.cwd(), path.join(tempDir, "custom-elements.json"));
+
+  await writeCustomElements(components, { inputDir: "src", outFile });
+
+  const manifest = JSON.parse(readFileSync(path.join(tempDir, "custom-elements.json"), "utf-8"));
+  return {
+    module: manifest.modules[0],
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+  };
+}
+
+describe("writeCustomElements", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("emits schemaVersion 1.0.0 and a javascript-module per component", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "custom-elements.json"));
+    const components: ComponentDocs = new Map([
+      ["Zeta", mockComponentDocApi("Zeta", "Zeta.svelte")],
+      ["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")],
+    ]);
+
+    try {
+      await writeCustomElements(components, { inputDir: "src", outFile });
+      const manifest = JSON.parse(readFileSync(path.join(tempDir, "custom-elements.json"), "utf-8"));
+
+      expect(manifest.schemaVersion).toBe("1.0.0");
+      // Deterministic ordering: sorted alphabetically by moduleName, same as the JSON writer.
+      expect(manifest.modules.map((m: CemModule) => m.declarations[0].name)).toEqual(["Alpha", "Zeta"]);
+      expect(manifest.modules[0].kind).toBe("javascript-module");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("emits a plain class declaration when customElementTag is absent", async () => {
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0]).toMatchObject({
+        kind: "class",
+        name: "Button",
+      });
+      expect(module.declarations[0].tagName).toBeUndefined();
+      expect(module.declarations[0].customElement).toBeUndefined();
+      expect(module.exports).toEqual([
+        { kind: "js", name: "Button", declaration: { name: "Button", module: module.path } },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("maps the custom-element tag name to tagName/customElement and adds the definition export", async () => {
+    const components: ComponentDocs = new Map([
+      ["Badge", mockComponentDocApi("Badge", "Badge.svelte", { customElementTag: "x-badge" })],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0]).toMatchObject({
+        tagName: "x-badge",
+        customElement: true,
+      });
+      expect(module.exports).toContainEqual({
+        kind: "custom-element-definition",
+        name: "x-badge",
+        declaration: { name: "Badge", module: module.path },
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("maps props to members, attributes, events, and slots", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Widget",
+        mockComponentDocApi("Widget", "Widget.svelte", {
+          customElementTag: "x-widget",
+          props: [
+            mockProp("label", { type: "string", value: '"hi"', description: "The label." }),
+            mockProp("count", { type: "number" }),
+            mockProp("data", { type: "Record<string, unknown>" }),
+          ],
+          events: [mockEvent("change", { detail: "string", description: "Fires on change." })],
+          slots: [mockSlot(), mockSlot({ default: false, name: "footer", description: "Footer content." })],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      const declaration = module.declarations[0];
+
+      expect(declaration.members).toEqual([
+        { kind: "field", name: "label", type: { text: "string" }, default: '"hi"', description: "The label." },
+        { kind: "field", name: "count", type: { text: "number" } },
+        { kind: "field", name: "data", type: { text: "Record<string, unknown>" } },
+      ]);
+
+      // Only bare primitive-typed props become attributes; "data" is skipped.
+      expect(declaration.attributes).toEqual([
+        { name: "label", fieldName: "label", type: { text: "string" }, default: '"hi"', description: "The label." },
+        { name: "count", fieldName: "count", type: { text: "number" } },
+      ]);
+
+      expect(declaration.events).toEqual([
+        { name: "change", type: { text: "CustomEvent<string>" }, description: "Fires on change." },
+      ]);
+
+      expect(declaration.slots).toEqual([{ name: "" }, { name: "footer", description: "Footer content." }]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("drops attributes that collide on the same lowercased name", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Clash",
+        mockComponentDocApi("Clash", "Clash.svelte", {
+          props: [mockProp("value", { type: "string" }), mockProp("Value", { type: "string" })],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].attributes).toEqual([]);
+      expect(module.declarations[0].members).toHaveLength(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("excludes forwarded events; only dispatched (including $host) events are included", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Forwarder",
+        mockComponentDocApi("Forwarder", "Forwarder.svelte", {
+          events: [
+            mockEvent("click", { type: "forwarded", element: "button" } as Partial<SerializedComponentEvent>),
+            mockEvent("ready", { detail: "null" }),
+          ],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].events).toEqual([{ name: "ready", type: { text: "CustomEvent<null>" } }]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("carries a deprecated prop's deprecation onto its member and attribute", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Old",
+        mockComponentDocApi("Old", "Old.svelte", {
+          props: [mockProp("legacy", { type: "string", deprecated: "Use `modern` instead." })],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].members[0]).toMatchObject({
+        deprecated: "Use `modern` instead.",
+      });
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Adds a new built-in "custom-elements" writer that emits custom-elements.json, the schemaVersion 1.0.0 Custom Elements Manifest format used by Storybook autodocs, VS Code/JetBrains HTML data, and other CEM-aware tooling. Enable it with customElements: true (customElementsOptions.outFile to override the path) or the --custom-elements CLI flag.

To support this, the parser now extracts the custom-element tag name from <svelte:options customElement="x-foo" /> (both the string and object forms) into a new customElementTag field on ParsedComponent, sourced from the modern-mode AST pass runes-props.ts already runs, so no extra parsing is added. The schema and its tests were updated to match.

The manifest maps props to class members, derives attributes conservatively (only bare string/number/boolean-typed props, using Svelte's own default lowercased attribute name, with colliding names dropped on both sides), maps dispatched and $host-dispatched events to CustomEvent types, and maps named/default slots. Components without customElement still get a plain class declaration. The pure manifest-building logic lives in a new writer-custom-elements-core module with no node:fs/node:path dependency, mirroring the existing markdown/ts-definitions core split, which also let me add a "Custom Elements" tab to the playground that reuses it directly in the browser.

Risk is low and contained to the new writer and the additive customElementTag field. The main thing to watch is the attribute-derivation heuristic: it's intentionally conservative, so some real Svelte custom elements will end up with valid props documented as members but not surfaced as attributes if their type isn't a bare primitive or their name collides after lowercasing.