### PR TITLE
fix(resolve-types): stop fabricating types for props parameterized by a component's own generic

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -165,6 +165,13 @@ export interface ParsedComponentTypeScriptMetadata {
   canonicalPropNames: string[];
   localTypeDeclarations: string[];
   typeImportStatements: string[];
+  /**
+   * Whether `canonicalPropsType` mentions one of the component's own
+   * `<script generics="...">` parameters (e.g. `Props<T>`). The semantic
+   * resolver has no binding for `T`, so `resolveTypes` must leave this
+   * component's props as their AST-derived text rather than expand them.
+   */
+  referencesComponentGenerics?: boolean;
 }
 
 export const PARSED_COMPONENT_TYPE_SCRIPT_METADATA = Symbol("sveld.parsedComponentTypeScriptMetadata");

--- a/src/parser/type-resolution.ts
+++ b/src/parser/type-resolution.ts
@@ -1,6 +1,30 @@
-import type { LocalTypeDeclaration, ModernRunesTypeNode, ParsedComponentTypeScriptMetadata } from "../ComponentParser";
+import type {
+  ComponentGenerics,
+  LocalTypeDeclaration,
+  ModernRunesTypeNode,
+  ParsedComponentTypeScriptMetadata,
+} from "../ComponentParser";
 import type { ParserContext } from "./context";
 import { sourceAtPos } from "./source-position";
