### PR TITLE
fix(parser): break circular export * cycles in parseExports

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -182,7 +182,7 @@ export function collectComponents(input: string, glob: boolean, documentExports 
   if (isFile) {
     const entry = readFileSync(input, "utf-8");
     try {
-      exports = parseExports(entry, rootDir);
+      exports = parseExports(entry, rootDir, new Set([resolve(input)]));
     } catch (error) {
       // Without documentExports, throw. With it, warn and continue.
       if (!documentExports) throw error;

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -67,8 +67,12 @@ function parseProgram(source: string): ProgramNode {
  * //   App: { source: "./App.svelte", default: true }
  * // }
  * ```
+ *
+ * @param resolving - Absolute paths currently being resolved on this call
+ *   stack, used to break `export *` cycles between files that re-export
+ *   each other. Callers should not pass this; it is threaded internally.
  */
-export function parseExports(source: string, dir: string) {
+export function parseExports(source: string, dir: string, resolving: Set<string> = new Set()) {
   let ast = astCache.get(source);
 
   if (!ast) {
@@ -103,8 +107,13 @@ export function parseExports(source: string, dir: string) {
           }
       }
 
+      if (resolving.has(file_path)) continue;
+      resolving.add(file_path);
+
       const export_file = readFileSync(file_path, "utf-8");
-      const exports = parseExports(export_file, dirname(file_path));
+      const exports = parseExports(export_file, dirname(file_path), resolving);
+
+      resolving.delete(file_path);
 
       for (const [key, value] of Object.entries(exports)) {
         const source = asRelativeSourcePath(normalizeSeparators(`./${join(node.source.value, value.source)}`));

--- a/tests/parse-exports.test.ts
+++ b/tests/parse-exports.test.ts
@@ -1,6 +1,27 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { parseExports } from "../src/parse-exports";
 
 describe("parseExports", () => {
+  test("circular `export *` between two barrel files does not overflow the stack", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-circular-"));
+
+    try {
+      writeFileSync(path.join(dir, "A.js"), `export * from "./B.js";\nexport { helper } from "./helper.js";\n`);
+      writeFileSync(path.join(dir, "B.js"), `export * from "./A.js";\nexport { other } from "./other.js";\n`);
+      writeFileSync(path.join(dir, "helper.js"), "export const helper = 1;\n");
+      writeFileSync(path.join(dir, "other.js"), "export const other = 2;\n");
+
+      const source = `export * from "./B.js";\nexport { helper } from "./helper.js";\n`;
+
+      const result = parseExports(source, dir);
+      expect(Object.keys(result).sort()).toEqual(["helper", "other"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("single default export", () => {
     const source = `export { default } from "./Component.svelte";`;
 


### PR DESCRIPTION
Two barrel files that re-export each other via export * (e.g. A.js does export * from "./B.js" and B.js does export * from "./A.js") crash the whole build with an unhandled RangeError, because parseExports in src/parse-exports.ts recurses into itself on ExportAllDeclaration with no visited-file guard. parse-entry-exports.ts already solves the same problem for its own recursive walk with a computing set, but parse-exports.ts had no equivalent.

This threads a resolving set of absolute file paths through the recursive ExportAllDeclaration handling. A file already on the current resolution stack is skipped instead of re-entered, so a cycle resolves the exports that are still resolvable instead of crashing. bundle.ts seeds the set with the entry file's own resolved path so a cycle that loops back to the entry file is also caught.

Risk is low and localized to this one recursion path. The main thing to watch for is diamond-shaped re-export graphs (two branches both pulling exports from the same file, without a cycle) still resolving correctly, since the guard only skips a file while it is actively on the stack, not after it has already been fully resolved and popped. Added a unit test in tests/parse-exports.test.ts covering the circular case, and the full existing suite (703 tests) plus tsc --noEmit still pass.