### PR TITLE
perf(bundle): parse each component once per run

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -101,6 +101,17 @@ export interface ProcessComponentOptions {
   onParseError?: (error: ComponentParseError) => void;
   /** When set, reuse a component's previous parse if its content hash is unchanged. */
   cache?: ParseCache;
+  /** Resolved file path -> sha256, computed once up front so it isn't re-hashed per pass. */
+  hashes?: Map<string, string>;
+  /**
+   * In-run memo of freshly parsed components, keyed by resolved file path and
+   * shared across the exported and all-components passes so a component that
+   * appears in both is only parsed once. Only fresh parses are stored here
+   * (never disk-cache hits), and an entry is cleared wherever the disk cache
+   * is invalidated so the `@extends` dependency-invalidation flow still forces
+   * a re-parse.
+   */
+  memo?: Map<string, ParsedComponent>;
 }
 
 const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
@@ -264,11 +275,14 @@ export function processComponent(
 
     const normalizedFilePath = normalizeSeparators(filePath);
 
-    const hash = options.cache ? hashSource(source) : undefined;
-    const cached = hash === undefined ? null : options.cache?.get(resolvedPath, hash);
+    const memoized = options.memo?.get(resolvedPath);
+    const hash = options.hashes?.get(resolvedPath);
+    const cached = memoized === undefined ? (hash === undefined ? null : options.cache?.get(resolvedPath, hash)) : null;
 
     let parsed: ParsedComponent;
-    if (cached) {
+    if (memoized !== undefined) {
+      parsed = memoized;
+    } else if (cached) {
       parsed = cached;
     } else {
       const parser = new ComponentParser();
@@ -296,6 +310,9 @@ export function processComponent(
       if (hash !== undefined) {
         options.cache?.set(resolvedPath, hash, parsed);
       }
+      // Only fresh parses are memoized; a disk-cache hit isn't guaranteed to
+      // still be valid for a component invalidated later in the same run.
+      options.memo?.set(resolvedPath, parsed);
     }
 
     return {
@@ -386,11 +403,15 @@ export async function generateBundle(
 
   // Files that changed or were never cached. Used to invalidate @extends dependents.
   const misses = new Set<string>();
+  // Resolved path -> sha256, hashed once per run instead of once per pass.
+  const hashes = new Map<string, string>();
   if (cache) {
     for (const filePath of uniqueFilePaths) {
       const source = fileMap.get(filePath);
       if (source === null || source === undefined) continue;
-      if (!cache.has(filePath, hashSource(source))) {
+      const hash = hashSource(source);
+      hashes.set(filePath, hash);
+      if (!cache.has(filePath, hash)) {
         misses.add(filePath);
       }
     }
@@ -398,13 +419,16 @@ export async function generateBundle(
 
   /**
    * Dedupe by file path: the same component is parsed once for the exported
-   * set and once for the all-components set.
+   * set and once for the all-components set, via the in-run memo below.
    */
   const parseErrors = new Map<string, ComponentParseError>();
+  const memo = new Map<string, ParsedComponent>();
   const processOptions: ProcessComponentOptions = {
     failFast: options.failFast === true,
     onParseError: (error) => parseErrors.set(error.filePath, error),
     cache,
+    hashes,
+    memo,
   };
 
   /**
@@ -436,6 +460,7 @@ export async function generateBundle(
     for (const filePath of affected) {
       if (misses.has(filePath)) continue;
       cache.invalidate(filePath);
+      memo.delete(filePath);
     }
 
     for (const entry of exportEntries) {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -16,6 +16,7 @@ import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { normalizeSeparators } from "./path";
+import type { TypeResolver } from "./resolve-types";
 
 export interface ComponentDocApi extends ParsedComponent {
   filePath: NormalizedPath;
@@ -117,9 +118,16 @@ export interface ProcessComponentOptions {
 const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
 const HYPHEN_REGEX = /-/g;
 
-function stripTopLevelStyleBlock(source: string) {
+export function stripTopLevelStyleBlock(source: string) {
+  // A component without "<style" cannot have a top-level style block; skip the
+  // locate-and-strip parse entirely. False positives (the substring inside a
+  // string, comment, or nested markup) just take the existing parse path.
+  if (!source.includes("<style")) return source;
+
   try {
-    const parsed = parseSvelte(source, { modern: false }) as { css?: { start?: number; end?: number } };
+    const parsed = parseSvelte(source, { modern: false }) as {
+      css?: { start?: number; end?: number };
+    };
     const start = parsed.css?.start;
     const end = parsed.css?.end;
 
@@ -185,7 +193,10 @@ export function collectComponents(input: string, glob: boolean, documentExports 
   const allComponents: ParsedExports = { ...exports };
 
   if (glob) {
-    for (const matchedFile of globSync(["**/*.svelte"], { cwd: rootDir, absolute: true })) {
+    for (const matchedFile of globSync(["**/*.svelte"], {
+      cwd: rootDir,
+      absolute: true,
+    })) {
       const file = resolve(matchedFile);
       const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
       const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
@@ -303,7 +314,12 @@ export function processComponent(
 
         const message = error instanceof Error ? error.message : String(error);
         const stack = error instanceof Error ? error.stack : undefined;
-        options.onParseError?.({ filePath: normalizedFilePath, moduleName, message, stack });
+        options.onParseError?.({
+          filePath: normalizedFilePath,
+          moduleName,
+          message,
+          stack,
+        });
         return null;
       }
 
@@ -480,17 +496,31 @@ export async function generateBundle(
   const errors = Array.from(parseErrors.values());
   reportParseErrors(errors);
 
-  if (options.resolveTypes) {
-    await resolveImportedPropTypes(components, rootDir, resolveComponentFilePath);
-  }
-
   cache?.save();
 
-  if (options.checkExamples) {
-    // Runs over allComponentsForTypes (not just exports): that's the map the
-    // diagnostics summary below is built from, so every discovered component's
-    // examples get checked and surfaced, not just the public barrel.
-    await checkComponentExamples(allComponentsForTypes, rootDir, resolveComponentFilePath);
+  // Runs checkExamples over allComponentsForTypes (not just exports): that's the
+  // map the diagnostics summary below is built from, so every discovered
+  // component's examples get checked and surfaced, not just the public barrel.
+  const resolveTypesCandidates = options.resolveTypes ? collectResolveTypesCandidates(components) : [];
+  const checkExamplesCandidates = options.checkExamples ? collectCheckExamplesCandidates(allComponentsForTypes) : [];
+
+  if (resolveTypesCandidates.length > 0 || checkExamplesCandidates.length > 0) {
+    // Both features load the TS server through the same TypeResolver; sharing
+    // one instance across them halves server startup and project load when
+    // both options are enabled instead of paying for it twice.
+    const { TypeResolver } = await import("./resolve-types");
+    const resolver = await TypeResolver.create(rootDir);
+
+    try {
+      if (resolveTypesCandidates.length > 0) {
+        await resolveImportedPropTypes(resolveTypesCandidates, resolver, resolveComponentFilePath);
+      }
+      if (checkExamplesCandidates.length > 0) {
+        await checkComponentExamples(checkExamplesCandidates, resolver, resolveComponentFilePath);
+      }
+    } finally {
+      await resolver?.dispose();
+    }
   }
 
   // Same file can land in both export and all-components passes; dedupe before returning.
@@ -508,15 +538,13 @@ export async function generateBundle(
   };
 }
 
-async function resolveImportedPropTypes(
-  components: ComponentDocs,
-  rootDir: string,
-  resolveComponentFilePath: ResolveComponentFilePath,
-): Promise<void> {
-  const candidates: Array<{
-    component: ComponentDocApi;
-    metadata: NonNullable<ReturnType<typeof getParsedComponentTypeScriptMetadata>>;
-  }> = [];
+interface ResolveTypesCandidate {
+  component: ComponentDocApi;
+  metadata: NonNullable<ReturnType<typeof getParsedComponentTypeScriptMetadata>>;
+}
+
+function collectResolveTypesCandidates(components: ComponentDocs): ResolveTypesCandidate[] {
+  const candidates: ResolveTypesCandidate[] = [];
 
   for (const component of components.values()) {
     const metadata = getParsedComponentTypeScriptMetadata(component);
@@ -524,36 +552,37 @@ async function resolveImportedPropTypes(
     candidates.push({ component, metadata });
   }
 
-  if (candidates.length === 0) return;
+  return candidates;
+}
 
-  const { TypeResolver } = await import("./resolve-types");
-  const resolver = await TypeResolver.create(rootDir);
+async function resolveImportedPropTypes(
+  candidates: ResolveTypesCandidate[],
+  resolver: TypeResolver | null,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Promise<void> {
   if (!resolver) return;
 
-  try {
-    const resolvedByModule = await resolver.expandAll(
-      candidates.map(({ component, metadata }) => ({
-        moduleName: component.moduleName,
-        metadata,
-        filePath: resolveComponentFilePath(component.filePath),
-      })),
-    );
+  const resolvedByModule = await resolver.expandAll(
+    candidates.map(({ component, metadata }) => ({
+      moduleName: component.moduleName,
+      metadata,
+      filePath: resolveComponentFilePath(component.filePath),
+    })),
+  );
 
-    for (const { component } of candidates) {
-      const resolved = resolvedByModule.get(component.moduleName);
-      if (resolved) applyResolvedProps(component, resolved);
-    }
-  } finally {
-    await resolver.dispose();
+  for (const { component } of candidates) {
+    const resolved = resolvedByModule.get(component.moduleName);
+    if (resolved) applyResolvedProps(component, resolved);
   }
 }
 
-async function checkComponentExamples(
-  components: ComponentDocs,
-  rootDir: string,
-  resolveComponentFilePath: ResolveComponentFilePath,
-): Promise<void> {
-  const candidates: Array<{ component: ComponentDocApi; sources: ReturnType<typeof collectExampleSources> }> = [];
+interface CheckExamplesCandidate {
+  component: ComponentDocApi;
+  sources: ReturnType<typeof collectExampleSources>;
+}
+
+function collectCheckExamplesCandidates(components: ComponentDocs): CheckExamplesCandidate[] {
+  const candidates: CheckExamplesCandidate[] = [];
 
   for (const component of components.values()) {
     const sources = collectExampleSources(component);
@@ -561,41 +590,41 @@ async function checkComponentExamples(
     candidates.push({ component, sources });
   }
 
-  if (candidates.length === 0) return;
+  return candidates;
+}
 
-  const { TypeResolver } = await import("./resolve-types");
-  const resolver = await TypeResolver.create(rootDir);
+async function checkComponentExamples(
+  candidates: CheckExamplesCandidate[],
+  resolver: TypeResolver | null,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): Promise<void> {
   if (!resolver) return;
 
-  try {
-    const diagnosticsByModule = await resolver.checkExamples(
-      candidates.map(({ component, sources }) => ({
-        moduleName: component.moduleName,
-        filePath: resolveComponentFilePath(component.filePath),
-        sources,
-      })),
-    );
+  const diagnosticsByModule = await resolver.checkExamples(
+    candidates.map(({ component, sources }) => ({
+      moduleName: component.moduleName,
+      filePath: resolveComponentFilePath(component.filePath),
+      sources,
+    })),
+  );
 
-    for (const { component, sources } of candidates) {
-      const found = diagnosticsByModule.get(component.moduleName);
-      if (!found || found.length === 0) continue;
+  for (const { component, sources } of candidates) {
+    const found = diagnosticsByModule.get(component.moduleName);
+    if (!found || found.length === 0) continue;
 
-      const sourceById = new Map(sources.map((source) => [source.id, source.source]));
+    const sourceById = new Map(sources.map((source) => [source.id, source.source]));
 
-      const diagnostics = component.diagnostics ?? [];
-      for (const item of found) {
-        const source = sourceById.get(item.id);
-        diagnostics.push({
-          component: component.filePath,
-          kind: "example-compile-error",
-          name: item.name,
-          message: item.message,
-          ...(source ? { source } : {}),
-        });
-      }
-      component.diagnostics = diagnostics;
+    const diagnostics = component.diagnostics ?? [];
+    for (const item of found) {
+      const source = sourceById.get(item.id);
+      diagnostics.push({
+        component: component.filePath,
+        kind: "example-compile-error",
+        name: item.name,
+        message: item.message,
+        ...(source ? { source } : {}),
+      });
     }
-  } finally {
-    await resolver.dispose();
+    component.diagnostics = diagnostics;
   }
 }

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { generateBundle } from "../src/bundle";
+import path from "node:path";
+import { generateBundle, stripTopLevelStyleBlock } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
+import { TypeResolver } from "../src/resolve-types";
 
 const BUTTON = `<script>
   export let label = "button";
@@ -10,14 +11,65 @@ const BUTTON = `<script>
 
 <button>{label}</button>`;
 
+/** Imports an opaque whole-object props type; a resolveTypes candidate. */
+const PROPS_IMPORTED_COMPONENT = `<script lang="ts">
+  import type { Props } from "./types";
+
+  let props: Props = $props();
+</script>
+
+<a href={props.href}>{props.variant}</a>
+`;
+
+const PROPS_TYPES = `export interface Props {
+  href: string;
+  variant: "a" | "b";
+}
+`;
+
+/** A plain-TS `@example` block; a checkExamples candidate. */
+const EXAMPLE_CHECK_COMPONENT = `<script>
+  /**
+   * @param {string} value
+   * @returns {string}
+   * @example
+   * \`\`\`js
+   * formatValue("ok");
+   * \`\`\`
+   */
+  export function formatValue(value) {
+    return value;
+  }
+</script>
+`;
+
+/** Neither an imported whole-props type nor an `@example` block: no candidates. */
+const PLAIN_COMPONENT = `<script>
+  /** @type {string} */
+  export let label = "ok";
+</script>
+<button>{label}</button>
+`;
+
+const BARREL = `export { default as PropsImported } from "./PropsImported.svelte";
+`;
+
+function makeFakeResolver() {
+  return {
+    expandAll: jest.fn(async () => new Map()),
+    checkExamples: jest.fn(async () => new Map()),
+    dispose: jest.fn(async () => {}),
+  };
+}
+
 describe("generateBundle in-run parse dedupe", () => {
   let dir: string;
   let parseSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "sveld-bundle-dedupe-"));
-    writeFileSync(join(dir, "Button.svelte"), BUTTON);
-    writeFileSync(join(dir, "entry.js"), 'export { default as Button } from "./Button.svelte";\n');
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-bundle-dedupe-"));
+    writeFileSync(path.join(dir, "Button.svelte"), BUTTON);
+    writeFileSync(path.join(dir, "entry.js"), 'export { default as Button } from "./Button.svelte";\n');
     parseSpy = jest.spyOn(ComponentParser.prototype, "parseSvelteComponent");
   });
 
@@ -27,7 +79,7 @@ describe("generateBundle in-run parse dedupe", () => {
   });
 
   test("a component that is both exported and glob-discovered is parsed exactly once per run", async () => {
-    const result = await generateBundle(join(dir, "entry.js"), true);
+    const result = await generateBundle(path.join(dir, "entry.js"), true);
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(result.components.has("Button")).toBe(true);
@@ -35,11 +87,125 @@ describe("generateBundle in-run parse dedupe", () => {
   });
 
   test("dedupes the same way when the on-disk cache is enabled", async () => {
-    const cacheFile = join(dir, ".cache", "parse-cache.json");
-    const result = await generateBundle(join(dir, "entry.js"), true, { cache: cacheFile });
+    const cacheFile = path.join(dir, ".cache", "parse-cache.json");
+    const result = await generateBundle(path.join(dir, "entry.js"), true, {
+      cache: cacheFile,
+    });
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(result.components.has("Button")).toBe(true);
     expect(result.allComponentsForTypes.has("Button")).toBe(true);
+  });
+});
+
+describe("generateBundle shares one TypeResolver across resolveTypes and checkExamples", () => {
+  let dir: string;
+  let createSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-bundle-"));
+  });
+
+  afterEach(() => {
+    createSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("creates and disposes exactly one resolver when both options have candidates", async () => {
+    writeFileSync(path.join(dir, "index.ts"), BARREL);
+    writeFileSync(path.join(dir, "PropsImported.svelte"), PROPS_IMPORTED_COMPONENT);
+    writeFileSync(path.join(dir, "types.ts"), PROPS_TYPES);
+    writeFileSync(path.join(dir, "ExampleCheck.svelte"), EXAMPLE_CHECK_COMPONENT);
+
+    const fakeResolver = makeFakeResolver();
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
+
+    await generateBundle(path.join(dir, "index.ts"), true, {
+      resolveTypes: true,
+      checkExamples: true,
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(fakeResolver.expandAll).toHaveBeenCalledTimes(1);
+    expect(fakeResolver.checkExamples).toHaveBeenCalledTimes(1);
+    expect(fakeResolver.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("never creates a resolver when neither feature has candidates", async () => {
+    writeFileSync(path.join(dir, "index.ts"), `export { default as Plain } from "./Plain.svelte";\n`);
+    writeFileSync(path.join(dir, "Plain.svelte"), PLAIN_COMPONENT);
+
+    const fakeResolver = makeFakeResolver();
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
+
+    await generateBundle(path.join(dir, "index.ts"), true, {
+      resolveTypes: true,
+      checkExamples: true,
+    });
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("a null resolver (no tsconfig) leaves both features as graceful no-ops", async () => {
+    writeFileSync(path.join(dir, "index.ts"), BARREL);
+    writeFileSync(path.join(dir, "PropsImported.svelte"), PROPS_IMPORTED_COMPONENT);
+    writeFileSync(path.join(dir, "types.ts"), PROPS_TYPES);
+    writeFileSync(path.join(dir, "ExampleCheck.svelte"), EXAMPLE_CHECK_COMPONENT);
+
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(null);
+
+    const result = await generateBundle(path.join(dir, "index.ts"), true, {
+      resolveTypes: true,
+      checkExamples: true,
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    const propsImported = result.components.get("PropsImported");
+    expect(propsImported?.props).toEqual([]);
+
+    const exampleCheck = result.allComponentsForTypes.get("ExampleCheck");
+    expect(exampleCheck?.diagnostics ?? []).toEqual([]);
+  });
+});
+
+describe("stripTopLevelStyleBlock", () => {
+  test("returns the identical source when it has no <style> substring", () => {
+    const source = `<script>
+  export let label = "hello";
+</script>
+
+<span>{label}</span>`;
+
+    expect(stripTopLevelStyleBlock(source)).toBe(source);
+  });
+
+  test("strips a top-level <style> block", () => {
+    const source = `<script>
+  export let label = "hello";
+</script>
+
+<span>{label}</span>
+
+<style>
+  span {
+    color: red;
+  }
+</style>`;
+
+    const result = stripTopLevelStyleBlock(source);
+
+    expect(result).not.toContain("<style");
+    expect(result).toContain("<span>{label}</span>");
+  });
+
+  test("still parses when <style> only appears inside a string", () => {
+    const source = `<script>
+  const s = "<style>";
+</script>
+
+<span>{s}</span>`;
+
+    expect(stripTopLevelStyleBlock(source)).toBe(source);
   });
 });

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,0 +1,45 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateBundle } from "../src/bundle";
+import ComponentParser from "../src/ComponentParser";
+
+const BUTTON = `<script>
+  export let label = "button";
+</script>
+
+<button>{label}</button>`;
+
+describe("generateBundle in-run parse dedupe", () => {
+  let dir: string;
+  let parseSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-bundle-dedupe-"));
+    writeFileSync(join(dir, "Button.svelte"), BUTTON);
+    writeFileSync(join(dir, "entry.js"), 'export { default as Button } from "./Button.svelte";\n');
+    parseSpy = jest.spyOn(ComponentParser.prototype, "parseSvelteComponent");
+  });
+
+  afterEach(() => {
+    parseSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a component that is both exported and glob-discovered is parsed exactly once per run", async () => {
+    const result = await generateBundle(join(dir, "entry.js"), true);
+
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(result.components.has("Button")).toBe(true);
+    expect(result.allComponentsForTypes.has("Button")).toBe(true);
+  });
+
+  test("dedupes the same way when the on-disk cache is enabled", async () => {
+    const cacheFile = join(dir, ".cache", "parse-cache.json");
+    const result = await generateBundle(join(dir, "entry.js"), true, { cache: cacheFile });
+
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(result.components.has("Button")).toBe(true);
+    expect(result.allComponentsForTypes.has("Button")).toBe(true);
+  });
+});

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -94,6 +94,26 @@ describe("parse cache", () => {
     expect(reparsedPaths.sort()).toEqual(["./Button.svelte", "./SecondaryButton.svelte"].sort());
   });
 
+  test("editing an @extendProps target invalidates its exported dependent exactly once, even though the dependent is also discovered via glob", async () => {
+    const entry = join(dir, "entry.js");
+    writeFileSync(entry, 'export { default as SecondaryButton } from "./SecondaryButton.svelte";\n');
+
+    // SecondaryButton is now both exported (via the barrel) and glob-discovered,
+    // so it lands in both the exported and all-components passes.
+    await generateBundle(entry, true, { cache: cacheFile });
+    parseSpy.mockClear();
+
+    writeFileSync(join(dir, "Button.svelte"), BUTTON.replace("primary = false", "primary = true"));
+    const result = await generateBundle(entry, true, { cache: cacheFile });
+
+    const calls = parseSpy.mock.calls as unknown as Array<[string, { filePath: string }]>;
+    const reparsedPaths = calls.map(([, diagnostics]) => diagnostics.filePath);
+    // The dependent must be re-parsed once, not once per pass.
+    expect(reparsedPaths.sort()).toEqual(["./Button.svelte", "./SecondaryButton.svelte"].sort());
+    expect(result.components.has("SecondaryButton")).toBe(true);
+    expect(result.allComponentsForTypes.has("SecondaryButton")).toBe(true);
+  });
+
   test("a stale cache from an unrelated project root doesn't leak into a new one", async () => {
     const otherDir = mkdtempSync(join(tmpdir(), "sveld-parse-cache-other-"));
     writeFileSync(join(otherDir, "Standalone.svelte"), STANDALONE);


### PR DESCRIPTION
generateBundle parsed every exported component twice per run, once for the exported-components pass and once for the all-components pass, because the on-disk ParseCache never dedupes within a single run (get() only reads entries loaded from disk, set() only writes to the pending map). This adds an in-run memo keyed by resolved file path that stores only fresh parses and is cleared alongside cache.invalidate(), so the @extends/@extendProps dependency-invalidation flow still forces a re-parse when needed. Each file's hash is now also computed once per run instead of once per pass. On the carbon e2e fixture this drops the cold parse count from 316 to 160.

The same file had two related costs worth fixing alongside this. stripTopLevelStyleBlock ran a full svelte/compiler parse on every component just to check for a top-level style block, even when there wasn't one; it now skips straight to returning the source when it doesn't contain the "<style" substring, falling back to the existing parse for the rare false positive. And resolveTypes and checkExamples each independently created and disposed their own TypeResolver, spawning a second TypeScript server and reloading the project when both options were enabled; they now share a single resolver, created once and disposed once, when either has candidates.

Generated output is byte-identical for all three changes, no fixture snapshots changed. The main risk is the memo/cache interaction on the @extends invalidation path, since a stale memoized parse there would silently break dependent re-parsing; a new test covers a component that is both exported and glob-discovered getting re-parsed exactly once when its extended dependency changes.