### PR TITLE
perf(bundle): share one TypeResolver across resolveTypes and checkExamples

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -16,6 +16,7 @@ import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { normalizeSeparators } from "./path";
+import type { TypeResolver } from "./resolve-types";
 
 export interface ComponentDocApi extends ParsedComponent {
   filePath: NormalizedPath;
@@ -455,17 +456,31 @@ export async function generateBundle(
   const errors = Array.from(parseErrors.values());
   reportParseErrors(errors);
 
-  if (options.resolveTypes) {
-    await resolveImportedPropTypes(components, rootDir, resolveComponentFilePath);
-  }
-
   cache?.save();
 
-  if (options.checkExamples) {
-    // Runs over allComponentsForTypes (not just exports): that's the map the
-    // diagnostics summary below is built from, so every discovered component's
-    // examples get checked and surfaced, not just the public barrel.
-    await checkComponentExamples(allComponentsForTypes, rootDir, resolveComponentFilePath);
+  // Runs checkExamples over allComponentsForTypes (not just exports): that's the
+  // map the diagnostics summary below is built from, so every discovered
+  // component's examples get checked and surfaced, not just the public barrel.
+  const resolveTypesCandidates = options.resolveTypes ? collectResolveTypesCandidates(components) : [];
+  const checkExamplesCandidates = options.checkExamples ? collectCheckExamplesCandidates(allComponentsForTypes) : [];
+
+  if (resolveTypesCandidates.length > 0 || checkExamplesCandidates.length > 0) {
+    // Both features load the TS server through the same TypeResolver; sharing
+    // one instance across them halves server startup and project load when
+    // both options are enabled instead of paying for it twice.
+    const { TypeResolver } = await import("./resolve-types");
+    const resolver = await TypeResolver.create(rootDir);
+
+    try {
+      if (resolveTypesCandidates.length > 0) {
+        await resolveImportedPropTypes(resolveTypesCandidates, resolver, resolveComponentFilePath);
+      }
+      if (checkExamplesCandidates.length > 0) {
+        await checkComponentExamples(checkExamplesCandidates, resolver, resolveComponentFilePath);
+      }
+    } finally {
+      await resolver?.dispose();
+    }
   }
 
   // Same file can land in both export and all-components passes; dedupe before returning.
@@ -483,15 +498,13 @@ export async function generateBundle(
   };
 }
 
-async function resolveImportedPropTypes(
-  components: ComponentDocs,
-  rootDir: string,
-  resolveComponentFilePath: ResolveComponentFilePath,
-): Promise<void> {
-  const candidates: Array<{
-    component: ComponentDocApi;
-    metadata: NonNullable<ReturnType<typeof getParsedComponentTypeScriptMetadata>>;
-  }> = [];
+interface ResolveTypesCandidate {
+  component: ComponentDocApi;
+  metadata: NonNullable<ReturnType<typeof getParsedComponentTypeScriptMetadata>>;
+}
+
+function collectResolveTypesCandidates(components: ComponentDocs): ResolveTypesCandidate[] {
+  const candidates: ResolveTypesCandidate[] = [];
 
   for (const component of components.values()) {
     const metadata = getParsedComponentTypeScriptMetadata(component);
@@ -499,36 +512,37 @@ async function resolveImportedPropTypes(
     candidates.push({ component, metadata });
   }
 
-  if (candidates.length === 0) return;
+  return candidates;
+}
 
-  const { TypeResolver } = await import("./resolve-types");
-  const resolver = await TypeResolver.create(rootDir);
+async function resolveImportedPropTypes(
+  candidates: ResolveTypesCandidate[],
+  resolver: TypeResolver | null,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Promise<void> {
   if (!resolver) return;
 
-  try {
-    const resolvedByModule = await resolver.expandAll(
-      candidates.map(({ component, metadata }) => ({
-        moduleName: component.moduleName,
-        metadata,
-        filePath: resolveComponentFilePath(component.filePath),
-      })),
-    );
+  const resolvedByModule = await resolver.expandAll(
+    candidates.map(({ component, metadata }) => ({
+      moduleName: component.moduleName,
+      metadata,
+      filePath: resolveComponentFilePath(component.filePath),
+    })),
+  );
 
-    for (const { component } of candidates) {
-      const resolved = resolvedByModule.get(component.moduleName);
-      if (resolved) applyResolvedProps(component, resolved);
-    }
-  } finally {
-    await resolver.dispose();
+  for (const { component } of candidates) {
+    const resolved = resolvedByModule.get(component.moduleName);
+    if (resolved) applyResolvedProps(component, resolved);
   }
 }
 
-async function checkComponentExamples(
-  components: ComponentDocs,
-  rootDir: string,
-  resolveComponentFilePath: ResolveComponentFilePath,
-): Promise<void> {
-  const candidates: Array<{ component: ComponentDocApi; sources: ReturnType<typeof collectExampleSources> }> = [];
+interface CheckExamplesCandidate {
+  component: ComponentDocApi;
+  sources: ReturnType<typeof collectExampleSources>;
+}
+
+function collectCheckExamplesCandidates(components: ComponentDocs): CheckExamplesCandidate[] {
+  const candidates: CheckExamplesCandidate[] = [];
 
   for (const component of components.values()) {
     const sources = collectExampleSources(component);
@@ -536,41 +550,41 @@ async function checkComponentExamples(
     candidates.push({ component, sources });
   }
 
-  if (candidates.length === 0) return;
+  return candidates;
+}
 
-  const { TypeResolver } = await import("./resolve-types");
-  const resolver = await TypeResolver.create(rootDir);
+async function checkComponentExamples(
+  candidates: CheckExamplesCandidate[],
+  resolver: TypeResolver | null,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Promise<void> {
   if (!resolver) return;
 
-  try {
-    const diagnosticsByModule = await resolver.checkExamples(
-      candidates.map(({ component, sources }) => ({
-        moduleName: component.moduleName,
-        filePath: resolveComponentFilePath(component.filePath),
-        sources,
-      })),
-    );
+  const diagnosticsByModule = await resolver.checkExamples(
+    candidates.map(({ component, sources }) => ({
+      moduleName: component.moduleName,
+      filePath: resolveComponentFilePath(component.filePath),
+      sources,
+    })),
+  );
 
-    for (const { component, sources } of candidates) {
-      const found = diagnosticsByModule.get(component.moduleName);
-      if (!found || found.length === 0) continue;
+  for (const { component, sources } of candidates) {
+    const found = diagnosticsByModule.get(component.moduleName);
+    if (!found || found.length === 0) continue;
 
-      const sourceById = new Map(sources.map((source) => [source.id, source.source]));
+    const sourceById = new Map(sources.map((source) => [source.id, source.source]));
 
-      const diagnostics = component.diagnostics ?? [];
-      for (const item of found) {
-        const source = sourceById.get(item.id);
-        diagnostics.push({
-          component: component.filePath,
-          kind: "example-compile-error",
-          name: item.name,
-          message: item.message,
-          ...(source ? { source } : {}),
-        });
-      }
-      component.diagnostics = diagnostics;
+    const diagnostics = component.diagnostics ?? [];
+    for (const item of found) {
+      const source = sourceById.get(item.id);
+      diagnostics.push({
+        component: component.filePath,
+        kind: "example-compile-error",
+        name: item.name,
+        message: item.message,
+        ...(source ? { source } : {}),
+      });
     }
-  } finally {
-    await resolver.dispose();
+    component.diagnostics = diagnostics;
   }
 }

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { generateBundle } from "../src/bundle";
+import { TypeResolver } from "../src/resolve-types";
+
+/** Imports an opaque whole-object props type; a resolveTypes candidate. */
+const PROPS_IMPORTED_COMPONENT = `<script lang="ts">
+  import type { Props } from "./types";
+
+  let props: Props = $props();
+</script>
+
+<a href={props.href}>{props.variant}</a>
+`;
+
+const PROPS_TYPES = `export interface Props {
+  href: string;
+  variant: "a" | "b";
+}
+`;
+
+/** A plain-TS \`@example\` block; a checkExamples candidate. */
+const EXAMPLE_CHECK_COMPONENT = `<script>
+  /**
+   * @param {string} value
+   * @returns {string}
+   * @example
+   * \`\`\`js
+   * formatValue("ok");
+   * \`\`\`
+   */
+  export function formatValue(value) {
+    return value;
+  }
+</script>
+`;
+
+/** Neither an imported whole-props type nor an \`@example\` block: no candidates. */
+const PLAIN_COMPONENT = `<script>
+  /** @type {string} */
+  export let label = "ok";
+</script>
+<button>{label}</button>
+`;
+
+const BARREL = `export { default as PropsImported } from "./PropsImported.svelte";
+`;
+
+function makeFakeResolver() {
+  return {
+    expandAll: jest.fn(async () => new Map()),
+    checkExamples: jest.fn(async () => new Map()),
+    dispose: jest.fn(async () => {}),
+  };
+}
+
+describe("generateBundle shares one TypeResolver across resolveTypes and checkExamples", () => {
+  let dir: string;
+  let createSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-bundle-"));
+  });
+
+  afterEach(() => {
+    createSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("creates and disposes exactly one resolver when both options have candidates", async () => {
+    writeFileSync(path.join(dir, "index.ts"), BARREL);
+    writeFileSync(path.join(dir, "PropsImported.svelte"), PROPS_IMPORTED_COMPONENT);
+    writeFileSync(path.join(dir, "types.ts"), PROPS_TYPES);
+    writeFileSync(path.join(dir, "ExampleCheck.svelte"), EXAMPLE_CHECK_COMPONENT);
+
+    const fakeResolver = makeFakeResolver();
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
+
+    await generateBundle(path.join(dir, "index.ts"), true, { resolveTypes: true, checkExamples: true });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(fakeResolver.expandAll).toHaveBeenCalledTimes(1);
+    expect(fakeResolver.checkExamples).toHaveBeenCalledTimes(1);
+    expect(fakeResolver.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("never creates a resolver when neither feature has candidates", async () => {
+    writeFileSync(path.join(dir, "index.ts"), `export { default as Plain } from "./Plain.svelte";\n`);
+    writeFileSync(path.join(dir, "Plain.svelte"), PLAIN_COMPONENT);
+
+    const fakeResolver = makeFakeResolver();
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
+
+    await generateBundle(path.join(dir, "index.ts"), true, { resolveTypes: true, checkExamples: true });
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("a null resolver (no tsconfig) leaves both features as graceful no-ops", async () => {
+    writeFileSync(path.join(dir, "index.ts"), BARREL);
+    writeFileSync(path.join(dir, "PropsImported.svelte"), PROPS_IMPORTED_COMPONENT);
+    writeFileSync(path.join(dir, "types.ts"), PROPS_TYPES);
+    writeFileSync(path.join(dir, "ExampleCheck.svelte"), EXAMPLE_CHECK_COMPONENT);
+
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(null);
+
+    const result = await generateBundle(path.join(dir, "index.ts"), true, {
+      resolveTypes: true,
+      checkExamples: true,
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    const propsImported = result.components.get("PropsImported");
+    expect(propsImported?.props).toEqual([]);
+
+    const exampleCheck = result.allComponentsForTypes.get("ExampleCheck");
+    expect(exampleCheck?.diagnostics ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
resolveImportedPropTypes and checkComponentExamples each created and disposed their own TypeResolver, so a generateBundle run with both resolveTypes and checkExamples enabled spawned the TypeScript native-preview server twice and loaded the same tsconfig project twice. Server startup and project load dominate the cost of these opt-in features, so this doubled the overhead for no benefit.

generateBundle now collects candidates for both features up front, creates a single TypeResolver only when at least one candidate exists, runs the enabled helpers sequentially against it, and disposes it once in a finally block. The typescript import stays lazy, so the default AST-only path still never loads TypeScript, and a missing tsconfig or typescript package still degrades both features to a graceful no-op. Resolved props and example diagnostics are unchanged, and no fixture snapshots changed.

Risk is low and localized to src/bundle.ts. The main thing to watch for is the two features now running strictly sequentially against a shared resolver overlay instead of independently, but they use distinct virtual file prefixes so there's no overlay collision. Added tests/bundle.test.ts to pin the single create/dispose lifecycle, the skip-when-no-candidates case, and the null-resolver no-op case.