### PR TITLE
perf(writer): skip writing files whose content is unchanged

### DIFF
--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -7,6 +7,9 @@
  *   bun run bench --runs 5
  *   bun run bench --cache          # scratch parse cache: run 1 cold, later runs warm
  *   bun run bench --entry <path>   # benchmark another entry point (glob discovery)
+ *   bun run bench --reuse-outdir   # write every run into the same out dir, so
+ *                                  # run 1 populates it and runs 2+ exercise the
+ *                                  # writer's skip-unchanged-file path
  *
  * All output (types/JSON/Markdown and the parse cache) is written to a temp
  * directory, so benchmarking never touches a fixture's committed files.
@@ -28,6 +31,7 @@ interface BenchArgs {
   runs: number;
   cache: boolean;
   entry: string;
+  reuseOutDir: boolean;
 }
 
 interface RunTiming {
@@ -37,7 +41,7 @@ interface RunTiming {
 }
 
 function parseArgs(argv: string[]): BenchArgs {
-  const args: BenchArgs = { runs: DEFAULT_RUNS, cache: false, entry: DEFAULT_ENTRY };
+  const args: BenchArgs = { runs: DEFAULT_RUNS, cache: false, entry: DEFAULT_ENTRY, reuseOutDir: false };
 
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i];
@@ -54,6 +58,9 @@ function parseArgs(argv: string[]): BenchArgs {
       case "--cache":
         args.cache = true;
         break;
+      case "--reuse-outdir":
+        args.reuseOutDir = true;
+        break;
       case "--entry": {
         const value = argv[++i];
         if (value === undefined) {
@@ -64,7 +71,7 @@ function parseArgs(argv: string[]): BenchArgs {
         break;
       }
       default:
-        console.error(`bench: unknown flag "${flag}". Flags: --runs <n>, --cache, --entry <path>.`);
+        console.error(`bench: unknown flag "${flag}". Flags: --runs <n>, --cache, --entry <path>, --reuse-outdir.`);
         process.exit(1);
     }
   }
@@ -128,14 +135,19 @@ const args = parseArgs(process.argv.slice(2));
 const workDir = mkdtempSync(join(tmpdir(), "sveld-bench-"));
 const cacheFile = args.cache ? join(workDir, "parse-cache.json") : undefined;
 const cacheLabel = args.cache ? "cache on (run 1 cold, later runs warm)" : "cache off";
+// With --reuse-outdir every run writes into the same directory, so run 1
+// populates it and runs 2+ exercise the writer's skip-unchanged-file path.
+// Without it, each run gets its own fresh temp dir and every write is a miss.
+const sharedOutDir = args.reuseOutDir ? join(workDir, "out") : undefined;
+const outDirLabel = args.reuseOutDir ? ", reuse outdir" : "";
 
-console.log(`sveld bench: ${relative(process.cwd(), args.entry)} — ${args.runs} run(s), ${cacheLabel}`);
+console.log(`sveld bench: ${relative(process.cwd(), args.entry)} — ${args.runs} run(s), ${cacheLabel}${outDirLabel}`);
 
 const timings: RunTiming[] = [];
 try {
   for (let run = 1; run <= args.runs; run++) {
     // biome-ignore lint/performance/noAwaitInLoops: runs must execute sequentially so each phase is timed in isolation.
-    const timing = await benchOnce(args.entry, cacheFile, join(workDir, `run-${run}`));
+    const timing = await benchOnce(args.entry, cacheFile, sharedOutDir ?? join(workDir, `run-${run}`));
     timings.push(timing);
     console.log(`run ${run}  ${formatTiming(timing)}`);
   }

--- a/src/writer/Writer.ts
+++ b/src/writer/Writer.ts
@@ -1,17 +1,31 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { parse } from "node:path";
 
 export default class Writer {
   /**
+   * Skips the write when `filePath` already contains `raw`, so repeated runs
+   * over unchanged sources don't touch the file (or its mtime).
+   *
+   * @returns `true` if the file was written, `false` if it was already up to date.
+   *
    * @example
    * ```ts
    * const writer = new Writer();
    * await writer.write("./dist/index.d.ts", "export type Props = {};");
    * ```
    */
-  public async write(filePath: string, raw: string) {
+  public async write(filePath: string, raw: string): Promise<boolean> {
+    try {
+      if ((await readFile(filePath, "utf-8")) === raw) {
+        return false;
+      }
+    } catch {
+      // File doesn't exist yet (or can't be read); fall through to write it.
+    }
+
     await mkdir(parse(filePath).dir, { recursive: true });
     await writeFile(filePath, raw);
+    return true;
   }
 }
 

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -34,11 +34,11 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
   const output = withNormalizedFilePaths(document.components, options.inputDir);
 
   await Promise.all(
-    output.map((c) => {
+    output.map(async (c) => {
       const outFile = path.resolve(path.join(options.outDir || "", `${c.moduleName}.api.json`));
       const writer = createJsonWriter();
-      console.log(`created "${outFile}".`);
-      return writer.write(outFile, `${JSON.stringify(c, null, 2)}\n`);
+      const wasWritten = await writer.write(outFile, `${JSON.stringify(c, null, 2)}\n`);
+      console.log(`${wasWritten ? "created" : "unchanged"} "${outFile}".`);
     }),
   );
 }

--- a/tests/Writer.test.ts
+++ b/tests/Writer.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Writer, { createJsonWriter, createTypeScriptWriter } from "../src/writer/Writer";
@@ -48,5 +48,36 @@ describe("Writer", () => {
     await writer.write(filePath, "export type Props = {};");
 
     expect(await readFile(filePath, "utf-8")).toBe("export type Props = {};");
+  });
+
+  test("returns true and writes when the file doesn't exist yet", async () => {
+    const writer = new Writer();
+    const filePath = join(dir, "index.d.ts");
+
+    await expect(writer.write(filePath, "content")).resolves.toBe(true);
+    expect(await readFile(filePath, "utf-8")).toBe("content");
+  });
+
+  test("returns false and skips the write when content is unchanged", async () => {
+    const writer = new Writer();
+    const filePath = join(dir, "index.d.ts");
+
+    await writer.write(filePath, "content");
+    const mtimeBefore = (await stat(filePath)).mtimeMs;
+
+    await expect(writer.write(filePath, "content")).resolves.toBe(false);
+
+    expect((await stat(filePath)).mtimeMs).toBe(mtimeBefore);
+    expect(await readFile(filePath, "utf-8")).toBe("content");
+  });
+
+  test("returns true and overwrites when content has changed", async () => {
+    const writer = new Writer();
+    const filePath = join(dir, "index.d.ts");
+
+    await writeFile(filePath, "old content");
+
+    await expect(writer.write(filePath, "new content")).resolves.toBe(true);
+    expect(await readFile(filePath, "utf-8")).toBe("new content");
   });
 });


### PR DESCRIPTION
Every run rewrote all output files even when their content was byte
identical, which dominated warm runs now that parsing is cached. The
writer reads the existing file first and skips the write when the
content matches, so repeated runs only touch files that changed. This
also stops spurious mtime updates for tools watching the output.

The per-component .d.ts and JSON writers already batched their writes
with Promise.all, so no additional batching was needed there.

Generated output is byte identical and no snapshots changed.

## Log verb decision

Only the per-component JSON writer (`writer-json.ts`) already logged one
`created "..."` line per emitted file, so that's the only call site changed
to log `unchanged "..."` when `Writer#write` reports it skipped the write
(via a new `Promise<boolean>` return value; the `(path, raw)` parameters
are unchanged). The other writers (`writer-ts-definitions.ts`,
`writer-markdown.ts`, `writer-custom-elements.ts`) only ever logged a
single summary line per invocation, not one per file, so there was no
existing per-file verb to flip for those and they're left as-is.

## Benchmark

Added `--reuse-outdir` to `scripts/bench.ts` so every run writes into the
same directory (run 1 populates it, runs 2+ hit the skip-unchanged path).
Numbers below are medians from `bun run bench --runs 10 --cache --reuse-outdir`
on the carbon fixture (160 components), runs 2+ (steady state):

| | parse (median) | write (median) | total (median) |
|---|---|---|---|
| before (main) | 8ms | 25ms | 33ms |
| after | 8ms | 25ms | 33ms |

At the full-pipeline level the two are indistinguishable — noise from the
JSON/Markdown writer stages (unaffected by this change, they're cheap
already) and general machine load swamps the win, consistent with prior
perf work on this repo needing isolated microbenchmarks to see a clean
signal (see PRs #349, #350, #351).

Isolating just the `.d.ts` writer's per-file `Promise.all` loop (same
generated content, same output dir, 12 alternating trials, in-process)
shows a real, consistently reproducible improvement — the "after" case
was faster in every single trial:

```
old (always write):   median 20.8ms
new (skip unchanged):  median 17.7ms
```

The remaining ~17-18ms per run is per-component `.d.ts` string generation
(`writeTsDefinition`), not I/O — with the parse cache warm, that
generation is now the dominant cost in the write phase, so skipping
already-fast, already-parallelized file writes is a real but modest win
(~15%) rather than the larger drop originally hoped for.

`bun test`: all pass, 0 snapshot diffs.