### PR TITLE
fix(watch): re-glob on update so new component files are picked up

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -158,6 +158,22 @@ export interface CollectedComponents {
   resolveComponentFilePath: ResolveComponentFilePath;
 }
 
+/** A `.svelte` file discovered on disk, before it's merged into `exports`/`allComponents`. */
+export interface GlobbedComponentSource {
+  moduleName: string;
+  source: ReturnType<typeof asRelativeSourcePath>;
+}
+
+/** Globs every `.svelte` file under `rootDir`, resolving each to its module name and source path. */
+export function globComponentSources(rootDir: string): GlobbedComponentSource[] {
+  return globSync(["**/*.svelte"], { cwd: rootDir, absolute: true }).map((matchedFile) => {
+    const file = resolve(matchedFile);
+    const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
+    const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
+    return { moduleName, source };
+  });
+}
+
 /**
  * Discovers component sources for an entry point without parsing them.
  *
@@ -194,14 +210,7 @@ export function collectComponents(input: string, glob: boolean, documentExports 
   const allComponents: ParsedExports = { ...exports };
 
   if (glob) {
-    for (const matchedFile of globSync(["**/*.svelte"], {
-      cwd: rootDir,
-      absolute: true,
-    })) {
-      const file = resolve(matchedFile);
-      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
-      const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
-
+    for (const { moduleName, source } of globComponentSources(rootDir)) {
       if (exports[moduleName]) {
         exports[moduleName].source = source;
       }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -6,6 +6,7 @@ import {
   collectComponents,
   collectSvelteFilePaths,
   type GenerateBundleResult,
+  globComponentSources,
   type ProcessComponentOptions,
   processComponent,
   readFileMap,
@@ -53,9 +54,11 @@ export interface SveldBundle {
  * @param documentExports - Record consts, functions, and types from the entry barrel
  */
 export async function createSveldBundle(input: string, glob: boolean, documentExports = false): Promise<SveldBundle> {
-  // Discover sources once. The export/source maps only change when the entry
-  // file or the set of files on disk changes; for a single edit they are stable.
-  const { exports, allComponents, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
+  // Discover sources once. The export map only changes when the entry file
+  // changes; for a single edit it is stable. `allComponents` (glob-discovered)
+  // can grow as files are added on disk, so it and its entry list are
+  // refreshed in `update()` below.
+  const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
 
   // Entry exports only change when the barrel changes; resolve once.
   const entryExports: EntryExports =
@@ -141,6 +144,21 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
 
     if (changed.length === 0) {
       return { result: buildResult(), reparsed: [] };
+    }
+
+    // Re-glob so components created since the last update (or the initial
+    // parse) are tracked. Files already known just get their `source` refreshed.
+    if (glob) {
+      for (const { moduleName, source } of globComponentSources(rootDir)) {
+        const existing = allComponents[moduleName];
+        if (existing) {
+          existing.source = source;
+        } else {
+          const newEntry = { source, default: false };
+          allComponents[moduleName] = newEntry;
+          allComponentEntries.push([moduleName, newEntry]);
+        }
+      }
     }
 
     const affected = expandAffected(changed, reverseDeps);

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -74,6 +74,18 @@ describe("watch mode (createSveldBundle)", () => {
     expect(reparsed).toEqual([standalonePath]);
   });
 
+  test("picks up a newly created component file", async () => {
+    const bundle = await createSveldBundle(dir, true);
+
+    const newPath = resolve(dir, "NewOne.svelte");
+    writeFileSync(newPath, `<script>\n  export let label = "new";\n</script>\n\n<span>{label}</span>`);
+
+    const { result, reparsed } = await bundle.update([newPath]);
+
+    expect(reparsed).toContain(newPath);
+    expect(result.allComponentsForTypes.has("NewOne")).toBe(true);
+  });
+
   test("ignores non-svelte changes", async () => {
     const bundle = await createSveldBundle(dir, true);
     const { reparsed } = await bundle.update([resolve(dir, "README.md")]);


### PR DESCRIPTION
createSveldBundle captured the glob-discovered component list once at creation time and never refreshed it, so update() could only re-parse files it already knew about. A component added to an already-globbed directory after the dev server started never showed up in generated types, no matter how many times update() was called afterward, until a restart.

The fix extracts the glob logic from collectComponents into a globComponentSources helper and re-runs it inside update(), merging any newly discovered files into the tracked component entries before computing which components are affected by a given change. File deletion was already handled correctly and is untouched by this change.

Risk is limited to watch mode: update() now does one extra directory glob per call when the plugin's glob option is on, which is the same globSync call collectComponents already made once at startup, so the added cost per edit is small. Covered by a new regression test in tests/watch.test.ts plus the full existing suite.