### PR TITLE
feat(config): enable the parse cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,13 +284,13 @@ Without `resolveTypes`, JSON lists no props. With it, each field shows up with `
 
 ### Persistent parse cache (`cache`)
 
-By default, every component is re-parsed on every run. With `cache`, parsed output is written to disk and reused when the source file has not changed. That applies across runs, including CI on a fresh checkout.
+Parsed output is written to disk and reused when the source file has not changed, on by default. That applies across runs, including CI on a fresh checkout.
 
 ```ts
-await sveld({ json: true, cache: true });
+await sveld({ json: true });
 ```
 
-`cache: true` writes to `node_modules/.cache/sveld/parse-cache.json`. Pass a string to use a different location, e.g. `cache: ".cache/sveld.json"`. Also available as `--cache` / `--cache=<path>` on the CLI.
+By default this writes to `node_modules/.cache/sveld/parse-cache.json`. Pass a string to use a different location, e.g. `cache: ".cache/sveld.json"`, or `cache: false` to disable it. Also available as `--cache` / `--cache=<path>` / `--cache=false` on the CLI.
 
 If a component [`@extendProps`](#extendprops) / [`@extends`](#extendprops) another file, it is re-parsed when that dependency changes, same as in [`watch`](#available-options) mode. Bumping the `sveld` or Svelte version clears the cache.
 
@@ -648,7 +648,7 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
 - **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. Also available as `--resolve-types` (`--resolveTypes` remains as a deprecated alias). See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
-- **`cache`** (boolean | string, optional, default: `false`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path. Also available as `--cache` / `--cache=<path>`. See [Persistent parse cache](#persistent-parse-cache-cache).
+- **`cache`** (boolean | string, optional, default: `true`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. On by default, writing to `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path; pass `false` to disable. Also available as `--cache` / `--cache=<path>` / `--cache=false`. See [Persistent parse cache](#persistent-parse-cache-cache).
 - **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. Also available as `--check-examples` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
 - **`strict`** (boolean, optional, default: `false`): Exit with code `1` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -65,8 +65,9 @@ export interface GenerateBundleOptions {
   documentExports?: boolean;
   /**
    * Cache parsed component output to disk. Unchanged files skip re-parsing on
-   * later runs. `true` uses `node_modules/.cache/sveld/parse-cache.json`; a
-   * string sets a custom path. Off by default.
+   * later runs. On by default, writing to
+   * `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path.
+   * Pass `false` to disable.
    */
   cache?: boolean | string;
   /**
@@ -382,7 +383,9 @@ export async function generateBundle(
   const components: ComponentDocs = new Map();
   const allComponentsForTypes: ComponentDocs = new Map();
 
-  const cache = options.cache ? new ParseCache(resolveCacheFilePath(rootDir, options.cache)) : undefined;
+  // `cache` is on by default; only an explicit `false` disables it.
+  const cache =
+    options.cache === false ? undefined : new ParseCache(resolveCacheFilePath(rootDir, options.cache ?? true));
 
   // Files that changed or were never cached. Used to invalidate @extends dependents.
   const misses = new Set<string>();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ Options:
   --markdown            Generate component documentation in Markdown format
   --custom-elements     Generate a Custom Elements Manifest (custom-elements.json)
   --fail-fast           Abort the run when a single component fails to parse
-  --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (default path: node_modules/.cache/sveld/parse-cache.json)
+  --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (on by default, default path: node_modules/.cache/sveld/parse-cache.json; pass --cache=false to disable)
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
   --report-diagnostics  Print unresolved-type diagnostics to stderr
@@ -88,8 +88,8 @@ function parseCliFlag(arg: string): CliFlagResult {
     case "entry":
       return typeof value === "string" ? { kind: "option", option: { entry: value } } : { kind: "option", option: {} };
     case "cache":
-      // Bare `--cache` enables the default cache location; `--cache=<path>`
-      // overrides it; `--cache=false` disables it.
+      // The cache is on by default; bare `--cache` re-affirms the default
+      // location, `--cache=<path>` overrides it, and `--cache=false` disables it.
       if (value === "false") return { kind: "option", option: { cache: false } };
       return { kind: "option", option: { cache: typeof value === "string" ? value : true } };
     case "check":

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -186,6 +186,49 @@ describe("cli() unknown flag", () => {
   });
 });
 
+describe("cli() --cache", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-cache-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      '<script>\n  export let label = "";\n</script>\n<button>{label}</button>\n',
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("is on by default: a plain run creates the default cache file", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js"];
+
+    await cli(process);
+
+    expect(existsSync(join(dir, "src", "node_modules", ".cache", "sveld", "parse-cache.json"))).toBe(true);
+  });
+
+  test("--cache=false reaches generateBundle as false and creates no cache file", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--cache=false"];
+
+    await cli(process);
+
+    expect(existsSync(join(dir, "src", "node_modules", ".cache"))).toBe(false);
+  });
+});
+
 describe("cli() --types-format merges with config file typesOptions", () => {
   let dir: string;
   let previousCwd: string;

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -1,8 +1,9 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { generateBundle } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
+import { DEFAULT_CACHE_FILE } from "../src/parse-cache";
 
 const BUTTON = `<script>
   /** @restProps {button} */
@@ -109,5 +110,39 @@ describe("parse cache", () => {
     } finally {
       rmSync(otherDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("cache default", () => {
+  let dir: string;
+  let parseSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-parse-cache-default-"));
+    writeFileSync(join(dir, "Standalone.svelte"), STANDALONE);
+    parseSpy = jest.spyOn(ComponentParser.prototype, "parseSvelteComponent");
+  });
+
+  afterEach(() => {
+    parseSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("with no cache option, writes to the default path and hits it on the next run", async () => {
+    await generateBundle(dir, true);
+
+    expect(existsSync(join(dir, DEFAULT_CACHE_FILE))).toBe(true);
+
+    parseSpy.mockClear();
+    const second = await generateBundle(dir, true);
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(second.allComponentsForTypes.has("Standalone")).toBe(true);
+  });
+
+  test("cache: false disables the cache entirely", async () => {
+    await generateBundle(dir, true, { cache: false });
+
+    expect(existsSync(join(dir, DEFAULT_CACHE_FILE))).toBe(false);
   });
 });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -67,7 +67,7 @@ describe("generateBundle", () => {
     jest.spyOn(fs, "lstatSync").mockReturnValue({ isFile: () => false } as fs.Stats);
     const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
 
-    const result = await generateBundle(mockInput, false);
+    const result = await generateBundle(mockInput, false, { cache: false });
 
     // Should NOT attempt to read directory as file
     expect(readFileSyncSpy).not.toHaveBeenCalledWith(mockInput, "utf-8");
@@ -79,7 +79,7 @@ describe("generateBundle", () => {
 
     jest.spyOn(fs, "lstatSync").mockReturnValue({ isFile: () => false } as fs.Stats);
 
-    const result = await generateBundle(mockInput, true);
+    const result = await generateBundle(mockInput, true, { cache: false });
 
     // Should not crash and should populate exports from glob-discovered components
     expect(result.exports).toBeDefined();
@@ -90,12 +90,12 @@ describe("generateBundle", () => {
     const entryFile = path.join(process.cwd(), "tests", "fixtures-entry-exports", "entry.js");
 
     test("does not document entry exports by default", async () => {
-      const result = await generateBundle(entryFile, false);
+      const result = await generateBundle(entryFile, false, { cache: false });
       expect(result.entryExports).toEqual([]);
     });
 
     test("documents non-component entry exports when enabled", async () => {
-      const result = await generateBundle(entryFile, false, { documentExports: true });
+      const result = await generateBundle(entryFile, false, { documentExports: true, cache: false });
       const byName = new Map(result.entryExports.map((entry) => [entry.name, entry]));
 
       // Components are excluded from the entry exports collection.


### PR DESCRIPTION
The on-disk parse cache (src/parse-cache.ts) is validated by a per-file sha256 content hash plus a toolchain version stamp, with @extends/@extendProps dependency invalidation already handled in generateBundle. It was opt-in, so most runs re-parsed every component from scratch even though a warm cache is safe and drops the parse phase on the carbon e2e fixture from about 1.4s to about 60ms.

This flips the default to on. generateBundle now treats cache: undefined the same as true, and only an explicit cache: false disables it; a string still sets a custom cache path. The plugin and programmatic sveld() entry points already funneled through toGenerateBundleOptions, so they pick up the new default automatically. The CLI's --cache=false opt-out already existed and is unchanged; --help text and the cache option docs in README.md are updated to describe the new default and the opt-out. Watch mode (watch.ts) never accepted a cache option at all, so there was no default to change there.

Cache behavior itself (format, location, invalidation) is untouched, so output is byte-identical whether the cache is on, off, cold, or warm; verified this directly against the carbon fixture and via the full test suite (zero snapshot changes). A few pre-existing tests that called generateBundle against non-tmpdir or mocked paths needed an explicit cache: false, since they'd otherwise pick up the new default and start doing incidental disk I/O unrelated to what they're testing.

Main risk is the new default I/O: any run against an entry directory now writes node_modules/.cache/sveld/parse-cache.json unless a caller opts out. That write is best-effort (readCacheFile falls back to an empty cache on a missing or corrupt file), but it is a new side effect for consumers who don't want sveld touching disk beyond its declared outputs, or who run in read-only environments, so it is worth flagging in the changelog as a behavior change.