### PR TITLE
fix(parser): strip const/in/out modifiers from generics usage-site name

### DIFF
--- a/src/parser/generics.ts
+++ b/src/parser/generics.ts
@@ -4,6 +4,7 @@ import { collectReferencedTypeDependencies } from "./type-resolution";
 
 const LEADING_IDENTIFIER_REGEX = /^[A-Za-z_$][\w$]*/;
 const IDENTIFIER_REGEX = /[A-Za-z_$][\w$]*/g;
+const LEADING_TYPE_PARAM_MODIFIER_REGEX = /^(?:const|in|out)\s+/;
 
 /**
  * Splits a string on top-level commas, ignoring commas nested inside
@@ -42,7 +43,13 @@ export function parseGenericsAttribute(value: string): ComponentGenerics {
 
   if (constraints.length === 0) return null;
 
-  const names = constraints.map((constraint) => constraint.match(LEADING_IDENTIFIER_REGEX)?.[0] ?? constraint);
+  const names = constraints.map((constraint) => {
+    let usageSite = constraint;
+    while (LEADING_TYPE_PARAM_MODIFIER_REGEX.test(usageSite)) {
+      usageSite = usageSite.replace(LEADING_TYPE_PARAM_MODIFIER_REGEX, "");
+    }
+    return usageSite.match(LEADING_IDENTIFIER_REGEX)?.[0] ?? constraint;
+  });
 
   return [names.join(", "), constraints.join(", ")];
 }

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -36,6 +36,20 @@ const PRESERVED_SNIPPET_IMPORT_REGEX = /import\s+type\s+[^;]*\bSnippet\b[^;]*fro
 // Matches regex metacharacters that must be escaped before interpolating
 // a user-authored generic name into a RegExp.
 const REGEX_METACHARS = /[.*+?^${}()|[\]\\]/g;
+const LEADING_CONST_MODIFIER_REGEX = /^const\s+/;
+
+/**
+ * Strips a leading `const` type-parameter modifier from a single generic
+ * constraint (e.g. `"const T extends readonly string[]"` -> `"T extends
+ * readonly string[]"`). `const` is only legal on function, method, and class
+ * type parameters (TS1277) - a `type X<const T> = ...` alias declaration is a
+ * syntax error, even though `class X<const T>` is fine. Callers that build a
+ * `type`/`export type` declaration must strip it; callers that build a class
+ * declaration or interface method/construct signature must not.
+ */
+function stripConstModifierForTypeAlias(constraint: string): string {
+  return constraint.replace(LEADING_CONST_MODIFIER_REGEX, "");
+}
 
 /**
  * Formats a description for use in multi-line comment blocks.
@@ -173,7 +187,7 @@ function computeReferencedGenerics(generics: ComponentDocApi["generics"], text: 
   if (referenced.length === 0) return { declSuffix: EMPTY_STR, refSuffix: EMPTY_STR };
 
   return {
-    declSuffix: `<${referenced.map(({ constraint }) => constraint).join(", ")}>`,
+    declSuffix: `<${referenced.map(({ constraint }) => stripConstModifierForTypeAlias(constraint)).join(", ")}>`,
     refSuffix: `<${referenced.map(({ name }) => name).join(", ")}>`,
   };
 }
@@ -242,7 +256,10 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
         .filter(({ name }) => context.properties.some((prop) => referencesGeneric(prop.type, name)))
         .map(({ constraint }) => constraint);
 
-      const genericSuffix = referencedConstraints.length > 0 ? `<${referencedConstraints.join(", ")}>` : "";
+      const genericSuffix =
+        referencedConstraints.length > 0
+          ? `<${referencedConstraints.map(stripConstModifierForTypeAlias).join(", ")}>`
+          : "";
 
       /**
        * Use Record<string, never> for empty context objects instead of {}.
@@ -447,7 +464,11 @@ function genPropDef(
    * Full constraints for type definitions (e.g., `type $Props<T extends Foo = Bar>`).
    * Includes the full generic constraint with extends and default.
    */
