### PR TITLE
perf(bundle): skip style-strip parse when source has no style tag

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -107,7 +107,12 @@ export interface ProcessComponentOptions {
 const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
 const HYPHEN_REGEX = /-/g;
 
-function stripTopLevelStyleBlock(source: string) {
+export function stripTopLevelStyleBlock(source: string) {
+  // A component without "<style" cannot have a top-level style block; skip the
+  // locate-and-strip parse entirely. False positives (the substring inside a
+  // string, comment, or nested markup) just take the existing parse path.
+  if (!source.includes("<style")) return source;
+
   try {
     const parsed = parseSvelte(source, { modern: false }) as { css?: { start?: number; end?: number } };
     const start = parsed.css?.start;

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { generateBundle } from "../src/bundle";
+import { generateBundle, stripTopLevelStyleBlock } from "../src/bundle";
 import { TypeResolver } from "../src/resolve-types";
 
 /** Imports an opaque whole-object props type; a resolveTypes candidate. */
@@ -20,7 +20,7 @@ const PROPS_TYPES = `export interface Props {
 }
 `;
 
-/** A plain-TS \`@example\` block; a checkExamples candidate. */
+/** A plain-TS `@example` block; a checkExamples candidate. */
 const EXAMPLE_CHECK_COMPONENT = `<script>
   /**
    * @param {string} value
@@ -36,7 +36,7 @@ const EXAMPLE_CHECK_COMPONENT = `<script>
 </script>
 `;
 
-/** Neither an imported whole-props type nor an \`@example\` block: no candidates. */
+/** Neither an imported whole-props type nor an `@example` block: no candidates. */
 const PLAIN_COMPONENT = `<script>
   /** @type {string} */
   export let label = "ok";
@@ -77,7 +77,10 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     const fakeResolver = makeFakeResolver();
     createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
 
-    await generateBundle(path.join(dir, "index.ts"), true, { resolveTypes: true, checkExamples: true });
+    await generateBundle(path.join(dir, "index.ts"), true, {
+      resolveTypes: true,
+      checkExamples: true,
+    });
 
     expect(createSpy).toHaveBeenCalledTimes(1);
     expect(fakeResolver.expandAll).toHaveBeenCalledTimes(1);
@@ -92,7 +95,10 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     const fakeResolver = makeFakeResolver();
     createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
 
-    await generateBundle(path.join(dir, "index.ts"), true, { resolveTypes: true, checkExamples: true });
+    await generateBundle(path.join(dir, "index.ts"), true, {
+      resolveTypes: true,
+      checkExamples: true,
+    });
 
     expect(createSpy).not.toHaveBeenCalled();
   });
@@ -117,5 +123,46 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
 
     const exampleCheck = result.allComponentsForTypes.get("ExampleCheck");
     expect(exampleCheck?.diagnostics ?? []).toEqual([]);
+  });
+});
+
+describe("stripTopLevelStyleBlock", () => {
+  test("returns the identical source when it has no <style> substring", () => {
+    const source = `<script>
+  export let label = "hello";
+</script>
+
+<span>{label}</span>`;
+
+    expect(stripTopLevelStyleBlock(source)).toBe(source);
+  });
+
+  test("strips a top-level <style> block", () => {
+    const source = `<script>
+  export let label = "hello";
+</script>
+
+<span>{label}</span>
+
+<style>
+  span {
+    color: red;
+  }
+</style>`;
+
+    const result = stripTopLevelStyleBlock(source);
+
+    expect(result).not.toContain("<style");
+    expect(result).toContain("<span>{label}</span>");
+  });
+
+  test("still parses when <style> only appears inside a string", () => {
+    const source = `<script>
+  const s = "<style>";
+</script>
+
+<span>{s}</span>`;
+
+    expect(stripTopLevelStyleBlock(source)).toBe(source);
   });
 });


### PR DESCRIPTION
stripTopLevelStyleBlock ran a full svelte/compiler parse on every component just to locate the top-level style block range, before ComponentParser ran its own full compile on the stripped source. That's two complete AST passes per component, even though most components in real libraries have no style block at all (155 of 160 in the carbon e2e fixture).

This adds a cheap substring guard: if the source has no "<style" substring, it cannot contain a style block, so the locate-and-strip parse is skipped entirely and the source is returned unchanged. Sources that do contain the substring (including false positives inside strings or comments) fall through to the existing parse path unchanged, so behavior for actual style blocks is unaffected.

stripTopLevelStyleBlock is now exported and covered by focused unit tests for the three relevant cases: no style substring, a real top-level style block, and a false-positive substring inside a string. Generated output is unaffected, all 376 fixture snapshots pass unchanged, and the full test suite, typecheck, and biome all pass.

Risk is low since the change only short-circuits a parse call based on a substring check; the worst case for a wrong guard would be a missed style-block strip, which the existing fixture and unit test coverage rules out.