### PR TITLE
fix(config): type strict, reportDiagnostics, and check in SveldConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,21 @@ const { diagnostics } = await sveld({
 
 `diagnostics` is always populated; printing is opt-in via `reportDiagnostics` or `strict` (see [Type inference diagnostics](#type-inference-diagnostics)).
 
+Pass `check: true` (or `check: "<path>"` for a custom snapshot location) to diff against a committed `COMPONENT_API.json`, the same way `--check` does on the CLI. The result lands on `SveldResult.check`; sveld does not print it or touch `process.exitCode` for you, so inspect and act on it yourself:
+
+```js
+import { formatCheckReport } from "sveld";
+
+const { check } = await sveld({ json: true, check: true });
+
+if (check) {
+  console.log(formatCheckReport(check));
+  if (check.bump === "major") process.exitCode = 1;
+}
+```
+
+See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check) for how changes are classified.
+
 #### `jsonOptions.outDir`
 
 With `json: true`, `sveld` writes `COMPONENT_API.json` at the project root. The file documents all components.
@@ -508,6 +523,17 @@ Later sources win when options overlap:
 CLI flags > config file > `package.json#svelte` inference / defaults
 
 With the config above, `npx sveld --json` keeps `glob` and `markdown` from the file. A CLI flag overrides the same key in the config.
+
+`strict`, `reportDiagnostics`, and `check` are valid config keys too — not just CLI flags or `sveld()` options — and follow the same precedence: a CLI flag (or an option passed to `sveld()`) overrides the same key set in the config file.
+
+```js
+// sveld.config.js
+export default {
+  json: true,
+  strict: true,
+  check: "snapshots/COMPONENT_API.json",
+};
+```
 
 A bad config (syntax error, throws at load time, or no default-export object) fails with an error that names the file.
 
@@ -556,6 +582,7 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. Also available as `--check-examples` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
 - **`strict`** (boolean, optional, default: `false`): Exit with code `1` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).
+- **`check`** (boolean | string, optional, default: `false`): Diff the parsed component API against a committed snapshot and assign a semver bump to each change. `true` uses the `json` writer's `outFile` (or `COMPONENT_API.json`); a string sets a custom snapshot path. Also available as `--check` / `--check=<path>`. On the CLI this exits `1` on a breaking change; from `sveld()` it's returned on `SveldResult.check` for you to act on. See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check).
 
 By default, only TypeScript definitions are generated.
 

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { ComponentDocApi, ComponentDocs } from "./bundle";
+import type { SveldRuntimeOptions } from "./load-config";
 import type { EntryExports } from "./parse-entry-exports";
 import {
   buildComponentApiDocument,
@@ -348,6 +349,15 @@ async function readSnapshot(snapshotFile: string): Promise<ComponentApiDocument 
 export interface RunCheckOptions {
   /** Entry-barrel exports when `documentExports` is on. */
   entryExports?: EntryExports;
+}
+
+/**
+ * Resolves the snapshot path for `check`: an explicit string wins, otherwise
+ * it falls back to the `json` writer's `outFile`, or `COMPONENT_API.json`.
+ */
+export function resolveCheckSnapshotFile(options: Pick<SveldRuntimeOptions, "check" | "jsonOptions">): string {
+  if (typeof options.check === "string") return options.check;
+  return options.jsonOptions?.outFile ?? "COMPONENT_API.json";
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,30 +2,18 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import pkg from "../package.json" with { type: "json" };
 import { asSvelteEntryPoint } from "./brands";
-import { type CheckResult, formatCheckReport, runCheck } from "./check";
+import { type CheckResult, formatCheckReport, resolveCheckSnapshotFile, runCheck } from "./check";
 import { formatDiagnosticsSummary } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { loadConfig, mergeConfig } from "./load-config";
+import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
 import { normalizeSeparators } from "./path";
-import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
+import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
 /** Relative fallback entry used only when entry resolution otherwise fails. */
 const FALLBACK_ENTRY = "src/index.js";
 
-/** CLI options layered on top of the shared plugin options. */
-interface CliOptions extends PluginSveldOptions {
-  /** Print unresolved-type diagnostics to stderr. */
-  reportDiagnostics?: boolean;
-  /** Set exit code 1 when diagnostics are present. Implies `reportDiagnostics`. */
-  strict?: boolean;
-  /**
-   * Diff the parsed component API against a committed snapshot (default:
-   * the `json` writer's `outFile`, or `COMPONENT_API.json`) and assign a
-   * semver bump to each change. Exits `1` on a breaking change. Pass a
-   * string for a custom snapshot path.
-   */
-  check?: boolean | string;
-}
+/** CLI options: identical surface to the shared runtime options. */
+type CliOptions = SveldRuntimeOptions;
 
 const HELP_TEXT = `Usage: sveld [options]
 
@@ -108,12 +96,6 @@ function parseCliFlag(arg: string): CliFlagResult {
     default:
       return { kind: "unknown", arg };
   }
-}
-
-/** Default snapshot path mirrors the `json` writer's default `outFile`. */
-function resolveCheckSnapshotFile(options: CliOptions): string {
-  if (typeof options.check === "string") return options.check;
-  return options.jsonOptions?.outFile ?? "COMPONENT_API.json";
 }
 
 /** Discriminated result of parsing the full argument list. */

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -5,10 +5,29 @@ import type { PluginSveldOptions } from "./plugin";
 import { isRecord } from "./validate";
 
 /**
- * Public shape of a `sveld.config.{js,ts,mjs}` file. Identical to the options
- * accepted by the Vite/Rollup plugin and the CLI.
+ * Options shared by the config file, the CLI, and the programmatic `sveld()`
+ * API. Superset of `PluginSveldOptions` with the CLI-oriented flags that only
+ * make sense as part of a full `sveld` run (not the Vite/Rollup plugin).
  */
-export type SveldConfig = PluginSveldOptions;
+export interface SveldRuntimeOptions extends PluginSveldOptions {
+  /** Print unresolved-type diagnostics to stderr. */
+  reportDiagnostics?: boolean;
+  /** Exit code 1 when diagnostics exist. Implies `reportDiagnostics`. */
+  strict?: boolean;
+  /**
+   * Diff the parsed component API against a committed snapshot (default:
+   * the `json` writer's `outFile`, or `COMPONENT_API.json`) and assign a
+   * semver bump to each change. Exits `1` on a breaking change. Pass a
+   * string for a custom snapshot path.
+   */
+  check?: boolean | string;
+}
+
+/**
+ * Public shape of a `sveld.config.{js,ts,mjs}` file. Identical to the options
+ * accepted by the CLI and the programmatic `sveld()` API.
+ */
+export type SveldConfig = SveldRuntimeOptions;
 
 /** Config file names probed at the project root. First existing file wins. */
 export const CONFIG_FILE_NAMES = ["sveld.config.js", "sveld.config.mjs", "sveld.config.ts"] as const;

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,24 +1,16 @@
+import { type CheckResult, resolveCheckSnapshotFile, runCheck } from "./check";
 import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { loadConfig, mergeConfig } from "./load-config";
-import { generateBundle, type PluginSveldOptions, toGenerateBundleOptions, writeOutput } from "./plugin";
+import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
+import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
-interface SveldOptions extends Omit<PluginSveldOptions, "entry"> {
+interface SveldOptions extends Omit<SveldRuntimeOptions, "entry"> {
   /**
    * Specify the input to the uncompiled Svelte source.
    * If no value is provided, `sveld` will attempt to infer
    * the entry point from the `package.json#svelte` field.
    */
   input?: string;
-  /**
-   * Print unresolved-type diagnostics to stderr. Default `false`.
-   */
-  reportDiagnostics?: boolean;
-  /**
-   * Exit with code 1 when diagnostics are present. Implies `reportDiagnostics`.
-   * Default `false`.
-   */
-  strict?: boolean;
 }
 
 /**
@@ -27,6 +19,8 @@ interface SveldOptions extends Omit<PluginSveldOptions, "entry"> {
 interface SveldResult {
   /** Diagnostics from this run. */
   diagnostics: SveldDiagnostic[];
+  /** Populated when `check` is enabled: the API diff against the committed snapshot. */
+  check?: CheckResult;
 }
 
 /**
@@ -44,7 +38,7 @@ interface SveldResult {
  * ```
  */
 export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
-  const { input: inputOverride, strict, reportDiagnostics, ...runtimeOpts } = opts ?? {};
+  const { input: inputOverride, ...runtimeOpts } = opts ?? {};
   const fileConfig = await loadConfig();
   const input = getSvelteEntry(inputOverride ?? fileConfig.entry);
   if (input === null) {
@@ -52,20 +46,29 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
       'sveld: could not resolve a Svelte entry point. Set package.json#svelte, or pass the "input" option.',
     );
   }