-  const genericsName = def.generics ? `<${def.generics[1]}>` : "";
+  const genericsName = def.generics
+    ? `<${splitTopLevelCommas(def.generics[1])
+        .map((constraint) => stripConstModifierForTypeAlias(constraint.trim()))
+        .join(", ")}>`
+    : "";
   /**
    * Names only for type references (e.g., `keyof $Props<T>`).
    * Just the generic parameter name without constraints.

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -17595,6 +17595,73 @@ exports[`fixtures (JSON) "runes-typed-props/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-script-generics-attribute-const/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "items",
+      "kind": "let",
+      "type": "T",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "T",
+    "const T extends readonly string[]"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "generics/input.svelte" 1`] = `
 "{
   "source": {
@@ -23270,6 +23337,23 @@ export default class RunesTypedProps extends SvelteComponentTyped<
   RunesTypedPropsProps,
   Record<string, any>,
   Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-script-generics-attribute-const/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+type $Props<const T extends readonly string[]> = { items: T } & {
+  children?: (this: void) => void;
+};
+
+export type RunesScriptGenericsAttributeConstProps<const T extends readonly string[]> = $Props<T>;
+
+export default class RunesScriptGenericsAttributeConst<const T extends readonly string[]> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeConstProps<T>,
+  Record<string, any>,
+  { default: Record<string, never> }
 > {}
 "
 `;

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -17603,7 +17603,7 @@ exports[`fixtures (JSON) "runes-script-generics-attribute-const/input.svelte" 1`
       "column": 0
     },
     "end": {
-      "line": 6,
+      "line": 9,
       "column": 0
     }
   },
@@ -17622,11 +17622,11 @@ exports[`fixtures (JSON) "runes-script-generics-attribute-const/input.svelte" 1`
       "reactive": false,
       "source": {
         "start": {
-          "line": 2,
+          "line": 5,
           "column": 8
         },
         "end": {
-          "line": 2,
+          "line": 5,
           "column": 13
         }
       }
@@ -17640,11 +17640,11 @@ exports[`fixtures (JSON) "runes-script-generics-attribute-const/input.svelte" 1`
       "slot_props": "Record<string, never>",
       "source": {
         "start": {
-          "line": 5,
+          "line": 8,
           "column": 0
         },
         "end": {
-          "line": 5,
+          "line": 8,
           "column": 8
         }
       }
@@ -23344,11 +23344,11 @@ export default class RunesTypedProps extends SvelteComponentTyped<
 exports[`fixtures (TypeScript) "runes-script-generics-attribute-const/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
-type $Props<const T extends readonly string[]> = { items: T } & {
+type $Props<T extends readonly string[]> = { items: T } & {
   children?: (this: void) => void;
 };
 
-export type RunesScriptGenericsAttributeConstProps<const T extends readonly string[]> = $Props<T>;
+export type RunesScriptGenericsAttributeConstProps<T extends readonly string[]> = $Props<T>;
 
 export default class RunesScriptGenericsAttributeConst<const T extends readonly string[]> extends SvelteComponentTyped<
   RunesScriptGenericsAttributeConstProps<T>,

--- a/tests/fixtures/runes-script-generics-attribute-const/input.svelte
+++ b/tests/fixtures/runes-script-generics-attribute-const/input.svelte
@@ -1,4 +1,7 @@
-<script lang="ts" generics="const T extends readonly string[]">
+<script
+  lang="ts"
+  generics="const T extends readonly string[]"
+>
   let { items }: { items: T } = $props();
 </script>
 

--- a/tests/fixtures/runes-script-generics-attribute-const/input.svelte
+++ b/tests/fixtures/runes-script-generics-attribute-const/input.svelte
@@ -1,0 +1,5 @@
+<script lang="ts" generics="const T extends readonly string[]">
+  let { items }: { items: T } = $props();
+</script>
+
+<slot />

--- a/tests/fixtures/runes-script-generics-attribute-const/output.d.ts
+++ b/tests/fixtures/runes-script-generics-attribute-const/output.d.ts
@@ -1,10 +1,10 @@
 import { SvelteComponentTyped } from "svelte";
 
-type $Props<const T extends readonly string[]> = { items: T } & {
+type $Props<T extends readonly string[]> = { items: T } & {
   children?: (this: void) => void;
 };
 
-export type RunesScriptGenericsAttributeConstProps<const T extends readonly string[]> = $Props<T>;
+export type RunesScriptGenericsAttributeConstProps<T extends readonly string[]> = $Props<T>;
 
 export default class RunesScriptGenericsAttributeConst<const T extends readonly string[]> extends SvelteComponentTyped<
   RunesScriptGenericsAttributeConstProps<T>,

--- a/tests/fixtures/runes-script-generics-attribute-const/output.d.ts
+++ b/tests/fixtures/runes-script-generics-attribute-const/output.d.ts
@@ -1,0 +1,13 @@
+import { SvelteComponentTyped } from "svelte";
+
+type $Props<const T extends readonly string[]> = { items: T } & {
+  children?: (this: void) => void;
+};
+
+export type RunesScriptGenericsAttributeConstProps<const T extends readonly string[]> = $Props<T>;
+
+export default class RunesScriptGenericsAttributeConst<const T extends readonly string[]> extends SvelteComponentTyped<
+  RunesScriptGenericsAttributeConstProps<T>,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/runes-script-generics-attribute-const/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-const/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 6,
+      "line": 9,
       "column": 0
     }
   },
@@ -24,11 +24,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 2,
+          "line": 5,
           "column": 8
         },
         "end": {
-          "line": 2,
+          "line": 5,
           "column": 13
         }
       }
@@ -42,11 +42,11 @@
       "slot_props": "Record<string, never>",
       "source": {
         "start": {
-          "line": 5,
+          "line": 8,
           "column": 0
         },
         "end": {
-          "line": 5,
+          "line": 8,
           "column": 8
         }
       }

--- a/tests/fixtures/runes-script-generics-attribute-const/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-const/output.json
@@ -1,0 +1,63 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "items",
+      "kind": "let",
+      "type": "T",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "T",
+    "const T extends readonly string[]"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
sveld emitted syntactically invalid .d.ts for any component using a TypeScript 5.0+ const type parameter (or an in/out variance modifier) on its generics script attribute. parseGenericsAttribute derived the usage-site type name by matching a leading-identifier regex against the raw constraint string, so for something like const T extends readonly string[] it captured const instead of T. That bad name then got reused verbatim at every reference site in writer-ts-definitions-core.ts, producing things like TestProps<const>, which fails to parse since const is a reserved word.

The fix strips a leading const, in, or out modifier before extracting the usage-site identifier, while keeping the full modifier plus constraint string intact for the declaration site (e.g. class Test<const T extends readonly string[]>). Added a fixture, runes-script-generics-attribute-const, covering the const case and confirming usage sites now render as plain T while declarations keep the const modifier.

Risk is low and scoped to parsing of the generics script attribute. The only components affected are ones using const/in/out type-parameter modifiers, a narrow but real subset given the const modifier's popularity for preserving literal types through generic inference.