### PR TITLE
fix(parser): clamp bracket depth in `splitTopLevelCommas`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -133,6 +133,12 @@
       }
     },
     {
+      "includes": ["**/tests/fixtures/fuzz-generics-arrow-type-comma/input.svelte"],
+      "formatter": {
+        "enabled": false
+      }
+    },
+    {
       "includes": ["**/*.svg"],
       "formatter": {
         "enabled": false

--- a/src/parser/generics.ts
+++ b/src/parser/generics.ts
@@ -19,7 +19,7 @@ export function splitTopLevelCommas(value: string): string[] {
   for (let i = 0; i < value.length; i++) {
     const char = value[i];
     if (char === "<" || char === "(" || char === "[" || char === "{") depth++;
-    else if (char === ">" || char === ")" || char === "]" || char === "}") depth--;
+    else if (char === ">" || char === ")" || char === "]" || char === "}") depth = Math.max(depth - 1, 0);
     else if (char === "," && depth === 0) {
       parts.push(value.slice(start, i));
       start = i + 1;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -5747,6 +5747,94 @@ exports[`fixtures (JSON) "infer-basic/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "fuzz-generics-arrow-type-comma/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "onSelect",
+      "kind": "let",
+      "type": "Handler",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 12
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{\\n  onSelect: Handler;\\n  rows: ReadonlyArray<Row>;\\n}",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 0
+        },
+        "end": {
+          "line": 22,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Handler, Row",
+    "Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "context-underscore/input.svelte" 1`] = `
 "{
   "source": {
@@ -19341,6 +19429,39 @@ export default class InferBasic extends SvelteComponentTyped<
 
   fn: () => any;
 }
+"
+`;
+
+exports[`fixtures (TypeScript) "fuzz-generics-arrow-type-comma/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow> = {
+  onSelect: Handler;
+  rows: ReadonlyArray<Row>;
+} & {
+  children?: (this: void, ...args: [{
+        onSelect: Handler;
+        rows: ReadonlyArray<Row>;
+      }]) => void;
+};
+
+export type FuzzGenericsArrowTypeCommaProps<Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow> = $Props<Handler, Row>;
+
+export default class FuzzGenericsArrowTypeComma<Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  FuzzGenericsArrowTypeCommaProps<Handler, Row>,
+  Record<string, any>,
+  {
+    default: {
+      onSelect: Handler;
+      rows: ReadonlyArray<Row>;
+    };
+  }
+> {}
 "
 `;
 

--- a/tests/fixtures/fuzz-generics-arrow-type-comma/input.svelte
+++ b/tests/fixtures/fuzz-generics-arrow-type-comma/input.svelte
@@ -1,0 +1,22 @@
+<script
+  lang="ts"
+  generics="Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow"
+>
+  interface DataTableRow {
+    id: string | number;
+    [key: string]: any;
+  }
+
+  let {
+    onSelect,
+    rows,
+  }: {
+    onSelect: Handler;
+    rows: ReadonlyArray<Row>;
+  } = $props();
+</script>
+
+<slot
+  {onSelect}
+  {rows}
+/>

--- a/tests/fixtures/fuzz-generics-arrow-type-comma/output.d.ts
+++ b/tests/fixtures/fuzz-generics-arrow-type-comma/output.d.ts
@@ -1,0 +1,29 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface DataTableRow {
+  id: string | number;
+  [key: string]: any;
+}
+
+type $Props<Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow> = {
+  onSelect: Handler;
+  rows: ReadonlyArray<Row>;
+} & {
+  children?: (this: void, ...args: [{
+        onSelect: Handler;
+        rows: ReadonlyArray<Row>;
+      }]) => void;
+};
+
+export type FuzzGenericsArrowTypeCommaProps<Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow> = $Props<Handler, Row>;
+
+export default class FuzzGenericsArrowTypeComma<Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow> extends SvelteComponentTyped<
+  FuzzGenericsArrowTypeCommaProps<Handler, Row>,
+  Record<string, any>,
+  {
+    default: {
+      onSelect: Handler;
+      rows: ReadonlyArray<Row>;
+    };
+  }
+> {}

--- a/tests/fixtures/fuzz-generics-arrow-type-comma/output.json
+++ b/tests/fixtures/fuzz-generics-arrow-type-comma/output.json
@@ -1,0 +1,84 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 23,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "onSelect",
+      "kind": "let",
+      "type": "Handler",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 12
+        }
+      }
+    },
+    {
+      "name": "rows",
+      "kind": "let",
+      "type": "ReadonlyArray<Row>",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{\n  onSelect: Handler;\n  rows: ReadonlyArray<Row>;\n}",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 0
+        },
+        "end": {
+          "line": 22,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Handler, Row",
+    "Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
## Summary

Each closing bracket in `splitTopLevelCommas` decremented depth unconditionally, so any `>` not paired with a `<` (e.g. the arrow in a function-type generic constraint, `(x: string) => void`) drove depth negative. A later top-level comma then read as nested and failed to split, silently merging two generic parameters into one.

Clamp depth at 0 so an unmatched closer can't corrupt splitting of the parameters that follow it.

## How this was found

This was caught by a mutation-based fuzz harness for the `generics` script attribute parser: seed from `tests/fixtures/**/input.svelte`, mutate the `generics` attribute (among other targets), and run each mutant through `ComponentParser.parseSvelteComponent` + `writeTsDefinition` looking for crashes or malformed output. A mutation that introduced an arrow-function-type generic constraint (`(x: string) => void`) surfaced this depth-tracking bug — the fuzz harness itself isn't included in this PR, just the fix and a regression fixture pinning the exact input that triggered it (`fuzz-generics-arrow-type-comma`).

