### PR TITLE
feat(browser): add sveld/browser entry point for in-browser usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ export default class Button extends SvelteComponentTyped<
   - [CLI](#cli)
   - [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check)
   - [Node.js](#nodejs)
+  - [Browser](#browser)
   - [Config File](#config-file)
   - [Publishing to NPM](#publishing-to-npm)
 - [Available Options](#available-options)
@@ -567,6 +568,51 @@ sveld({
   },
 });
 ```
+
+### Browser
+
+`sveld/browser` is a Node-free subpath export for running `sveld` client-side — e.g. an in-browser Svelte playground or REPL that parses whatever `.svelte` source the user typed and renders docs for it live. It bundles with Vite, esbuild, webpack, or Rollup without a `node:fs`/`node:path` polyfill.
+
+It covers parsing one component's source and rendering that result to any output format `sveld` supports (JSON, Markdown, `.d.ts`, Custom Elements Manifest). It does not cover project-wide glob scanning, the config file, or the CLI/Vite plugin (`sveld()`/`pluginSveld()`) — those walk the filesystem and only make sense in Node. Use the main `sveld` entry point for those.
+
+```ts
+import {
+  asNormalizedPath,
+  ComponentParser,
+  buildComponentApiDocument,
+  writeMarkdownCore,
+  writeTsDefinition,
+  buildCustomElementsManifest,
+} from "sveld/browser";
+
+const parser = new ComponentParser();
+const moduleName = "Button";
+const filePath = "Button.svelte";
+const parsed = parser.parseSvelteComponent(source, { moduleName, filePath });
+
+// `parseSvelteComponent` returns component metadata only; add `moduleName`
+// and `filePath` yourself to match the `ComponentDocApi` shape the writers expect.
+const component = { ...parsed, moduleName, filePath: asNormalizedPath(filePath) };
+const components = new Map([[moduleName, component]]);
+
+// JSON
+const jsonDoc = buildComponentApiDocument(components);
+
+// Markdown
+const markdown = writeMarkdownCore(components);
+
+// TypeScript definitions (per component)
+const dts = writeTsDefinition(jsonDoc.components[0]);
+
+// Custom Elements Manifest
+const cem = buildCustomElementsManifest(components, {
+  resolveModulePath: (component) => component.filePath,
+});
+```
+
+`ComponentParser` is stateful but reusable across parses — call `parseSvelteComponent` again on the same instance for the next component instead of constructing a new one each time.
+
+See [`playground/`](playground) in this repo for a working example: it parses Svelte source typed into an editor and renders JSON, Markdown, TypeScript, and Custom Elements Manifest tabs, all client-side.
 
 ### Config File
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./browser": {
+      "types": "./lib/browser.d.ts",
+      "import": "./lib/browser.js",
+      "default": "./lib/browser.js"
     }
   },
   "scripts": {

--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -15,7 +15,7 @@
   import Json from "carbon-icons-svelte/lib/Json.svelte";
   import TextCreation from "carbon-icons-svelte/lib/TextCreation.svelte";
   import { type Component, onMount } from "svelte";
-  import ComponentParser from "../../src/ComponentParser";
+  import { ComponentParser } from "../../src/browser";
   import data from "./data";
   import Header from "./Header.svelte";
   import TabContentOverlay from "./TabContentOverlay.svelte";

--- a/playground/src/TabCustomElements.svelte
+++ b/playground/src/TabCustomElements.svelte
@@ -3,7 +3,7 @@
   export let moduleName = "";
 
   import json from "svelte-highlight/languages/json";
-  import { buildCustomElementsManifest } from "../../src/writer/writer-custom-elements-core";
+  import { buildCustomElementsManifest } from "../../src/browser";
   import CodeHighlighter from "./CodeHighlighter.svelte";
 
   let manifest = { schemaVersion: "1.0.0", modules: [] };

--- a/playground/src/TabMarkdown.svelte
+++ b/playground/src/TabMarkdown.svelte
@@ -3,7 +3,7 @@
   export let moduleName = "";
 
   import markdownLang from "svelte-highlight/languages/markdown";
-  import { writeMarkdownCore as writeMarkdown } from "../../src/writer/writer-markdown-core";
+  import { writeMarkdownCore as writeMarkdown } from "../../src/browser";
   import CodeHighlighter from "./CodeHighlighter.svelte";
 
   let code = "";

--- a/playground/src/TabTypeScript.svelte
+++ b/playground/src/TabTypeScript.svelte
@@ -3,7 +3,7 @@
   export let moduleName = "";
 
   import typescript from "svelte-highlight/languages/typescript";
-  import { writeTsDefinition } from "../../src/writer/writer-ts-definitions-core";
+  import { writeTsDefinition } from "../../src/browser";
   import CodeHighlighter from "./CodeHighlighter.svelte";
 
   $: code = writeTsDefinition({

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -15,12 +15,12 @@ async function emitTypeDeclarations() {
   }
 }
 
-async function buildProject() {
+async function buildEntry(entrypoint: string, target: "node" | "browser") {
   const result = await build({
-    entrypoints: ["./src/index.ts"],
+    entrypoints: [entrypoint],
     outdir: "./lib",
     format: "esm",
-    target: "node",
+    target,
     minify: true,
     sourcemap: false,
     // Default Bun behavior treats `node_modules` imports as external; bundle
@@ -29,15 +29,26 @@ async function buildProject() {
   });
 
   if (!result.success) {
-    console.error("Build failed");
+    console.error(`Build failed for ${entrypoint}`);
     for (const log of result.logs) {
       console.error(log);
     }
     if (!isWatchMode) {
       process.exit(1);
     }
-    return;
+    return false;
   }
+
+  return true;
+}
+
+async function buildProject() {
+  const [node, browser] = await Promise.all([
+    buildEntry("./src/index.ts", "node"),
+    buildEntry("./src/browser.ts", "browser"),
+  ]);
+
+  if (!node || !browser) return;
 
   await emitTypeDeclarations();
   console.log("✓ Build completed");

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,68 @@
+/**
+ * Browser-safe entry point.
+ *
+ * Everything exported here avoids Node built-ins (`node:fs`, `node:path`, ...),
+ * so it bundles for the browser (Vite, esbuild, webpack, Rollup) without a
+ * polyfill. It covers parsing a single component's source and rendering that
+ * result to JSON, Markdown, TypeScript definitions, or a Custom Elements
+ * Manifest — everything except the filesystem-driven project scanning
+ * (`sveld()`/`pluginSveld()`) and CLI, which only make sense in Node.
+ *
+ * @example
+ * ```ts
+ * import { asNormalizedPath, ComponentParser, buildComponentApiDocument } from "sveld/browser";
+ *
+ * const parser = new ComponentParser();
+ * const diagnostics = { moduleName: "Button", filePath: "Button.svelte" };
+ * const parsed = parser.parseSvelteComponent(source, diagnostics);
+ *
+ * // `parseSvelteComponent` returns component metadata only; add the fields
+ * // `ComponentDocApi` needs (`moduleName`, `filePath`) yourself.
+ * const component = {
+ *   ...parsed,
+ *   moduleName: diagnostics.moduleName,
+ *   filePath: asNormalizedPath(diagnostics.filePath),
+ * };
+ *
+ * const doc = buildComponentApiDocument(new Map([[component.moduleName, component]]));
+ * ```
+ */
+export { asNormalizedPath, type NormalizedPath } from "./brands";
+export { default as ComponentParser, type SerializedComponentEvent } from "./ComponentParser";
+export type { SveldDiagnostic, SveldDiagnosticKind } from "./diagnostics";
+export type { ComponentDocApi, ComponentDocs } from "./plugin";
+export {
+  type BuildComponentApiDocumentOptions,
+  buildComponentApiDocument,
+  COMPONENT_API_SCHEMA_VERSION,
+  type ComponentApiDocument,
+} from "./writer/document-model";
+export type { AppendType, MarkdownWriterBase, TocLine } from "./writer/MarkdownWriterBase";
+export { renderComponentsToMarkdown } from "./writer/markdown-render-utils";
+export {
+  type BuildCustomElementsManifestOptions,
+  buildCustomElementsManifest,
+  type CemAttribute,
+  type CemClassDeclaration,
+  type CemClassField,
+  type CemCustomElementExport,
+  type CemEvent,
+  type CemExport,
+  type CemJavaScriptExport,
+  type CemModule,
+  type CemSlot,
+  type CemType,
+  type CustomElementsManifest,
+} from "./writer/writer-custom-elements-core";
+export {
+  BrowserWriterMarkdown,
+  type WriteMarkdownCoreOptions,
+  writeMarkdownCore,
+} from "./writer/writer-markdown-core";
+export {
+  formatTsProps,
+  getContextDefs,
+  getTypeDefs,
+  type WriteTsDefinitionOptions,
+  writeTsDefinition,
+} from "./writer/writer-ts-definitions-core";

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+  asNormalizedPath,
+  buildComponentApiDocument,
+  buildCustomElementsManifest,
+  type ComponentDocApi,
+  ComponentParser,
+  writeMarkdownCore,
+  writeTsDefinition,
+} from "../src/browser";
+
+const NODE_BUILTIN_IMPORT_REGEX = /from\s+["']node:[^"']+["']|require\(\s*["']node:[^"']+["']\s*\)/;
+const RELATIVE_IMPORT_REGEX = /from\s+["'](\.\.?\/[^"']+)["']/g;
+// Uniform `import type { ... } from "..."` / `export type { ... } from "..."` statements are erased
+// by the compiler, so their target module never actually ships in the browser bundle - don't walk into them.
+// (Individual `type X` specifiers inside a mixed `export { a, type B } from "..."` statement still count
+// as a real import of that module, since `a` is a value.)
+const TYPE_ONLY_IMPORT_STATEMENT_REGEX = /\b(?:import|export)\s+type\s*\{[\s\S]*?\}\s*from\s*["'][^"']+["'];?/g;
+const FILE_EXTENSION_REGEX = /\.[a-zA-Z0-9]+$/;
+
+/** Strips `/* ... *\/` block comments (JSDoc included) so example code in doc comments doesn't get mistaken for real imports. */
+function stripBlockComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
+ * Walks every module reachable from `src/browser.ts` via relative imports
+ * and asserts none of them import a `node:*` built-in. Bare specifiers
+ * (npm packages like `svelte/compiler`) are out of scope; they're expected
+ * to be browser-safe on their own and get bundled by the consumer's tool.
+ */
+function collectRelativeImportGraph(entryFile: string): Map<string, string> {
+  const files = new Map<string, string>();
+  const queue = [entryFile];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (!file || files.has(file)) continue;
+
+    const source = readFileSync(file, "utf-8");
+    files.set(file, source);
+    const codeOnly = stripBlockComments(source).replace(TYPE_ONLY_IMPORT_STATEMENT_REGEX, "");
+
+    for (const match of codeOnly.matchAll(RELATIVE_IMPORT_REGEX)) {
+      const specifier = match[1];
+      // Imports of non-`.ts` files (e.g. `../../package.json`) already carry their extension.
+      const hasExtension = FILE_EXTENSION_REGEX.test(specifier);
+      const resolved = resolve(dirname(file), hasExtension ? specifier : `${specifier}.ts`);
+      if (!files.has(resolved)) queue.push(resolved);
+    }
+  }
+
+  return files;
+}
+
+function toComponentDocApi(
+  parsed: ReturnType<ComponentParser["parseSvelteComponent"]>,
+  moduleName: string,
+  filePath: string,
+): ComponentDocApi {
+  return { ...parsed, moduleName, filePath: asNormalizedPath(filePath) };
+}
+
+describe("sveld/browser", () => {
+  test("the entire relative-import graph is free of node: built-ins", () => {
+    const entry = join(__dirname, "..", "src", "browser.ts");
+    const graph = collectRelativeImportGraph(entry);
+
+    expect(graph.size).toBeGreaterThan(5);
+
+    const offenders = Array.from(graph.entries())
+      .filter(([, source]) => NODE_BUILTIN_IMPORT_REGEX.test(stripBlockComments(source)))
+      .map(([file]) => file);
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("parses a component and renders every output format", () => {
+    const source = `<script>
+  /** Button label */
+  export let label = "Click me";
+</script>
+<button>{label}</button>
+`;
+
+    const parser = new ComponentParser();
+    const parsed = parser.parseSvelteComponent(source, { moduleName: "Button", filePath: "Button.svelte" });
+    const components = new Map([["Button", toComponentDocApi(parsed, "Button", "Button.svelte")]]);
+
+    const jsonDoc = buildComponentApiDocument(components);
+    expect(jsonDoc.components).toHaveLength(1);
+    expect(jsonDoc.components[0].moduleName).toBe("Button");
+
+    const markdown = writeMarkdownCore(components);
+    expect(markdown).toContain("Button");
+
+    const dts = writeTsDefinition(jsonDoc.components[0]);
+    expect(dts).toContain("label");
+
+    const cem = buildCustomElementsManifest(components, {
+      resolveModulePath: (component) => component.filePath,
+    });
+    expect(cem.modules).toHaveLength(1);
+  });
+
+  test("a single ComponentParser instance can be reused across parses", () => {
+    const parser = new ComponentParser();
+
+    const first = parser.parseSvelteComponent("<script>export let a;</script>", {
+      moduleName: "A",
+      filePath: "A.svelte",
+    });
+    const second = parser.parseSvelteComponent("<script>export let b;</script>", {
+      moduleName: "B",
+      filePath: "B.svelte",
+    });
+
+    expect(first.props.map((p) => p.name)).toEqual(["a"]);
+    expect(second.props.map((p) => p.name)).toEqual(["b"]);
+  });
+});


### PR DESCRIPTION
Adds a Node-free subpath export, sveld/browser, covering ComponentParser and the JSON, Markdown, TypeScript definitions, and Custom Elements Manifest writers. It's meant for consumers running sveld client-side, like an in-browser Svelte playground or REPL, and bundles cleanly with Vite, esbuild, webpack, or Rollup without a node:fs or node:path polyfill. Project-wide glob scanning, the config file, and the CLI/Vite plugin stay Node-only since they depend on the filesystem.

The build now produces two entry points: index.ts for Node (unchanged) and the new browser.ts targeting the browser. package.json exposes the new surface at "sveld/browser". A test walks the full relative-import graph reachable from browser.ts and fails if any file in it pulls in a node: built-in, so this can't silently regress as the writer internals change.

The playground's four internal imports (ComponentParser and three writer-*-core modules) now go through the local src/browser barrel instead of reaching into individual writer files. This was verified to leave the built bundle unchanged (same chunk split, same size) and to keep Vite's live-source dev loop working, since it still resolves to raw TypeScript rather than the built package.

Main risk is the new export surface itself: if a future change to one of the re-exported modules (ComponentParser, the writer-*-core files, document-model, brands) introduces a node: import, it would silently break sveld/browser for consumers. The new browser.test.ts guards against that by scanning the whole import graph, so it should fail loudly in CI rather than at a consumer's build time.