+
+const GENERIC_TYPE_TEXT_IDENTIFIER_REGEX = /[A-Za-z_$][\w$]*/g;
+
+/**
+ * Whether `typeText` (e.g. a canonical `$props()` type like `Props<T>`)
+ * mentions one of `generics`' own parameter names as a bare identifier.
+ * Used to detect whole-props types parameterized by the component's own
+ * generic, which the semantic type resolver can't safely expand: it has no
+ * binding for the generic in its virtual module, so TypeScript treats it as
+ * an unresolved identifier and fabricates concrete-looking types instead.
+ */
+function typeTextReferencesGenerics(typeText: string, generics: ComponentGenerics): boolean {
+  if (!generics) return false;
+  const names = new Set(generics[0].split(",").map((name) => name.trim()));
+  for (const [name] of typeText.matchAll(GENERIC_TYPE_TEXT_IDENTIFIER_REGEX)) {
+    if (names.has(name)) return true;
+  }
+  return false;
+}
 
 /**
  * Looks up the modern-runes `$props()` declaration metadata recorded for the
@@ -278,5 +302,6 @@ export function buildTypeScriptMetadata(ctx: ParserContext): ParsedComponentType
     canonicalPropNames: Array.from(typedDeclaration.props.keys()).sort(),
     localTypeDeclarations,
     typeImportStatements: buildTypeImportStatements(ctx, typedDeclaration.referencedImportedTypes),
+    referencesComponentGenerics: typeTextReferencesGenerics(typedDeclaration.canonicalType, ctx.generics),
   };
 }

--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -93,6 +93,13 @@ export class TypeResolver {
     const virtualFiles = new Map<string, ResolveTarget>();
     for (const target of targets) {
       if (!target.metadata.canonicalPropsType) continue;
+      // The whole-props type references the component's own <script generics>
+      // parameter (e.g. `Props<T>`). The virtual module below has no binding
+      // for that generic, so the checker would treat it as an unresolved
+      // identifier and fabricate concrete-looking types (conditional types
+      // collapse to a union of both branches, `keyof T` becomes `string |
+      // number | symbol`, etc). Leave these props as their AST-derived text.
+      if (target.metadata.referencesComponentGenerics) continue;
       const virtualFile = this.virtualFileName(target.filePath, target.moduleName);
       this.overlay.set(virtualFile, buildVirtualModule(target.metadata));
       virtualFiles.set(virtualFile, target);

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -14926,6 +14926,35 @@ exports[`fixtures (JSON) "context-template-tag/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-whole-props-generic-resolve-types/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 15,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "T",
+    "T extends Identifiable"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "runes-whole-props-imported/input.svelte" 1`] = `
 "{
   "source": {
@@ -22218,6 +22247,26 @@ export default class ContextTemplateTag<Row extends DataTableRow = DataTableRow>
   ContextTemplateTagProps<Row>,
   Record<string, any>,
   { default: Record<string, never> }
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-whole-props-generic-resolve-types/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Props } from "./types";
+
+interface Identifiable {
+  id: string;
+}
+
+type $Props<T extends Identifiable> = Props<T>;
+
+export type RunesWholePropsGenericResolveTypesProps<T extends Identifiable> = $Props<T>;
+
+export default class RunesWholePropsGenericResolveTypes<T extends Identifiable> extends SvelteComponentTyped<
+  RunesWholePropsGenericResolveTypesProps<T>,
+  Record<string, any>,
+  Record<string, never>
 > {}
 "
 `;

--- a/tests/fixtures/runes-whole-props-generic-resolve-types/input.svelte
+++ b/tests/fixtures/runes-whole-props-generic-resolve-types/input.svelte
@@ -1,0 +1,14 @@
+<script
+  lang="ts"
+  generics="T extends Identifiable"
+>
+  import type { Props } from "./types";
+
+  interface Identifiable {
+    id: string;
+  }
+
+  let props: Props<T> = $props();
+</script>
+
+<p>{props.item.id}</p>

--- a/tests/fixtures/runes-whole-props-generic-resolve-types/output.d.ts
+++ b/tests/fixtures/runes-whole-props-generic-resolve-types/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Props } from "./types";
+
+interface Identifiable {
+  id: string;
+}
+
+type $Props<T extends Identifiable> = Props<T>;
+
+export type RunesWholePropsGenericResolveTypesProps<T extends Identifiable> = $Props<T>;
+
+export default class RunesWholePropsGenericResolveTypes<T extends Identifiable> extends SvelteComponentTyped<
+  RunesWholePropsGenericResolveTypesProps<T>,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-whole-props-generic-resolve-types/output.json
+++ b/tests/fixtures/runes-whole-props-generic-resolve-types/output.json
@@ -1,0 +1,25 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 15,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "T",
+    "T extends Identifiable"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-whole-props-generic-resolve-types/types.ts
+++ b/tests/fixtures/runes-whole-props-generic-resolve-types/types.ts
@@ -1,0 +1,12 @@
+export interface StringWrap {
+  text: string;
+}
+export interface ObjectWrap<T> {
+  value: T;
+}
+export type Wrapped<T> = T extends string ? StringWrap : ObjectWrap<T>;
+export interface Props<T> {
+  item: T;
+  wrapped: Wrapped<T>;
+  keys: keyof T;
+}

--- a/tests/resolve-types.test.ts
+++ b/tests/resolve-types.test.ts
@@ -9,6 +9,9 @@ const COMPONENT_PATH = path.join(FIXTURE_DIR, "input.svelte");
 const UNION_FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "runes-whole-props-union-resolve-types");
 const UNION_COMPONENT_PATH = path.join(UNION_FIXTURE_DIR, "input.svelte");
 
+const GENERIC_FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "runes-whole-props-generic-resolve-types");
+const GENERIC_COMPONENT_PATH = path.join(GENERIC_FIXTURE_DIR, "input.svelte");
+
 async function parseFixture() {
   const source = await Bun.file(COMPONENT_PATH).text();
   const parser = new ComponentParser();
@@ -24,6 +27,15 @@ async function parseUnionFixture() {
   return parser.parseSvelteComponent(source, {
     moduleName: "RunesWholePropsUnionResolveTypes",
     filePath: asNormalizedPath(UNION_COMPONENT_PATH),
+  });
+}
+
+async function parseGenericFixture() {
+  const source = await Bun.file(GENERIC_COMPONENT_PATH).text();
+  const parser = new ComponentParser();
+  return parser.parseSvelteComponent(source, {
+    moduleName: "RunesWholePropsGenericResolveTypes",
+    filePath: asNormalizedPath(GENERIC_COMPONENT_PATH),
   });
 }
 
@@ -99,5 +111,39 @@ describe("opt-in TypeScript semantic resolution", () => {
     expect(byName.kind).toMatchObject({ type: '"click" | "hover"', isRequired: true, typeSource: "typescript" });
     expect(byName.target).toMatchObject({ type: "string", isRequired: false, typeSource: "typescript" });
     expect(byName.duration).toMatchObject({ type: "number", isRequired: false, typeSource: "typescript" });
+  }, 30_000);
+
+  test("resolveTypes leaves a whole-props type parameterized by the component's own generic unexpanded", async () => {
+    const parsed = await parseGenericFixture();
+    const metadata = getParsedComponentTypeScriptMetadata(parsed);
+    if (!metadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
+
+    expect(metadata.canonicalPropsType).toBe("Props<T>");
+    expect(metadata.referencesComponentGenerics).toBe(true);
+
+    const resolver = await TypeResolver.create(GENERIC_FIXTURE_DIR);
+    expect(resolver).not.toBeNull();
+    if (!resolver) return;
+
+    try {
+      const resolved = await resolver.expandAll([
+        {
+          moduleName: "RunesWholePropsGenericResolveTypes",
+          metadata,
+          filePath: GENERIC_COMPONENT_PATH,
+        },
+      ]);
+
+      // No entry: the resolver must not fabricate types for a generic it
+      // can't bind, rather than guessing at (and getting wrong) unions.
+      expect(resolved.has("RunesWholePropsGenericResolveTypes")).toBe(false);
+
+      applyResolvedProps(parsed, resolved.get("RunesWholePropsGenericResolveTypes") ?? []);
+    } finally {
+      await resolver.dispose();
+    }
+
+    // Falls back to the same opaque, AST-derived shape the default path produces.
+    expect(parsed.props).toEqual([]);
   }, 30_000);
 });


### PR DESCRIPTION
When resolveTypes is enabled, a component whose whole-props type references its own script generics parameter (for example Props<T>) had that parameter treated as a free, undeclared identifier in the resolver's virtual module. TypeScript degrades an unresolved type parameter toward any, which silently collapses conditional types into a union of both branches and turns keyof T into string | number | symbol. This produced wrong, fabricated prop types with no diagnostic, which is worse than the AST-mode fallback resolveTypes is meant to improve on.

The fix detects when a component's canonical props type references its own generic parameter names and skips semantic expansion for that component, falling back to the same opaque, AST-derived props shape the default (non resolveTypes) path already produces correctly.

Adds a new fixture (runes-whole-props-generic-resolve-types) and a resolve-types test covering the case. Risk is limited to the resolveTypes opt-in path: components without self-referential generics in their whole-props type are unaffected, and the change only removes incorrect output in favor of the existing opaque fallback.