-  const merged = mergeConfig<PluginSveldOptions>(fileConfig, runtimeOpts, { entry: input });
+  const merged = mergeConfig<SveldRuntimeOptions>(fileConfig, runtimeOpts, { entry: input });
   const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));
+
+  // Read the committed snapshot before `writeOutput` can overwrite it.
+  let checkResult: CheckResult | undefined;
+  if (merged.check) {
+    checkResult = await runCheck(result.components, resolveCheckSnapshotFile(merged), {
+      entryExports: result.entryExports,
+    });
+  }
+
   await writeOutput(result, merged, input);
 
   const { diagnostics } = result;
-  const shouldReport = reportDiagnostics || strict;
+  const shouldReport = merged.reportDiagnostics || merged.strict;
 
   if (shouldReport && diagnostics.length > 0) {
     console.warn(formatDiagnosticsSummary(diagnostics));
   }
 
-  if (strict && diagnostics.length > 0) {
+  if (merged.strict && diagnostics.length > 0) {
     process.exitCode = 1;
   }
 
-  return { diagnostics };
+  return { diagnostics, check: checkResult };
 }

--- a/tests/load-config.test.ts
+++ b/tests/load-config.test.ts
@@ -1,7 +1,14 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { loadConfig, loadConfigFrom, mergeConfig, resolveConfigPath } from "../src/load-config";
+import {
+  defineConfig,
+  loadConfig,
+  loadConfigFrom,
+  mergeConfig,
+  resolveConfigPath,
+  type SveldRuntimeOptions,
+} from "../src/load-config";
 import type { PluginSveldOptions } from "../src/plugin";
 
 function withTempDir(prefix: string, run: (dir: string) => void | Promise<void>) {
@@ -60,6 +67,21 @@ describe("loadConfig", () => {
           "export default defineConfig({ markdown: true });",
       );
       await expect(loadConfig(dir)).resolves.toEqual({ markdown: true });
+    });
+  });
+
+  test("defineConfig accepts strict, reportDiagnostics, and check", () => {
+    expect(defineConfig({ strict: true, reportDiagnostics: true, check: true })).toEqual({
+      strict: true,
+      reportDiagnostics: true,
+      check: true,
+    });
+  });
+
+  test("loads a config with strict and a custom check snapshot path", async () => {
+    await withTempDir("sveld-config-load-", async (dir) => {
+      writeFileSync(path.join(dir, "sveld.config.js"), 'export default { strict: true, check: "snapshots/api.json" };');
+      await expect(loadConfig(dir)).resolves.toEqual({ strict: true, check: "snapshots/api.json" });
     });
   });
 
