### PR TITLE
perf(types): batch TypeResolver checker calls to cut RPC round trips

### DIFF
--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -104,18 +104,63 @@ export class TypeResolver {
     });
 
     try {
-      const entries = await Promise.all(
-        Array.from(
-          virtualFiles,
-          async ([virtualFile, target]): Promise<[string, ResolvedComponentProp[]]> => [
-            target.moduleName,
-            await this.resolveFile(snapshot, virtualFile),
-          ],
-        ),
+      // Every virtual file belongs to the same `openProject` snapshot, so the
+      // project (and its checker) is shared; look it up once instead of once
+      // per file. Each lookup and each unbatched checker call below is a
+      // round trip to the native TS server process, so cutting call count
+      // matters far more here than in an in-process compiler API.
+      const [firstFile] = virtualFiles.keys();
+      const project = await snapshot.getDefaultProjectForFile(firstFile);
+      if (!project) return results;
+      const checker = project.checker;
+
+      // Phase 1: per-file type-at-position + properties-of-type (no batch API; different files/types).
+      const perFile = await Promise.all(
+        Array.from(virtualFiles, async ([virtualFile, target]) => {
+          const content = this.overlay.get(virtualFile);
+          if (!content) return null;
+          const position = bindingPosition(content);
+          const type = await checker.getTypeAtPosition(virtualFile, position);
+          if (!type) return null;
+          const properties: TS[] = await checker.getPropertiesOfType(type);
+          const symbols = properties.filter((symbol: TS) => symbol.name && !symbol.name.startsWith("__"));
+          return { moduleName: target.moduleName, symbols };
+        }),
       );
-      for (const [moduleName, props] of entries) {
-        results.set(moduleName, props);
-      }
+
+      // Phase 2: batch getTypeOfSymbol across every prop of every component in one round trip.
+      const allSymbols: TS[] = [];
+      const owner: number[] = [];
+      perFile.forEach((entry, fileIndex) => {
+        if (!entry) return;
+        for (const symbol of entry.symbols) {
+          allSymbols.push(symbol);
+          owner.push(fileIndex);
+        }
+      });
+      const propTypes: TS[] = allSymbols.length > 0 ? await checker.getTypeOfSymbol(allSymbols) : [];
+
+      // Phase 3: typeToString has no batch overload; fire concurrently.
+      const typeTexts = await Promise.all(
+        propTypes.map((propType) => (propType ? checker.typeToString(propType) : Promise.resolve("any"))),
+      );
+
+      const byFile = new Map<number, ResolvedComponentProp[]>();
+      allSymbols.forEach((symbol, i) => {
+        const isOptional = (symbol.flags & this.symbolFlags.Optional) !== 0;
+        let typeText = typeTexts[i];
+        if (isOptional) typeText = typeText.replace(TRAILING_UNDEFINED, "");
+        const list = byFile.get(owner[i]) ?? [];
+        list.push({ name: symbol.name, type: typeText, isRequired: !isOptional });
+        byFile.set(owner[i], list);
+      });
+
+      perFile.forEach((entry, fileIndex) => {
+        if (!entry) return;
+        const resolved = byFile.get(fileIndex) ?? [];
+        resolved.sort((a, b) => a.name.localeCompare(b.name));
+        results.set(entry.moduleName, resolved);
+      });
     } finally {
       await snapshot.dispose?.();
     }
@@ -153,11 +198,12 @@ export class TypeResolver {
     });
 
     try {
+      const [firstExample] = examples;
+      const project = await snapshot.getDefaultProjectForFile(firstExample.file);
+      if (!project) return results;
+
       await Promise.all(
         examples.map(async ({ moduleName, source, file }) => {
-          const project = await snapshot.getDefaultProjectForFile(file);
-          if (!project) return;
-
           const [syntactic, semantic]: [TS[], TS[]] = await Promise.all([
             project.program.getSyntacticDiagnostics(file),
             project.program.getSemanticDiagnostics(file),
@@ -188,38 +234,6 @@ export class TypeResolver {
   async dispose(): Promise<void> {
     this.overlay.clear();
     await this.api?.close?.();
-  }
-
-  private async resolveFile(snapshot: TS, virtualFile: string): Promise<ResolvedComponentProp[]> {
-    const content = this.overlay.get(virtualFile);
-    if (!content) return [];
-
-    const project = await snapshot.getDefaultProjectForFile(virtualFile);
-    if (!project) return [];
-
-    const checker = project.checker;
-    const position = bindingPosition(content);
-    const type = await checker.getTypeAtPosition(virtualFile, position);
-    if (!type) return [];
-
-    const properties: TS[] = await checker.getPropertiesOfType(type);
-
-    const resolved = await Promise.all(
-      properties
-        // Skip synthetic/internal members.
-        .filter((symbol: TS) => symbol.name && !symbol.name.startsWith("__"))
-        .map(async (symbol: TS): Promise<ResolvedComponentProp> => {
-          const propType = await checker.getTypeOfSymbol(symbol);
-          const isOptional = (symbol.flags & this.symbolFlags.Optional) !== 0;
-          let typeText = propType ? await checker.typeToString(propType) : "any";
-          if (isOptional) typeText = typeText.replace(TRAILING_UNDEFINED, "");
-
-          return { name: symbol.name, type: typeText, isRequired: !isOptional };
-        }),
-    );
-
-    resolved.sort((a, b) => a.name.localeCompare(b.name));
-    return resolved;
   }
 
   private createFileSystem() {


### PR DESCRIPTION
Profiling showed the TypeScript side of resolveTypes/checkExamples has
no in-process ts.Program to reuse: it talks to the TS7 native preview
(tsgo) as a subprocess over JSON-RPC, so every checker call is a wire
round trip. TypeResolver was issuing one getDefaultProjectForFile call
per virtual file and one getTypeOfSymbol call per prop, even though
every virtual file in a run shares the same openProject snapshot and
the native API exposes batch overloads for both.

expandAll now looks up the project once and reuses its checker for
every file, and batches getTypeOfSymbol across every prop of every
component into a single call. checkExamples gets the same
getDefaultProjectForFile fix. On a 160-component/6-prop synthetic
resolveTypes run this cuts total RPC requests from 2403 to 1285 (about
half); typeToString and the per-file getTypeAtPosition/
getPropertiesOfType calls have no batch overload and remain the
dominant residual cost.

Generated output is byte identical and no snapshots changed.

## Why not the carbon-fixture bench

`resolveTypes`/`checkExamples` are opt-in, and the carbon e2e fixture
(what `bun run bench` benchmarks by default) uses neither: no
component destructures `$props()` from an imported whole-object type,
and only 2 files have `@example` blocks. So `TypeResolver` is never
instantiated during a normal `bun run bench` run on carbon, and that
benchmark is unaffected by this change (verified below). The actual
hot path only runs when a consumer opts into `resolveTypes: true` or
`checkExamples: true`, so it was profiled with a synthetic harness
that builds N virtual components with imported prop types instead.

## Profile breakdown (RPC request counts, synthetic 160-component/6-prop run)

Counted via a `Client.apiRequest` interceptor (each checker method call
is exactly one JSON-RPC round trip to the tsgo subprocess):

| method | before | after |
|---|---|---|
| `getTypeOfSymbol` / `getTypesOfSymbols` | 960 | 1 (batched) |
| `typeToString` | 960 | 960 (no batch overload) |
| `getDefaultProjectForFile` | 160 | 1 |
| `getTypeAtPosition` | 160 | 160 (no cross-file batch overload) |
| `getPropertiesOfType` | 160 | 160 (no batch overload) |
| **TOTAL** | **2403** | **1285** |

At 20 props/component the reduction is similar in proportion: 6883 → 3525 requests.

## Wall-clock (synthetic harness, isolated process per trial, `resolveTypes` on 160 components x 6 props)

Machine load was noisy (swings sometimes exceeded 2x even within one
arm), so this is directional, not precise — the request-count table
above is the reliable signal:

| | run 1 | run 2 | run 3 | run 4 | run 5 | avg |
|---|---|---|---|---|---|---|
| before | 3005.8ms | 2488.3ms | 2354.5ms | 4776.0ms | 3487.7ms | 3222.5ms |
| after | 2186.9ms | 2333.7ms | 1807.9ms | 3344.5ms | 2301.8ms | 2395.0ms |

~1.3x average speedup, consistent direction across all 5 trials.

## carbon-fixture bench (unaffected, as expected — resolveTypes/checkExamples not exercised)

```
$ bun run bench --runs 5
run 1  parse 1522ms  write 157ms  total 1679ms
run 2  parse 71ms  write 368ms  total 439ms
run 3  parse 30ms  write 145ms  total 175ms
run 4  parse 71ms  write 150ms  total 220ms
run 5  parse 30ms  write 104ms  total 134ms
median parse 71ms  write 150ms  total 220ms
```

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 702 pass, 0 fail, 380 snapshots unchanged
- [x] `bun run test:fixtures-types` clean
- [x] `bun run test:e2e` passes
- [x] Manual synthetic-harness profiling (RPC request counts + wall clock) before/after