### PR TITLE
feat(cli): add --help/--version, kebab-case flags, unknown-flag errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,10 @@ npx sveld --json --markdown
 
 If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
 
+Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
+
+Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
+
 ### CI: API-drift checks (`--check`)
 
 `--check` diffs the parsed component API against a committed `COMPONENT_API.json` snapshot, assigns a semver bump to each change, and exits `1` when it finds a breaking change.
@@ -547,9 +551,9 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`markdownOptions`** (object, optional): Options for Markdown output.
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
-- **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
+- **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. Also available as `--resolve-types` (`--resolveTypes` remains as a deprecated alias). See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
 - **`cache`** (boolean | string, optional, default: `false`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path. Also available as `--cache` / `--cache=<path>`. See [Persistent parse cache](#persistent-parse-cache-cache).
-- **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
+- **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. Also available as `--check-examples` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
 - **`strict`** (boolean, optional, default: `false`): Exit with code `1` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import pkg from "../package.json" with { type: "json" };
 import { asSvelteEntryPoint } from "./brands";
 import { type CheckResult, formatCheckReport, runCheck } from "./check";
 import { formatDiagnosticsSummary } from "./diagnostics";
@@ -26,44 +27,86 @@ interface CliOptions extends PluginSveldOptions {
   check?: boolean | string;
 }
 
-function parseCliFlag(arg: string): Partial<CliOptions> {
+const HELP_TEXT = `Usage: sveld [options]
+
+Generate TypeScript definitions and component documentation for a Svelte
+library. With no flags, only TypeScript definitions are generated for the
+entry resolved from package.json#svelte.
+
+Options:
+  --entry=<path>        Entry point to uncompiled Svelte source (default: package.json "svelte" field)
+  --glob                Analyze all *.svelte files instead of the entry barrel
+  --types               Generate TypeScript definitions (default: true)
+  --json                Generate component documentation in JSON format
+  --markdown            Generate component documentation in Markdown format
+  --fail-fast           Abort the run when a single component fails to parse
+  --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (default path: node_modules/.cache/sveld/parse-cache.json)
+  --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
+  --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
+  --report-diagnostics  Print unresolved-type diagnostics to stderr
+  --strict              Exit with code 1 when diagnostics exist (implies --report-diagnostics)
+  --check[=<path>]      Diff the parsed API against a committed snapshot; exit 1 on a breaking change (default path: COMPONENT_API.json)
+  --help                Print this help message and exit
+  --version             Print the installed sveld version and exit
+`;
+
+/** Discriminated result of parsing a single CLI argument, kept side-effect free. */
+type CliFlagResult =
+  | { kind: "option"; option: Partial<CliOptions> }
+  | { kind: "help" }
+  | { kind: "version" }
+  | { kind: "unknown"; arg: string };
+
+/** Maps deprecated camelCase flag spellings to their canonical kebab-case form. */
+const FLAG_ALIASES: Record<string, string> = {
+  resolveTypes: "resolve-types",
+  checkExamples: "check-examples",
+};
+
+function parseCliFlag(arg: string): CliFlagResult {
   if (!arg.startsWith("--")) {
-    return {};
+    return { kind: "unknown", arg };
   }
 
   const eqIndex = arg.indexOf("=");
-  const flag = eqIndex === -1 ? arg.slice(2) : arg.slice(2, eqIndex);
+  const rawFlag = eqIndex === -1 ? arg.slice(2) : arg.slice(2, eqIndex);
   const value = eqIndex === -1 ? true : arg.slice(eqIndex + 1);
+  const flag = FLAG_ALIASES[rawFlag] ?? rawFlag;
 
   switch (flag) {
+    case "help":
+      return { kind: "help" };
+    case "version":
+      return { kind: "version" };
     case "glob":
     case "types":
     case "json":
     case "markdown":
-      return { [flag]: value === true || value === "true" };
+      return { kind: "option", option: { [flag]: value === true || value === "true" } };
     case "strict":
-      return { strict: value === true || value === "true" };
+      return { kind: "option", option: { strict: value === true || value === "true" } };
     case "report-diagnostics":
-      return { reportDiagnostics: value === true || value === "true" };
-    case "resolveTypes":
-    case "checkExamples":
-      return { [flag]: value === true || value === "true" };
+      return { kind: "option", option: { reportDiagnostics: value === true || value === "true" } };
+    case "resolve-types":
+      return { kind: "option", option: { resolveTypes: value === true || value === "true" } };
+    case "check-examples":
+      return { kind: "option", option: { checkExamples: value === true || value === "true" } };
     case "fail-fast":
-      return { failFast: value === true || value === "true" };
+      return { kind: "option", option: { failFast: value === true || value === "true" } };
     case "entry":
-      return typeof value === "string" ? { entry: value } : {};
+      return typeof value === "string" ? { kind: "option", option: { entry: value } } : { kind: "option", option: {} };
     case "cache":
       // Bare `--cache` enables the default cache location; `--cache=<path>`
       // overrides it; `--cache=false` disables it.
-      if (value === "false") return { cache: false };
-      return { cache: typeof value === "string" ? value : true };
+      if (value === "false") return { kind: "option", option: { cache: false } };
+      return { kind: "option", option: { cache: typeof value === "string" ? value : true } };
     case "check":
       // Bare `--check` diffs against the default snapshot path;
       // `--check=<path>` overrides it; `--check=false` disables it.
-      if (value === "false") return { check: false };
-      return { check: typeof value === "string" ? value : true };
+      if (value === "false") return { kind: "option", option: { check: false } };
+      return { kind: "option", option: { check: typeof value === "string" ? value : true } };
     default:
-      return {};
+      return { kind: "unknown", arg };
   }
 }
 
@@ -73,14 +116,27 @@ function resolveCheckSnapshotFile(options: CliOptions): string {
   return options.jsonOptions?.outFile ?? "COMPONENT_API.json";
 }
 
-export function parseCliOptions(argv: string[]): CliOptions {
+/** Discriminated result of parsing the full argument list. */
+export type CliParseResult =
+  | { kind: "options"; options: CliOptions }
+  | { kind: "help" }
+  | { kind: "version" }
+  | { kind: "unknown"; arg: string };
+
+export function parseCliOptions(argv: string[]): CliParseResult {
   const options: CliOptions = {};
 
   for (const arg of argv) {
-    Object.assign(options, parseCliFlag(arg));
+    const result = parseCliFlag(arg);
+
+    if (result.kind !== "option") {
+      return result;
+    }
+
+    Object.assign(options, result.option);
   }
 
-  return options;
+  return { kind: "options", options };
 }
 
 /**
@@ -94,7 +150,26 @@ export function parseCliOptions(argv: string[]): CliOptions {
  * ```
  */
 export async function cli(process: NodeJS.Process) {
-  const cliOptions = parseCliOptions(process.argv.slice(2));
+  const parsed = parseCliOptions(process.argv.slice(2));
+
+  if (parsed.kind === "help") {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (parsed.kind === "version") {
+    console.log(pkg.version);
+    return;
+  }
+
+  if (parsed.kind === "unknown") {
+    console.error(`Unknown flag: ${parsed.arg}`);
+    console.error("Run sveld --help for a list of available flags.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const cliOptions = parsed.options;
   const fileConfig = await loadConfig();
   const options = mergeConfig<CliOptions>(fileConfig, cliOptions);
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,55 +5,96 @@ import { cli, parseCliOptions } from "../src/cli";
 
 describe("parseCliOptions", () => {
   test("--fail-fast enables failFast", () => {
-    expect(parseCliOptions(["--fail-fast"])).toEqual({ failFast: true });
+    expect(parseCliOptions(["--fail-fast"])).toEqual({ kind: "options", options: { failFast: true } });
   });
 
   test("--fail-fast=false disables failFast", () => {
-    expect(parseCliOptions(["--fail-fast=false"])).toEqual({ failFast: false });
+    expect(parseCliOptions(["--fail-fast=false"])).toEqual({ kind: "options", options: { failFast: false } });
   });
 
   test("failFast is absent by default", () => {
-    expect(parseCliOptions(["--glob", "--types"])).toEqual({ glob: true, types: true });
+    expect(parseCliOptions(["--glob", "--types"])).toEqual({
+      kind: "options",
+      options: { glob: true, types: true },
+    });
   });
 
   test("--cache enables the default cache location", () => {
-    expect(parseCliOptions(["--cache"])).toEqual({ cache: true });
+    expect(parseCliOptions(["--cache"])).toEqual({ kind: "options", options: { cache: true } });
   });
 
   test("--cache=<path> sets a custom cache location", () => {
-    expect(parseCliOptions(["--cache=.cache/sveld.json"])).toEqual({ cache: ".cache/sveld.json" });
+    expect(parseCliOptions(["--cache=.cache/sveld.json"])).toEqual({
+      kind: "options",
+      options: { cache: ".cache/sveld.json" },
+    });
   });
 
   test("--cache=false disables the cache", () => {
-    expect(parseCliOptions(["--cache=false"])).toEqual({ cache: false });
+    expect(parseCliOptions(["--cache=false"])).toEqual({ kind: "options", options: { cache: false } });
   });
 
   test("--check enables the default snapshot check", () => {
-    expect(parseCliOptions(["--check"])).toEqual({ check: true });
+    expect(parseCliOptions(["--check"])).toEqual({ kind: "options", options: { check: true } });
   });
 
   test("--check=<path> sets a custom snapshot location", () => {
-    expect(parseCliOptions(["--check=api-snapshot.json"])).toEqual({ check: "api-snapshot.json" });
+    expect(parseCliOptions(["--check=api-snapshot.json"])).toEqual({
+      kind: "options",
+      options: { check: "api-snapshot.json" },
+    });
   });
 
   test("--check=false disables the check", () => {
-    expect(parseCliOptions(["--check=false"])).toEqual({ check: false });
+    expect(parseCliOptions(["--check=false"])).toEqual({ kind: "options", options: { check: false } });
   });
 
-  test("--checkExamples enables checkExamples", () => {
-    expect(parseCliOptions(["--checkExamples"])).toEqual({ checkExamples: true });
+  test("--check-examples and --checkExamples produce identical options", () => {
+    const canonical = parseCliOptions(["--check-examples"]);
+    const alias = parseCliOptions(["--checkExamples"]);
+    expect(canonical).toEqual({ kind: "options", options: { checkExamples: true } });
+    expect(alias).toEqual(canonical);
+  });
+
+  test("--resolve-types and --resolveTypes produce identical options", () => {
+    const canonical = parseCliOptions(["--resolve-types"]);
+    const alias = parseCliOptions(["--resolveTypes"]);
+    expect(canonical).toEqual({ kind: "options", options: { resolveTypes: true } });
+    expect(alias).toEqual(canonical);
   });
 
   test("--report-diagnostics enables reportDiagnostics", () => {
-    expect(parseCliOptions(["--report-diagnostics"])).toEqual({ reportDiagnostics: true });
+    expect(parseCliOptions(["--report-diagnostics"])).toEqual({
+      kind: "options",
+      options: { reportDiagnostics: true },
+    });
   });
 
   test("--report-diagnostics=false disables reportDiagnostics", () => {
-    expect(parseCliOptions(["--report-diagnostics=false"])).toEqual({ reportDiagnostics: false });
+    expect(parseCliOptions(["--report-diagnostics=false"])).toEqual({
+      kind: "options",
+      options: { reportDiagnostics: false },
+    });
   });
 
   test("--strict enables strict", () => {
-    expect(parseCliOptions(["--strict"])).toEqual({ strict: true });
+    expect(parseCliOptions(["--strict"])).toEqual({ kind: "options", options: { strict: true } });
+  });
+
+  test("unknown flag surfaces as an unknown result", () => {
+    expect(parseCliOptions(["--markdwon"])).toEqual({ kind: "unknown", arg: "--markdwon" });
+  });
+
+  test("a positional argument surfaces as an unknown result", () => {
+    expect(parseCliOptions(["foo"])).toEqual({ kind: "unknown", arg: "foo" });
+  });
+
+  test("--help short-circuits before later flags are parsed", () => {
+    expect(parseCliOptions(["--help", "--markdwon"])).toEqual({ kind: "help" });
+  });
+
+  test("--version short-circuits before later flags are parsed", () => {
+    expect(parseCliOptions(["--version", "--markdwon"])).toEqual({ kind: "version" });
   });
 });
 
@@ -100,5 +141,40 @@ describe("cli() entry resolution failures", () => {
 
     expect(process.exitCode).toBe(0);
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('falling back to "src/index.js"'));
+  });
+});
+
+describe("cli() unknown flag", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-unknown-flag-"));
+    process.chdir(dir);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("sets exitCode 1 and writes no output files for an unknown flag", async () => {
+    process.argv = ["bun", "cli.js", "--markdwon"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith("Unknown flag: --markdwon");
+    expect(existsSync(join(dir, "types"))).toBe(false);
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,8 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ESNext",
-    "module": "CommonJS"
+    "module": "ESNext",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Freezes the CLI flag surface ahead of v1. resolve-types and check-examples are now the documented kebab-case flags, with the old resolveTypes and checkExamples spellings kept as deprecated aliases so existing scripts keep working. Unknown flags (and any stray positional argument, since sveld takes none) now print an error to stderr and exit with code 1 instead of being silently ignored, which was previously an easy way for a typo'd flag in CI to go unnoticed. Added --help and --version, with the version pulled from package.json via a JSON import that gets bundled into the build.

Internally, parseCliFlag now returns a discriminated result (option, help, version, or unknown) instead of doing console output itself, so cli() is the only place that owns side effects like writing to stderr or setting the exit code. This did require loosening tsconfig.build.json's module target from CommonJS to ESNext so tsc accepts the import attribute syntax used for the package.json import; the emitted declaration files look the same otherwise.

Main risk is the behavior change around unknown flags and positional arguments: anything relying on sveld silently ignoring a bad flag will now fail loudly with exit code 1. That's the intended v1 tightening, but worth flagging if any downstream CI script passes a flag sveld doesn't recognize.