### PR TITLE
fix(types): preserve variant-only properties in union whole-props resolution

### DIFF
--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -45,12 +45,14 @@ const EXAMPLE_CODE_START_LINE = 2;
 export class TypeResolver {
   private readonly api: TS;
   private readonly symbolFlags: TS;
+  private readonly typeFlags: TS;
   private readonly tsconfigPath: string;
   private readonly overlay = new Map<string, string>();
 
-  private constructor(api: TS, symbolFlags: TS, tsconfigPath: string) {
+  private constructor(api: TS, symbolFlags: TS, typeFlags: TS, tsconfigPath: string) {
     this.api = api;
     this.symbolFlags = symbolFlags;
+    this.typeFlags = typeFlags;
     this.tsconfigPath = tsconfigPath;
   }
 
@@ -76,7 +78,7 @@ export class TypeResolver {
       return null;
     }
 
-    const resolver = new TypeResolver(null, mod.SymbolFlags, tsconfigPath);
+    const resolver = new TypeResolver(null, mod.SymbolFlags, mod.TypeFlags, tsconfigPath);
     const api = new mod.API({ cwd, fs: resolver.createFileSystem() });
     // biome-ignore lint/suspicious/noExplicitAny: assign after fs closure is created.
     (resolver as any).api = api;
@@ -115,6 +117,10 @@ export class TypeResolver {
       const checker = project.checker;
 
       // Phase 1: per-file type-at-position + properties-of-type (no batch API; different files/types).
+      // `getPropertiesOfType` on a union type only returns properties shared by every
+      // constituent, so a discriminated union like `ClickEvent | HoverEvent` would silently
+      // drop `target`/`duration`. Walk each constituent too and fold in the variant-only
+      // properties, marking them optional since no single instance is guaranteed to have them.
       const perFile = await Promise.all(
         Array.from(virtualFiles, async ([virtualFile, target]) => {
           const content = this.overlay.get(virtualFile);
@@ -122,21 +128,45 @@ export class TypeResolver {
           const position = bindingPosition(content);
           const type = await checker.getTypeAtPosition(virtualFile, position);
           if (!type) return null;
-          const properties: TS[] = await checker.getPropertiesOfType(type);
-          const symbols = properties.filter((symbol: TS) => symbol.name && !symbol.name.startsWith("__"));
-          return { moduleName: target.moduleName, symbols };
+
+          const groups = new Map<string, { name: string; symbols: TS[]; forceOptional: boolean }>();
+          const sharedProperties: TS[] = await checker.getPropertiesOfType(type);
+          for (const symbol of sharedProperties) {
+            if (!symbol.name || symbol.name.startsWith("__")) continue;
+            groups.set(symbol.name, { name: symbol.name, symbols: [symbol], forceOptional: false });
+          }
+
+          const isUnion = (type.flags & this.typeFlags.Union) !== 0;
+          if (isUnion) {
+            const constituents: TS[] = await type.getTypes();
+            const perConstituentProperties = await Promise.all(
+              constituents.map((constituent) => checker.getPropertiesOfType(constituent)),
+            );
+            for (const constituentProperties of perConstituentProperties) {
+              for (const symbol of constituentProperties) {
+                if (!symbol.name || symbol.name.startsWith("__") || groups.has(symbol.name)) continue;
+                const existing = groups.get(symbol.name);
+                if (existing) existing.symbols.push(symbol);
+                else groups.set(symbol.name, { name: symbol.name, symbols: [symbol], forceOptional: true });
+              }
+            }
+          }
+
+          return { moduleName: target.moduleName, groups: Array.from(groups.values()) };
         }),
       );
 
-      // Phase 2: batch getTypeOfSymbol across every prop of every component in one round trip.
+      // Phase 2: batch getTypeOfSymbol across every prop occurrence of every component in one round trip.
       const allSymbols: TS[] = [];
-      const owner: number[] = [];
+      const owner: Array<{ fileIndex: number; groupIndex: number }> = [];
       perFile.forEach((entry, fileIndex) => {
         if (!entry) return;
-        for (const symbol of entry.symbols) {
-          allSymbols.push(symbol);
-          owner.push(fileIndex);
-        }
+        entry.groups.forEach((group, groupIndex) => {
+          for (const symbol of group.symbols) {
+            allSymbols.push(symbol);
+            owner.push({ fileIndex, groupIndex });
+          }
+        });
       });
       const propTypes: TS[] = allSymbols.length > 0 ? await checker.getTypeOfSymbol(allSymbols) : [];
 
@@ -145,19 +175,29 @@ export class TypeResolver {
         propTypes.map((propType) => (propType ? checker.typeToString(propType) : Promise.resolve("any"))),
       );
 
-      const byFile = new Map<number, ResolvedComponentProp[]>();
+      const textsByGroup = new Map<number, Map<number, string[]>>();
       allSymbols.forEach((symbol, i) => {
+        const { fileIndex, groupIndex } = owner[i];
         const isOptional = (symbol.flags & this.symbolFlags.Optional) !== 0;
         let typeText = typeTexts[i];
         if (isOptional) typeText = typeText.replace(TRAILING_UNDEFINED, "");
-        const list = byFile.get(owner[i]) ?? [];
-        list.push({ name: symbol.name, type: typeText, isRequired: !isOptional });
-        byFile.set(owner[i], list);
+        const fileGroups = textsByGroup.get(fileIndex) ?? new Map<number, string[]>();
+        const texts = fileGroups.get(groupIndex) ?? [];
+        texts.push(typeText);
+        fileGroups.set(groupIndex, texts);
+        textsByGroup.set(fileIndex, fileGroups);
       });
 
       perFile.forEach((entry, fileIndex) => {
         if (!entry) return;
-        const resolved = byFile.get(fileIndex) ?? [];
+        const fileGroups = textsByGroup.get(fileIndex);
+        const resolved: ResolvedComponentProp[] = entry.groups.map((group, groupIndex) => {
+          const texts = fileGroups?.get(groupIndex) ?? [];
+          const isRequired = !(
+            group.forceOptional || group.symbols.some((symbol) => (symbol.flags & this.symbolFlags.Optional) !== 0)
+          );
+          return { name: group.name, type: Array.from(new Set(texts)).join(" | "), isRequired };
+        });
         resolved.sort((a, b) => a.name.localeCompare(b.name));
         results.set(entry.moduleName, resolved);
       });

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -10196,6 +10196,48 @@ exports[`fixtures (JSON) "required/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "slot-plain-text-attribute-prop/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "{ color: \\"red\\" }",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "dispatched-events-string-literal-detail/input.svelte" 1`] = `
 "{
   "source": {
@@ -12378,6 +12420,32 @@ exports[`fixtures (JSON) "non-literal-defaults/input.svelte" 1`] = `
       }
     }
   ]
+}
+"
+`;
+
+exports[`fixtures (JSON) "runes-whole-props-union-resolve-types/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
 }
 "
 `;
@@ -20760,6 +20828,21 @@ export default class Required extends SvelteComponentTyped<
 "
 `;
 
