### PR TITLE
fix(parser): recognize $props() wrapped in `as`/`satisfies` casts

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -16,7 +16,13 @@ import type {
 import type { Node } from "estree-walker";
 import { walk } from "estree-walker";
 import { compile, parse } from "svelte/compiler";
-import { isCallExpressionNamed, isIdentifier, isLiteral, isMemberExpression } from "./ast-guards";
+import {
+  isCallExpressionNamed,
+  isIdentifier,
+  isLiteral,
+  isMemberExpression,
+  unwrapTypeCastExpression,
+} from "./ast-guards";
 import type { SveldDiagnostic } from "./diagnostics";
 import { getElementByTag } from "./element-tag-map";
 import { resolveMemberExpressionType } from "./parser/bindings";
@@ -1655,7 +1661,7 @@ export default class ComponentParser {
             "type" in parent &&
             parent.type === "Program" &&
             (node as VariableDeclaration).declarations.some((declarator) =>
-              isCallExpressionNamed(declarator.init, "$props"),
+              isCallExpressionNamed(unwrapTypeCastExpression(declarator.init), "$props"),
             )
           ) {
             parseRunesPropsDeclaration(this, this.ctx, node as VariableDeclaration);

--- a/src/ast-guards.ts
+++ b/src/ast-guards.ts
@@ -47,6 +47,32 @@ export function isCallExpressionNamed(node: unknown, calleeName: string): node i
   return !!node.callee && isObject(node.callee) && node.callee.type === "Identifier" && node.callee.name === calleeName;
 }
 
+/** Unwraps `expr as Type` / `expr satisfies Type`, returning the innermost expression. */
+export function unwrapTypeCastExpression(node: unknown): unknown {
+  if (
+    isObject(node) &&
+    (node.type === "TSAsExpression" || node.type === "TSSatisfiesExpression") &&
+    "expression" in node
+  ) {
+    return unwrapTypeCastExpression(node.expression);
+  }
+
+  return node;
+}
+
+/** The type node from `expr as Type` / `expr satisfies Type`, if `node` is such a cast. */
+export function getTypeCastAnnotation(node: unknown): unknown {
+  if (
+    isObject(node) &&
+    (node.type === "TSAsExpression" || node.type === "TSSatisfiesExpression") &&
+    "typeAnnotation" in node
+  ) {
+    return node.typeAnnotation;
+  }
+
+  return undefined;
+}
+
 export function isNewExpression(node: unknown): node is NewExpression {
   return isObject(node) && node.type === "NewExpression";
 }

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -1,6 +1,6 @@
 import type { AssignmentPattern, Identifier, Property, VariableDeclaration, VariableDeclarator } from "estree";
 import { parse } from "svelte/compiler";
-import { isCallExpressionNamed } from "../ast-guards";
+import { getTypeCastAnnotation, isCallExpressionNamed, unwrapTypeCastExpression } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type {
   ModernRunesTypeMember,
@@ -20,6 +20,7 @@ import {
   getRunesPropsDeclarationMetadata,
   getRunesPropTypeMetadata,
   getTypeAnnotationText,
+  getTypeNodeText,
   getTypeReferenceName,
 } from "./type-resolution";
 
@@ -262,24 +263,30 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
     if (!statement || typeof statement !== "object" || !("declarations" in statement)) continue;
 
     for (const declarator of statement.declarations ?? []) {
-      if (!isCallExpressionNamed(declarator.init, "$props")) continue;
-      const canonicalType = getTypeAnnotationText(ctx, declarator.id?.typeAnnotation);
+      if (!isCallExpressionNamed(unwrapTypeCastExpression(declarator.init), "$props")) continue;
+
+      // `let props = $props() as Props` / `... satisfies Props` carry their type on the
+      // initializer rather than on `declarator.id`, so fall back to that when there's no
+      // explicit `: Props` annotation on the binding itself.
+      const castTypeNode = declarator.id?.typeAnnotation
+        ? undefined
+        : (getTypeCastAnnotation(declarator.init) as ModernRunesTypeNode | undefined);
+      const effectiveTypeNode = declarator.id?.typeAnnotation?.typeAnnotation ?? castTypeNode;
+
+      const canonicalType = declarator.id?.typeAnnotation
+        ? getTypeAnnotationText(ctx, declarator.id.typeAnnotation)
+        : getTypeNodeText(ctx, castTypeNode as { start?: number; end?: number } | undefined);
       const metadata = buildRunesPropTypeMetadataMap(
         parser,
         ctx,
-        declarator.id?.typeAnnotation?.typeAnnotation,
+        effectiveTypeNode,
         new Map(
           Array.from(ctx.localTypeDeclarationsByName.entries(), ([name, declaration]) => [name, declaration.node]),
         ),
       );
       const referencedImportedTypes = new Set<string>();
       const referencedLocalTypes = new Set<string>();
-      collectReferencedTypeDependencies(
-        ctx,
-        declarator.id?.typeAnnotation?.typeAnnotation,
-        referencedImportedTypes,
-        referencedLocalTypes,
-      );
+      collectReferencedTypeDependencies(ctx, effectiveTypeNode, referencedImportedTypes, referencedLocalTypes);
       collectGenericsAttributeTypeDependencies(ctx, referencedImportedTypes, referencedLocalTypes);
 
       if (declarator.start !== undefined) {
@@ -301,7 +308,7 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
 /** Top-level `$props()` declarations in runes components. */
 export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserContext, node: VariableDeclaration) {
   for (const declarator of node.declarations) {
-    if (!isCallExpressionNamed(declarator.init, "$props")) continue;
+    if (!isCallExpressionNamed(unwrapTypeCastExpression(declarator.init), "$props")) continue;
 
     if (declarator.id.type === "Identifier") {
       ctx.wholePropsLocals.add(declarator.id.name);

--- a/src/parser/scopes.ts
+++ b/src/parser/scopes.ts
@@ -8,7 +8,7 @@ import type {
   VariableDeclaration,
   VariableDeclarator,
 } from "estree";
-import { isCallExpressionNamed, isVariableDeclaration } from "../ast-guards";
+import { isCallExpressionNamed, isVariableDeclaration, unwrapTypeCastExpression } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type { LexicalScope, ScopeBinding, ScopeBindingKind } from "../ComponentParser";
 import type { ParserContext } from "./context";
@@ -182,7 +182,7 @@ export function declareVariableDeclaration(
   const variableDeclaration = declaration;
 
   for (const declarator of variableDeclaration.declarations) {
-    if (allowRunesProps && isCallExpressionNamed(declarator.init, "$props")) {
+    if (allowRunesProps && isCallExpressionNamed(unwrapTypeCastExpression(declarator.init), "$props")) {
       for (const binding of extractRunesScopeBindings(parser, variableDeclaration, declarator)) {
         declareScopeBinding(
           binding.kind === "prop" ? lexicalScope : varScope,

--- a/src/parser/type-resolution.ts
+++ b/src/parser/type-resolution.ts
@@ -91,6 +91,14 @@ export function getTypeAnnotationText(
   return sourceAtPos(ctx, start + 1, end)?.trim();
 }
 
+/** Returns the trimmed source text spanned by a bare type node (no leading `:`), if positions are available. */
+export function getTypeNodeText(ctx: ParserContext, typeNode: { start?: number; end?: number } | undefined) {
+  const start = typeNode?.start;
+  const end = typeNode?.end;
+  if (start === undefined || end === undefined) return undefined;
+  return sourceAtPos(ctx, start, end)?.trim();
+}
+
 /** Collect imported and local type names referenced by a type AST node. */
 export function collectReferencedTypeDependencies(
   ctx: ParserContext,

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -2647,6 +2647,75 @@ exports[`fixtures (JSON) "context-generics-dollar-name/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-props-as-cast/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "item",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 17
+        }
+      }
+    },
+    {
+      "name": "disabled",
+      "kind": "let",
+      "type": "boolean",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 4
+        },
+        "end": {
+          "line": 4,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-uncontrolled-state-prop/input.svelte" 1`] = `
 "{
   "source": {
@@ -10039,6 +10108,75 @@ exports[`fixtures (JSON) "input-events/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-props-satisfies-cast/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "item",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 17
+        }
+      }
+    },
+    {
+      "name": "disabled",
+      "kind": "let",
+      "type": "boolean",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 4
+        },
+        "end": {
+          "line": 4,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "required/input.svelte" 1`] = `
 "{
   "source": {
@@ -10229,6 +10367,75 @@ exports[`fixtures (JSON) "slot-plain-text-attribute-prop/input.svelte" 1`] = `
       }
     }
   ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-props-as-cast-destructured/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "type": "number",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
   "events": [],
   "typedefs": [],
   "generics": null,
@@ -18622,6 +18829,26 @@ export default class ContextGenericsDollarName<Value$Type extends string> extend
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-props-as-cast/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface Props {
+  item: string;
+  disabled?: boolean;
+}
+
+type $Props = Props;
+
+export type RunesPropsAsCastProps = $Props;
+
+export default class RunesPropsAsCast extends SvelteComponentTyped<
+  RunesPropsAsCastProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "runes-uncontrolled-state-prop/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -20807,6 +21034,26 @@ export default class InputEvents extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "runes-props-satisfies-cast/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface Props {
+  item: string;
+  disabled?: boolean;
+}
+
+type $Props = Props;
+
+export type RunesPropsSatisfiesCastProps = $Props;
+
+export default class RunesPropsSatisfiesCast extends SvelteComponentTyped<
+  RunesPropsSatisfiesCastProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "required/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -20868,6 +21115,24 @@ export default class SlotPlainTextAttributeProp extends SvelteComponentTyped<
   SlotPlainTextAttributePropProps,
   Record<string, any>,
   { default: { color: "red" } }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-props-as-cast-destructured/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+type $Props = {
+  value: number;
+  label?: string
+};
+
+export type RunesPropsAsCastDestructuredProps = $Props;
+
+export default class RunesPropsAsCastDestructured extends SvelteComponentTyped<
+  RunesPropsAsCastDestructuredProps,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;

--- a/tests/fixtures/runes-props-as-cast-destructured/input.svelte
+++ b/tests/fixtures/runes-props-as-cast-destructured/input.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { value, label } = $props() as { value: number; label?: string };
+</script>
+
+<p>{value} {label}</p>

--- a/tests/fixtures/runes-props-as-cast-destructured/output.d.ts
+++ b/tests/fixtures/runes-props-as-cast-destructured/output.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+type $Props = {
+  value: number;
+  label?: string
+};
+
+export type RunesPropsAsCastDestructuredProps = $Props;
+
+export default class RunesPropsAsCastDestructured extends SvelteComponentTyped<
+  RunesPropsAsCastDestructuredProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-props-as-cast-destructured/output.json
+++ b/tests/fixtures/runes-props-as-cast-destructured/output.json
@@ -1,0 +1,65 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "type": "number",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-props-as-cast/input.svelte
+++ b/tests/fixtures/runes-props-as-cast/input.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  interface Props {
+    item: string;
+    disabled?: boolean;
+  }
+  let props = $props() as Props;
+</script>
+
+<button disabled={props.disabled}>{props.item}</button>

--- a/tests/fixtures/runes-props-as-cast/output.d.ts
+++ b/tests/fixtures/runes-props-as-cast/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface Props {
+  item: string;
+  disabled?: boolean;
+}
+
+type $Props = Props;
+
+export type RunesPropsAsCastProps = $Props;
+
+export default class RunesPropsAsCast extends SvelteComponentTyped<
+  RunesPropsAsCastProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-props-as-cast/output.json
+++ b/tests/fixtures/runes-props-as-cast/output.json
@@ -1,0 +1,65 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "item",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 17
+        }
+      }
+    },
+    {
+      "name": "disabled",
+      "kind": "let",
+      "type": "boolean",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 4
+        },
+        "end": {
+          "line": 4,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-props-satisfies-cast/input.svelte
+++ b/tests/fixtures/runes-props-satisfies-cast/input.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  interface Props {
+    item: string;
+    disabled?: boolean;
+  }
+  let props = $props() satisfies Props;
+</script>
+
+<button disabled={props.disabled}>{props.item}</button>

--- a/tests/fixtures/runes-props-satisfies-cast/output.d.ts
+++ b/tests/fixtures/runes-props-satisfies-cast/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface Props {
+  item: string;
+  disabled?: boolean;
+}
+
+type $Props = Props;
+
+export type RunesPropsSatisfiesCastProps = $Props;
+
+export default class RunesPropsSatisfiesCast extends SvelteComponentTyped<
+  RunesPropsSatisfiesCastProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-props-satisfies-cast/output.json
+++ b/tests/fixtures/runes-props-satisfies-cast/output.json
@@ -1,0 +1,65 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "item",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 17
+        }
+      }
+    },
+    {
+      "name": "disabled",
+      "kind": "let",
+      "type": "boolean",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 4
+        },
+        "end": {
+          "line": 4,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
Casting the $props() call instead of annotating the destructuring pattern (let props = $props() as Props, or the satisfies variant) is a common TypeScript style. sveld's isCallExpressionNamed guard required declarator.init to be a CallExpression directly, so it never recognized the call once it was wrapped in a TSAsExpression or TSSatisfiesExpression. The whole-props identifier form silently produced zero props (an empty Record<string, never> in the generated d.ts), and the destructured form dropped type and optionality info for every prop, with no error or diagnostic surfaced anywhere.

The fix unwraps as/satisfies casts before the $props() check at all four detection sites (ComponentParser.ts, parser/scopes.ts, and both checks in parser/runes-props.ts), and falls back to reading the type off the cast expression itself when the declarator has no type annotation of its own, so the extracted metadata matches what the equivalent uncast declaration already produces.

Added three fixtures covering the whole-props as-cast, destructured as-cast, and satisfies forms. Full test suite, typecheck, and lint all pass. Risk is limited to $props() detection logic; the change is additive (widens what's recognized as a props declaration) rather than altering behavior for existing uncast forms, and the full snapshot suite confirms no regressions there.