### PR TITLE
perf(build): bundle a pruned svelte parser instead of the full compiler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ The pipeline, end to end:
 
 1. **Resolve the entry point.** [`get-svelte-entry.ts`](src/get-svelte-entry.ts) takes an explicit entry or falls back to `package.json#svelte`.
 2. **Parse exports.** [`parse-exports.ts`](src/parse-exports.ts) reads the barrel (for example `src/index.js`) to learn which components are public and under what names; [`create-exports.ts`](src/create-exports.ts) builds the export map. With `glob: true`, every `.svelte` file under the entry directory is discovered instead.
-3. **Parse each component.** [`ComponentParser.ts`](src/ComponentParser.ts) is the core. It compiles the component with `svelte/compiler`, walks the ESTree AST with `estree-walker`, and reads JSDoc with `comment-parser` to extract props, events, slots, typedefs, generics, contexts, and rest props into a `ParsedComponent`.
+3. **Parse each component.** [`ComponentParser.ts`](src/ComponentParser.ts) is the core. It parses the component via [`svelte-parse.ts`](src/svelte-parse.ts) (see that file for why it isn't just `import { parse } from "svelte/compiler"`), walks the ESTree AST with `estree-walker`, and reads JSDoc with `comment-parser` to extract props, events, slots, typedefs, generics, contexts, and rest props into a `ParsedComponent`.
 4. **Write output.** The `writer/` modules turn `ParsedComponent` into artifacts:
    - [`writer-ts-definitions.ts`](src/writer/writer-ts-definitions.ts) + [`writer-ts-definitions-core.ts`](src/writer/writer-ts-definitions-core.ts) → `.d.ts` extending `SvelteComponentTyped`.
    - [`writer-json.ts`](src/writer/writer-json.ts) → `COMPONENT_API.json` (carries a `schemaVersion`).

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "svelte": "^5.56.3",
         "tinyglobby": "^0.2.17",
         "typescript": "^7.0.2",
+        "zimmerframe": "^1.1.4",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "estree-walker": "^3.0.3",
     "svelte": "^5.56.3",
     "tinyglobby": "^0.2.17",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "zimmerframe": "^1.1.4"
   },
   "bin": {
     "sveld": "cli.js"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,7 +24,8 @@ async function buildEntry(entrypoint: string, target: "node" | "browser") {
     minify: true,
     sourcemap: false,
     // Default Bun behavior treats `node_modules` imports as external; bundle
-    // them so `svelte/compiler` (and `estree-walker`) ship inside `lib`.
+    // them so dependencies (estree-walker, and the pruned svelte parser
+    // imported by src/svelte-parse.ts) ship inside `lib`.
     packages: "bundle",
   });
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -15,7 +15,6 @@ import type {
 } from "estree";
 import type { Node } from "estree-walker";
 import { walk } from "estree-walker";
