### PR TITLE
fix(build): read svelte's version from svelte/compiler, not svelte/package.json

### DIFF
--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import { version as svelteVersion } from "svelte/package.json";
+import { VERSION as svelteVersion } from "svelte/compiler";
 import { version as sveldVersion } from "../package.json";
 import {
   PARSED_COMPONENT_TYPE_SCRIPT_METADATA,

--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -1,4 +1,4 @@
-import { version as svelteVersion } from "svelte/package.json";
+import { VERSION as svelteVersion } from "svelte/compiler";
 import { name as packageName, version as packageVersion } from "../../package.json";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";


### PR DESCRIPTION
parse-cache.ts and document-model.ts statically imported the version
field from svelte/package.json. That import is a latent trap for any
build that stops bundling svelte, since Bun's bundler (and some other
bundlers) drop import attributes (`with { type: "json" }`) on
externalized imports, so a plain JSON import breaks under Node's
strict ESM loader once svelte is no longer inlined.

svelte/compiler already exports VERSION and needs no import
attribute, and it's already imported elsewhere in the browser-safe
code path.

## Why this is its own PR

I found this while working on #370, which externalizes svelte out of
the bundle. Once svelte is external, this import broke under Node's
strict ESM loader (verified by smoke-testing the built artifact in a
clean Node project). This fix stands alone: it has no behavioral
change today since svelte is still fully bundled on main, and no
bundle-size impact. #370 will be rebased on top of this once it merges.

## Test plan

- [x] `bun test` — 735 pass, 0 fail, zero snapshot changes
- [x] `bun run build` — `lib/index.js` is byte identical before and after (1,272,130 bytes)