### PR TITLE
fix(parser): substitute generic type arguments in runes prop types

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -135,6 +135,10 @@ export type ModernRunesTypeNode = {
   typeName?: unknown;
   types?: ModernRunesTypeNode[];
   members?: ModernRunesTypeMember[];
+  /** Declaration-side `<T, U = Default>` (interfaces/type aliases). */
+  typeParameters?: { params?: Array<{ name?: string }> };
+  /** Reference-side `<string, number>` concrete arguments (`TSTypeReference`). */
+  typeArguments?: { params?: ModernRunesTypeNode[] };
 };
 
 export type ModernRunesTypeMember = {

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -24,6 +24,41 @@ import {
   getTypeReferenceName,
 } from "./type-resolution";
 
+/** Any identifier-shaped token, used to substitute type-parameter names within a type's source text. */
+const IDENTIFIER_TOKEN_REGEX = /[A-Za-z_$][\w$]*/g;
+
+/**
+ * Maps a referenced interface/type-alias's own type-parameter names (`Props<T>`) to the
+ * concrete type-argument source text supplied at the reference site (`Props<string>`).
+ */
+function buildTypeParameterSubstitutions(
+  ctx: ParserContext,
+  declaration: ModernRunesTypeNode,
+  reference: ModernRunesTypeNode,
+): Map<string, string> {
+  const substitutions = new Map<string, string>();
+  const typeParams = declaration.typeParameters?.params;
+  const typeArgs = reference.typeArguments?.params;
+  if (!typeParams?.length || !typeArgs?.length) return substitutions;
+
+  for (let index = 0; index < typeParams.length; index++) {
+    const paramName = typeParams[index]?.name;
+    const argNode = typeArgs[index];
+    if (!paramName || argNode?.start === undefined || argNode?.end === undefined) continue;
+
+    const argText = sourceAtPos(ctx, argNode.start, argNode.end)?.trim();
+    if (argText) substitutions.set(paramName, argText);
+  }
+
+  return substitutions;
+}
+
+/** Replaces bare occurrences of substituted type-parameter names within a type's source text. */
+function substituteTypeParameters(type: string, substitutions: Map<string, string>): string {
+  if (substitutions.size === 0) return type;
+  return type.replace(IDENTIFIER_TOKEN_REGEX, (token) => substitutions.get(token) ?? token);
+}
+
 /** Flatten a runes `$props()` type node into prop name -> metadata, following local aliases and intersections. */
 export function buildRunesPropTypeMetadataMap(
   parser: ComponentParser,
@@ -95,8 +130,14 @@ export function buildRunesPropTypeMetadataMap(
       );
       visitedTypeNames.delete(typeName);
 
+      const substitutions = buildTypeParameterSubstitutions(ctx, declaration, typeNode);
       for (const [propName, memberMetadata] of nestedMetadata) {
-        metadata.set(propName, memberMetadata);
+        metadata.set(
+          propName,
+          substitutions.size === 0
+            ? memberMetadata
+            : { ...memberMetadata, type: substituteTypeParameters(memberMetadata.type, substitutions) },
+        );
       }
       break;
     }

--- a/tests/__snapshots__/fixtures.test.ts.snap
+++ b/tests/__snapshots__/fixtures.test.ts.snap
@@ -16953,6 +16953,75 @@ exports[`fixtures (JSON) "typedef-type-predicate/input.svelte" 1`] = `
 "
 `;
 
+exports[`fixtures (JSON) "runes-generic-interface-type-args/input.svelte" 1`] = `
+"{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 8
+        },
+        "end": {
+          "line": 6,
+          "column": 13
+        }
+      }
+    },
+    {
+      "name": "onchange",
+      "kind": "let",
+      "type": "(v: string) => void",
+      "typeSource": "typescript",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 15
+        },
+        "end": {
+          "line": 6,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}
+"
+`;
+
 exports[`fixtures (JSON) "slots-spread/input.svelte" 1`] = `
 "{
   "source": {
@@ -23293,6 +23362,26 @@ export type TypedefTypePredicateProps = {
 
 export default class TypedefTypePredicate extends SvelteComponentTyped<
   TypedefTypePredicateProps,
+  Record<string, any>,
+  Record<string, never>
+> {}
+"
+`;
+
+exports[`fixtures (TypeScript) "runes-generic-interface-type-args/input.svelte" 1`] = `
+"import { SvelteComponentTyped } from "svelte";
+
+interface Props<T> {
+  value: T;
+  onchange?: (v: T) => void;
+}
+
+type $Props = Props<string>;
+
+export type RunesGenericInterfaceTypeArgsProps = $Props;
+
+export default class RunesGenericInterfaceTypeArgs extends SvelteComponentTyped<
+  RunesGenericInterfaceTypeArgsProps,
   Record<string, any>,
   Record<string, never>
 > {}

--- a/tests/fixtures/runes-generic-interface-type-args/input.svelte
+++ b/tests/fixtures/runes-generic-interface-type-args/input.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  interface Props<T> {
+    value: T;
+    onchange?: (v: T) => void;
+  }
+  let { value, onchange }: Props<string> = $props();
+</script>
+
+<input
+  {value}
+  on:change={() => onchange?.(value)}
+>

--- a/tests/fixtures/runes-generic-interface-type-args/output.d.ts
+++ b/tests/fixtures/runes-generic-interface-type-args/output.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+interface Props<T> {
+  value: T;
+  onchange?: (v: T) => void;
+}
+
+type $Props = Props<string>;
+
+export type RunesGenericInterfaceTypeArgsProps = $Props;
+
+export default class RunesGenericInterfaceTypeArgs extends SvelteComponentTyped<
+  RunesGenericInterfaceTypeArgsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-generic-interface-type-args/output.json
+++ b/tests/fixtures/runes-generic-interface-type-args/output.json
@@ -1,0 +1,65 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 8
+        },
+        "end": {
+          "line": 6,
+          "column": 13
+        }
+      }
+    },
+    {
+      "name": "onchange",
+      "kind": "let",
+      "type": "(v: string) => void",
+      "typeSource": "typescript",
+      "isFunction": true,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 15
+        },
+        "end": {
+          "line": 6,
+          "column": 23
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
When a prop is typed with a generic interface instantiated with a concrete argument, like Props<T> used as Props<string>, sveld kept the raw type-parameter name T in the parsed prop metadata instead of substituting in the concrete argument. The .d.ts output stayed correct by accident because tsc resolves T itself against the verbatim-emitted type alias, but generated Markdown docs rendered the literal T in the props table, which is a real, user-visible documentation bug.

buildRunesPropTypeMetadataMap now builds a substitution map from a referenced interface or type alias's own type parameters to the concrete type arguments supplied at the reference site, and applies it via identifier-token replacement when flattening the referenced members into prop type strings. Component-level generics (the script generics attribute, where the type parameter is intentionally left free) are unaffected since substitution only kicks in when the reference site supplies concrete type arguments.

Added a fixture, runes-generic-interface-type-args, covering the case from the bug report. Full test suite passes (704 tests), including the existing runes-generics fixture that exercises free component-level generics, confirming no regression there. Risk is low and scoped to prop type-string rendering; worth watching for edge cases where a nested type re-declares a type parameter with the same name (shadowing), since substitution is token-based rather than scope-aware.