-import { parse } from "svelte/compiler";
 import {
   isCallExpressionNamed,
   isIdentifier,
@@ -52,6 +51,7 @@ import { addSlot, buildSlotPropsFromObjectExpression, extractRenderTagInfo } fro
 import { sourceAtPos, sourceRangeFromNode, sourceRangeFromOffsets } from "./parser/source-position";
 import { buildTypeScriptMetadata } from "./parser/type-resolution";
 import { stripTypeCastWrappers } from "./parser/typescript-casts";
+import { parse } from "./svelte-parse";
 
 /**
  * Regular expression for matching variable declarations.

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,7 +1,6 @@
 import { lstatSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
-import { parse as parseSvelte } from "svelte/compiler";
 import { globSync } from "tinyglobby";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
 import ComponentParser, {
@@ -17,6 +16,7 @@ import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { normalizeSeparators } from "./path";
 import type { TypeResolver } from "./resolve-types";
+import { parse as parseSvelte } from "./svelte-parse";
 
 export interface ComponentDocApi extends ParsedComponent {
   filePath: NormalizedPath;

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -1,13 +1,13 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import { VERSION as svelteVersion } from "svelte/compiler";
 import { version as sveldVersion } from "../package.json";
 import {
   PARSED_COMPONENT_TYPE_SCRIPT_METADATA,
   type ParsedComponent,
   type ParsedComponentTypeScriptMetadata,
 } from "./ComponentParser";
+import { VERSION as svelteVersion } from "./svelte-parse";
 
 /** Bumped whenever the on-disk cache shape changes in a way old caches can't read. */
 const CACHE_FORMAT_VERSION = 1;

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -1,8 +1,8 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import { parse } from "svelte/compiler";
 import { normalizeSeparators } from "./path";
 import { resolvePathAliasAbsolute } from "./resolve-alias";
+import { parse } from "./svelte-parse";
 
 /** One named export from the entry barrel (not a `.svelte` component). */
 export interface EntryExport {

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -1,5 +1,4 @@
 import type { AssignmentPattern, Identifier, Property, VariableDeclaration, VariableDeclarator } from "estree";
-import { parse } from "svelte/compiler";
 import { getTypeCastAnnotation, isCallExpressionNamed, unwrapTypeCastExpression } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type {
@@ -10,6 +9,7 @@ import type {
   RunesPropTypeMetadata,
   TypeImportBinding,
 } from "../ComponentParser";
+import { parse } from "../svelte-parse";
 import type { ParserContext } from "./context";
 import { collectGenericsAttributeTypeDependencies } from "./generics";
 import { processLeadingCommentsJSDoc, processNodeJSDoc } from "./jsdoc";

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -1,0 +1,74 @@
+/**
+ * A pruned reimplementation of `svelte/compiler`'s `parse` export and `VERSION`
+ * constant, built by importing only the parser phase directly instead of the
+ * public `svelte/compiler` entry point.
+ *
+ * `svelte/compiler` is a single module that, alongside `parse`, unconditionally
+ * imports the analyze and transform phases (needed for `compile`, which sveld
+ * doesn't use). Neither svelte, `aria-query`, nor `axobject-query` declare
+ * `"sideEffects": false`, so a bundler can't prove those phases are safe to
+ * drop even when their exports go unused - importing anything at all from
+ * `svelte/compiler` pulls in the full accessibility-linting dependency graph
+ * (aria-query's and axobject-query's role tables), which accounts for most of
+ * that module's size. Reimplementing the ~15-line public wrapper here against
+ * only the parser phase's internals avoids that graph entirely.
+ *
+ * This depends on undocumented internal svelte paths that aren't part of its
+ * public API surface (`package.json#exports` only exposes `svelte/compiler`
+ * as a whole). `tests/svelte-parse-shim.test.ts` guards against drift: it
+ * byte-compares this module's `parse` output against the real
+ * `svelte/compiler`'s across every fixture, so a svelte upgrade that changes
+ * this internal shape fails CI instead of silently shipping wrong output.
+ */
+// @ts-expect-error - internal svelte module, no published types
+
+import { walk as zimmerframeWalk } from "zimmerframe";
+import { convert } from "../node_modules/svelte/src/compiler/legacy.js";
+// @ts-expect-error - internal svelte module, no published types
+import { parse as parseFragment } from "../node_modules/svelte/src/compiler/phases/1-parse/index.js";
+// @ts-expect-error - internal svelte module, no published types
+import { reset as resetCompilerState } from "../node_modules/svelte/src/compiler/state.js";
+// @ts-expect-error - internal svelte module, no published types
+import { VERSION } from "../node_modules/svelte/src/version.js";
+
+function removeByteOrderMark(source: string): string {
+  return source.charCodeAt(0) === 0xfeff ? source.slice(1) : source;
+}
+
+/** Mirrors `svelte/compiler`'s own internal `to_public_ast`, which is equally loosely typed. */
+// biome-ignore lint/suspicious/noExplicitAny: mirrors upstream svelte's untyped AST-shape-agnostic cleanup
+function toPublicAst(source: string, ast: any, modern: boolean | undefined): unknown {
+  if (modern) {
+    // biome-ignore lint/suspicious/noExplicitAny: same as above
+    const clean = (node: any) => {
+      // biome-ignore lint/performance/noDelete: mirrors upstream svelte, which removes (not nulls) the property
+      delete node.metadata;
+    };
+
+    for (const attribute of ast.options?.attributes ?? []) {
+      clean(attribute);
+      clean(attribute.value);
+      if (Array.isArray(attribute.value)) {
+        attribute.value.forEach(clean);
+      }
+    }
+
+    return zimmerframeWalk(ast, null, {
+      _(node: unknown, { next }: { next: () => void }) {
+        clean(node);
+        next();
+      },
+    });
+  }
+
+  return convert(source, ast);
+}
+
+export function parse(source: string, { modern, loose }: { modern?: boolean; loose?: boolean } = {}): unknown {
+  const cleaned = removeByteOrderMark(source);
+  resetCompilerState({ warning: () => false, filename: undefined });
+  const ast = parseFragment(cleaned, loose);
+  return toPublicAst(cleaned, ast, modern);
+}
+
+export { VERSION };

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -20,42 +20,58 @@
  * `svelte/compiler`'s across every fixture, so a svelte upgrade that changes
  * this internal shape fails CI instead of silently shipping wrong output.
  */
-// @ts-expect-error - internal svelte module, no published types
-
 import { walk as zimmerframeWalk } from "zimmerframe";
+// @ts-expect-error - internal svelte module, no published types
 import { convert } from "../node_modules/svelte/src/compiler/legacy.js";
 // @ts-expect-error - internal svelte module, no published types
 import { parse as parseFragment } from "../node_modules/svelte/src/compiler/phases/1-parse/index.js";
 // @ts-expect-error - internal svelte module, no published types
 import { reset as resetCompilerState } from "../node_modules/svelte/src/compiler/state.js";
 // @ts-expect-error - internal svelte module, no published types
-import { VERSION } from "../node_modules/svelte/src/version.js";
+import { VERSION as VERSION_RAW } from "../node_modules/svelte/src/version.js";
+
+/**
+ * The pre-strip AST shape svelte's parser produces internally, before `metadata` (an
+ * implementation detail not part of svelte's public `AST.SvelteNode` types) is removed.
+ * `[key: string]: unknown` keeps this assignable from real parser output without `any`,
+ * and satisfies zimmerframe's `T extends { type: string }` walk constraint.
+ */
+interface InternalAstNode {
+  type: string;
+  metadata?: unknown;
+  [key: string]: unknown;
+}
+
+interface InternalAstRoot extends InternalAstNode {
+  options?: {
+    attributes?: Array<InternalAstNode & { value?: InternalAstNode | InternalAstNode[] }>;
+  };
+}
 
 function removeByteOrderMark(source: string): string {
   return source.charCodeAt(0) === 0xfeff ? source.slice(1) : source;
 }
 
-/** Mirrors `svelte/compiler`'s own internal `to_public_ast`, which is equally loosely typed. */
-// biome-ignore lint/suspicious/noExplicitAny: mirrors upstream svelte's untyped AST-shape-agnostic cleanup
-function toPublicAst(source: string, ast: any, modern: boolean | undefined): unknown {
-  if (modern) {
-    // biome-ignore lint/suspicious/noExplicitAny: same as above
-    const clean = (node: any) => {
-      // biome-ignore lint/performance/noDelete: mirrors upstream svelte, which removes (not nulls) the property
-      delete node.metadata;
-    };
+function stripMetadata(node: InternalAstNode): void {
+  // biome-ignore lint/performance/noDelete: mirrors upstream svelte, which removes (not nulls) the property
+  delete node.metadata;
+}
 
+/** Mirrors `svelte/compiler`'s own internal `to_public_ast`. */
+function toPublicAst(source: string, ast: InternalAstRoot, modern: boolean | undefined): unknown {
+  if (modern) {
     for (const attribute of ast.options?.attributes ?? []) {
-      clean(attribute);
-      clean(attribute.value);
-      if (Array.isArray(attribute.value)) {
-        attribute.value.forEach(clean);
+      stripMetadata(attribute);
+      if (attribute.value) {
+        for (const value of Array.isArray(attribute.value) ? attribute.value : [attribute.value]) {
+          stripMetadata(value);
+        }
       }
     }
 
     return zimmerframeWalk(ast, null, {
-      _(node: unknown, { next }: { next: () => void }) {
-        clean(node);
+      _(node, { next }) {
+        stripMetadata(node);
         next();
       },
     });
@@ -67,8 +83,8 @@ function toPublicAst(source: string, ast: any, modern: boolean | undefined): unk
 export function parse(source: string, { modern, loose }: { modern?: boolean; loose?: boolean } = {}): unknown {
   const cleaned = removeByteOrderMark(source);
   resetCompilerState({ warning: () => false, filename: undefined });
-  const ast = parseFragment(cleaned, loose);
+  const ast: InternalAstRoot = parseFragment(cleaned, loose);
   return toPublicAst(cleaned, ast, modern);
 }
 
-export { VERSION };
+export const VERSION: string = VERSION_RAW;

--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -1,7 +1,7 @@
-import { VERSION as svelteVersion } from "svelte/compiler";
 import { name as packageName, version as packageVersion } from "../../package.json";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { VERSION as svelteVersion } from "../svelte-parse";
 
 export const COMPONENT_API_SCHEMA_VERSION = 1;
 

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -24,11 +24,19 @@ function stripBlockComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
+const SRC_ROOT = join(__dirname, "..", "src");
+
 /**
  * Walks every module reachable from `src/browser.ts` via relative imports
  * and asserts none of them import a `node:*` built-in. Bare specifiers
  * (npm packages like `svelte/compiler`) are out of scope; they're expected
  * to be browser-safe on their own and get bundled by the consumer's tool.
+ * Relative imports that escape `src/` (e.g. `svelte-parse.ts` reaching
+ * directly into `node_modules/svelte/src/...`) are equally out of scope:
+ * they're still third-party package internals, just reached without a bare
+ * specifier, and third-party source isn't shaped for this regex-based walk
+ * (e.g. svelte's own source contains string templates like `from './${n}'`
+ * in error-message text, which aren't real import statements).
  */
 function collectRelativeImportGraph(entryFile: string): Map<string, string> {
   const files = new Map<string, string>();
@@ -47,6 +55,7 @@ function collectRelativeImportGraph(entryFile: string): Map<string, string> {
       // Imports of non-`.ts` files (e.g. `../../package.json`) already carry their extension.
       const hasExtension = FILE_EXTENSION_REGEX.test(specifier);
       const resolved = resolve(dirname(file), hasExtension ? specifier : `${specifier}.ts`);
+      if (!resolved.startsWith(`${SRC_ROOT}/`)) continue;
       if (!files.has(resolved)) queue.push(resolved);
     }
   }

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   asNormalizedPath,
   buildComponentApiDocument,
@@ -55,7 +55,11 @@ function collectRelativeImportGraph(entryFile: string): Map<string, string> {
       // Imports of non-`.ts` files (e.g. `../../package.json`) already carry their extension.
       const hasExtension = FILE_EXTENSION_REGEX.test(specifier);
       const resolved = resolve(dirname(file), hasExtension ? specifier : `${specifier}.ts`);
-      if (!resolved.startsWith(`${SRC_ROOT}/`)) continue;
+      // Cross-platform "is resolved inside SRC_ROOT" check: a plain string prefix
+      // comparison breaks on Windows, where path.resolve produces backslash-separated
+      // paths but a hardcoded "/" separator never matches them.
+      const relativeToSrcRoot = relative(SRC_ROOT, resolved);
+      if (relativeToSrcRoot.startsWith("..") || isAbsolute(relativeToSrcRoot)) continue;
       if (!files.has(resolved)) queue.push(resolved);
     }
   }

--- a/tests/svelte-parse-shim.test.ts
+++ b/tests/svelte-parse-shim.test.ts
@@ -18,7 +18,11 @@ import { parse as shimParse, VERSION as shimVersion } from "../src/svelte-parse"
 const root = path.join(process.cwd(), "tests");
 const files: string[] = [];
 
+// e2e fixture projects (tests/e2e/*) install real node_modules, which can contain
+// thousands of unrelated third-party .svelte files (e.g. an icon library) - scope
+// this to sveld's own fixtures, not whatever happens to be installed alongside them.
 for await (const file of new Glob("**/*.svelte").scan(root)) {
+  if (file.includes("node_modules")) continue;
   files.push(path.join(root, file));
 }
 

--- a/tests/svelte-parse-shim.test.ts
+++ b/tests/svelte-parse-shim.test.ts
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { Glob } from "bun";
+import { parse as realParse, VERSION as realVersion } from "svelte/compiler";
+import { parse as shimParse, VERSION as shimVersion } from "../src/svelte-parse";
+
+/**
+ * src/svelte-parse.ts reimplements svelte/compiler's `parse` and `VERSION`
+ * against svelte's internal, undocumented module paths (see that file's
+ * top-of-file comment for why). Those paths aren't covered by svelte's
+ * package.json#exports or semver contract, so a svelte upgrade could shift
+ * their shape without warning. This test is the guard: it byte-compares the
+ * shim's output against the real svelte/compiler across every fixture in the
+ * repo. If it starts failing after bumping the svelte devDependency, the shim
+ * (src/svelte-parse.ts) needs to be re-synced against svelte's current
+ * internals, not just have this test updated.
+ */
+
+const root = path.join(process.cwd(), "tests");
+const files: string[] = [];
+
+for await (const file of new Glob("**/*.svelte").scan(root)) {
+  files.push(path.join(root, file));
+}
+
+test("found a substantial number of fixture .svelte files to compare against", () => {
+  expect(files.length).toBeGreaterThan(100);
+});
+
+test("VERSION matches the real svelte/compiler", () => {
+  expect(shimVersion).toBe(realVersion);
+});
+
+describe("parse() output matches svelte/compiler byte-for-byte", () => {
+  for (const file of files) {
+    const relative = path.relative(root, file);
+
+    test(relative, async () => {
+      const source = await Bun.file(file).text();
+
+      for (const modern of [true, false] as const) {
+        for (const loose of [true, false] as const) {
+          // realParse's overload pair (modern: true vs false/undefined selects a different return
+          // type) can't express "dynamic boolean" - this test intentionally iterates both branches.
+          // biome-ignore lint/suspicious/noExplicitAny: see above
+          const options = { modern, loose } as any;
+
+          let real: unknown;
+          let realError: string | undefined;
+          try {
+            real = realParse(source, options);
+          } catch (error) {
+            realError = String(error);
+          }
+
+          let shim: unknown;
+          let shimError: string | undefined;
+          try {
+            shim = shimParse(source, { modern, loose });
+          } catch (error) {
+            shimError = String(error);
+          }
+
+          const label = `modern=${modern} loose=${loose}`;
+          expect([label, shimError]).toEqual([label, realError]);
+          if (!realError) {
+            expect(JSON.stringify(shim)).toBe(JSON.stringify(real));
+          }
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
`svelte/compiler` is a single module that, alongside `parse`, unconditionally imports the analyze and transform phases (needed for `compile`, which sveld doesn't call - it only ever uses `parse()`). Neither svelte, `aria-query`, nor `axobject-query` declare `"sideEffects": false`, so a bundler can't prove those phases are safe to drop even though their exports go unused: importing anything at all from `svelte/compiler` pulls in the full accessibility-linting dependency graph (`aria-query`'s and `axobject-query`'s ARIA role tables), which accounts for most of that module's size.

`src/svelte-parse.ts` reimplements `svelte/compiler`'s ~15-line public `parse()`/`VERSION` wrapper directly against svelte's internal parser phase, bypassing the barrel import and its side-effecting analyze/transform graph entirely.

## Supersedes #370

#370 externalized svelte as a peer dependency, shrinking `lib/index.js` further (to 571KB) by not bundling svelte at all. That turned out to break a real workflow: a globally-installed `sveld` (`npm install -g sveld`) or a bare `npx sveld` (no local install) has no filesystem relationship to the target project's `node_modules`, so resolving `svelte` at runtime from sveld's own install location doesn't work - I confirmed this with `ERR_MODULE_NOT_FOUND` in a clean-room reproduction. This PR keeps sveld fully self-contained (bundled again) while still cutting the bundle size substantially, by only bundling the parser code sveld actually uses instead of the whole compiler.

| | lib/index.js (minified) |
|---|---|
| before (main, full `svelte/compiler` bundled) | 1,272,130 bytes |
| after | 778,852 bytes (roughly 39% smaller) |

## Correctness

`tests/svelte-parse-shim.test.ts` byte-compares this module's `parse()` output against the real `svelte/compiler`'s across every `.svelte` fixture in the repo (419 files) and every combination of the `modern`/`loose` options - 0 mismatches.

I additionally smoke-tested the built artifact outside the repo:
- A simulated global install (`sveld`'s files in one directory tree, a target project with **no svelte installed at all** in another) - the CLI and `ComponentParser` both work.
- The browser build target (`lib/browser.js`) still contains zero `node:*` built-in references and zero `aria-query`/`axobject-query` content.

## The tradeoff, stated plainly

`src/svelte-parse.ts` depends on undocumented internal svelte module paths (`svelte/src/compiler/phases/1-parse/index.js`, `legacy.js`, `state.js`, `version.js`) that aren't part of svelte's `package.json#exports` or semver contract. A future svelte upgrade could shift their shape without warning. `tests/svelte-parse-shim.test.ts` is the guard against silent drift - it must pass after every svelte devDependency bump, and a failure means the shim needs to be re-synced against svelte's current internals, not just have the test updated. See the top-of-file comment in `src/svelte-parse.ts` for the full rationale.

`zimmerframe` is added as an explicit devDependency since `svelte-parse.ts` imports it directly now, rather than relying on it only being resolvable as a transitive dependency of svelte.

