### PR TITLE
fix(parser): make dispatched events consistently win over forwarded

### DIFF
--- a/src/parser/events.ts
+++ b/src/parser/events.ts
@@ -34,8 +34,25 @@ export function addDispatchedEvent(
 
   const default_detail = !has_argument && !detail ? "null" : assignValueOrUndefined(detail);
   const event_description = description;
-  if (ctx.events.has(name)) {
-    const existing_event = ctx.events.get(name) as DispatchedEvent;
+  const existing_event = ctx.events.get(name);
+  if (existing_event?.type === "forwarded") {
+    /**
+     * A dispatched event always takes precedence over a forwarded event of the same
+     * name, regardless of which was detected first during the walk (forwarding is
+     * recorded as soon as the template is visited, while createEventDispatcher()
+     * dispatches are only resolved after the whole walk completes). Non-conflicting
+     * metadata from the forwarded event is preserved as a fallback.
+     */
+    ctx.events.set(name, {
+      type: "dispatched",
+      name,
+      detail: default_detail,
+      description: event_description || existing_event.description,
+      deprecated: deprecated ?? existing_event.deprecated,
+      tags: tags ?? existing_event.tags,
+      source: source || existing_event.source,
+    });
+  } else if (existing_event) {
     const merged_tags = existing_event.tags ?? tags;
     ctx.events.set(name, {
       ...existing_event,

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -4183,6 +4183,49 @@ exports[`fixtures (JSON) "binary-expression-numeric/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "dispatched-and-forwarded-same-event-name-host-dispatch/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 15,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "click",
+      "detail": "1",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 4
+        },
+        "end": {
+          "line": 5,
+          "column": 66
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "customElementTag": "my-el",
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "typedef-branded-types/input.svelte" 1`] = `
 "{
   "source": {
@@ -5482,6 +5525,47 @@ exports[`fixtures (JSON) "mixed-events/input.svelte" 1`] = `
         "end": {
           "line": 13,
           "column": 37
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "dispatched-and-forwarded-same-event-name/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "click",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 4
+        },
+        "end": {
+          "line": 6,
+          "column": 31
         }
       }
     }
@@ -17078,9 +17162,8 @@ exports[`fixtures (JSON) "forwarded-and-dispatched-events/input.svelte" 1`] = `
   "slots": [],
   "events": [
     {
-      "type": "forwarded",
+      "type": "dispatched",
       "name": "change",
-      "element": "input",
       "source": {
         "start": {
           "line": 8,
@@ -19061,6 +19144,19 @@ export default class BinaryExpressionNumeric extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "dispatched-and-forwarded-same-event-name-host-dispatch/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedAndForwardedSameEventNameHostDispatchProps = Record<string, never>;
+
+export default class DispatchedAndForwardedSameEventNameHostDispatch extends SvelteComponentTyped<
+  DispatchedAndForwardedSameEventNameHostDispatchProps,
+  { click: CustomEvent<1> },
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "typedef-branded-types/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -19440,6 +19536,19 @@ export default class MixedEvents extends SvelteComponentTyped<
     blur: FocusEvent | CustomEvent<FocusEvent>;
     "custom-focus": CustomEvent<FocusEvent | number>;
   },
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "dispatched-and-forwarded-same-event-name/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedAndForwardedSameEventNameProps = Record<string, never>;
+
+export default class DispatchedAndForwardedSameEventName extends SvelteComponentTyped<
+  DispatchedAndForwardedSameEventNameProps,
+  { click: CustomEvent<any> },
   Record<string, never>
 > {}
 "
@@ -23101,7 +23210,7 @@ export type ForwardedAndDispatchedEventsProps = Record<string, never>;
 
 export default class ForwardedAndDispatchedEvents extends SvelteComponentTyped<
   ForwardedAndDispatchedEventsProps,
-  { change: WindowEventMap["change"] },
+  { change: CustomEvent<any> },
   Record<string, never>
 > {}
 "

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/input.svelte
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/input.svelte
@@ -1,0 +1,14 @@
+<svelte:options customElement="my-el" />
+
+<script>
+  function onClick() {
+    $host().dispatchEvent(new CustomEvent("click", { detail: 1 }));
+  }
+</script>
+
+<button
+  on:click={onClick}
+  on:click
+>
+  click
+</button>

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.d.ts
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.d.ts
@@ -1,0 +1,9 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedAndForwardedSameEventNameHostDispatchProps = Record<string, never>;
+
+export default class DispatchedAndForwardedSameEventNameHostDispatch extends SvelteComponentTyped<
+  DispatchedAndForwardedSameEventNameHostDispatchProps,
+  { click: CustomEvent<1> },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.json
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.json
@@ -5,11 +5,11 @@
       "column": 0
     },
     "end": {
-      "line": 16,
+      "line": 15,
       "column": 0
     }
   },
-  "syntaxMode": "legacy",
+  "syntaxMode": "runes",
   "scriptLanguage": "js",
   "props": [],
   "moduleExports": [],
@@ -17,15 +17,16 @@
   "events": [
     {
       "type": "dispatched",
-      "name": "change",
+      "name": "click",
+      "detail": "1",
       "source": {
         "start": {
-          "line": 8,
+          "line": 5,
           "column": 4
         },
         "end": {
-          "line": 8,
-          "column": 43
+          "line": 5,
+          "column": 66
         }
       }
     }
@@ -33,5 +34,6 @@
   "typedefs": [],
   "generics": null,
   "contexts": [],
+  "customElementTag": "my-el",
   "diagnostics": []
 }

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/input.svelte
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/input.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+  function onClick() {
+    dispatch("click", { x: 1 });
+  }
+</script>
+
+<button
+  on:click={onClick}
+  on:click
+>
+  click me
+</button>

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/output.d.ts
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/output.d.ts
@@ -1,0 +1,9 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedAndForwardedSameEventNameProps = Record<string, never>;
+
+export default class DispatchedAndForwardedSameEventName extends SvelteComponentTyped<
+  DispatchedAndForwardedSameEventNameProps,
+  { click: CustomEvent<any> },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/output.json
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/output.json
@@ -17,15 +17,15 @@
   "events": [
     {
       "type": "dispatched",
-      "name": "change",
+      "name": "click",
       "source": {
         "start": {
-          "line": 8,
+          "line": 6,
           "column": 4
         },
         "end": {
-          "line": 8,
-          "column": 43
+          "line": 6,
+          "column": 31
         }
       }
     }

--- a/tests/fixtures/forwarded-and-dispatched-events/output.d.ts
+++ b/tests/fixtures/forwarded-and-dispatched-events/output.d.ts
@@ -4,6 +4,6 @@ export type ForwardedAndDispatchedEventsProps = Record<string, never>;
 
 export default class ForwardedAndDispatchedEvents extends SvelteComponentTyped<
   ForwardedAndDispatchedEventsProps,
-  { change: WindowEventMap["change"] },
+  { change: CustomEvent<any> },
   Record<string, never>
 > {}


### PR DESCRIPTION
When a component both forwards an event and dispatches an event of the same name, which one won in the generated types was an accident of AST walk order rather than an intentional rule. createEventDispatcher() dispatches were resolved after the whole component walk finished, so they lost to a forwarding entry that was already claimed during the template walk. $host().dispatchEvent() calls, by contrast, were detected during the script portion of the same walk, which runs before the template portion, so they happened to win over forwarding. Same conceptual conflict, two different outcomes depending on which dispatch mechanism was used.

The fix is in addDispatchedEvent in src/parser/events.ts: when a dispatch call targets an event name that's already recorded as forwarded, it now converts that entry to dispatched, taking the dispatch's detail type as primary and falling back to the forwarded entry's description, deprecated, tags, and source for anything the dispatch call didn't specify. This makes dispatched always take precedence over forwarded, independent of detection order.

Added two fixtures pinning both directions (dispatched-and-forwarded-same-event-name for createEventDispatcher, and a -host-dispatch variant for $host().dispatchEvent()), and updated the pre-existing forwarded-and-dispatched-events fixture, whose expected output had encoded the old forwarding-wins behavior by accident.

Risk is low and localized to the event type-merging logic in the parser. The main behavior change is that any component relying on the old (undocumented, order-dependent) forwarding-wins outcome for createEventDispatcher-based dispatch will now see the dispatched type instead, which is the intended fix but is technically a generated-output change for that specific pattern.