### PR TITLE
perf(parser): fuse per-component AST walks into shared traversals

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -34,7 +34,10 @@ import {
   parseRunesPropsDeclaration,
 } from "./parser/runes-props";
 import {
-  buildScopeDeclarations,
+  createScopeWalkState,
+  enterNestedScopeDeclarationNode,
+  initComponentScope,
+  leaveNestedScopeDeclarationNode,
   markReactivePropsFromMutationTarget,
   resolveIdentifierToReactiveProp,
 } from "./parser/scopes";
@@ -1347,6 +1350,14 @@ export default class ComponentParser {
     this.buildVariableInfoCache();
     parseCustomTypes(this.ctx, this);
 
+    /**
+     * Not fused with the componentRoot walk below: `module` (`<script context="module">`) is a
+     * disjoint AST rooted separately from `instance`/`html`, not a subtree reachable from either,
+     * so there is no shared root to traverse once. Wrapping both in one synthetic root would
+     * require branch-tracking to keep module-export handling (addModuleExport) from firing on
+     * instance-level exports (addProp) and vice versa, for a pass that most components skip
+     * entirely (module scripts are rare) - not worth the added complexity here.
+     */
     if (this.ctx.parsed?.module) {
       walk(this.ctx.parsed?.module as unknown as Node, {
         enter: (node) => {
@@ -1501,11 +1512,22 @@ export default class ComponentParser {
       html: this.ctx.parsed.html,
     } as unknown as Node;
 
-    buildScopeDeclarations(this, this.ctx, componentRoot);
+    initComponentScope(this, this.ctx);
     this.ctx.activeScopes.push(this.ctx.componentScope);
+    const scopeWalkState = createScopeWalkState(this.ctx);
 
     walk(componentRoot, {
       enter: (node, parent, _prop) => {
+        /**
+         * Declares nested scope bindings for `node` (if it's a scope owner) before anything
+         * below reads `ctx.scopeDeclarations` for it. This fuses what was previously a separate
+         * full walk (scope analysis) into this traversal: a node's own scope only ever depends
+         * on its ancestors and itself, never on siblings or descendants, so building it here
+         * on entry and consuming it immediately after is equivalent to building the whole map
+         * in a prior pass.
+         */
+        enterNestedScopeDeclarationNode(this, this.ctx, scopeWalkState, node);
+
         const nodeScope = this.ctx.scopeDeclarations.get(node as unknown as object);
         if (nodeScope) {
           this.ctx.activeScopes.push(nodeScope);
@@ -2086,6 +2108,7 @@ export default class ComponentParser {
         if (this.ctx.scopeDeclarations.has(node as unknown as object)) {
           this.ctx.activeScopes.pop();
         }
+        leaveNestedScopeDeclarationNode(scopeWalkState, node);
       },
     });
 

--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -402,6 +402,12 @@ export function inferReturnTypeFromNode(
 /**
  * Walk a block body and collect each `return`'s argument, skipping nested
  * functions. Bare `return;` becomes `null`.
+ *
+ * Not fused with the componentRoot walk: this runs from `processInitializer`, called
+ * synchronously while the outer walk is still on the ancestor `ExportNamedDeclaration`/
+ * `VariableDeclaration` node, so it needs the inferred type before the outer walk would
+ * otherwise reach these descendant statements. Deferring it to ride along with the outer
+ * traversal would mean computing prop types in a second pass instead of inline.
  */
 export function collectReturnArguments(body: unknown): unknown[] {
   const returnArgs: unknown[] = [];

--- a/src/parser/scopes.ts
+++ b/src/parser/scopes.ts
@@ -8,8 +8,6 @@ import type {
   VariableDeclaration,
   VariableDeclarator,
 } from "estree";
-import type { Node } from "estree-walker";
-import { walk } from "estree-walker";
 import { isCallExpressionNamed, isVariableDeclaration } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type { LexicalScope, ScopeBinding, ScopeBindingKind } from "../ComponentParser";
@@ -317,83 +315,102 @@ export function collectComponentScopeDeclarations(parser: ComponentParser, ctx: 
   }
 }
 
-/** Walks the component AST, declaring bindings for every nested lexical/function scope it encounters. */
-export function collectNestedScopeDeclarations(parser: ComponentParser, ctx: ParserContext, componentRoot: Node) {
-  const varScopeStack: LexicalScope[] = [ctx.componentScope];
-
-  walk(componentRoot, {
-    enter: (node) => {
-      if (!isScopeOwner(node)) return;
-
-      const scope = getOrCreateScope(ctx, node as unknown as object);
-      const currentVarScope = varScopeStack[varScopeStack.length - 1] ?? ctx.componentScope;
-      const nodeType = String(node.type);
-
-      switch (nodeType) {
-        case "FunctionDeclaration":
-        case "FunctionExpression":
-        case "ArrowFunctionExpression":
-          declareFunctionLikeScopeBindings(
-            node as FunctionExpression | ArrowFunctionExpression | FunctionDeclaration,
-            scope,
-          );
-          break;
-        case "BlockStatement":
-          collectDirectBlockDeclarations(parser, (node as { body?: unknown }).body, scope, currentVarScope);
-          break;
-        case "CatchClause":
-          if ("param" in node) {
-            for (const identifier of collectPatternIdentifiers((node as { param?: Pattern }).param)) {
-              declareScopeBinding(scope, identifier, { kind: "local" });
-            }
-          }
-          break;
-        case "EachBlock": {
-          const eachBlock = node as { context?: Pattern; index?: Identifier | string };
-          for (const identifier of collectPatternIdentifiers(eachBlock.context)) {
-            declareScopeBinding(scope, identifier, { kind: "local" });
-          }
-          if (typeof eachBlock.index === "string") {
-            declareScopeBinding(scope, eachBlock.index, { kind: "local" });
-          } else if (eachBlock.index && "name" in eachBlock.index) {
-            declareScopeBinding(scope, eachBlock.index.name, { kind: "local" });
-          }
-          break;
-        }
-        case "ThenBlock":
-          if ("value" in node) {
-            for (const identifier of collectPatternIdentifiers((node as { value?: Pattern }).value)) {
-              declareScopeBinding(scope, identifier, { kind: "local" });
-            }
-          }
-          break;
-        case "CatchBlock":
-          if ("error" in node) {
-            for (const identifier of collectPatternIdentifiers((node as { error?: Pattern }).error)) {
-              declareScopeBinding(scope, identifier, { kind: "local" });
-            }
-          }
-          break;
-      }
-
-      if (isFunctionScopeOwner(node)) {
-        varScopeStack.push(scope);
-      }
-    },
-    leave: (node) => {
-      if (isFunctionScopeOwner(node)) {
-        varScopeStack.pop();
-      }
-    },
-  });
-}
-
-/** Rebuilds `ctx.componentScope` / `ctx.scopeDeclarations` / `ctx.activeScopes` from scratch for `componentRoot`. */
-export function buildScopeDeclarations(parser: ComponentParser, ctx: ParserContext, componentRoot: Node) {
+/**
+ * Resets `ctx.componentScope` / `ctx.scopeDeclarations` / `ctx.activeScopes` and declares the
+ * top-level `<script>` bindings. Does not walk the component tree; nested scope declarations are
+ * built incrementally by {@link enterNestedScopeDeclarationNode} inside the caller's own traversal
+ * of `componentRoot` (fused with prop/slot/event extraction there rather than walked separately).
+ */
+export function initComponentScope(parser: ComponentParser, ctx: ParserContext) {
   ctx.componentScope.clear();
   ctx.scopeDeclarations = new WeakMap();
   ctx.activeScopes.length = 0;
 
   collectComponentScopeDeclarations(parser, ctx, ctx.parsed?.instance);
-  collectNestedScopeDeclarations(parser, ctx, componentRoot);
+}
+
+/** Mutable stack tracking the enclosing `var`-hoisting scope while walking `componentRoot`. */
+export type ScopeWalkState = { varScopeStack: LexicalScope[] };
+
+/** Creates the scope-walk state for a fresh traversal of `componentRoot`, seeded with `ctx.componentScope`. */
+export function createScopeWalkState(ctx: ParserContext): ScopeWalkState {
+  return { varScopeStack: [ctx.componentScope] };
+}
+
+/**
+ * Per-node `enter` step of the (formerly standalone) nested-scope-declaration walk. Declares
+ * bindings for `node` if it's a scope owner and pushes it as the active `var` scope for its
+ * descendants. Must be called during the same top-down traversal of `componentRoot` that
+ * {@link leaveNestedScopeDeclarationNode} tears down, and before any logic that reads
+ * `ctx.scopeDeclarations` for `node` itself (its own scope is only created here, on entry).
+ */
+export function enterNestedScopeDeclarationNode(
+  parser: ComponentParser,
+  ctx: ParserContext,
+  state: ScopeWalkState,
+  node: unknown,
+) {
+  if (!isScopeOwner(node)) return;
+
+  const scope = getOrCreateScope(ctx, node as unknown as object);
+  const currentVarScope = state.varScopeStack[state.varScopeStack.length - 1] ?? ctx.componentScope;
+  const nodeType = String((node as { type: string }).type);
+
+  switch (nodeType) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression":
+      declareFunctionLikeScopeBindings(
+        node as FunctionExpression | ArrowFunctionExpression | FunctionDeclaration,
+        scope,
+      );
+      break;
+    case "BlockStatement":
+      collectDirectBlockDeclarations(parser, (node as { body?: unknown }).body, scope, currentVarScope);
+      break;
+    case "CatchClause":
+      if ("param" in (node as object)) {
+        for (const identifier of collectPatternIdentifiers((node as { param?: Pattern }).param)) {
+          declareScopeBinding(scope, identifier, { kind: "local" });
+        }
+      }
+      break;
+    case "EachBlock": {
+      const eachBlock = node as { context?: Pattern; index?: Identifier | string };
+      for (const identifier of collectPatternIdentifiers(eachBlock.context)) {
+        declareScopeBinding(scope, identifier, { kind: "local" });
+      }
+      if (typeof eachBlock.index === "string") {
+        declareScopeBinding(scope, eachBlock.index, { kind: "local" });
+      } else if (eachBlock.index && "name" in eachBlock.index) {
+        declareScopeBinding(scope, eachBlock.index.name, { kind: "local" });
+      }
+      break;
+    }
+    case "ThenBlock":
+      if ("value" in (node as object)) {
+        for (const identifier of collectPatternIdentifiers((node as { value?: Pattern }).value)) {
+          declareScopeBinding(scope, identifier, { kind: "local" });
+        }
+      }
+      break;
+    case "CatchBlock":
+      if ("error" in (node as object)) {
+        for (const identifier of collectPatternIdentifiers((node as { error?: Pattern }).error)) {
+          declareScopeBinding(scope, identifier, { kind: "local" });
+        }
+      }
+      break;
+  }
+
+  if (isFunctionScopeOwner(node)) {
+    state.varScopeStack.push(scope);
+  }
+}
+
+/** Per-node `leave` step counterpart to {@link enterNestedScopeDeclarationNode}. */
+export function leaveNestedScopeDeclarationNode(state: ScopeWalkState, node: unknown) {
+  if (isFunctionScopeOwner(node)) {
+    state.varScopeStack.pop();
+  }
 }


### PR DESCRIPTION
Each component's AST was traversed multiple times by independent
estree-walker passes: the module script walk, the template root walk,
scope analysis, and prop extraction. Passes that visit the same root
now share a single traversal that dispatches to the existing handler
functions.

Generated output is byte identical and no snapshots changed.

Of the four walk sites, only the template-root walk (`ComponentParser.ts`)
and the scope-declaration walk (`parser/scopes.ts`) shared a root
(`componentRoot`) and were safe to fuse: a node's own scope only ever
depends on its ancestors and itself, never on siblings or descendants not
yet visited, so building it on entry and consuming it immediately after is
equivalent to building the whole map in a prior pass. The module-script
walk traverses a disjoint root (not reachable from `componentRoot`) and the
function-body walk in `parser/props.ts` needs its result synchronously,
before the outer walk would otherwise reach those descendant statements —
both are left unfused with comments explaining why.
