### PR TITLE
feat(parser): support the script generics attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -2524,14 +2524,15 @@ import Button from "./Button.svelte";
 
 ### `@template`
 
-Svelte supports defining generics via the [`generics` attribute](https://svelte.dev/docs/svelte/typescript) on the script tag, but this requires `lang="ts"`.
+Svelte supports defining generics via the [`generics` attribute](https://svelte.dev/docs/svelte/typescript) on the script tag, but this requires `lang="ts"`:
 
 ```svelte
-<!-- Requires lang="ts" -->
 <script lang="ts" generics="Row extends DataTableRow = any"></script>
 ```
 
-Because `sveld` targets JavaScript-only usage as a baseline, generics use the standard JSDoc `@template` tag. `@generics` is also supported as an alias.
+`sveld` reads the `generics` attribute directly, and it's the recommended way to declare generics for `lang="ts"` components. Because `sveld` also targets JavaScript-only usage as a baseline, plain JS (or JS-with-JSDoc) components instead use the standard JSDoc `@template` tag; `@generics` is also supported as an alias.
+
+**Precedence:** if a component declares generics both ways, the `generics` attribute wins — it's the compiler-checked source of truth — and the `@generics`/`@template` tag is reported as a `syntax-skipped` diagnostic rather than silently dropped. The attribute is invalid without `lang="ts"`; if present on a plain-JS script, sveld reports `syntax-skipped` and ignores it rather than guessing.
 
 **Signature:** Uses standard [JSDoc `@template` syntax](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template):
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -24,6 +24,7 @@ import { createParserContext, type ParserContext } from "./parser/context";
 import { parseSetContextCall } from "./parser/contexts";
 import { recordDiagnostic } from "./parser/diagnostics";
 import { addDispatchedEvent, literalDetailToTypeText, parseHostDispatchEventCall } from "./parser/events";
+import { parseGenericsAttribute } from "./parser/generics";
 import { getCommentTags, parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
 import { addProp, processInitializer } from "./parser/props";
 import { maybeSetRestProps } from "./parser/rest-props";
@@ -233,6 +234,8 @@ export interface ProcessedInitializer {
 type ModernScriptAttribute = {
   name?: string;
   value?: Array<{ data?: string; raw?: string }> | boolean;
+  start?: number;
+  end?: number;
 };
 
 export type ModernScriptNode = {
@@ -715,6 +718,41 @@ export default class ComponentParser {
     }
 
     return hasPlainScript ? "js" : undefined;
+  }
+
+  /**
+   * Reads the `generics` attribute off the instance script (Svelte only allows
+   * it there, and only alongside `lang="ts"`). Returns the raw value for later
+   * precedence resolution against `@generics`/`@template` JSDoc tags, or
+   * `undefined` if absent. Records a `syntax-skipped` diagnostic and returns
+   * `undefined` if the attribute is present without `lang="ts"`, since sveld
+   * can't safely guess how to parse it as plain JavaScript.
+   */
+  resolveScriptGenericsAttribute(parsed: {
+    instance?: ModernScriptNode;
+  }): { value: string; source?: SourceRange } | undefined {
+    const genericsAttribute = parsed.instance?.attributes?.find((attribute) => attribute.name === "generics");
+    if (!genericsAttribute) return undefined;
+
+    const source = sourceRangeFromNode(this.ctx, genericsAttribute);
+    const langAttribute = parsed.instance?.attributes?.find((attribute) => attribute.name === "lang");
+    const language = langAttribute ? ComponentParser.getStaticAttributeValue(langAttribute)?.toLowerCase() : undefined;
+
+    if (language !== "ts") {
+      recordDiagnostic(
+        this.ctx,
+        "syntax-skipped",
+        "generics",
+        `<script generics="..."> requires lang="ts"; the generics attribute was ignored because the script is not TypeScript.`,
+        source,
+      );
+      return undefined;
+    }
+
+    const value = ComponentParser.getStaticAttributeValue(genericsAttribute);
+    if (!value) return undefined;
+
+    return { value, source };
   }
 
   private static assignValue(value?: "" | string) {
@@ -2201,6 +2239,23 @@ export default class ComponentParser {
         if (!new RegExp(`\\b${escapedName}\\b`).test(referencedTypeText)) continue;
         this.accumulateGeneric(name, constraint);
       }
+    }
+
+    /**
+     * The `generics` script attribute is the compiler-checked source of truth,
+     * so it wins over any `@generics`/`@template` JSDoc tags parsed above.
+     */
+    if (this.ctx.scriptGenericsAttribute) {
+      if (this.ctx.generics) {
+        recordDiagnostic(
+          this.ctx,
+          "syntax-skipped",
+          "generics",
+          `Both the "generics" script attribute and @generics/@template JSDoc tags declare component generics; the script attribute takes precedence and the JSDoc declaration was ignored.`,
+          this.ctx.scriptGenericsAttribute.source,
+        );
+      }
+      this.ctx.generics = parseGenericsAttribute(this.ctx.scriptGenericsAttribute.value);
     }
 
     const moduleExportsArray = ComponentParser.mapToArray(this.ctx.moduleExports);

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -68,6 +68,13 @@ export interface ParserContext {
   /** Component generic type parameters (null if no generics) */
   generics: ComponentGenerics;
 
+  /**
+   * Raw `generics` script attribute value (with `lang="ts"` already validated),
+   * held until the end of parsing so it can override any `@generics`/`@template`
+   * JSDoc-derived {@link ParserContext.generics}.
+   */
+  scriptGenericsAttribute?: { value: string; source?: SourceRange };
+
   /** Diagnostics for the parse in progress. */
   readonly diagnosticRecords: SveldDiagnostic[];
 
@@ -190,6 +197,7 @@ export function createParserContext(): ParserContext {
     componentComment: undefined,
     componentCommentSource: undefined,
     generics: null,
+    scriptGenericsAttribute: undefined,
     diagnosticRecords: [],
     componentFilePath: "",
 

--- a/src/parser/generics.ts
+++ b/src/parser/generics.ts
@@ -1,0 +1,78 @@
+import type { ComponentGenerics } from "../ComponentParser";
+import type { ParserContext } from "./context";
+import { collectReferencedTypeDependencies } from "./type-resolution";
+
+const LEADING_IDENTIFIER_REGEX = /^[A-Za-z_$][\w$]*/;
+const IDENTIFIER_REGEX = /[A-Za-z_$][\w$]*/g;
+
+/**
+ * Splits a string on top-level commas, ignoring commas nested inside
+ * `<>`, `()`, `[]`, or `{}`. Shared by the `generics` script attribute parser
+ * and the TypeScript definition writer, both of which must separate generic
+ * constraint declarations that may themselves contain commas (e.g. `Value extends Record<string, any>`).
+ */
+export function splitTopLevelCommas(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === "<" || char === "(" || char === "[" || char === "{") depth++;
+    else if (char === ">" || char === ")" || char === "]" || char === "}") depth--;
+    else if (char === "," && depth === 0) {
+      parts.push(value.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+}
+
+/**
+ * Parses the `generics` script attribute value (a TypeScript type-parameter
+ * list, e.g. `"Row extends DataTableRow = DataTableRow, Header"`) into the
+ * same `[names, constraints]` tuple the `@generics`/`@template` JSDoc tags produce.
+ */
+export function parseGenericsAttribute(value: string): ComponentGenerics {
+  const constraints = splitTopLevelCommas(value)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  if (constraints.length === 0) return null;
+
+  const names = constraints.map((constraint) => constraint.match(LEADING_IDENTIFIER_REGEX)?.[0] ?? constraint);
+
+  return [names.join(","), constraints.join(", ")];
+}
+
+/**
+ * Extends `referencedImportedTypes`/`referencedLocalTypes` with any type names
+ * mentioned in the `generics` script attribute (e.g. the `DataTableRow` in
+ * `Row extends DataTableRow = DataTableRow`). These names only appear in the
+ * raw attribute string, not in the `$props()` type annotation AST that
+ * {@link collectReferencedTypeDependencies} normally walks, so without this
+ * they would never get hoisted into the emitted `.d.ts`.
+ */
+export function collectGenericsAttributeTypeDependencies(
+  ctx: ParserContext,
+  referencedImportedTypes: Set<string>,
+  referencedLocalTypes: Set<string>,
+) {
+  const value = ctx.scriptGenericsAttribute?.value;
+  if (!value) return;
+
+  for (const [name] of value.matchAll(IDENTIFIER_REGEX)) {
+    if (ctx.typeImportBindingsByLocalName.has(name)) {
+      referencedImportedTypes.add(name);
+    }
+
+    if (referencedLocalTypes.has(name)) continue;
+    const localDeclaration = ctx.localTypeDeclarationsByName.get(name);
+    if (!localDeclaration) continue;
+
+    referencedLocalTypes.add(name);
+    collectReferencedTypeDependencies(ctx, localDeclaration.node, referencedImportedTypes, referencedLocalTypes);
+  }
+}

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -11,6 +11,7 @@ import type {
   TypeImportBinding,
 } from "../ComponentParser";
 import type { ParserContext } from "./context";
+import { collectGenericsAttributeTypeDependencies } from "./generics";
 import { processLeadingCommentsJSDoc, processNodeJSDoc } from "./jsdoc";
 import { addProp, processInitializer, unwrapBindableInitializer } from "./props";
 import { sourceAtPos, sourceRangeFromNode } from "./source-position";
@@ -194,6 +195,7 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
 
   ctx.scriptLanguage = parser.resolveScriptLanguage(modernParsed);
   ctx.customElementTag = modernParsed.options?.customElement?.tag;
+  ctx.scriptGenericsAttribute = parser.resolveScriptGenericsAttribute(modernParsed);
   const body = modernParsed.instance?.content?.body ?? [];
 
   for (const statement of body) {
@@ -278,6 +280,7 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
         referencedImportedTypes,
         referencedLocalTypes,
       );
+      collectGenericsAttributeTypeDependencies(ctx, referencedImportedTypes, referencedLocalTypes);
 
       if (declarator.start !== undefined) {
         const declarationMetadata: RunesPropsDeclarationMetadata = {

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -1,4 +1,5 @@
 import { type DeprecatedValue, getParsedComponentTypeScriptMetadata } from "../ComponentParser";
+import { splitTopLevelCommas } from "../parser/generics";
 import type { ComponentDocApi } from "../plugin";
 
 const ANY_TYPE = "any";
@@ -136,30 +137,6 @@ export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">) {
 }
 
 /**
- * Splits a string on top-level commas, ignoring commas nested inside
- * `<>`, `()`, `[]`, or `{}`. Used to separate generic constraint declarations
- * that may themselves contain commas (e.g. `Value extends Record<string, any>`).
- */
-function splitTopLevel(value: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let start = 0;
-
-  for (let i = 0; i < value.length; i++) {
-    const char = value[i];
-    if (char === "<" || char === "(" || char === "[" || char === "{") depth++;
-    else if (char === ">" || char === ")" || char === "]" || char === "}") depth--;
-    else if (char === "," && depth === 0) {
-      parts.push(value.slice(start, i));
-      start = i + 1;
-    }
-  }
-
-  parts.push(value.slice(start));
-  return parts;
-}
-
-/**
  * Returns whether a property type references a generic type parameter by name,
  * matching on word boundaries so `Value` doesn't match `ValueType`.
  */
@@ -208,7 +185,7 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
       ? []
       : def.generics[0].split(",").map((name, index) => ({
           name: name.trim(),
-          constraint: (splitTopLevel(def.generics?.[1] ?? "")[index] ?? name).trim(),
+          constraint: (splitTopLevelCommas(def.generics?.[1] ?? "")[index] ?? name).trim(),
         }));
 
   return def.contexts

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -1405,4 +1405,18 @@ describe("ComponentParser", () => {
 
     warn.mockRestore();
   });
+
+  test('ignores the generics script attribute without lang="ts" and reports syntax-skipped', () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script generics="Row extends DataTableRow = DataTableRow">
+        export let row;
+      </script>
+    `;
+
+    const result = parser.parseSvelteComponent(source, diagnostics);
+
+    expect(result.generics).toBeNull();
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ kind: "syntax-skipped", name: "generics" }));
+  });
 });

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -1,5 +1,391 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
+exports[`fixtures (JSON) "runes-script-generics-attribute-multiple/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 25,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 11
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    },
+    {
+      "name": "key",
+      "kind": "let",
+      "type": "K",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 4
+        },
+        "end": {
+          "line": 13,
+          "column": 7
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<Row>, rows: ReadonlyArray<Row> }",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 0
+        },
+        "end": {
+          "line": 24,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row,K",
+    "Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-script-generics-attribute/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 11
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<Row>, rows: ReadonlyArray<Row> }",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 0
+        },
+        "end": {
+          "line": 22,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-script-generics-attribute-jsdoc-conflict/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 26,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 11
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 4
+        },
+        "end": {
+          "line": 15,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<Row>, rows: ReadonlyArray<Row> }",
+      "source": {
+        "start": {
+          "line": 22,
+          "column": 0
+        },
+        "end": {
+          "line": 25,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-script-generics-attribute-jsdoc-conflict/input.svelte",
+      "kind": "syntax-skipped",
+      "name": "generics",
+      "message": "Both the \\"generics\\" script attribute and @generics/@template JSDoc tags declare component generics; the script attribute takes precedence and the JSDoc declaration was ignored.",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 52
+        }
+      }
+    }
+  ]
+}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-script-generics-attribute-multiple/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never> = {
+  headers: ReadonlyArray<Row>;
+  rows: ReadonlyArray<Row>;
+  key?: K;
+} & {
+  children?: (this: void, ...args: [{ headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> }]) => void;
+};
+
+export type RunesScriptGenericsAttributeMultipleProps<
+  Row extends DataTableRow = DataTableRow,
+  K extends keyof Map<string, Row> = never,
+> = $Props<Row, K>;
+
+export default class RunesScriptGenericsAttributeMultiple<
+  Row extends DataTableRow = DataTableRow,
+  K extends keyof Map<string, Row> = never,
+> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeMultipleProps<Row, K>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> } }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-script-generics-attribute/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Row extends DataTableRow = DataTableRow> = {
+  headers: ReadonlyArray<Row>;
+  rows: ReadonlyArray<Row>;
+} & {
+  children?: (this: void, ...args: [{ headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> }]) => void;
+};
+
+export type RunesScriptGenericsAttributeProps<Row extends DataTableRow = DataTableRow> = $Props<Row>;
+
+export default class RunesScriptGenericsAttribute<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> } }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-script-generics-attribute-jsdoc-conflict/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Row extends DataTableRow = DataTableRow> = {
+  headers: ReadonlyArray<Row>;
+  rows: ReadonlyArray<Row>;
+} & {
+  children?: (this: void, ...args: [{ headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> }]) => void;
+};
+
+export type RunesScriptGenericsAttributeJsdocConflictProps<Row extends DataTableRow = DataTableRow> = $Props<Row>;
+
+export default class RunesScriptGenericsAttributeJsdocConflict<
+  Row extends DataTableRow = DataTableRow,
+> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeJsdocConflictProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> } }
+> {}
+"
+`;
+
 exports[`fixtures (JSON) "runes-callback-annotated/input.svelte" 1`] = `
 "{
   "source": {

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -189,7 +189,7 @@ describe("component API JSON schema", () => {
 
     expect(api.schemaVersion).toBe(1);
     expect(objectProperty(api, "generator")).toMatchObject({ name: "sveld" });
-    expect(api.total).toBe(1);
+    expect(api.total).toBe(2);
 
     const components = arrayProperty(api, "components");
     const runesButton = findObjectByProperty(components, "moduleName", "RunesButton");

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -113,6 +113,29 @@ describe("ComponentParser diagnostics", () => {
     expect(syntaxDiagnostic?.source).toBeDefined();
     expect(props.map((p) => p.name)).toContain("title");
   });
+
+  test("the generics script attribute wins over @generics/@template JSDoc tags, flagged as syntax-skipped", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script lang="ts" generics="Row extends DataTableRow = DataTableRow">
+        /**
+         * @generics {Header extends string = string} Header
+         */
+        interface DataTableRow {
+          id: string | number;
+        }
+
+        let { row }: { row: Row } = $props();
+      </script>
+    `;
+
+    const { diagnostics, generics } = parser.parseSvelteComponent(source, parseContext);
+    const conflictDiagnostic = diagnostics?.find((d) => d.kind === "syntax-skipped" && d.name === "generics");
+
+    expect(generics).toEqual(["Row", "Row extends DataTableRow = DataTableRow"]);
+    expect(conflictDiagnostic).toBeDefined();
+    expect(conflictDiagnostic?.message).toContain("JSDoc declaration was ignored");
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/e2e/svelte5-runes/COMPONENT_API.json
+++ b/tests/e2e/svelte5-runes/COMPONENT_API.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.32.8",
+    "version": "0.34.1",
     "svelteVersion": "5.56.3"
   },
-  "total": 1,
+  "total": 2,
   "components": [
     {
       "moduleName": "RunesButton",
@@ -98,6 +98,57 @@
       "typedefs": [],
       "generics": null,
       "rest_props": { "type": "Element", "name": "button" },
+      "contexts": []
+    },
+    {
+      "moduleName": "RunesGenericList",
+      "filePath": "src/RunesGenericList.svelte",
+      "source": {
+        "start": { "line": 1, "column": 0 },
+        "end": { "line": 18, "column": 0 }
+      },
+      "syntaxMode": "runes",
+      "scriptLanguage": "ts",
+      "props": [
+        {
+          "name": "items",
+          "kind": "let",
+          "type": "Item[]",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 5, "column": 4 },
+            "end": { "line": 5, "column": 9 }
+          }
+        },
+        {
+          "name": "row",
+          "kind": "let",
+          "type": "Snippet<[item: Item]>",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 6, "column": 4 },
+            "end": { "line": 6, "column": 7 }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [],
+      "events": [],
+      "typedefs": [],
+      "generics": [
+        "Item",
+        "Item extends { id: string | number } = { id: string }"
+      ],
       "contexts": []
     }
   ]

--- a/tests/e2e/svelte5-runes/COMPONENT_INDEX.md
+++ b/tests/e2e/svelte5-runes/COMPONENT_INDEX.md
@@ -3,6 +3,7 @@
 ## Components
 
 - [`RunesButton`](#runesbutton)
+- [`RunesGenericList`](#runesgenericlist)
 
 ---
 
@@ -22,6 +23,23 @@
 | Slot name | Default | Props                           | Fallback | Description |
 | :-------- | :------ | :------------------------------ | :------- | :---------- |
 | --        | Yes     | <code>{ value: string } </code> | --       | --          |
+
+### Events
+
+None.
+
+## `RunesGenericList`
+
+### Props
+
+| Prop name | Required | Kind             | Reactive | Binding | Type                               | Default value | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------- | :------------ | :---------- |
+| items     | Yes      | <code>let</code> | No       | --      | <code>Item[]</code>                | --            | --          |
+| row       | Yes      | <code>let</code> | No       | --      | <code>Snippet<[item: Item]></code> | --            | --          |
+
+### Slots
+
+None.
 
 ### Events
 

--- a/tests/e2e/svelte5-runes/bun.lock
+++ b/tests/e2e/svelte5-runes/bun.lock
@@ -7,6 +7,8 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "svelte": "^5.55.0",
+        "svelte-check": "^4.0.0",
+        "typescript": "^5.7.0",
         "vite": "^8.0.3",
       },
     },
@@ -66,6 +68,8 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
 
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.0", "", {}, "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg=="],
+
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.0.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -81,6 +85,8 @@
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -128,6 +134,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
@@ -138,15 +146,23 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "svelte": ["svelte@5.55.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw=="],
 
+    "svelte-check": ["svelte-check@4.7.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 

--- a/tests/e2e/svelte5-runes/package.json
+++ b/tests/e2e/svelte5-runes/package.json
@@ -6,11 +6,14 @@
   "svelte": "./src/index.js",
   "types": "./types/index.d.ts",
   "scripts": {
+    "svelte-check": "svelte-check --workspace test",
     "build": "vite build"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "svelte": "^5.55.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.7.0",
     "vite": "^8.0.3"
   }
 }

--- a/tests/e2e/svelte5-runes/src/RunesGenericList.svelte
+++ b/tests/e2e/svelte5-runes/src/RunesGenericList.svelte
@@ -1,0 +1,17 @@
+<script lang="ts" generics="Item extends { id: string | number } = { id: string }">
+  import type { Snippet } from "svelte";
+
+  let {
+    items,
+    row,
+  }: {
+    items: Item[];
+    row: Snippet<[item: Item]>;
+  } = $props();
+</script>
+
+<ul>
+  {#each items as item (item.id)}
+    <li>{@render row(item)}</li>
+  {/each}
+</ul>

--- a/tests/e2e/svelte5-runes/src/index.js
+++ b/tests/e2e/svelte5-runes/src/index.js
@@ -1,1 +1,2 @@
 export { default as RunesButton } from "./RunesButton.svelte";
+export { default as RunesGenericList } from "./RunesGenericList.svelte";

--- a/tests/e2e/svelte5-runes/test/test.svelte
+++ b/tests/e2e/svelte5-runes/test/test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { RunesGenericList } from "../src";
+
+  interface Todo {
+    id: number;
+    label: string;
+  }
+
+  const todos: Todo[] = [{ id: 1, label: "Write generics support" }];
+</script>
+
+<RunesGenericList items={todos}>
+  {#snippet row(todo)}
+    <span>{todo.label}</span>
+  {/snippet}
+</RunesGenericList>

--- a/tests/e2e/svelte5-runes/tsconfig.json
+++ b/tests/e2e/svelte5-runes/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "checkJs": true,
+    "types": []
+  },
+  "include": ["src/**/*", "test/**/*", "types/**/*"]
+}

--- a/tests/e2e/svelte5-runes/types/RunesGenericList.svelte.d.ts
+++ b/tests/e2e/svelte5-runes/types/RunesGenericList.svelte.d.ts
@@ -1,0 +1,19 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Snippet } from "svelte";
+
+type $Props<Item extends { id: string | number } = { id: string }> = {
+  items: Item[];
+  row: Snippet<[item: Item]>;
+};
+
+export type RunesGenericListProps<
+  Item extends { id: string | number } = { id: string },
+> = $Props<Item>;
+
+export default class RunesGenericList<
+  Item extends { id: string | number } = { id: string },
+> extends SvelteComponentTyped<
+  RunesGenericListProps<Item>,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/e2e/svelte5-runes/types/index.d.ts
+++ b/tests/e2e/svelte5-runes/types/index.d.ts
@@ -1,1 +1,2 @@
 export { default as RunesButton } from "./RunesButton.svelte";
+export { default as RunesGenericList } from "./RunesGenericList.svelte";

--- a/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/input.svelte
+++ b/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/input.svelte
@@ -1,0 +1,25 @@
+<script
+  lang="ts"
+  generics="Row extends DataTableRow = DataTableRow"
+>
+  /**
+   * @generics {Header extends string = string} Header
+   */
+  interface DataTableRow {
+    id: string | number;
+    [key: string]: any;
+  }
+
+  let {
+    headers,
+    rows,
+  }: {
+    headers: ReadonlyArray<Row>;
+    rows: ReadonlyArray<Row>;
+  } = $props();
+</script>
+
+<slot
+  {headers}
+  {rows}
+/>

--- a/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/output.d.ts
+++ b/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/output.d.ts
@@ -1,0 +1,23 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Row extends DataTableRow = DataTableRow> = {
+  headers: ReadonlyArray<Row>;
+  rows: ReadonlyArray<Row>;
+} & {
+  children?: (this: void, ...args: [{ headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> }]) => void;
+};
+
+export type RunesScriptGenericsAttributeJsdocConflictProps<Row extends DataTableRow = DataTableRow> = $Props<Row>;
+
+export default class RunesScriptGenericsAttributeJsdocConflict<
+  Row extends DataTableRow = DataTableRow,
+> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeJsdocConflictProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/output.json
@@ -1,0 +1,101 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 26,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 11
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 4
+        },
+        "end": {
+          "line": 15,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<Row>, rows: ReadonlyArray<Row> }",
+      "source": {
+        "start": {
+          "line": 22,
+          "column": 0
+        },
+        "end": {
+          "line": 25,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-script-generics-attribute-jsdoc-conflict/input.svelte",
+      "kind": "syntax-skipped",
+      "name": "generics",
+      "message": "Both the \"generics\" script attribute and @generics/@template JSDoc tags declare component generics; the script attribute takes precedence and the JSDoc declaration was ignored.",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 52
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/runes-script-generics-attribute-multiple/input.svelte
+++ b/tests/fixtures/runes-script-generics-attribute-multiple/input.svelte
@@ -1,0 +1,24 @@
+<script
+  lang="ts"
+  generics="Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"
+>
+  interface DataTableRow {
+    id: string | number;
+    [key: string]: any;
+  }
+
+  let {
+    headers,
+    rows,
+    key,
+  }: {
+    headers: ReadonlyArray<Row>;
+    rows: ReadonlyArray<Row>;
+    key?: K;
+  } = $props();
+</script>
+
+<slot
+  {headers}
+  {rows}
+/>

--- a/tests/fixtures/runes-script-generics-attribute-multiple/output.d.ts
+++ b/tests/fixtures/runes-script-generics-attribute-multiple/output.d.ts
@@ -1,0 +1,28 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never> = {
+  headers: ReadonlyArray<Row>;
+  rows: ReadonlyArray<Row>;
+  key?: K;
+} & {
+  children?: (this: void, ...args: [{ headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> }]) => void;
+};
+
+export type RunesScriptGenericsAttributeMultipleProps<
+  Row extends DataTableRow = DataTableRow,
+  K extends keyof Map<string, Row> = never,
+> = $Props<Row, K>;
+
+export default class RunesScriptGenericsAttributeMultiple<
+  Row extends DataTableRow = DataTableRow,
+  K extends keyof Map<string, Row> = never,
+> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeMultipleProps<Row, K>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/runes-script-generics-attribute-multiple/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-multiple/output.json
@@ -1,0 +1,105 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 25,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 11
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    },
+    {
+      "name": "key",
+      "kind": "let",
+      "type": "K",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 4
+        },
+        "end": {
+          "line": 13,
+          "column": 7
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<Row>, rows: ReadonlyArray<Row> }",
+      "source": {
+        "start": {
+          "line": 21,
+          "column": 0
+        },
+        "end": {
+          "line": 24,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row,K",
+    "Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-script-generics-attribute/input.svelte
+++ b/tests/fixtures/runes-script-generics-attribute/input.svelte
@@ -1,0 +1,22 @@
+<script
+  lang="ts"
+  generics="Row extends DataTableRow = DataTableRow"
+>
+  interface DataTableRow {
+    id: string | number;
+    [key: string]: any;
+  }
+
+  let {
+    headers,
+    rows,
+  }: {
+    headers: ReadonlyArray<Row>;
+    rows: ReadonlyArray<Row>;
+  } = $props();
+</script>
+
+<slot
+  {headers}
+  {rows}
+/>

--- a/tests/fixtures/runes-script-generics-attribute/output.d.ts
+++ b/tests/fixtures/runes-script-generics-attribute/output.d.ts
@@ -1,0 +1,21 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Row extends DataTableRow = DataTableRow> = {
+  headers: ReadonlyArray<Row>;
+  rows: ReadonlyArray<Row>;
+} & {
+  children?: (this: void, ...args: [{ headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> }]) => void;
+};
+
+export type RunesScriptGenericsAttributeProps<Row extends DataTableRow = DataTableRow> = $Props<Row>;
+
+export default class RunesScriptGenericsAttribute<Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeProps<Row>,
+  Record<string, any>,
+  { default: { headers: ReadonlyArray<Row>; rows: ReadonlyArray<Row> } }
+> {}

--- a/tests/fixtures/runes-script-generics-attribute/output.json
+++ b/tests/fixtures/runes-script-generics-attribute/output.json
@@ -1,0 +1,84 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "headers",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 11
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ headers: ReadonlyArray<Row>, rows: ReadonlyArray<Row> }",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 0
+        },
+        "end": {
+          "line": 22,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Row",
+    "Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/parser-generics.test.ts
+++ b/tests/parser-generics.test.ts
@@ -1,0 +1,59 @@
+import { parseGenericsAttribute, splitTopLevelCommas } from "../src/parser/generics";
+
+describe("splitTopLevelCommas", () => {
+  test("splits a simple comma-separated list", () => {
+    expect(splitTopLevelCommas("Row, Header")).toEqual(["Row", " Header"]);
+  });
+
+  test("ignores commas nested inside angle brackets", () => {
+    expect(splitTopLevelCommas("K extends keyof Map<string, Row> = never")).toEqual([
+      "K extends keyof Map<string, Row> = never",
+    ]);
+  });
+
+  test("ignores commas nested inside parentheses", () => {
+    expect(splitTopLevelCommas("Fn extends (a: string, b: number) => void")).toEqual([
+      "Fn extends (a: string, b: number) => void",
+    ]);
+  });
+
+  test("ignores commas nested inside braces", () => {
+    expect(splitTopLevelCommas("Row extends { a: string, b: number }")).toEqual([
+      "Row extends { a: string, b: number }",
+    ]);
+  });
+
+  test("ignores commas nested inside brackets", () => {
+    expect(splitTopLevelCommas("Row extends [string, number]")).toEqual(["Row extends [string, number]"]);
+  });
+
+  test("splits multiple top-level params each containing nested commas", () => {
+    expect(
+      splitTopLevelCommas("Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"),
+    ).toEqual(["Row extends DataTableRow = DataTableRow", " K extends keyof Map<string, Row> = never"]);
+  });
+});
+
+describe("parseGenericsAttribute", () => {
+  test("returns null for an empty value", () => {
+    expect(parseGenericsAttribute("")).toBeNull();
+    expect(parseGenericsAttribute("   ")).toBeNull();
+  });
+
+  test("parses a single constrained generic", () => {
+    expect(parseGenericsAttribute("Row extends DataTableRow = DataTableRow")).toEqual([
+      "Row",
+      "Row extends DataTableRow = DataTableRow",
+    ]);
+  });
+
+  test("parses a bare generic name with no constraint", () => {
+    expect(parseGenericsAttribute("Row")).toEqual(["Row", "Row"]);
+  });
+
+  test("parses multiple generics, one containing a comma in its constraint", () => {
+    expect(
+      parseGenericsAttribute("Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"),
+    ).toEqual(["Row,K", "Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"]);
+  });
+});


### PR DESCRIPTION
Svelte 5's idiomatic way to declare component generics is the generics script attribute (script lang="ts" generics="..."), but sveld only read the nonstandard `@generics/@template` JSDoc tags. That meant TS-first Svelte 5 libraries authored the official way lost their generics in the emitted .d.ts.

This parses the generics attribute directly, requiring lang="ts" (otherwise it's reported as a syntax-skipped diagnostic since sveld can't safely guess how to parse it as plain JS). The attribute value is split into type parameters with a depth-aware comma splitter, shared with the writer, so constraints containing generics of their own (e.g. K extends keyof Map<string, Row>) split correctly. The parsed result flows into the same [names, constraints] representation `@generics/@template` already produce, so the JSON schema and downstream writer are unaffected. When both the attribute and a JSDoc tag are present, the attribute wins and the JSDoc declaration is reported as ignored via a syntax-skipped diagnostic. Types referenced only inside a generic constraint (not in the props themselves) are now hoisted into the emitted .d.ts, since without that they'd reference an undefined type.

Added three fixtures (single generic, multiple with a nested-comma constraint, attribute-vs-JSDoc conflict), unit tests for the splitter and diagnostics, and a new generic component in the svelte5-runes e2e project with a svelte-check consumer that verifies the generic type actually flows through a real tsc check. README's @template section documents the new precedence rule.

Risk is mostly around the new script-attribute parsing path in ComponentParser and runes-props, since it changes how ctx.generics gets populated for TS components; existing JSDoc-only components are unaffected since the new code path only activates when the attribute is present. Worth watching for edge cases in components mixing the attribute with slot-level `@template` generics, which aren't covered by the new fixtures.