+exports[`fixtures (TypeScript) "slot-plain-text-attribute-prop/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+export type SlotPlainTextAttributePropProps = {
+  children?: (this: void, ...args: [{ color: "red" }]) => void;
+};
+
+export default class SlotPlainTextAttributeProp extends SvelteComponentTyped<
+  SlotPlainTextAttributePropProps,
+  Record<string, any>,
+  { default: { color: "red" } }
+> {}
+"
+`;
+
 exports[`fixtures (TypeScript) "dispatched-events-string-literal-detail/input.svelte" 1`] = `
 "import { SvelteComponentTyped } from "svelte";
 
@@ -21351,6 +21434,22 @@ export type NonLiteralDefaultsProps = {
 
 export default class NonLiteralDefaults extends SvelteComponentTyped<
   NonLiteralDefaultsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-whole-props-union-resolve-types/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Props } from "./types";
+
+type $Props = Props;
+
+export type RunesWholePropsUnionResolveTypesProps = $Props;
+
+export default class RunesWholePropsUnionResolveTypes extends SvelteComponentTyped<
+  RunesWholePropsUnionResolveTypesProps,
   Record<string, any>,
   Record<string, never>
 > {}
@@ -23206,63 +23305,6 @@ export default class SlotDescriptionHyphensInline extends SvelteComponentTyped<
     /** Row id maps to server-side UUID v4 (not v1-v3). */
     item: { id: string };
   }
-> {}
-"
-`;
-
-exports[`fixtures (JSON) "slot-plain-text-attribute-prop/input.svelte" 1`] = `
-"{
-  "source": {
-    "start": {
-      "line": 1,
-      "column": 0
-    },
-    "end": {
-      "line": 5,
-      "column": 0
-    }
-  },
-  "syntaxMode": "legacy",
-  "scriptLanguage": "js",
-  "props": [],
-  "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "{ color: \\"red\\" }",
-      "source": {
-        "start": {
-          "line": 4,
-          "column": 0
-        },
-        "end": {
-          "line": 4,
-          "column": 20
-        }
-      }
-    }
-  ],
-  "events": [],
-  "typedefs": [],
-  "generics": null,
-  "contexts": [],
-  "diagnostics": []
-}
-"
-`;
-
-exports[`fixtures (TypeScript) "slot-plain-text-attribute-prop/input.svelte" 1`] = `
-"import { SvelteComponentTyped } from "svelte";
-
-export type SlotPlainTextAttributePropProps = {
-  children?: (this: void, ...args: [{ color: "red" }]) => void;
-};
-
-export default class SlotPlainTextAttributeProp extends SvelteComponentTyped<
-  SlotPlainTextAttributePropProps,
-  Record<string, any>,
-  { default: { color: "red" } }
 > {}
 "
 `;

--- a/tests/fixtures/runes-whole-props-union-resolve-types/input.svelte
+++ b/tests/fixtures/runes-whole-props-union-resolve-types/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Props } from "./types";
+
+  let props: Props = $props();
+</script>
+
+<div data-kind={props.kind}></div>

