### PR TITLE
feat(writer): add Svelte 5 Component output format for .d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The goal is to get third-party Svelte libraries working with the Svelte Language
 
 For `lang="ts"` components, `sveld` keeps source-level prop type annotations when it can, instead of forcing JSDoc. That covers legacy `export let` props, typed `$props()` destructuring, typed whole-object `$props()` captures, local `interface`/`type` declarations, and imported type references in emitted `.d.ts` files.
 
-Generated `.d.ts` files extend `SvelteComponentTyped` from `svelte`, so TypeScript and the Svelte Language Server work whether consumers use Svelte 3, Svelte 4, or Svelte 5.
+By default, generated `.d.ts` files extend `SvelteComponentTyped` from `svelte`, so TypeScript and the Svelte Language Server work whether consumers use Svelte 3, Svelte 4, or Svelte 5. Set `typesOptions.format: "component"` to instead emit the Svelte 5 `Component` type; see [`typesOptions.format`](#typesoptionsformat).
 
 ## When to use sveld
 
@@ -120,6 +120,7 @@ export default class Button extends SvelteComponentTyped<
 - [When to use sveld](#when-to-use-sveld)
 - [Approach](#approach)
 - [Features](#features)
+  - [`.d.ts` output format (`typesOptions.format`)](#dts-output-format-typesoptionsformat)
   - [Opt-in semantic resolution (`resolveTypes`)](#opt-in-semantic-resolution-resolvetypes)
   - [Persistent parse cache (`cache`)](#persistent-parse-cache-cache)
   - [Compile-checked `@example` blocks (`checkExamples`)](#compile-checked-example-blocks-checkexamples)
@@ -186,6 +187,70 @@ When both TypeScript syntax and JSDoc are present, `sveld` resolves prop types i
 `sveld` stays AST-only. It copies imported and local type text into generated `.d.ts` output but does not run project-wide semantic resolution with the TypeScript compiler. Opaque imported whole-object `$props()` types can therefore stay in declarations without being fully expanded into JSON metadata.
 
 ## Features
+
+### `.d.ts` output format (`typesOptions.format`)
+
+`typesOptions.format` controls the shape of generated `.d.ts` files: `"class"` (the default) or `"component"`.
+
+`"class"` extends `SvelteComponentTyped`, deprecated in Svelte 5 and plausibly removed in Svelte 6:
+
+```ts
+import { SvelteComponentTyped } from "svelte";
+
+export type ButtonProps = { label?: string };
+
+export default class Button extends SvelteComponentTyped<
+  ButtonProps,
+  { click: WindowEventMap["click"] },
+  { default: Record<string, never> }
+> {}
+```
+
+`"component"` emits the Svelte 5 `Component` type instead:
+
+```ts
+import type { Component } from "svelte";
+
+export type ButtonProps = { label?: string; onclick?: (event: WindowEventMap["click"]) => void };
+export type ButtonExports = Record<string, never>;
+
+declare const Button: Component<ButtonProps, ButtonExports, "">;
+export default Button;
+```
+
+Publish `"component"` if you target Svelte 5+ consumers. `"class"` remains compatible with Svelte 3, 4, and 5.
+
+```ts
+await sveld({ types: true, typesOptions: { format: "component" } });
+```
+
+Also available as `--types-format=component` on the CLI.
+
+`"component"`'s three type parameters:
+
+- **Props**: the same `$Props`/`<Name>Props` type as `"class"`. Runes components already declare callback props (e.g. `onclick`) as regular props. Legacy (non-runes) components additionally get `on<name>?: (event: Type) => void` callback props for every dispatched and forwarded event, so Svelte 5 consumers can attach handlers as props instead of `on:event`.
+- **Exports**: the component's accessor props (exported `function`/`const` members), the same members that render as class members under `"class"`.
+- **Bindings**: a union of string literals for props declared with `$bindable(...)` (runes) or marked `@bindable writable` ([see `binding`](#binding)) (legacy) — e.g. `"value"`, or `"value" | "open"` for more than one. `""` when the component declares none, matching Svelte's own convention for "no bindings."
+
+**Generic components.** A `declare const X: Component<...>` value can't itself carry a generic type parameter the way a class can, so generic components (`@template`/`generics`) get a per-component interface instead of `Component<...>` directly:
+
+```ts
+interface GenericListComponent {
+  new <Item extends { id: string | number } = { id: string }>(
+    options: ComponentConstructorOptions<GenericListProps<Item>>,
+  ): SvelteComponent<GenericListProps<Item>> & GenericListExports;
+  <Item extends { id: string | number } = { id: string }>(
+    this: void,
+    internals: ComponentInternals,
+    props: GenericListProps<Item>,
+  ): { $on?(...): () => void; $set?(...): void } & GenericListExports;
+  z_$$bindings?: "";
+}
+declare const GenericList: GenericListComponent;
+export default GenericList;
+```
+
+Both signatures carry their own generic parameter (not the `const` itself), so `Item` is inferred per usage site, e.g. `<GenericList items={numbers} />` infers `Item` from `numbers`. The `new` signature is the one place `"component"` format still touches a legacy type (`SvelteComponent`/`ComponentConstructorOptions`, not the deprecated `SvelteComponentTyped`): the Svelte language server resolves generic inference for `<Comp prop={...} />` template usage through `new`, not the plain call signature, confirmed by comparing against `@sveltejs/package`'s own generated output for the same component. Omitting it silently breaks inference instead of erroring, so it stays in even though it means one legacy import for generic components.
 
 ### Opt-in semantic resolution (`resolveTypes`)
 
@@ -407,7 +472,7 @@ npx sveld --json --markdown
 
 If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
 
-Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
+Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
 
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 
@@ -572,7 +637,8 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`glob`** (boolean, optional): Enable glob mode to analyze all `*.svelte` files.
 - **`documentExports`** (boolean, optional): Include consts, functions, and types from the entry barrel in JSON (`exports`) and Markdown ("Exports"). Off by default. See [Documenting Entry Exports](#documenting-entry-exports).
 - **`types`** (boolean, optional, default: `true`): Generate TypeScript definitions.
-- **`typesOptions`** (object, optional): Options for TypeScript definition generation, including `outDir`, `preamble`, and `printWidth`.
+- **`typesOptions`** (object, optional): Options for TypeScript definition generation, including `outDir`, `preamble`, `printWidth`, and `format`.
+  - **`format`** (`"class"` | `"component"`, optional, default: `"class"`): `.d.ts` output shape. `"class"` extends `SvelteComponentTyped`; `"component"` emits the Svelte 5 `Component` type. Also available as `--types-format`. See [`.d.ts` output format](#dts-output-format-typesoptionsformat).
 - **`json`** (boolean, optional): Generate component documentation in JSON format.
 - **`jsonOptions`** (object, optional): Options for JSON output.
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ Options:
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
   --report-diagnostics  Print unresolved-type diagnostics to stderr
   --strict              Exit with code 1 when diagnostics exist (implies --report-diagnostics)
+  --types-format=<format>  ".d.ts" output format: "class" (default) or "component" (Svelte 5 Component<...>)
   --check[=<path>]      Diff the parsed API against a committed snapshot; exit 1 on a breaking change (default path: COMPONENT_API.json)
   --help                Print this help message and exit
   --version             Print the installed sveld version and exit
@@ -96,6 +97,10 @@ function parseCliFlag(arg: string): CliFlagResult {
       // `--check=<path>` overrides it; `--check=false` disables it.
       if (value === "false") return { kind: "option", option: { check: false } };
       return { kind: "option", option: { check: typeof value === "string" ? value : true } };
+    case "types-format":
+      return typeof value === "string"
+        ? { kind: "option", option: { typesOptions: { format: value as "class" | "component" } } }
+        : { kind: "option", option: {} };
     default:
       return { kind: "unknown", arg };
   }
@@ -157,6 +162,14 @@ export async function cli(process: NodeJS.Process) {
   const cliOptions = parsed.options;
   const fileConfig = await loadConfig();
   const options = mergeConfig<CliOptions>(fileConfig, cliOptions);
+
+  /**
+   * `mergeConfig` shallow-merges: `--types-format` alone would otherwise
+   * replace a config file's whole `typesOptions` object instead of adding to it.
+   */
+  if (fileConfig.typesOptions || cliOptions.typesOptions) {
+    options.typesOptions = { ...fileConfig.typesOptions, ...cliOptions.typesOptions };
+  }
 
   const resolvedEntry = getSvelteEntry(options.entry);
   let input: string;

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -146,6 +146,38 @@ function referencesGeneric(propType: string, name: string): boolean {
 }
 
 /**
+ * Pairs each `@template`/`generics` name with its full constraint declaration
+ * (e.g. `Row extends DataTableRow = DataTableRow`), splitting only at
+ * top-level commas since a constraint may itself contain commas (e.g.
+ * `Record<string, any>`).
+ */
+function getGenericParams(generics: ComponentDocApi["generics"]): Array<{ name: string; constraint: string }> {
+  if (generics === null) return [];
+  return generics[0].split(",").map((name, index) => ({
+    name: name.trim(),
+    constraint: (splitTopLevelCommas(generics[1] ?? "")[index] ?? name).trim(),
+  }));
+}
+
+/**
+ * Computes the generic parameter list a standalone type declaration needs
+ * to parameterize with, given the text of its body: only the generics it
+ * actually references, in declaration order. Returns the full constraint
+ * form (for the declaration site, e.g. `<Row extends Foo = Bar>`) and the
+ * name-only form (for reference sites, e.g. `<Row>`).
+ */
+function computeReferencedGenerics(generics: ComponentDocApi["generics"], text: string) {
+  const referenced = getGenericParams(generics).filter(({ name }) => referencesGeneric(text, name));
+
+  if (referenced.length === 0) return { declSuffix: EMPTY_STR, refSuffix: EMPTY_STR };
+
+  return {
+    declSuffix: `<${referenced.map(({ constraint }) => constraint).join(", ")}>`,
+    refSuffix: `<${referenced.map(({ name }) => name).join(", ")}>`,
+  };
+}
+
+/**
  * Generates TypeScript type definitions for component contexts.
  *
  * Creates exported type definitions for each context, including generic
@@ -290,6 +322,13 @@ function genPropDef(
   def: Pick<ComponentDocApi, "props" | "rest_props" | "moduleName" | "extends" | "generics" | "slots"> & {
     canonicalPropNames?: Set<string>;
     canonicalPropsType?: string;
+    /**
+     * Legacy component events to render as `on<name>?: (event: Type) => void`
+     * callback props. Only passed for `"component"` format on legacy
+     * components; runes components already have callback props declared
+     * as regular props.
+     */
+    events?: ComponentDocApi["events"];
   },
 ) {
   /**
@@ -393,7 +432,9 @@ function genPropDef(
         })()
       : "";
 
-  const snippet_props = [...named_snippet_props, children_snippet_prop].filter(Boolean);
+  const event_callback_props = def.events ? genEventCallbackProps({ events: def.events }, existingPropNames) : [];
+
+  const snippet_props = [...named_snippet_props, children_snippet_prop, ...event_callback_props].filter(Boolean);
 
   const props = [...extra_initial_props, ...snippet_props].join("\n");
 
@@ -705,20 +746,53 @@ const STANDARD_DOM_EVENTS = new Set([
   "compositionend",
 ] satisfies readonly string[]);
 
+function createDispatchedEventType(detail: string = ANY_TYPE) {
+  if (CUSTOM_EVENT_REGEX.test(detail)) return detail;
+  return `CustomEvent<${detail}>`;
+}
+
+/**
+ * Check if an event name is a standard DOM event that exists in WindowEventMap.
+ * Standard DOM events should use WindowEventMap for better type inference.
+ */
+function isStandardDomEvent(eventName: string): boolean {
+  return STANDARD_DOM_EVENTS.has(eventName);
+}
+
+/**
+ * Computes the TypeScript type for a single component event, shared between
+ * the `{ event: Type }` map (`class` format) and the `on<name>` callback prop
+ * type (`component` format).
+ */
+function computeEventTypeString(event: ComponentDocApi["events"][number]): string {
+  switch (event.type) {
+    case "dispatched":
+      return createDispatchedEventType(event.detail);
+    case "forwarded": {
+      const elementName = event.element;
+      const isComponent = elementName && COMPONENT_NAME_REGEX.test(elementName);
+      const isStandardEvent = !isComponent || isStandardDomEvent(event.name);
+
+      const hasExplicitDetail =
+        event.detail !== undefined && event.detail !== "undefined" && !(event.detail === "null" && isStandardEvent);
+      const hasExplicitNullForCustomComponent = event.detail === "null" && !isStandardEvent;
+
+      if (hasExplicitDetail || hasExplicitNullForCustomComponent) {
+        return createDispatchedEventType(event.detail);
+      } else if (isStandardEvent) {
+        return `${mapEvent()}["${event.name}"]`;
+      } else {
+        return createDispatchedEventType();
+      }
+    }
+    default: {
+      const _exhaustive: never = event;
+      return _exhaustive;
+    }
+  }
+}
+
 function genEventDef(def: Pick<ComponentDocApi, "events">) {
-  const createDispatchedEvent = (detail: string = ANY_TYPE) => {
-    if (CUSTOM_EVENT_REGEX.test(detail)) return detail;
-    return `CustomEvent<${detail}>`;
-  };
-
-  /**
-   * Check if an event name is a standard DOM event that exists in WindowEventMap.
-   * Standard DOM events should use WindowEventMap for better type inference.
-   */
-  const isStandardDomEvent = (eventName: string): boolean => {
-    return STANDARD_DOM_EVENTS.has(eventName);
-  };
-
   if (def.events.length === 0) return EMPTY_EVENTS;
 
   const events_map = def.events
@@ -729,40 +803,35 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
         description = `${eventComment}\n`;
       }
 
-      let eventType: string;
-      switch (event.type) {
-        case "dispatched":
-          eventType = createDispatchedEvent(event.detail);
-          break;
-        case "forwarded": {
-          const elementName = event.element;
-          const isComponent = elementName && COMPONENT_NAME_REGEX.test(elementName);
-          const isStandardEvent = !isComponent || isStandardDomEvent(event.name);
-
-          const hasExplicitDetail =
-            event.detail !== undefined && event.detail !== "undefined" && !(event.detail === "null" && isStandardEvent);
-          const hasExplicitNullForCustomComponent = event.detail === "null" && !isStandardEvent;
-
-          if (hasExplicitDetail || hasExplicitNullForCustomComponent) {
-            eventType = createDispatchedEvent(event.detail);
-          } else if (isStandardEvent) {
-            eventType = `${mapEvent()}["${event.name}"]`;
-          } else {
-            eventType = createDispatchedEvent();
-          }
-          break;
-        }
-        default: {
-          const _exhaustive: never = event;
-          return _exhaustive;
-        }
-      }
-
-      return `${description}${clampKey(event.name)}: ${eventType};\n`;
+      return `${description}${clampKey(event.name)}: ${computeEventTypeString(event)};\n`;
     })
     .join("");
 
   return `{${events_map}}`;
+}
+
+/**
+ * Generates `on<name>?: (event: Type) => void;` prop entries for legacy
+ * (non-runes) components in `"component"` format. Runes components already
+ * declare callback props (e.g. `onclick`) as regular props, so this is only
+ * called for legacy components. Skips names that collide with an existing prop.
+ */
+function genEventCallbackProps(def: Pick<ComponentDocApi, "events">, existingPropNames: Set<string>): string[] {
+  return def.events
+    .map((event) => {
+      const propName = `on${event.name}`;
+      if (existingPropNames.has(propName)) return undefined;
+
+      let description = "";
+      const eventComment = formatSlotJsDoc(event.description, event.tags, event.deprecated);
+      if (eventComment) {
+        description = `${eventComment}\n      `;
+      }
+
+      return `
+      ${description}${clampKey(propName)}?: (event: ${computeEventTypeString(event)}) => void;`;
+    })
+    .filter((entry): entry is string => entry !== undefined);
 }
 
 /**
@@ -820,6 +889,117 @@ function genAccessors(def: Pick<ComponentDocApi, "props">) {
     ${prop.name}: ${functionType};`;
     })
     .join("\n");
+}
+
+/**
+ * Generates the `Exports` type for `"component"` format: the same accessor
+ * props (exported `function`/`const` members) that render as class members
+ * in `"class"` format, rendered instead as an object type's members.
+ *
+ * The declaration is parameterized only with the generics its members
+ * actually reference (same convention as {@link getContextDefs}), and
+ * `exports_ref` is the corresponding reference form (e.g. `FooExports<Row>`)
+ * for use at the call site.
+ */
+function genExportsDef(def: Pick<ComponentDocApi, "props" | "moduleName" | "generics">) {
+  const exports_name = `${def.moduleName}Exports`;
+  const accessors = genAccessors({ props: def.props });
+
+  if (accessors.trim() === "") {
+    return { exports_name, exports_ref: exports_name, exports_def: `export type ${exports_name} = ${EMPTY_OBJECT};` };
+  }
+
+  const { declSuffix, refSuffix } = computeReferencedGenerics(def.generics, accessors);
+
+  return {
+    exports_name,
+    exports_ref: `${exports_name}${refSuffix}`,
+    exports_def: `export type ${exports_name}${declSuffix} = {${accessors}\n  };`,
+  };
+}
+
+/**
+ * Generates the `Bindings` union for `"component"` format: a union of string
+ * literals for props declared with `$bindable(...)` (runes) or marked
+ * `@bindable writable` (legacy), or `""` when the component declares none.
+ */
+function genBindingsUnion(def: Pick<ComponentDocApi, "props">): string {
+  const bindableNames = def.props
+    .filter((prop) => prop.bindable === true || prop.binding === "writable")
+    .map((prop) => `"${prop.name}"`);
+
+  return bindableNames.length === 0 ? EMPTY_STR : bindableNames.join(" | ");
+}
+
+/**
+ * Generates the `declare const <Name>: Component<Props, Exports, Bindings>;`
+ * shell for `"component"` format, in place of the `SvelteComponentTyped` class.
+ * `$$Component` stands in for the identifier when `moduleName` is "default"
+ * (an anonymous default export), since `declare const` requires a name.
+ */
+function genComponentDeclaration(def: { moduleName: string; propsRef: string; exportsRef: string; bindings: string }) {
+  const identifier = def.moduleName === "default" ? "$$Component" : def.moduleName;
+  const bindingsLiteral = def.bindings === EMPTY_STR ? '""' : def.bindings;
+
+  return `declare const ${identifier}: Component<
+      ${def.propsRef},
+      ${def.exportsRef},
+      ${bindingsLiteral}
+    >;
+    export default ${identifier};`;
+}
+
+/**
+ * Generates the `"component"` format shell for a GENERIC component. A
+ * `declare const` can't itself carry a generic type parameter the way a
+ * class can, so instead of `Component<Props, Exports, Bindings>` this emits
+ * a per-component interface with two generic signatures instead:
+ *
+ * - a `(internals, props) => {...} & Exports` call signature, mirroring the
+ *   `Component` interface's own shape, for consumers that call/mount the
+ *   component directly;
+ * - a `new (options) => SvelteComponent<...> & Exports` construct signature,
+ *   because the Svelte language server's template checker resolves generic
+ *   inference for `<Comp prop={...} />` usage through `new`, not the call
+ *   signature - confirmed empirically against `@sveltejs/package`'s own
+ *   generated output, which emits both for the same reason. Omitting it
+ *   silently breaks per-usage inference: attributes type-check against the
+ *   generic's default/constraint instead of the actual usage, which is
+ *   exactly the "silent wrong types" failure this format must avoid.
+ *
+ * This is the one place `"component"` format still touches a legacy type
+ * (`SvelteComponent`/`ComponentConstructorOptions`, not the deprecated
+ * `SvelteComponentTyped`), because it's the only way to get correct
+ * generic inference for template usage.
+ */
+function genGenericComponentDeclaration(def: {
+  moduleName: string;
+  generic: string;
+  propsRef: string;
+  exportsRef: string;
+  bindings: string;
+}) {
+  const identifier = def.moduleName === "default" ? "$$Component" : def.moduleName;
+  const interfaceName = `${identifier}Component`;
+  const bindingsLiteral = def.bindings === EMPTY_STR ? '""' : def.bindings;
+
+  return `interface ${interfaceName} {
+      new ${def.generic}(
+        options: ComponentConstructorOptions<${def.propsRef}>
+      ): SvelteComponent<${def.propsRef}> & ${def.exportsRef};
+      ${def.generic}(
+        this: void,
+        internals: ComponentInternals,
+        props: ${def.propsRef}
+      ): {
+        $on?(type: string, callback: (e: any) => void): () => void;
+        $set?(props: Partial<${def.propsRef}>): void;
+      } & ${def.exportsRef};
+      element?: typeof HTMLElement;
+      z_$$bindings?: ${bindingsLiteral};
+    }
+    declare const ${identifier}: ${interfaceName};
+    export default ${identifier};`;
 }
 
 function genImports(def: Pick<ComponentDocApi, "extends">) {
@@ -924,7 +1104,19 @@ function genComponentShell(def: {
     }`;
 }
 
-export function writeTsDefinition(component: ComponentDocApi) {
+export interface WriteTsDefinitionOptions {
+  /**
+   * `"class"` (default) extends the deprecated `SvelteComponentTyped`.
+   * `"component"` emits `declare const X: Component<Props, Exports, Bindings>`
+   * instead, for Svelte 5+ consumers. Generic components get a per-component
+   * interface with a generic call signature instead of `Component<...>`
+   * directly, since a `declare const` can't itself carry a generic type
+   * parameter (see `genGenericComponentDeclaration`).
+   */
+  format?: "class" | "component";
+}
+
+export function writeTsDefinition(component: ComponentDocApi, options?: WriteTsDefinitionOptions) {
   const typeScriptMetadata = getParsedComponentTypeScriptMetadata(component);
   const {
     moduleName,
@@ -938,7 +1130,12 @@ export function writeTsDefinition(component: ComponentDocApi) {
     extends: _extends,
     componentComment,
     contexts,
+    syntaxMode,
   } = component;
+
+  const useComponentFormat = options?.format === "component";
+  const isGenericComponent = generics !== null;
+
   const { props_name, prop_def } = genPropDef({
     moduleName,
     props,
@@ -948,6 +1145,7 @@ export function writeTsDefinition(component: ComponentDocApi) {
     slots,
     canonicalPropNames: new Set(typeScriptMetadata?.canonicalPropNames ?? []),
     canonicalPropsType: typeScriptMetadata?.canonicalPropsType,
+    events: useComponentFormat && syntaxMode === "legacy" ? events : undefined,
   });
 
   const generic = generics ? `<${generics[1]}>` : "";
@@ -957,10 +1155,16 @@ export function writeTsDefinition(component: ComponentDocApi) {
   const contextDefs = getContextDefs({ contexts, generics });
   const preservedTypeImports = (typeScriptMetadata?.typeImportStatements ?? []).join("\n");
   const preservedLocalTypeDeclarations = (typeScriptMetadata?.localTypeDeclarations ?? []).join("\n\n");
+
+  const { exports_ref, exports_def } = useComponentFormat
+    ? genExportsDef({ props, moduleName, generics })
+    : { exports_ref: EMPTY_STR, exports_def: EMPTY_STR };
+  const bindings = useComponentFormat ? genBindingsUnion({ props }) : EMPTY_STR;
+
   const snippetImportNeeded =
     !PRESERVED_SNIPPET_IMPORT_REGEX.test(preservedTypeImports) &&
     SNIPPET_TYPE_REFERENCE_REGEX.test(
-      `${prop_def}\n${moduleExportsDef}\n${typeDefs}\n${contextDefs}\n${preservedLocalTypeDeclarations}`,
+      `${prop_def}\n${moduleExportsDef}\n${typeDefs}\n${contextDefs}\n${preservedLocalTypeDeclarations}\n${exports_def}`,
     );
 
   /**
@@ -974,8 +1178,22 @@ export function writeTsDefinition(component: ComponentDocApi) {
   const needsHTMLAttributes =
     rest_props?.type === "Element" && rest_props.name === "svelte:element" && !rest_props.thisValue;
 
+  /**
+   * Generic components can't use `Component<...>` directly (a `declare const`
+   * can't carry its own generic type parameter), so they hand-roll an
+   * interface instead (see `genGenericComponentDeclaration`). It needs
+   * `SvelteComponent`/`ComponentConstructorOptions` for the `new` signature
+   * template-checking depends on, plus `ComponentInternals` for the call
+   * signature. Not `SvelteComponentTyped`, which stays avoided.
+   */
+  const componentTypeImport = useComponentFormat
+    ? isGenericComponent
+      ? `import type { SvelteComponent, ComponentConstructorOptions, ComponentInternals${snippetImportNeeded ? ", Snippet" : ""} } from "svelte";`
+      : `import type { Component${snippetImportNeeded ? ", Snippet" : ""} } from "svelte";`
+    : `import { SvelteComponentTyped${snippetImportNeeded ? ", type Snippet" : ""} } from "svelte";`;
+
   const importSection = [
-    `import { SvelteComponentTyped${snippetImportNeeded ? ", type Snippet" : ""} } from "svelte";`,
+    componentTypeImport,
     needsSvelteHTMLElements ? `import type { SvelteHTMLElements } from "svelte/elements";` : "",
     needsHTMLAttributes ? `import type { HTMLAttributes } from "svelte/elements";` : "",
     preservedTypeImports,
@@ -984,25 +1202,33 @@ export function writeTsDefinition(component: ComponentDocApi) {
     .filter(Boolean)
     .join("\n");
 
-  const bodySection = [
-    moduleExportsDef,
-    typeDefs,
-    preservedLocalTypeDeclarations,
-    contextDefs,
-    prop_def,
-    [
-      genComponentComment({ componentComment }),
-      genComponentShell({
+  const componentDeclaration = useComponentFormat
+    ? isGenericComponent
+      ? genGenericComponentDeclaration({
+          moduleName,
+          generic,
+          propsRef: genericProps,
+          exportsRef: exports_ref,
+          bindings,
+        })
+      : genComponentDeclaration({ moduleName, propsRef: genericProps, exportsRef: exports_ref, bindings })
+    : genComponentShell({
         moduleName,
         generic,
         genericProps,
         events: genEventDef({ events }),
         slots: genSlotDef({ slots }),
         accessors: genAccessors({ props }),
-      }),
-    ]
-      .filter(Boolean)
-      .join("\n"),
+      });
+
+  const bodySection = [
+    moduleExportsDef,
+    typeDefs,
+    preservedLocalTypeDeclarations,
+    contextDefs,
+    prop_def,
+    exports_def,
+    [genComponentComment({ componentComment }), componentDeclaration].filter(Boolean).join("\n"),
   ]
     .map((section) => section.trim())
     .filter(Boolean)

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -4,7 +4,7 @@ import type { ParsedExports } from "../parse-exports";
 import type { ComponentDocs } from "../plugin";
 import { buildComponentApiDocument } from "./document-model";
 import { createTypeScriptWriter } from "./Writer";
-import { writeTsDefinition } from "./writer-ts-definitions-core";
+import { type WriteTsDefinitionOptions, writeTsDefinition } from "./writer-ts-definitions-core";
 
 /**
  * Re-export browser-compatible functions from core module.
@@ -19,6 +19,7 @@ export {
   formatTsProps,
   getContextDefs,
   getTypeDefs,
+  type WriteTsDefinitionOptions,
   writeTsDefinition,
 } from "./writer-ts-definitions-core";
 
@@ -29,6 +30,7 @@ export {
  * @property inputDir - The input directory containing source components
  * @property preamble - Text to prepend to the main `index.d.ts` file
  * @property exports - Parsed export information for generating the index file
+ * @property format - `"class"` (default) or `"component"`; see {@link WriteTsDefinitionOptions}
  *
  * @example
  * ```ts
@@ -40,7 +42,7 @@ export {
  * };
  * ```
  */
-export interface WriteTsDefinitionsOptions {
+export interface WriteTsDefinitionsOptions extends WriteTsDefinitionOptions {
   outDir: string;
   inputDir: string;
   preamble: string;
@@ -87,7 +89,7 @@ export default async function writeTsDefinitions(components: ComponentDocs, opti
   const document = buildComponentApiDocument(components);
   const writePromises = document.components.map(async (component) => {
     const ts_filepath = convertSvelteExt(join(options.outDir, component.filePath));
-    await writer.write(ts_filepath, writeTsDefinition(component));
+    await writer.write(ts_filepath, writeTsDefinition(component, { format: options.format }));
   });
 
   await Promise.all([...writePromises, writer.write(ts_base_path, indexDTs)]);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cli, parseCliOptions } from "../src/cli";
@@ -79,6 +79,13 @@ describe("parseCliOptions", () => {
 
   test("--strict enables strict", () => {
     expect(parseCliOptions(["--strict"])).toEqual({ kind: "options", options: { strict: true } });
+  });
+
+  test("--types-format=component sets typesOptions.format", () => {
+    expect(parseCliOptions(["--types-format=component"])).toEqual({
+      kind: "options",
+      options: { typesOptions: { format: "component" } },
+    });
   });
 
   test("unknown flag surfaces as an unknown result", () => {
@@ -176,5 +183,43 @@ describe("cli() unknown flag", () => {
     expect(errorSpy).toHaveBeenCalledWith("Unknown flag: --markdwon");
     expect(existsSync(join(dir, "types"))).toBe(false);
     expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+  });
+});
+
+describe("cli() --types-format merges with config file typesOptions", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-types-format-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      '<script>\n  export let label = "";\n</script>\n<button>{label}</button>\n',
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    writeFileSync(join(dir, "sveld.config.js"), 'export default { typesOptions: { outDir: "custom-types" } };\n');
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--types-format=component keeps the config file's typesOptions.outDir", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types-format=component"];
+
+    await cli(process);
+
+    const outputPath = join(dir, "custom-types", "Button.svelte.d.ts");
+    expect(existsSync(outputPath)).toBe(true);
+    expect(readFileSync(outputPath, "utf-8")).toContain("declare const Button: Component<");
   });
 });

--- a/tests/e2e/svelte5-runes-component-format/COMPONENT_API.json
+++ b/tests/e2e/svelte5-runes-component-format/COMPONENT_API.json
@@ -1,0 +1,208 @@
+{
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.34.1",
+    "svelteVersion": "5.56.3"
+  },
+  "total": 3,
+  "components": [
+    {
+      "moduleName": "LegacyPanel",
+      "filePath": "src/LegacyPanel.svelte",
+      "source": {
+        "start": { "line": 1, "column": 0 },
+        "end": { "line": 18, "column": 0 }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "ts",
+      "props": [
+        {
+          "name": "title",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 4, "column": 2 },
+            "end": { "line": 4, "column": 27 }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button",
+          "source": {
+            "start": { "line": 15, "column": 10 },
+            "end": { "line": 15, "column": 18 }
+          }
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "source": {
+            "start": { "line": 9, "column": 4 },
+            "end": { "line": 9, "column": 41 }
+          }
+        }
+      ],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    },
+    {
+      "moduleName": "RunesButton",
+      "filePath": "src/RunesButton.svelte",
+      "source": {
+        "start": { "line": 1, "column": 0 },
+        "end": { "line": 28, "column": 0 }
+      },
+      "syntaxMode": "runes",
+      "scriptLanguage": "ts",
+      "props": [
+        {
+          "name": "label",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 5, "column": 4 },
+            "end": { "line": 5, "column": 9 }
+          }
+        },
+        {
+          "name": "onclick",
+          "kind": "let",
+          "type": "(event: MouseEvent) => void",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 6, "column": 4 },
+            "end": { "line": 6, "column": 11 }
+          }
+        },
+        {
+          "name": "onpress",
+          "kind": "let",
+          "type": "(value: string) => void",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 7, "column": 4 },
+            "end": { "line": 7, "column": 11 }
+          }
+        },
+        {
+          "name": "value",
+          "kind": "let",
+          "bindable": true,
+          "type": "string",
+          "typeSource": "typescript",
+          "value": "\"ready\"",
+          "defaultValue": {
+            "raw": "\"ready\"",
+            "kind": "literal",
+            "value": "ready"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": true,
+          "source": {
+            "start": { "line": 8, "column": 4 },
+            "end": { "line": 8, "column": 30 }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [
+        {
+          "name": null,
+          "default": true,
+          "slot_props": "{ value: string }",
+          "source": {
+            "start": { "line": 26, "column": 2 },
+            "end": { "line": 26, "column": 33 }
+          }
+        }
+      ],
+      "events": [],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    },
+    {
+      "moduleName": "RunesGenericList",
+      "filePath": "src/RunesGenericList.svelte",
+      "source": {
+        "start": { "line": 1, "column": 0 },
+        "end": { "line": 18, "column": 0 }
+      },
+      "syntaxMode": "runes",
+      "scriptLanguage": "ts",
+      "props": [
+        {
+          "name": "items",
+          "kind": "let",
+          "type": "Item[]",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 5, "column": 4 },
+            "end": { "line": 5, "column": 9 }
+          }
+        },
+        {
+          "name": "row",
+          "kind": "let",
+          "type": "Snippet<[item: Item]>",
+          "typeSource": "typescript",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": { "line": 6, "column": 4 },
+            "end": { "line": 6, "column": 7 }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [],
+      "events": [],
+      "typedefs": [],
+      "generics": [
+        "Item",
+        "Item extends { id: string | number } = { id: string }"
+      ],
+      "contexts": []
+    }
+  ]
+}

--- a/tests/e2e/svelte5-runes-component-format/COMPONENT_INDEX.md
+++ b/tests/e2e/svelte5-runes-component-format/COMPONENT_INDEX.md
@@ -1,0 +1,66 @@
+# Component Index
+
+## Components
+
+- [`LegacyPanel`](#legacypanel)
+- [`RunesButton`](#runesbutton)
+- [`RunesGenericList`](#runesgenericlist)
+
+---
+
+## `LegacyPanel`
+
+### Props
+
+| Prop name | Required | Kind             | Reactive | Binding | Type                | Default value | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :------------------ | :------------ | :---------- |
+| title     | Yes      | <code>let</code> | No       | --      | <code>string</code> | --            | --          |
+
+### Slots
+
+None.
+
+### Events
+
+| Event name | Type       | Detail | Description |
+| :--------- | :--------- | :----- | :---------- |
+| click      | forwarded  | --     | --          |
+| close      | dispatched | --     | --          |
+
+## `RunesButton`
+
+### Props
+
+| Prop name | Required | Kind             | Reactive | Binding | Type                                     | Default value        | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------------- | :------------------- | :---------- |
+| value     | No       | <code>let</code> | Yes      | --      | <code>string</code>                      | <code>"ready"</code> | --          |
+| label     | Yes      | <code>let</code> | No       | --      | <code>string</code>                      | --                   | --          |
+| onclick   | No       | <code>let</code> | No       | --      | <code>(event: MouseEvent) => void</code> | --                   | --          |
+| onpress   | No       | <code>let</code> | No       | --      | <code>(value: string) => void</code>     | --                   | --          |
+
+### Slots
+
+| Slot name | Default | Props                           | Fallback | Description |
+| :-------- | :------ | :------------------------------ | :------- | :---------- |
+| --        | Yes     | <code>{ value: string } </code> | --       | --          |
+
+### Events
+
+None.
+
+## `RunesGenericList`
+
+### Props
+
+| Prop name | Required | Kind             | Reactive | Binding | Type                               | Default value | Description |
+| :-------- | :------- | :--------------- | :------- | :------ | :--------------------------------- | :------------ | :---------- |
+| items     | Yes      | <code>let</code> | No       | --      | <code>Item[]</code>                | --            | --          |
+| row       | Yes      | <code>let</code> | No       | --      | <code>Snippet<[item: Item]></code> | --            | --          |
+
+### Slots
+
+None.
+
+### Events
+
+None.

--- a/tests/e2e/svelte5-runes-component-format/bun.lock
+++ b/tests/e2e/svelte5-runes-component-format/bun.lock
@@ -1,0 +1,171 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "svelte5-runes-component-format",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^7.0.0",
+        "svelte": "^5.55.0",
+        "svelte-check": "^4.0.0",
+        "typescript": "^5.7.0",
+        "vite": "^8.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
+
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.0", "", {}, "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.1.2", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.2.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "svelte": ["svelte@5.56.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw=="],
+
+    "svelte-check": ["svelte-check@4.7.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+  }
+}

--- a/tests/e2e/svelte5-runes-component-format/package.json
+++ b/tests/e2e/svelte5-runes-component-format/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "svelte5-runes-component-format",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "svelte": "./src/index.js",
+  "types": "./types/index.d.ts",
+  "scripts": {
+    "svelte-check": "svelte-check --workspace test",
+    "build": "vite build && svelte-check --workspace test"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "svelte": "^5.55.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^8.0.3"
+  }
+}

--- a/tests/e2e/svelte5-runes-component-format/src/LegacyPanel.svelte
+++ b/tests/e2e/svelte5-runes-component-format/src/LegacyPanel.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let title: string;
+
+  const dispatch = createEventDispatcher<{ close: { reason: string } }>();
+
+  function handleClose() {
+    dispatch("close", { reason: "user" });
+  }
+</script>
+
+<div>
+  <h2>{title}</h2>
+  <button on:click>Forwarded</button>
+  <button on:click={handleClose}>Close</button>
+</div>

--- a/tests/e2e/svelte5-runes-component-format/src/RunesButton.svelte
+++ b/tests/e2e/svelte5-runes-component-format/src/RunesButton.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  let {
+    label,
+    onclick,
+    onpress,
+    value = $bindable("ready"),
+    children,
+  }: {
+    label: string;
+    onclick?: (event: MouseEvent) => void;
+    onpress?: (value: string) => void;
+    value?: string;
+    children?: Snippet<[{ value: string }]>;
+  } = $props();
+</script>
+
+<button
+  onclick={(event) => {
+    onclick?.(event);
+    onpress?.(value);
+  }}
+>
+  {label}
+  {@render children?.({ value })}
+</button>

--- a/tests/e2e/svelte5-runes-component-format/src/RunesGenericList.svelte
+++ b/tests/e2e/svelte5-runes-component-format/src/RunesGenericList.svelte
@@ -1,0 +1,17 @@
+<script lang="ts" generics="Item extends { id: string | number } = { id: string }">
+  import type { Snippet } from "svelte";
+
+  let {
+    items,
+    row,
+  }: {
+    items: Item[];
+    row: Snippet<[item: Item]>;
+  } = $props();
+</script>
+
+<ul>
+  {#each items as item (item.id)}
+    <li>{@render row(item)}</li>
+  {/each}
+</ul>

--- a/tests/e2e/svelte5-runes-component-format/src/index.js
+++ b/tests/e2e/svelte5-runes-component-format/src/index.js
@@ -1,0 +1,3 @@
+export { default as LegacyPanel } from "./LegacyPanel.svelte";
+export { default as RunesButton } from "./RunesButton.svelte";
+export { default as RunesGenericList } from "./RunesGenericList.svelte";

--- a/tests/e2e/svelte5-runes-component-format/test/test.svelte
+++ b/tests/e2e/svelte5-runes-component-format/test/test.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { LegacyPanel, RunesButton, RunesGenericList } from "../types";
+
+  interface Todo {
+    id: number;
+    label: string;
+  }
+
+  const todos: Todo[] = [{ id: 1, label: "Write generics support" }];
+
+  let value = $state("ready");
+</script>
+
+<RunesButton
+  label="Click me"
+  bind:value
+  onclick={(event) => console.log(event.clientX)}
+  onpress={(pressedValue) => console.log(pressedValue.toUpperCase())}
+/>
+
+<LegacyPanel
+  title="Settings"
+  onclose={(event) => console.log(event.detail.reason)}
+  onclick={(event) => console.log(event.clientX)}
+/>
+
+<RunesGenericList items={todos}>
+  {#snippet row(todo)}
+    <span>{todo.label}</span>
+  {/snippet}
+</RunesGenericList>

--- a/tests/e2e/svelte5-runes-component-format/tsconfig.json
+++ b/tests/e2e/svelte5-runes-component-format/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "checkJs": true,
+    "types": []
+  },
+  "include": ["src/**/*", "test/**/*", "types/**/*"]
+}

--- a/tests/e2e/svelte5-runes-component-format/types/LegacyPanel.svelte.d.ts
+++ b/tests/e2e/svelte5-runes-component-format/types/LegacyPanel.svelte.d.ts
@@ -1,0 +1,17 @@
+import type { Component } from "svelte";
+
+export type LegacyPanelProps = {
+  /**
+   * @default undefined
+   */
+  title: string;
+
+  onclick?: (event: WindowEventMap["click"]) => void;
+
+  onclose?: (event: CustomEvent<any>) => void;
+};
+
+export type LegacyPanelExports = Record<string, never>;
+
+declare const LegacyPanel: Component<LegacyPanelProps, LegacyPanelExports, "">;
+export default LegacyPanel;

--- a/tests/e2e/svelte5-runes-component-format/types/RunesButton.svelte.d.ts
+++ b/tests/e2e/svelte5-runes-component-format/types/RunesButton.svelte.d.ts
@@ -1,0 +1,21 @@
+import type { Component } from "svelte";
+import type { Snippet } from "svelte";
+
+type $Props = {
+  label: string;
+  onclick?: (event: MouseEvent) => void;
+  onpress?: (value: string) => void;
+  value?: string;
+  children?: Snippet<[{ value: string }]>;
+};
+
+export type RunesButtonProps = $Props;
+
+export type RunesButtonExports = Record<string, never>;
+
+declare const RunesButton: Component<
+  RunesButtonProps,
+  RunesButtonExports,
+  "value"
+>;
+export default RunesButton;

--- a/tests/e2e/svelte5-runes-component-format/types/RunesGenericList.svelte.d.ts
+++ b/tests/e2e/svelte5-runes-component-format/types/RunesGenericList.svelte.d.ts
@@ -1,0 +1,35 @@
+import type {
+  SvelteComponent,
+  ComponentConstructorOptions,
+  ComponentInternals,
+} from "svelte";
+import type { Snippet } from "svelte";
+
+type $Props<Item extends { id: string | number } = { id: string }> = {
+  items: Item[];
+  row: Snippet<[item: Item]>;
+};
+
+export type RunesGenericListProps<
+  Item extends { id: string | number } = { id: string },
+> = $Props<Item>;
+
+export type RunesGenericListExports = Record<string, never>;
+
+interface RunesGenericListComponent {
+  new <Item extends { id: string | number } = { id: string }>(
+    options: ComponentConstructorOptions<RunesGenericListProps<Item>>,
+  ): SvelteComponent<RunesGenericListProps<Item>> & RunesGenericListExports;
+  <Item extends { id: string | number } = { id: string }>(
+    this: void,
+    internals: ComponentInternals,
+    props: RunesGenericListProps<Item>,
+  ): {
+    $on?(type: string, callback: (e: any) => void): () => void;
+    $set?(props: Partial<RunesGenericListProps<Item>>): void;
+  } & RunesGenericListExports;
+  element?: typeof HTMLElement;
+  z_$$bindings?: "";
+}
+declare const RunesGenericList: RunesGenericListComponent;
+export default RunesGenericList;

--- a/tests/e2e/svelte5-runes-component-format/types/index.d.ts
+++ b/tests/e2e/svelte5-runes-component-format/types/index.d.ts
@@ -1,0 +1,3 @@
+export { default as LegacyPanel } from "./LegacyPanel.svelte";
+export { default as RunesButton } from "./RunesButton.svelte";
+export { default as RunesGenericList } from "./RunesGenericList.svelte";

--- a/tests/e2e/svelte5-runes-component-format/vite.config.js
+++ b/tests/e2e/svelte5-runes-component-format/vite.config.js
@@ -1,0 +1,28 @@
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import sveld from "sveld";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    svelte(),
+    sveld({
+      types: true,
+      typesOptions: {
+        printWidth: 80,
+        format: "component",
+      },
+      json: true,
+      markdown: true,
+    }),
+  ],
+  build: {
+    lib: {
+      entry: "./src/index.js",
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: {
+      external: ["svelte"],
+    },
+  },
+});

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -700,3 +700,279 @@ describe("writerTsDefinition", () => {
     expect(output).toContain("export type TypedButtonProps = $Props;");
   });
 });
+
+describe(`writeTsDefinition with format: "component"`, () => {
+  test("plain props component emits declare const with Component<Props>", () => {
+    const component_api: ComponentDocApi = {
+      moduleName: "Button",
+      filePath: asNormalizedPath("./src/Button.svelte"),
+      syntaxMode: "runes",
+      props: [
+        {
+          name: "label",
+          kind: "let",
+          type: "string",
+          value: '""',
+          isFunction: false,
+          isFunctionDeclaration: false,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+        },
+      ],
+      moduleExports: [],
+      slots: [],
+      events: [],
+      typedefs: [],
+      generics: null,
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(component_api, { format: "component" });
+    expect(output).toContain('import type { Component } from "svelte";');
+    expect(output).not.toContain("SvelteComponentTyped");
+    expect(output).toContain("export type ButtonExports = Record<string, never>;");
+    expect(output).toContain(
+      `declare const Button: Component<
+      ButtonProps,
+      ButtonExports,
+      ""
+    >;
+    export default Button;`,
+    );
+  });
+
+  test('$bindable props populate the Bindings union; none produces ""', () => {
+    const bindableComponent: ComponentDocApi = {
+      moduleName: "TextInput",
+      filePath: asNormalizedPath("./src/TextInput.svelte"),
+      syntaxMode: "runes",
+      props: [
+        {
+          name: "value",
+          kind: "let",
+          bindable: true,
+          type: "string",
+          value: '""',
+          isFunction: false,
+          isFunctionDeclaration: false,
+          isRequired: false,
+          constant: false,
+          reactive: true,
+        },
+        {
+          name: "disabled",
+          kind: "let",
+          binding: "writable",
+          type: "boolean",
+          value: "false",
+          isFunction: false,
+          isFunctionDeclaration: false,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+        },
+        {
+          name: "label",
+          kind: "let",
+          type: "string",
+          value: '""',
+          isFunction: false,
+          isFunctionDeclaration: false,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+        },
+      ],
+      moduleExports: [],
+      slots: [],
+      events: [],
+      typedefs: [],
+      generics: null,
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(bindableComponent, { format: "component" });
+    expect(output).toContain('"value" | "disabled"');
+
+    const noBindableComponent: ComponentDocApi = {
+      ...bindableComponent,
+      props: bindableComponent.props.map(({ bindable: _bindable, binding: _binding, ...prop }) => prop),
+    };
+    const noBindableOutput = writeTsDefinition(noBindableComponent, { format: "component" });
+    expect(noBindableOutput).toContain(
+      `declare const TextInput: Component<
+      TextInputProps,
+      TextInputExports,
+      ""
+    >;`,
+    );
+  });
+
+  test("legacy dispatched and forwarded events become on* callback props", () => {
+    const component_api: ComponentDocApi = {
+      moduleName: "Modal",
+      filePath: asNormalizedPath("./src/Modal.svelte"),
+      syntaxMode: "legacy",
+      props: [],
+      moduleExports: [],
+      slots: [],
+      events: [
+        { type: "dispatched", name: "close", detail: "{ id: string }" },
+        {
+          type: "forwarded",
+          name: "click",
+          element: "button",
+        },
+      ],
+      typedefs: [],
+      generics: null,
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(component_api, { format: "component" });
+    expect(output).toContain("onclose?: (event: CustomEvent<{ id: string }>) => void;");
+    expect(output).toContain('onclick?: (event: WindowEventMap["click"]) => void;');
+  });
+
+  test("does not add on* callback props for runes components", () => {
+    const component_api: ComponentDocApi = {
+      moduleName: "RunesButton",
+      filePath: asNormalizedPath("./src/RunesButton.svelte"),
+      syntaxMode: "runes",
+      props: [
+        {
+          name: "onclick",
+          kind: "let",
+          type: "(event: MouseEvent) => void",
+          isFunction: true,
+          isFunctionDeclaration: false,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+        },
+      ],
+      moduleExports: [],
+      slots: [],
+      events: [{ type: "dispatched", name: "close", detail: "{ id: string }" }],
+      typedefs: [],
+      generics: null,
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(component_api, { format: "component" });
+    expect(output).not.toContain("onclose");
+  });
+
+  test("exported accessors populate the Exports shape", () => {
+    const component_api: ComponentDocApi = {
+      moduleName: "Tree",
+      filePath: asNormalizedPath("./src/Tree.svelte"),
+      syntaxMode: "legacy",
+      props: [
+        {
+          name: "expandAll",
+          kind: "function",
+          type: "() => any",
+          isFunction: true,
+          isFunctionDeclaration: true,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+          returnType: "void",
+        },
+      ],
+      moduleExports: [],
+      slots: [],
+      events: [],
+      typedefs: [],
+      generics: null,
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(component_api, { format: "component" });
+    expect(output).toContain("export type TreeExports = {");
+    expect(output).toContain("expandAll: () => void;");
+    expect(output).toContain(
+      `declare const Tree: Component<
+      TreeProps,
+      TreeExports,
+      ""
+    >;`,
+    );
+  });
+
+  test("generic components emit an interface with a generic call signature", () => {
+    const component_api: ComponentDocApi = {
+      moduleName: "GenericList",
+      filePath: asNormalizedPath("./src/GenericList.svelte"),
+      syntaxMode: "runes",
+      props: [
+        {
+          name: "items",
+          kind: "let",
+          type: "Row[]",
+          isFunction: false,
+          isFunctionDeclaration: false,
+          isRequired: true,
+          constant: false,
+          reactive: false,
+        },
+      ],
+      moduleExports: [],
+      slots: [],
+      events: [],
+      typedefs: [],
+      generics: ["Row", "Row extends { id: string } = { id: string }"],
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(component_api, { format: "component" });
+    expect(output).not.toContain("SvelteComponentTyped");
+    expect(output).toContain(
+      'import type { SvelteComponent, ComponentConstructorOptions, ComponentInternals } from "svelte";',
+    );
+    expect(output).toContain("interface GenericListComponent {");
+    expect(output).toContain(
+      "new <Row extends { id: string } = { id: string }>(\n        options: ComponentConstructorOptions<GenericListProps<Row>>\n      ): SvelteComponent<GenericListProps<Row>> & GenericListExports;",
+    );
+    expect(output).toContain(
+      "<Row extends { id: string } = { id: string }>(\n        this: void,\n        internals: ComponentInternals,\n        props: GenericListProps<Row>",
+    );
+    expect(output).toContain("declare const GenericList: GenericListComponent;");
+    expect(output).toContain("export default GenericList;");
+  });
+
+  test("generic Exports type is parameterized only when it references the generic", () => {
+    const component_api: ComponentDocApi = {
+      moduleName: "GenericTree",
+      filePath: asNormalizedPath("./src/GenericTree.svelte"),
+      syntaxMode: "legacy",
+      props: [
+        {
+          name: "getSelected",
+          kind: "function",
+          type: "() => any",
+          isFunction: true,
+          isFunctionDeclaration: true,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+          returnType: "Row[]",
+        },
+      ],
+      moduleExports: [],
+      slots: [],
+      events: [],
+      typedefs: [],
+      generics: ["Row", "Row extends { id: string } = { id: string }"],
+      rest_props: undefined,
+    };
+
+    const output = writeTsDefinition(component_api, { format: "component" });
+    expect(output).toContain("export type GenericTreeExports<Row extends { id: string } = { id: string }> = {");
+    expect(output).toContain("getSelected: () => Row[];");
+    expect(output).toContain("props: GenericTreeProps<Row>");
+    expect(output).toContain("} & GenericTreeExports<Row>;");
+  });
+});


### PR DESCRIPTION
Adds typesOptions.format ("class" | "component", default "class"), so consumers can opt into Svelte 5's Component type (declare const X: Component<Props, Exports, Bindings>) instead of the deprecated SvelteComponentTyped. Bindings comes from $bindable(...)/`@bindable` writable props, Exports from the same accessor props that render as class members today, and legacy dispatched/forwarded events become on<name> callback props since runes components already expose those as regular props.

Generic components can't use Component<...> directly, since a declare const can't carry its own type parameter the way a class can. Rather than falling back to the class emission for those, this generates a per-component interface with a new <T>(...) construct signature and a <T>(internals, props) call signature, both carrying the generic themselves, then declares the const against that interface. This mirrors what @sveltejs/package itself emits for generic Svelte 5 components.

  - I verified the new signature specifically is load-bearing: stripping it from svelte-package's own generated output reproduces a silent inference bug where template usage resolves the generic to its default instead of the caller's actual type, the same class of issue tracked in sveltejs/svelte#14505 and sveltejs/language-tools#12202. Restoring it fixes it, so it stays, built on SvelteComponent/ComponentConstructorOptions rather than SvelteComponentTyped.

Wired through the plugin, config file, and --types-format on the CLI. Default output stays byte-identical to existing snapshots. The new e2e project type-checks generated output with svelte-check, including a deliberate type break to confirm generic inference is real and not just syntactically generic-looking.

This will become the default output format for v1 (Svelte 5 first).