### PR TITLE
build(scripts): disable parse cache when --cache is not given

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:fix": "biome check --write --unsafe .",
     "build": "bun scripts/build.ts",
     "bench": "bun scripts/bench.ts",
+    "bench:cache": "bun scripts/bench.ts --cache",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -102,7 +102,10 @@ async function benchOnce(input: string, cacheFile: string | undefined, outDir: s
   mkdirSync(outDir, { recursive: true });
 
   const start = performance.now();
-  const result = await generateBundle(input, true, { cache: cacheFile });
+  // generateBundle enables the on-disk parse cache unless `cache` is explicitly
+  // false, so an undefined cacheFile must be mapped to false or the "cache off"
+  // runs silently read the warm cache in node_modules/.cache/sveld/.
+  const result = await generateBundle(input, true, { cache: cacheFile ?? false });
   const parsed = performance.now();
 
   // Every writer resolves its output paths against process.cwd(); run the


### PR DESCRIPTION
The bench script labels its default mode "cache off" but passed { cache: undefined } to generateBundle, which enables the on-disk parse cache unless cache is explicitly false. Default bench runs therefore read the warm cache in node_modules/.cache/sveld/ and reported parse times roughly 10x faster than a real cold parse (~13ms vs ~174ms median on the carbon fixture).

This maps an undefined cache file to cache: false so the default mode measures cold parses as advertised, and adds a bench:cache package script that exposes the existing --cache mode (run 1 cold, later runs warm).

Risk is limited to the benchmark tooling, no library code changes. The only observable effect is that default bench numbers get larger because they now measure real parses, so comparisons against previously recorded medians are not apples to apples.