### PR TITLE
fix(writer): await writeOutput so disk writes finish before callers return

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,7 +123,7 @@ export async function cli(process: NodeJS.Process) {
     });
   }
 
-  writeOutput(result, options, input);
+  await writeOutput(result, options, input);
 
   const { diagnostics } = result;
   const shouldReport = options.reportDiagnostics || options.strict;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -232,13 +232,15 @@ export async function writeOutput(result: GenerateBundleResult, opts: PluginSvel
     } satisfies WriteMarkdownOptions);
   }
 
-  for (const [name, writerOptions] of Object.entries(opts?.additionalWriters ?? {})) {
+  const additionalWrites = Object.entries(opts?.additionalWriters ?? {}).map(([name, writerOptions]) => {
     const writer = getWriter(name);
     if (!writer) {
       console.warn(`sveld: no writer registered with name "${name}"; skipping.`);
-      continue;
+      return undefined;
     }
     const components = writer.componentSet === "all" ? result.allComponentsForTypes : result.components;
-    await writer.write(components, writerOptions);
-  }
+    return writer.write(components, writerOptions);
+  });
+
+  await Promise.all(additionalWrites);
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -81,7 +81,7 @@ interface SveldPlugin {
   enforce?: "pre" | "post";
   buildStart(): void | Promise<void>;
   generateBundle(): Promise<void>;
-  writeBundle(): void;
+  writeBundle(): Promise<void>;
   /** Vite dev-server HMR hook (serve mode). */
   handleHotUpdate?(ctx: HotUpdateContext): void;
   /** Rollup/Vite watch hook (build `--watch`). */
@@ -109,7 +109,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
     pending.clear();
     try {
       const { result: next } = await bundle.update(changed);
-      writeOutput(next, opts || {}, input);
+      await writeOutput(next, opts || {}, input);
     } catch (error) {
       console.error("sveld: failed to regenerate types in watch mode:", error);
     }
@@ -135,7 +135,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
         // covers both `vite dev` (where generateBundle/writeBundle never fire)
         // and `vite build --watch`.
         bundle = await createSveldBundle(input, opts?.glob === true, opts?.documentExports === true);
-        writeOutput(bundle.result, opts || {}, input);
+        await writeOutput(bundle.result, opts || {}, input);
       }
     },
     async generateBundle() {
@@ -145,9 +145,9 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
         result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
       }
     },
-    writeBundle() {
+    async writeBundle() {
       if (watch) return;
-      if (input != null) writeOutput(result, opts || {}, input);
+      if (input != null) await writeOutput(result, opts || {}, input);
     },
     handleHotUpdate(ctx) {
       scheduleUpdate(ctx.file);
@@ -178,7 +178,7 @@ function runBuiltInWriter(name: "types" | "json" | "markdown", components: Compo
  *
  * @example
  * ```ts
- * writeOutput(result, {
+ * await writeOutput(result, {
  *   types: true,
  *   json: true,
  *   markdown: true
@@ -186,7 +186,7 @@ function runBuiltInWriter(name: "types" | "json" | "markdown", components: Compo
  * // Generates: types/*.d.ts, COMPONENT_API.json, COMPONENT_INDEX.md
  * ```
  */
-export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptions, input: string) {
+export async function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptions, input: string) {
   const inputDir = dirname(input);
 
   if (opts?.types !== false) {
@@ -195,7 +195,7 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
      * This ensures TypeScript definitions are available for all components,
      * not just exported ones, which is useful for type checking.
      */
-    runBuiltInWriter("types", result.allComponentsForTypes, {
+    await runBuiltInWriter("types", result.allComponentsForTypes, {
       outDir: "types",
       preamble: "",
       ...opts?.typesOptions,
@@ -210,7 +210,7 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
      * JSON output should only include components that are actually exported,
      * matching the public API surface.
      */
-    runBuiltInWriter("json", result.components, {
+    await runBuiltInWriter("json", result.components, {
       outFile: "COMPONENT_API.json",
       ...opts?.jsonOptions,
       input,
@@ -225,7 +225,7 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
      * Documentation should only include exported components that are
      * part of the public API.
      */
-    runBuiltInWriter("markdown", result.components, {
+    await runBuiltInWriter("markdown", result.components, {
       outFile: "COMPONENT_INDEX.md",
       ...opts?.markdownOptions,
       entryExports: result.entryExports,
@@ -239,6 +239,6 @@ export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptio
       continue;
     }
     const components = writer.componentSet === "all" ? result.allComponentsForTypes : result.components;
-    writer.write(components, writerOptions);
+    await writer.write(components, writerOptions);
   }
 }

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -54,7 +54,7 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   }
   const merged = mergeConfig<PluginSveldOptions>(fileConfig, runtimeOpts, { entry: input });
   const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));
-  writeOutput(result, merged, input);
+  await writeOutput(result, merged, input);
 
   const { diagnostics } = result;
   const shouldReport = reportDiagnostics || strict;

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -205,10 +205,14 @@ describe("sveld() strict mode", () => {
   });
 
   test("returns the aggregated diagnostics array and stays non-failing by default", async () => {
+    // Bun ignores `process.exitCode = undefined` once a numeric code has been
+    // set earlier in the process, so assert against the pre-call value rather
+    // than an unreachable literal `undefined`.
+    const exitCodeBefore = process.exitCode;
     const { diagnostics } = await sveld({ input: relativeDir, glob: true, types: false });
 
     expect(diagnostics.some((d) => d.kind === "event-no-source" && d.name === "phantom")).toBe(true);
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(exitCodeBefore);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
writeOutput() in src/plugin.ts fired its writer.write() calls without awaiting them, and none of its callers, cli(), sveld(), and the Rollup plugin hooks, awaited writeOutput() either. In tests/cli.test.ts this let await cli(process) return before the pending types write finished, so afterEach's rmSync on the temp dir raced ahead of it, producing the ENOENT "Unhandled error between tests" seen in CI. I reproduced this locally by looping the full suite against 4635df1 (HEAD before this fix). It's also a real bug in the documented await sveld(...) API, which resolved before its output files actually existed on disk.

Made writeOutput async and awaited every internal write, then awaited it at all four call sites: cli.ts, sveld.ts, and the plugin's flush/buildStart/writeBundle hooks (writeBundle now returns Promise<void>).

Fixing the race changed test scheduling enough to expose a second, previously latent bug: cli.test.ts's afterEach hardcodes process.exitCode = 0, because Bun ignores process.exitCode = undefined once a number has been set. Under bun test --parallel, test files share that global, so diagnostics.test.ts's expect(process.exitCode).toBeUndefined() became unreachable. Adjusted that assertion to compare against the pre-call value instead of an unreachable literal undefined.

Risk is low. The behavior change is only that output writes now complete before the calling function resolves, which is what callers already assumed. Worth watching CI for any timing-sensitive test that relied on the old fire-and-forget behavior, though the full suite passed cleanly across five repeated runs locally.