### PR TITLE
feat(build)!: externalize svelte into a peer dependency

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,8 +24,11 @@ async function buildEntry(entrypoint: string, target: "node" | "browser") {
     minify: true,
     sourcemap: false,
     // Default Bun behavior treats `node_modules` imports as external; bundle
-    // them so `svelte/compiler` (and `estree-walker`) ship inside `lib`.
+    // them so dependencies like `estree-walker` ship inside `lib`. `svelte`
+    // is excluded below since it's a peer dependency resolved from the
+    // consumer's node_modules.
     packages: "bundle",
+    external: ["svelte"],
   });
 
   if (!result.success) {


### PR DESCRIPTION
The svelte compiler was bundled into lib/index.js, accounting for
roughly 65 percent of the published bundle. Every consumer of sveld
already has svelte installed, so the compiler is now resolved from the
consumer's node_modules instead, as an implicit peer dependency.

BREAKING CHANGE: sveld now parses components with the consumer's
installed svelte version instead of a bundled copy, and requires
svelte to be installed alongside it.

Generated output is byte identical and no snapshots changed.

Stacked on #371 (fixes a latent bug in the svelte-version lookup that
this PR would otherwise trigger). Base branch will retarget to `main`
automatically once #371 merges.

## Behavioral note

Today sveld ships a pinned copy of the svelte compiler, so parsing is deterministic regardless of the consumer's svelte version. After this change, sveld parses with the consumer's installed svelte. That is arguably more correct (matches the syntax their app actually uses; new template grammar like `{@attach}` arrives with their own upgrade), but it is a real behavior change and makes this a breaking release.

## No formal peerDependencies declaration

sveld relies on `modernAst` (compile option) and `compiled.metadata.runes`, both present since svelte 5.0.0, so in practice it needs svelte 5+. We deliberately did not add a `peerDependencies` entry for this, though: sveld can't verify a consumer's svelte version at install time, and some consumers may still have svelte 3/4 installed in their project for reasons unrelated to sveld. A strict `>=5.0.0` peer dependency would surface as an install-time conflict (or a noisy warning) for those projects even though sveld itself would only fail at parse time if actually invoked against an incompatible svelte version. svelte remains a devDependency for tests and is resolved from the consumer's node_modules at runtime, same as any other externalized dependency.

| | lib/index.js (minified) |
|---|---|
| before (main) | 1,272,130 bytes (~1.24 MB) |
| after | 571,418 bytes (~558 KB) |

## Test plan

- [x] `bun test` — 735 pass, 0 fail, zero snapshot changes
- [x] `bun run build`; confirmed `lib/index.js` no longer contains `svelte/compiler` source and imports it externally instead
- [x] Smoke-tested the built artifact in a clean temp project (plain Node, svelte 5.56.3 installed): `ComponentParser.parseSvelteComponent` and the CLI both run correctly against the consumer's svelte install