### PR TITLE
fix(parser): set isFunction for TS-typed callback props with no default

### DIFF
--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -394,7 +394,8 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
         !!propertyJSDoc?.params?.length ||
         propertyJSDoc?.returnType !== undefined ||
         propertyJSDoc?.type?.includes("=>") ||
-        !!inheritedType?.includes("=>");
+        !!inheritedType?.includes("=>") ||
+        !!typeMetadata?.type?.includes("=>");
       const type = typeMetadata?.type ?? propertyJSDoc?.type ?? inheritedType ?? inferredType;
       const typeSource = parser.resolveTypeSource({
         hasTypeScriptType: typeMetadata?.type !== undefined,

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -8159,6 +8159,54 @@ exports[`fixtures (JSON) "forwarded-events-typed/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-callback-prop-ts-type-no-default/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "measure",
+      "kind": "let",
+      "type": "(node: HTMLElement) => Attachment",
+      "typeSource": "typescript",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 15
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "prop-default-identifier-jsdoc/input.svelte" 1`] = `
 "{
   "source": {
@@ -9294,7 +9342,7 @@ exports[`fixtures (JSON) "runes-attachment-factory/input.svelte" 1`] = `
       "kind": "let",
       "type": "(text: string) => Attachment",
       "typeSource": "typescript",
-      "isFunction": false,
+      "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
       "constant": false,
@@ -20133,6 +20181,22 @@ export default class ForwardedEventsTyped extends SvelteComponentTyped<
     /** Fired when the button receives focus */
     focus: WindowEventMap["focus"];
   },
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-callback-prop-ts-type-no-default/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { measure?: (node: HTMLElement) => Attachment };
+
+export type RunesCallbackPropTsTypeNoDefaultProps = $Props;
+
+export default class RunesCallbackPropTsTypeNoDefault extends SvelteComponentTyped<
+  RunesCallbackPropTsTypeNoDefaultProps,
+  Record<string, any>,
   Record<string, never>
 > {}
 "

--- a/tests/fixtures/runes-callback-prop-ts-type-no-default/input.svelte
+++ b/tests/fixtures/runes-callback-prop-ts-type-no-default/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Attachment } from "svelte/attachments";
+
+  let { measure }: { measure?: (node: HTMLElement) => Attachment } = $props();
+</script>
+
+<div {@attach measure}></div>

--- a/tests/fixtures/runes-callback-prop-ts-type-no-default/output.d.ts
+++ b/tests/fixtures/runes-callback-prop-ts-type-no-default/output.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+import type { Attachment } from "svelte/attachments";
+
+type $Props = { measure?: (node: HTMLElement) => Attachment };
+
+export type RunesCallbackPropTsTypeNoDefaultProps = $Props;
+
+export default class RunesCallbackPropTsTypeNoDefault extends SvelteComponentTyped<
+  RunesCallbackPropTsTypeNoDefaultProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-callback-prop-ts-type-no-default/output.json
+++ b/tests/fixtures/runes-callback-prop-ts-type-no-default/output.json
@@ -13,9 +13,9 @@
   "scriptLanguage": "ts",
   "props": [
     {
-      "name": "createTooltip",
+      "name": "measure",
       "kind": "let",
-      "type": "(text: string) => Attachment",
+      "type": "(node: HTMLElement) => Attachment",
       "typeSource": "typescript",
       "isFunction": true,
       "isFunctionDeclaration": false,
@@ -29,7 +29,7 @@
         },
         "end": {
           "line": 4,
-          "column": 21
+          "column": 15
         }
       }
     }


### PR DESCRIPTION
Callback props declared with a plain TS interface or object type annotation and no default value, the common attachment-factory pattern like measure?: (node: HTMLElement) => Attachment, were reported as isFunction: false in the JSON API even though the type is clearly a function signature. The isFunction check only looked at JSDoc and the inherited type string, never the parsed TypeScript type text, so it missed this case even though the same semantics expressed through JSDoc `@type` already produced isFunction: true.

The fix adds a check on the parsed TS type text in src/parser/runes-props.ts. The .d.ts output was already correct since it takes a separate canonical-type path that regex-checks the type string for "=>", so this only changes the JSON output.

This also corrects the pre-existing runes-attachment-factory fixture, which had the same bug pattern, and adds a new fixture for a TS-typed callback prop with no default value. Risk is low: the change only widens isFunction detection to one more case in the JSON output path, and the full test suite (704 tests) and fixture type-check pass.