### PR TITLE
fix(parse-entry-exports): warn instead of silently dropping unparseable re-exports

### DIFF
--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -270,7 +270,9 @@ function parseModule(filePath: string): { source: ModuleSource; body: AstNode[] 
     const ast = parse(text, { modern: true }) as { instance?: { content?: { body?: unknown } } };
     const body = asNodeArray(ast.instance?.content?.body);
     return { source: { text, filePath, dir: dirname(filePath) }, body };
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Warning: Failed to parse entry export module ${filePath}: ${message}`);
     return null;
   }
 }

--- a/tests/parse-entry-exports.test.ts
+++ b/tests/parse-entry-exports.test.ts
@@ -1,3 +1,5 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { type EntryExport, parseEntryExports } from "../src/parse-entry-exports";
 
@@ -128,5 +130,44 @@ describe("parseEntryExports", () => {
     expect(byName(exports, "clamp").source).toBe("./utils.ts");
     expect(byName(exports, "Theme").source).toBe("./types.ts");
     expect(byName(exports, "DEFAULT_THEME").source).toBe("./index.ts");
+  });
+
+  test("warns and skips a re-exported module the underlying parser can't handle, instead of throwing", () => {
+    // Not written under tests/fixtures-entry-exports because the redeclaration
+    // below (valid to acorn-typescript, rejected by tsc/biome) would otherwise
+    // trip up `tsc --noEmit` and `biome lint`, which both cover tests/**/*.
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-entry-exports-parse-failure-"));
+    try {
+      writeFileSync(path.join(dir, "types.ts"), 'export type Theme = "light" | "dark";\n');
+      writeFileSync(
+        path.join(dir, "theme.ts"),
+        [
+          'import type { Theme } from "./types";',
+          "",
+          'export const Theme: { current: Theme } = { current: "light" };',
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(path.join(dir, "other.ts"), 'export const VERSION = "1.0.0";\n');
+      writeFileSync(
+        path.join(dir, "index.ts"),
+        ['export { Theme } from "./theme";', 'export { VERSION } from "./other";', ""].join("\n"),
+      );
+
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const exports = parseEntryExports(path.join(dir, "index.ts"));
+
+      // The unaffected module's exports still come through.
+      expect(byName(exports, "VERSION")).toMatchObject({ name: "VERSION", kind: "const" });
+
+      // The module the parser can't handle contributes no type info, but the
+      // failure is surfaced instead of failing silently.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("theme.ts"));
+
+      warn.mockRestore();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
When a module in the entry barrel's re-export graph fails to parse, parseModule caught the error and returned null with no diagnostic anywhere in the pipeline. collectModuleExports then cached an empty export list for that file, so its exports quietly vanished from generated docs with no warning that anything went wrong.

This surfaces on a real, valid TypeScript pattern: a type-only import shadowed by a same-named value export (declaration merging), which acorn-typescript throws on with "Identifier has already been declared". Since the failure only shows up when a specific module in the graph can't be parsed, a project could ship stale or incomplete docs indefinitely with zero signal.

The fix routes the caught error through console.warn with the file path and message, matching the existing pattern already used for the sibling parseExports failure path in bundle.ts. It does not change what gets returned for the failing module, callers still get an empty or best-effort export list for it, just now with a visible warning instead of silence.

Risk is low. The change only adds a warning on an already-failing path; no behavior change for the success path. Added a regression test in tests/parse-entry-exports.test.ts using a temp directory (kept out of tests/fixtures-entry-exports since the redeclaration needed to trigger the parser error would otherwise fail tsc and biome lint, which both check tests/**/*).