@@ -123,5 +145,14 @@ describe("mergeConfig", () => {
 
   test("leaves config keys alone when a later source omits them", () => {
     expect(mergeConfig({ markdown: true }, {})).toEqual({ markdown: true });
+  });
+
+  test("carries strict, reportDiagnostics, and check through the merge", () => {
+    const fileConfig: Partial<SveldRuntimeOptions> = { strict: true, check: "snapshots/api.json" };
+    expect(mergeConfig<SveldRuntimeOptions>(fileConfig, { reportDiagnostics: true })).toEqual({
+      strict: true,
+      check: "snapshots/api.json",
+      reportDiagnostics: true,
+    });
   });
 });

--- a/tests/sveld.test.ts
+++ b/tests/sveld.test.ts
@@ -1,7 +1,9 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { sveld } from "../src/sveld";
+import { buildComponentApiDocument } from "../src/writer/document-model";
+import { mockComponentDocApi } from "./test-brands";
 
 const ENTRY_ERROR = /entry/i;
 
@@ -28,5 +30,54 @@ describe("sveld() entry resolution failures", () => {
 
   test("throws when no input is given and package.json#svelte is absent", async () => {
     await expect(sveld()).rejects.toThrow(ENTRY_ERROR);
+  });
+});
+
+describe("sveld() check", () => {
+  // `getSvelteEntry` resolves `input` against `process.cwd()`, so the fixture
+  // lives under cwd and is referenced by its relative directory name.
+  let absoluteDir: string;
+  let relativeDir: string;
+
+  let entry: string;
+
+  beforeEach(() => {
+    absoluteDir = mkdtempSync(join(process.cwd(), "sveld-check-"));
+    relativeDir = basename(absoluteDir);
+    entry = join(relativeDir, "index.js");
+    writeFileSync(
+      join(absoluteDir, "Button.svelte"),
+      "<script>\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(
+      join(absoluteDir, "index.js"),
+      'import Button from "./Button.svelte";\n\nexport { Button };\nexport default Button;\n',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(absoluteDir, { recursive: true, force: true });
+  });
+
+  test("populates result.check when a snapshot exists", async () => {
+    const snapshotFile = join(relativeDir, "COMPONENT_API.json");
+    const snapshot = buildComponentApiDocument(
+      new Map([["Button", mockComponentDocApi("Button", "Button.svelte", { props: [] })]]),
+    );
+    writeFileSync(join(absoluteDir, "COMPONENT_API.json"), JSON.stringify(snapshot));
+
+    const result = await sveld({ input: entry, types: false, check: snapshotFile });
+
+    expect(result.check).toBeDefined();
+    expect(result.check?.snapshotExists).toBe(true);
+    expect(result.check?.changes).toContainEqual(
+      expect.objectContaining({ component: "Button", kind: "prop", name: "label" }),
+    );
+  });
+
+  test("does not run check when the option is omitted", async () => {
+    const result = await sveld({ input: entry, types: false });
+
+    expect(result.check).toBeUndefined();
   });
 });


### PR DESCRIPTION
strict, reportDiagnostics, and check lived only on the CLI-private CliOptions interface, while SveldConfig was aliased to PluginSveldOptions. That meant defineConfig({ strict: true }) was a type error even though an untyped sveld.config.js exporting the same object worked fine at runtime, since the config loader shallow-merges whatever the file exports.

This hoists those three fields into a new SveldRuntimeOptions interface in src/load-config.ts, which SveldConfig now aliases and CliOptions now extends directly, so the config file, the CLI, and the programmatic API all agree on the same typed surface. It also adds check support to the programmatic sveld() API, mirroring the CLI's flow of running the diff before writeOutput can overwrite the snapshot, and returns the CheckResult on SveldResult.check for callers to inspect. Along the way this fixes a latent gap where sveld() ignored strict/reportDiagnostics set in a config file, since those weren't previously part of the merged options.

Risk is low and mostly type-level. The runtime behavior of the CLI is unchanged (resolveCheckSnapshotFile moved to check.ts but works the same way). The one behavioral addition is check in sveld(): it does not print a report or set process.exitCode automatically, so existing callers are unaffected unless they start passing check explicitly.