--- a/tests/fixtures/runes-whole-props-union-resolve-types/output.d.ts
+++ b/tests/fixtures/runes-whole-props-union-resolve-types/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Props } from "./types";
+
+type $Props = Props;
+
+export type RunesWholePropsUnionResolveTypesProps = $Props;
+
+export default class RunesWholePropsUnionResolveTypes extends SvelteComponentTyped<
+  RunesWholePropsUnionResolveTypesProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-whole-props-union-resolve-types/output.json
+++ b/tests/fixtures/runes-whole-props-union-resolve-types/output.json
@@ -1,0 +1,22 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-whole-props-union-resolve-types/types.ts
+++ b/tests/fixtures/runes-whole-props-union-resolve-types/types.ts
@@ -1,0 +1,11 @@
+export interface ClickEvent {
+  kind: "click";
+  target: string;
+}
+
+export interface HoverEvent {
+  kind: "hover";
+  duration: number;
+}
+
+export type Props = ClickEvent | HoverEvent;

--- a/tests/resolve-types.test.ts
+++ b/tests/resolve-types.test.ts
@@ -6,12 +6,24 @@ import { TypeResolver } from "../src/resolve-types";
 const FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "runes-whole-props-imported");
 const COMPONENT_PATH = path.join(FIXTURE_DIR, "input.svelte");
 
+const UNION_FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "runes-whole-props-union-resolve-types");
+const UNION_COMPONENT_PATH = path.join(UNION_FIXTURE_DIR, "input.svelte");
+
 async function parseFixture() {
   const source = await Bun.file(COMPONENT_PATH).text();
   const parser = new ComponentParser();
   return parser.parseSvelteComponent(source, {
     moduleName: "RunesWholePropsImported",
     filePath: asNormalizedPath(COMPONENT_PATH),
+  });
+}
+
+async function parseUnionFixture() {
+  const source = await Bun.file(UNION_COMPONENT_PATH).text();
+  const parser = new ComponentParser();
+  return parser.parseSvelteComponent(source, {
+    moduleName: "RunesWholePropsUnionResolveTypes",
+    filePath: asNormalizedPath(UNION_COMPONENT_PATH),
   });
 }
 
@@ -56,5 +68,36 @@ describe("opt-in TypeScript semantic resolution", () => {
       isRequired: true,
       typeSource: "typescript",
     });
+  }, 30_000);
+
+  test("resolveTypes preserves variant-only properties from a discriminated union whole-props type", async () => {
+    const parsed = await parseUnionFixture();
+    const metadata = getParsedComponentTypeScriptMetadata(parsed);
+    if (!metadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
+
+    const resolver = await TypeResolver.create(UNION_FIXTURE_DIR);
+    expect(resolver).not.toBeNull();
+    if (!resolver) return;
+
+    try {
+      const resolved = await resolver.expandAll([
+        {
+          moduleName: "RunesWholePropsUnionResolveTypes",
+          metadata,
+          filePath: UNION_COMPONENT_PATH,
+        },
+      ]);
+
+      applyResolvedProps(parsed, resolved.get("RunesWholePropsUnionResolveTypes") ?? []);
+    } finally {
+      await resolver.dispose();
+    }
+
+    const byName = Object.fromEntries(parsed.props.map((prop) => [prop.name, prop]));
+    expect(Object.keys(byName).sort()).toEqual(["duration", "kind", "target"]);
+
+    expect(byName.kind).toMatchObject({ type: '"click" | "hover"', isRequired: true, typeSource: "typescript" });
+    expect(byName.target).toMatchObject({ type: "string", isRequired: false, typeSource: "typescript" });
+    expect(byName.duration).toMatchObject({ type: "number", isRequired: false, typeSource: "typescript" });
   }, 30_000);
 });


### PR DESCRIPTION
resolveTypes expands an imported whole-props type by calling getPropertiesOfType on it, but for a union type that TypeScript API only returns properties shared by every constituent. A discriminated union like ClickEvent | HoverEvent lost any field unique to one member, so target on ClickEvent and duration on HoverEvent silently vanished from the generated docs with no error.

The fix detects a union type and additionally walks each constituent with getTypes(), merging in properties not already covered by the shared set and marking them optional since no single instance of the union is guaranteed to have them. If the same property name shows up in more than one non-shared constituent, its resolved types get unioned together.

Adds the runes-whole-props-union-resolve-types fixture and a resolve-types test covering the discriminated union case, plus a fix for a noAwaitInLoops lint violation introduced by the per-constituent lookups. Risk is limited to the resolveTypes opt-in path; the non-union code path is unchanged and all existing snapshots and tests still pass. Worth watching for unions with many constituents or deeply nested unions of unions, which this handles for one level of flattening but doesn't recurse into.