### PR TITLE
feat(api)!: rename sveld() input option to entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,14 +508,16 @@ The CLI exits non-zero on any fatal error (an unreadable entry, a config file th
 
 You can also call `sveld` from Node.js. See [Requirements](#requirements) for supported Node versions and the ESM-only constraint.
 
-If no `input` is specified, `sveld` infers the entry point based on the `package.json#svelte` field. If no entry point can be resolved, `sveld()` throws with an actionable message (previously it resolved to `{ diagnostics: [] }` and generated nothing).
+If no `entry` is specified, `sveld` infers the entry point based on the `package.json#svelte` field. If no entry point can be resolved, `sveld()` throws with an actionable message (previously it resolved to `{ diagnostics: [] }` and generated nothing).
+
+> `input` was renamed to `entry` to match the CLI, plugin, and config. Calls passing `input` throw with a message pointing at `entry`.
 
 ```js
 import { sveld } from "sveld";
 import pkg from "./package.json" with { type: "json" };
 
 const { diagnostics } = await sveld({
-  input: "./src/index.js",
+  entry: "./src/index.js",
   glob: true,
   markdown: true,
   markdownOptions: {

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -4,14 +4,7 @@ import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
 import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
-interface SveldOptions extends Omit<SveldRuntimeOptions, "entry"> {
-  /**
-   * Specify the input to the uncompiled Svelte source.
-   * If no value is provided, `sveld` will attempt to infer
-   * the entry point from the `package.json#svelte` field.
-   */
-  input?: string;
-}
+type SveldOptions = SveldRuntimeOptions;
 
 /**
  * Result of a programmatic `sveld` run.
@@ -29,7 +22,7 @@ interface SveldResult {
  * @example
  * ```ts
  * await sveld({
- *   input: "./src",
+ *   entry: "./src",
  *   types: true,
  *   json: true,
  *   markdown: true,
@@ -38,12 +31,16 @@ interface SveldResult {
  * ```
  */
 export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
-  const { input: inputOverride, ...runtimeOpts } = opts ?? {};
+  if (opts && "input" in opts) {
+    throw new Error("sveld: the `input` option was renamed to `entry`.");
+  }
+
+  const { entry: entryOverride, ...runtimeOpts } = opts ?? {};
   const fileConfig = await loadConfig();
-  const input = getSvelteEntry(inputOverride ?? fileConfig.entry);
+  const input = getSvelteEntry(entryOverride ?? fileConfig.entry);
   if (input === null) {
     throw new Error(
-      'sveld: could not resolve a Svelte entry point. Set package.json#svelte, or pass the "input" option.',
+      'sveld: could not resolve a Svelte entry point. Set package.json#svelte, or pass the "entry" option.',
     );
   }
   const merged = mergeConfig<SveldRuntimeOptions>(fileConfig, runtimeOpts, { entry: input });
@@ -63,7 +60,7 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   const shouldReport = merged.reportDiagnostics || merged.strict;
 
   if (shouldReport && diagnostics.length > 0) {
-    console.warn(formatDiagnosticsSummary(diagnostics));
+    console.error(formatDiagnosticsSummary(diagnostics));
   }
 
   if (merged.strict && diagnostics.length > 0) {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -200,17 +200,17 @@ describe("diagnostics helpers", () => {
 });
 
 describe("sveld() strict mode", () => {
-  // `getSvelteEntry` resolves `input` against `process.cwd()`, so the fixture
+  // `getSvelteEntry` resolves `entry` against `process.cwd()`, so the fixture
   // lives under cwd and is referenced by its relative directory name.
   let absoluteDir: string;
   let relativeDir: string;
   let previousExitCode: typeof process.exitCode;
-  let warnSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
     previousExitCode = process.exitCode;
     process.exitCode = undefined;
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.spyOn(console, "log").mockImplementation(() => {});
     absoluteDir = mkdtempSync(join(process.cwd(), "sveld-diagnostics-"));
     relativeDir = basename(absoluteDir);
@@ -227,30 +227,37 @@ describe("sveld() strict mode", () => {
     jest.restoreAllMocks();
   });
 
+  // `errorSpy` wraps the process-wide `console.error`, which other test files also spy on
+  // concurrently under `bun test --parallel`. Assert on message content rather than call
+  // count/order so unrelated, interleaved calls don't produce false positives/negatives.
+  const summaryCalls = (spy: ReturnType<typeof jest.spyOn>) =>
+    spy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .filter((message: string) => message.includes("unresolved types found"));
+
   test("returns the aggregated diagnostics array and stays non-failing by default", async () => {
     // Bun ignores `process.exitCode = undefined` once a numeric code has been
     // set earlier in the process, so assert against the pre-call value rather
     // than an unreachable literal `undefined`.
     const exitCodeBefore = process.exitCode;
-    const { diagnostics } = await sveld({ input: relativeDir, glob: true, types: false });
+    const { diagnostics } = await sveld({ entry: relativeDir, glob: true, types: false });
 
     expect(diagnostics.some((d) => d.kind === "event-no-source" && d.name === "phantom")).toBe(true);
     expect(process.exitCode).toBe(exitCodeBefore);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(summaryCalls(errorSpy)).toHaveLength(0);
   });
 
-  test("reportDiagnostics: true prints the summary", async () => {
-    await sveld({ input: relativeDir, glob: true, types: false, reportDiagnostics: true });
+  test("reportDiagnostics: true prints the summary to console.error", async () => {
+    await sveld({ entry: relativeDir, glob: true, types: false, reportDiagnostics: true });
 
-    expect(warnSpy).toHaveBeenCalled();
-    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("unresolved types found");
+    expect(summaryCalls(errorSpy).length).toBeGreaterThan(0);
   });
 
   test("strict: true sets a non-zero exit code when diagnostics exist", async () => {
-    const { diagnostics } = await sveld({ input: relativeDir, glob: true, types: false, strict: true });
+    const { diagnostics } = await sveld({ entry: relativeDir, glob: true, types: false, strict: true });
 
     expect(diagnostics.length).toBeGreaterThan(0);
     expect(process.exitCode).toBe(1);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(summaryCalls(errorSpy).length).toBeGreaterThan(0);
   });
 });

--- a/tests/sveld.test.ts
+++ b/tests/sveld.test.ts
@@ -6,6 +6,7 @@ import { buildComponentApiDocument } from "../src/writer/document-model";
 import { mockComponentDocApi } from "./test-brands";
 
 const ENTRY_ERROR = /entry/i;
+const INPUT_RENAMED_ERROR = /renamed to `entry`/;
 
 describe("sveld() entry resolution failures", () => {
   let dir: string;
@@ -24,17 +25,22 @@ describe("sveld() entry resolution failures", () => {
     jest.restoreAllMocks();
   });
 
-  test("throws when the given input does not resolve", async () => {
-    await expect(sveld({ input: "does-not-exist/" })).rejects.toThrow(ENTRY_ERROR);
+  test("throws when the given entry does not resolve", async () => {
+    await expect(sveld({ entry: "does-not-exist/" })).rejects.toThrow(ENTRY_ERROR);
   });
 
-  test("throws when no input is given and package.json#svelte is absent", async () => {
+  test("throws when no entry is given and package.json#svelte is absent", async () => {
     await expect(sveld()).rejects.toThrow(ENTRY_ERROR);
+  });
+
+  test("throws when the removed `input` option is passed", async () => {
+    const legacyOpts = { input: "./src" } as unknown as Parameters<typeof sveld>[0];
+    await expect(sveld(legacyOpts)).rejects.toThrow(INPUT_RENAMED_ERROR);
   });
 });
 
 describe("sveld() check", () => {
-  // `getSvelteEntry` resolves `input` against `process.cwd()`, so the fixture
+  // `getSvelteEntry` resolves `entry` against `process.cwd()`, so the fixture
   // lives under cwd and is referenced by its relative directory name.
   let absoluteDir: string;
   let relativeDir: string;
@@ -66,7 +72,7 @@ describe("sveld() check", () => {
     );
     writeFileSync(join(absoluteDir, "COMPONENT_API.json"), JSON.stringify(snapshot));
 
-    const result = await sveld({ input: entry, types: false, check: snapshotFile });
+    const result = await sveld({ entry, types: false, check: snapshotFile });
 
     expect(result.check).toBeDefined();
     expect(result.check?.snapshotExists).toBe(true);
@@ -76,7 +82,7 @@ describe("sveld() check", () => {
   });
 
   test("does not run check when the option is omitted", async () => {
-    const result = await sveld({ input: entry, types: false });
+    const result = await sveld({ entry, types: false });
 
     expect(result.check).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- The plugin, CLI, and config all name the entry point `entry`; the programmatic `sveld()` API alone used `input`. This renames it for a single consistent surface across all three entry points.
- `input` is removed outright — no alias, no deprecation window (pre-1.0). Passing `input` throws immediately with a message pointing at `entry`, so plain-JS callers (no type checker) fail loudly instead of silently falling back to `package.json#svelte` inference.
- The diagnostics summary now prints via `console.error` instead of `console.warn`, matching the CLI's stream.

## Breaking change

```
BREAKING CHANGE: sveld({ input }) is no longer accepted; use
sveld({ entry }). Calls passing `input` throw with a migration message.
```

Migration: rename `input` to `entry` in any `sveld({ input: ... })` call.

## Test plan

- [x] `bun test sveld` / `bun test diagnostics` — updated unit tests cover: `entry` resolution, `input` throwing with a message naming `entry`, and the diagnostics summary landing on `console.error`
- [x] `bun run test` (full suite, `--parallel`) — 690/690 passing
- [x] `bun run typecheck` — passes
- [x] `bunx biome check` on changed files — clean
- [x] Repo-wide sweep (`rg -n '\binput\b'`) confirms no remaining call sites, tests, or docs pass `input` to `sveld()`