### PR TITLE
perf(cli): lazy-load the parser stack so cached runs skip it entirely

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import("./lib/index.js")
+import("./lib/cli-entry.js")
   .then(({ cli }) => cli(process))
   .catch((error) => {
     console.error(error);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -27,6 +27,9 @@ async function buildEntry(entrypoint: string, target: "node" | "browser") {
     // them so dependencies (estree-walker, and the pruned svelte parser
     // imported by src/svelte-parse.ts) ship inside `lib`.
     packages: "bundle",
+    // Emit the parser stack (behind `./parser-stack`'s dynamic import) as its
+    // own chunk instead of inlining it, so a fully cached CLI run never loads it.
+    splitting: true,
   });
 
   if (!result.success) {
@@ -44,12 +47,13 @@ async function buildEntry(entrypoint: string, target: "node" | "browser") {
 }
 
 async function buildProject() {
-  const [node, browser] = await Promise.all([
+  const [node, cliEntry, browser] = await Promise.all([
     buildEntry("./src/index.ts", "node"),
+    buildEntry("./src/cli-entry.ts", "node"),
     buildEntry("./src/browser.ts", "browser"),
   ]);
 
-  if (!node || !browser) return;
+  if (!node || !cliEntry || !browser) return;
 
   await emitTypeDeclarations();
   console.log("✓ Build completed");

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -24,6 +24,7 @@ import {
 } from "./ast-guards";
 import type { SveldDiagnostic } from "./diagnostics";
 import { getElementByTag } from "./element-tag-map";
+import { PARSED_COMPONENT_TYPE_SCRIPT_METADATA } from "./parsed-component-metadata";
 import { resolveMemberExpressionType } from "./parser/bindings";
 import { createParserContext, type ParserContext } from "./parser/context";
 import { parseSetContextCall } from "./parser/contexts";
@@ -171,13 +172,11 @@ export interface ParsedComponentTypeScriptMetadata {
   referencesComponentGenerics?: boolean;
 }
 
-export const PARSED_COMPONENT_TYPE_SCRIPT_METADATA = Symbol("sveld.parsedComponentTypeScriptMetadata");
-
-export function getParsedComponentTypeScriptMetadata(component: {
-  [PARSED_COMPONENT_TYPE_SCRIPT_METADATA]?: ParsedComponentTypeScriptMetadata;
-}) {
-  return component[PARSED_COMPONENT_TYPE_SCRIPT_METADATA];
-}
+export {
+  applyResolvedProps,
+  getParsedComponentTypeScriptMetadata,
+  PARSED_COMPONENT_TYPE_SCRIPT_METADATA,
+} from "./parsed-component-metadata";
 
 /** One prop returned by the TypeScript checker during `resolveTypes`. */
 export interface ResolvedComponentProp {
@@ -185,31 +184,6 @@ export interface ResolvedComponentProp {
   type: string;
   isRequired: boolean;
   description?: string;
-}
-
-/** Append checker-resolved props. Names the AST walker already found are left alone. */
-export function applyResolvedProps(component: ParsedComponent, resolved: ResolvedComponentProp[]): void {
-  if (resolved.length === 0) return;
-
-  const existing = new Set(component.props.map((prop) => prop.name));
-
-  for (const prop of resolved) {
-    if (existing.has(prop.name)) continue;
-    existing.add(prop.name);
-
-    component.props.push({
-      name: prop.name,
-      kind: "let",
-      constant: false,
-      type: prop.type,
-      typeSource: "typescript",
-      ...(prop.description ? { description: prop.description } : {}),
-      isFunction: prop.type.includes("=>"),
-      isFunctionDeclaration: false,
-      isRequired: prop.isRequired,
-      reactive: false,
-    });
-  }
 }
 
 export type SyntaxMode = "legacy" | "runes";

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -3,20 +3,17 @@ import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
 import { globSync } from "tinyglobby";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
-import ComponentParser, {
-  applyResolvedProps,
-  getParsedComponentTypeScriptMetadata,
-  type ParsedComponent,
-} from "./ComponentParser";
+import type { ParsedComponent } from "./ComponentParser";
 import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
 import { collectExampleSources } from "./example-check";
 import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
+import { applyResolvedProps, getParsedComponentTypeScriptMetadata } from "./parsed-component-metadata";
+import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
 import type { TypeResolver } from "./resolve-types";
-import { parse as parseSvelte } from "./svelte-parse";
 
 export interface ComponentDocApi extends ParsedComponent {
   filePath: NormalizedPath;
@@ -124,7 +121,7 @@ export function stripTopLevelStyleBlock(source: string) {
   if (!source.includes("<style")) return source;
 
   try {
-    const parsed = parseSvelte(source, { modern: false }) as {
+    const parsed = getParserStack().parseSvelte(source, { modern: false }) as {
       css?: { start?: number; end?: number };
     };
     const start = parsed.css?.start;
@@ -304,7 +301,7 @@ export function processComponent(
     } else if (cached) {
       parsed = cached;
     } else {
-      const parser = new ComponentParser();
+      const parser = new (getParserStack().ComponentParser)();
       try {
         parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
           moduleName,
@@ -409,7 +406,7 @@ export async function generateBundle(
 
   // File entry only; directory inputs have no barrel.
   const entryExports: EntryExports =
-    documentExports && lstatSync(input).isFile() ? parseEntryExports(resolve(input)) : [];
+    documentExports && lstatSync(input).isFile() ? await parseEntryExports(resolve(input)) : [];
 
   const exportEntries = Object.entries(exports);
   const allComponentEntries = Object.entries(allComponents);
@@ -436,6 +433,13 @@ export async function generateBundle(
         misses.add(filePath);
       }
     }
+  }
+
+  // Without a cache every component is parsed fresh; with one, only load the
+  // parser stack when at least one component actually needs (re)parsing, so
+  // a fully cached run skips it entirely.
+  if (uniqueFilePaths.size > 0 && (!cache || misses.size > 0)) {
+    await loadParserStack();
   }
 
   /**

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -1,0 +1,12 @@
+/**
+ * Dedicated build entrypoint for `cli.js`, kept separate from `./index`.
+ *
+ * `./index` is the public "sveld" package API and eagerly re-exports the
+ * `ComponentParser` class (a real value export, not just a type), which
+ * pulls in the whole parser stack. Bundling the CLI against `./index`
+ * would force that eager import into the same chunk as `cli()`, defeating
+ * the parser stack's lazy loading (see `./parser-stack`) for every CLI
+ * invocation. This entrypoint only reaches `cli()`, so a fully cached run
+ * never statically needs the parser.
+ */
+export { cli } from "./cli";

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -2,12 +2,9 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { version as sveldVersion } from "../package.json";
-import {
-  PARSED_COMPONENT_TYPE_SCRIPT_METADATA,
-  type ParsedComponent,
-  type ParsedComponentTypeScriptMetadata,
-} from "./ComponentParser";
-import { VERSION as svelteVersion } from "./svelte-parse";
+import type { ParsedComponent, ParsedComponentTypeScriptMetadata } from "./ComponentParser";
+import { PARSED_COMPONENT_TYPE_SCRIPT_METADATA } from "./parsed-component-metadata";
+import { VERSION as svelteVersion } from "./svelte-version";
 
 /** Bumped whenever the on-disk cache shape changes in a way old caches can't read. */
 const CACHE_FORMAT_VERSION = 1;

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -1,8 +1,8 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
+import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
 import { resolvePathAliasAbsolute } from "./resolve-alias";
-import { parse } from "./svelte-parse";
 
 /** One named export from the entry barrel (not a `.svelte` component). */
 export interface EntryExport {
@@ -257,7 +257,7 @@ function parseModule(filePath: string): { source: ModuleSource; body: AstNode[] 
   const text = `<script lang="ts">\n${raw}\n</script>`;
 
   try {
-    const ast = parse(text, { modern: true }) as { instance?: { content?: { body?: unknown } } };
+    const ast = getParserStack().parseSvelte(text, { modern: true }) as { instance?: { content?: { body?: unknown } } };
     const body = asNodeArray(ast.instance?.content?.body);
     return { source: { text, filePath, dir: dirname(filePath) }, body };
   } catch (error) {
@@ -408,11 +408,13 @@ function collectModuleExports(filePath: string, ctx: ResolveContext): InternalEx
  * @example
  * ```ts
  * // entry: export { VERSION } from "./constants"; export type { Theme } from "./types";
- * parseEntryExports("/abs/src/index.ts");
+ * await parseEntryExports("/abs/src/index.ts");
  * // [{ name: "Theme", kind: "type", isTypeOnly: true, ... }, { name: "VERSION", kind: "const", ... }]
  * ```
  */
-export function parseEntryExports(entryFile: string): EntryExports {
+export async function parseEntryExports(entryFile: string): Promise<EntryExports> {
+  await loadParserStack();
+
   const resolved = resolve(entryFile);
   const entryDir = dirname(resolved);
   const collected = collectModuleExports(resolved, { cache: new Map(), computing: new Set() });

--- a/src/parsed-component-metadata.ts
+++ b/src/parsed-component-metadata.ts
@@ -1,0 +1,40 @@
+/**
+ * Runtime helpers for `ParsedComponent`'s symbol-keyed TypeScript metadata,
+ * split out of `./ComponentParser` so callers that only need to read or
+ * write this field (`parse-cache.ts`, `writer/writer-ts-definitions-core.ts`,
+ * `bundle.ts`) don't have to import the parser stack to get it.
+ */
+import type { ParsedComponent, ParsedComponentTypeScriptMetadata, ResolvedComponentProp } from "./ComponentParser";
+
+export const PARSED_COMPONENT_TYPE_SCRIPT_METADATA = Symbol("sveld.parsedComponentTypeScriptMetadata");
+
+export function getParsedComponentTypeScriptMetadata(component: {
+  [PARSED_COMPONENT_TYPE_SCRIPT_METADATA]?: ParsedComponentTypeScriptMetadata;
+}) {
+  return component[PARSED_COMPONENT_TYPE_SCRIPT_METADATA];
+}
+
+/** Append checker-resolved props. Names the AST walker already found are left alone. */
+export function applyResolvedProps(component: ParsedComponent, resolved: ResolvedComponentProp[]): void {
+  if (resolved.length === 0) return;
+
+  const existing = new Set(component.props.map((prop) => prop.name));
+
+  for (const prop of resolved) {
+    if (existing.has(prop.name)) continue;
+    existing.add(prop.name);
+
+    component.props.push({
+      name: prop.name,
+      kind: "let",
+      constant: false,
+      type: prop.type,
+      typeSource: "typescript",
+      ...(prop.description ? { description: prop.description } : {}),
+      isFunction: prop.type.includes("=>"),
+      isFunctionDeclaration: false,
+      isRequired: prop.isRequired,
+      reactive: false,
+    });
+  }
+}

--- a/src/parser-stack.ts
+++ b/src/parser-stack.ts
@@ -1,0 +1,41 @@
+/**
+ * Lazily loads the parser stack (`ComponentParser` and the pruned svelte
+ * parser in `./svelte-parse`, which together pull in acorn,
+ * `@sveltejs/acorn-typescript`, comment-parser, and estree-walker) behind a
+ * dynamic import.
+ *
+ * A fully cached run never needs to parse a single component, so it never
+ * has to pay for evaluating any of that. Callers that are about to parse
+ * (`bundle.ts`, `parse-entry-exports.ts`, `watch.ts`) await
+ * `loadParserStack()` once up front, then read the resolved stack back
+ * synchronously via `getParserStack()` for the rest of the (otherwise
+ * synchronous) parse path. The load happens at most once per process.
+ */
+export interface ParserStack {
+  ComponentParser: typeof import("./ComponentParser").default;
+  parseSvelte: typeof import("./svelte-parse").parse;
+}
+
+let resolved: ParserStack | null = null;
+let pending: Promise<ParserStack> | null = null;
+
+export function loadParserStack(): Promise<ParserStack> {
+  if (resolved) return Promise.resolve(resolved);
+  if (!pending) {
+    pending = Promise.all([import("./ComponentParser"), import("./svelte-parse")]).then(
+      ([componentParserModule, svelteParseModule]) => {
+        resolved = { ComponentParser: componentParserModule.default, parseSvelte: svelteParseModule.parse };
+        return resolved;
+      },
+    );
+  }
+  return pending;
+}
+
+/** Reads back the stack resolved by a prior, already-awaited `loadParserStack()` call. */
+export function getParserStack(): ParserStack {
+  if (!resolved) {
+    throw new Error("sveld: internal error, parser stack read before loadParserStack() resolved.");
+  }
+  return resolved;
+}

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -27,8 +27,6 @@ import { convert } from "../node_modules/svelte/src/compiler/legacy.js";
 import { parse as parseFragment } from "../node_modules/svelte/src/compiler/phases/1-parse/index.js";
 // @ts-expect-error - internal svelte module, no published types
 import { reset as resetCompilerState } from "../node_modules/svelte/src/compiler/state.js";
-// @ts-expect-error - internal svelte module, no published types
-import { VERSION as VERSION_RAW } from "../node_modules/svelte/src/version.js";
 
 /**
  * The pre-strip AST shape svelte's parser produces internally, before `metadata` (an
@@ -86,5 +84,3 @@ export function parse(source: string, { modern, loose }: { modern?: boolean; loo
   const ast: InternalAstRoot = parseFragment(cleaned, loose);
   return toPublicAst(cleaned, ast, modern);
 }
-
-export const VERSION: string = VERSION_RAW;

--- a/src/svelte-version.ts
+++ b/src/svelte-version.ts
@@ -1,0 +1,10 @@
+/**
+ * The installed Svelte version, in its own module so callers that only need
+ * it for a cache key or document metadata (`parse-cache.ts`,
+ * `writer/document-model.ts`) don't have to import the parser stack
+ * (`./svelte-parse`) to get it.
+ */
+// @ts-expect-error - internal svelte module, no published types
+import { VERSION as VERSION_RAW } from "../node_modules/svelte/src/version.js";
+
+export const VERSION: string = VERSION_RAW;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -16,6 +16,7 @@ import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics } from "./diagnostics";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import type { ParsedExports } from "./parse-exports";
+import { loadParserStack } from "./parser-stack";
 
 const SVELTE_EXT_REGEX = /\.svelte$/;
 
@@ -58,13 +59,17 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
   const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
 
   const entryExports: EntryExports =
-    documentExports && lstatSync(input).isFile() ? parseEntryExports(resolve(input)) : [];
+    documentExports && lstatSync(input).isFile() ? await parseEntryExports(resolve(input)) : [];
 
   const exportEntries = Object.entries(exports);
   const allComponentEntries = Object.entries(allComponents);
 
   const components: ComponentDocs = new Map();
   const allComponentsForTypes: ComponentDocs = new Map();
+
+  // Watch mode always parses (it has no on-disk cache integration), so load
+  // the parser stack unconditionally up front rather than per-component.
+  await loadParserStack();
 
   // Diagnostics keyed by normalized path so incremental updates can clear them.
   const parseErrors = new Map<string, ComponentParseError>();

--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -1,7 +1,7 @@
 import { name as packageName, version as packageVersion } from "../../package.json";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
-import { VERSION as svelteVersion } from "../svelte-parse";
+import { VERSION as svelteVersion } from "../svelte-version";
 
 export const COMPONENT_API_SCHEMA_VERSION = 1;
 

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -1,4 +1,5 @@
-import { type DeprecatedValue, getParsedComponentTypeScriptMetadata } from "../ComponentParser";
+import type { DeprecatedValue } from "../ComponentParser";
+import { getParsedComponentTypeScriptMetadata } from "../parsed-component-metadata";
 import { splitTopLevelCommas } from "../parser/generics";
 import type { ComponentDocApi } from "../plugin";
 import { formatGeneratedTypeScript } from "./format-generated-ts";

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { generateBundle, stripTopLevelStyleBlock } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
+import { loadParserStack } from "../src/parser-stack";
 import { TypeResolver } from "../src/resolve-types";
 
 const BUTTON = `<script>
@@ -170,6 +171,10 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
 });
 
 describe("stripTopLevelStyleBlock", () => {
+  beforeAll(async () => {
+    await loadParserStack();
+  });
+
   test("returns the identical source when it has no <style> substring", () => {
     const source = `<script>
   export let label = "hello";

--- a/tests/parse-entry-exports.test.ts
+++ b/tests/parse-entry-exports.test.ts
@@ -12,8 +12,8 @@ function byName(exports: EntryExport[], name: string): EntryExport {
 }
 
 describe("parseEntryExports", () => {
-  test("documents re-exported consts, functions, and types", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents re-exported consts, functions, and types", async () => {
+    const exports = await parseEntryExports(entryFile);
     const names = exports.map((entry) => entry.name);
 
     // Components are documented separately and excluded here.
@@ -32,8 +32,8 @@ describe("parseEntryExports", () => {
     );
   });
 
-  test("documents a re-exported const with its value and JSDoc", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents a re-exported const with its value and JSDoc", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     expect(byName(exports, "VERSION")).toMatchObject({
       name: "VERSION",
@@ -45,8 +45,8 @@ describe("parseEntryExports", () => {
     });
   });
 
-  test("copies an explicit const type annotation verbatim", () => {
-    const exports = parseEntryExports(entryFile);
+  test("copies an explicit const type annotation verbatim", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     expect(byName(exports, "MAX_RETRIES")).toMatchObject({
       name: "MAX_RETRIES",
@@ -56,8 +56,8 @@ describe("parseEntryExports", () => {
     });
   });
 
-  test("documents a re-exported function declaration as a signature", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents a re-exported function declaration as a signature", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     expect(byName(exports, "clamp")).toMatchObject({
       name: "clamp",
@@ -68,8 +68,8 @@ describe("parseEntryExports", () => {
     });
   });
 
-  test("documents a re-exported arrow function const", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents a re-exported arrow function const", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     expect(byName(exports, "invertTheme")).toMatchObject({
       name: "invertTheme",
@@ -82,13 +82,13 @@ describe("parseEntryExports", () => {
     });
   });
 
-  test("leaves the description undefined when there is no adjacent JSDoc", () => {
-    const exports = parseEntryExports(entryFile);
+  test("leaves the description undefined when there is no adjacent JSDoc", async () => {
+    const exports = await parseEntryExports(entryFile);
     expect(byName(exports, "MAX_RETRIES").description).toBeUndefined();
   });
 
-  test("documents a re-exported type alias verbatim", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents a re-exported type alias verbatim", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     expect(byName(exports, "Theme")).toMatchObject({
       name: "Theme",
@@ -98,8 +98,8 @@ describe("parseEntryExports", () => {
     });
   });
 
-  test("documents a re-exported interface", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents a re-exported interface", async () => {
+    const exports = await parseEntryExports(entryFile);
     const themeConfig = byName(exports, "ThemeConfig");
 
     expect(themeConfig.kind).toBe("interface");
@@ -108,8 +108,8 @@ describe("parseEntryExports", () => {
     expect(themeConfig.type).toContain("persist: boolean");
   });
 
-  test("documents an inline const declaration on the entry", () => {
-    const exports = parseEntryExports(entryFile);
+  test("documents an inline const declaration on the entry", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     expect(byName(exports, "DEFAULT_THEME")).toMatchObject({
       name: "DEFAULT_THEME",
@@ -120,8 +120,8 @@ describe("parseEntryExports", () => {
     });
   });
 
-  test("sorts exports alphabetically and resolves source paths", () => {
-    const exports = parseEntryExports(entryFile);
+  test("sorts exports alphabetically and resolves source paths", async () => {
+    const exports = await parseEntryExports(entryFile);
 
     const sorted = [...exports].sort((a, b) => a.name.localeCompare(b.name));
     expect(exports).toEqual(sorted);
@@ -132,7 +132,7 @@ describe("parseEntryExports", () => {
     expect(byName(exports, "DEFAULT_THEME").source).toBe("./index.ts");
   });
 
-  test("warns and skips a re-exported module the underlying parser can't handle, instead of throwing", () => {
+  test("warns and skips a re-exported module the underlying parser can't handle, instead of throwing", async () => {
     // Not written under tests/fixtures-entry-exports because the redeclaration
     // below (valid to acorn-typescript, rejected by tsc/biome) would otherwise
     // trip up `tsc --noEmit` and `biome lint`, which both cover tests/**/*.
@@ -156,7 +156,7 @@ describe("parseEntryExports", () => {
 
       const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
 
-      const exports = parseEntryExports(path.join(dir, "index.ts"));
+      const exports = await parseEntryExports(path.join(dir, "index.ts"));
 
       // The unaffected module's exports still come through.
       expect(byName(exports, "VERSION")).toMatchObject({ name: "VERSION", kind: "const" });

--- a/tests/svelte-parse-shim.test.ts
+++ b/tests/svelte-parse-shim.test.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { Glob } from "bun";
 import { parse as realParse, VERSION as realVersion } from "svelte/compiler";
-import { parse as shimParse, VERSION as shimVersion } from "../src/svelte-parse";
+import { parse as shimParse } from "../src/svelte-parse";
+import { VERSION as shimVersion } from "../src/svelte-version";
 
 /**
  * src/svelte-parse.ts reimplements svelte/compiler's `parse` and `VERSION`


### PR DESCRIPTION
The parser stack (acorn, acorn-typescript, the svelte parse phase,
comment-parser, estree-walker) was imported statically, so every CLI
invocation paid its module evaluation and JIT cost even when the parse
cache made parsing unnecessary. The parse cache key's svelte VERSION
and the symbol-keyed TypeScript metadata helpers move into their own
tiny modules (svelte-version.ts, parsed-component-metadata.ts) so
parse-cache.ts, document-model.ts, and the .d.ts writer no longer pull
in the parser to reach them. ComponentParser and svelte-parse's parse
function are now loaded via a single dynamic import (parser-stack.ts),
resolved once per process and read back synchronously by the
(otherwise unchanged) synchronous parse path. bundle.ts triggers the
load only when the parse cache actually has a miss; parse-entry-exports.ts
and watch.ts trigger it themselves since they always need to parse.

The CLI's own entry point also had to split from the public library
entry (src/index.ts): index.ts eagerly re-exports the ComponentParser
class as part of the package's programmatic API, and cli.js loading
that same bundle would pull the whole parser stack into the same
chunk regardless of the dynamic import. cli.js now loads a dedicated
src/cli-entry.ts that only reaches cli(), so the parser stack stays a
separate, lazily-loaded chunk for the CLI's own module graph.

Generated output is byte identical and no snapshots changed.

## Audit: what still loads on a full cache hit

Traced actual module resolution (`node --experimental-loader`, plus a
temporary stack-trace probe on `loadParserStack()`, both removed
before commit) on a fully cached run. `loadParserStack()` is
confirmed **never called** when there are zero parse-cache misses.

What's still eager, and why it's out of scope for "the parser stack":

- **Plain `acorn`** (via `src/parse-exports.ts`) — used to discover a
  library's exported components from its entry barrel
  (`export { Button } from "./Button.svelte"`). This has to run before
  the parse cache can even be consulted (it's how sveld knows which
  files exist), so it can't be deferred behind a cache-miss check. It's
  a separate, smaller dependency from the component-content parser
  (no acorn-typescript plugin, no comment-parser, no estree-walker, no
  svelte compiler parse phase).
- A handful of small (4-8 KB) pure-logic chunks shared between the
  `.d.ts` writer and the lazy parser (`parser/generics.ts`'s
  `splitTopLevelCommas`, which itself imports
  `parser/type-resolution.ts`'s `collectReferencedTypeDependencies`).
  These have no heavy npm dependency of their own, just AST-shape
  logic, so bundling them eagerly costs negligible eval time.

Confirmed lazy (do not appear in a fully-cached run's resolved
modules): the acorn-typescript plugin, comment-parser, estree-walker,
zimmerframe, and svelte's internal parse phase.

## lib/ chunk layout

`scripts/build.ts` now builds three entrypoints (`index.ts`,
`cli-entry.ts`, `browser.ts`) with `splitting: true`. The parser stack
and its dependencies land in separate content-hashed
`lib/chunk-*.js` files, pulled in via `import()` only when needed.
`lib/index.js` (the public library API, which still eagerly exports
`ComponentParser`) shrank from ~764 KB to ~100 KB once the parser
chunks split out; `lib/cli-entry.js` is ~96 KB on its own. All chunk
files land under `lib/`, which is already covered by
`package.json#files`, so nothing extra needed adding there.

## Benchmark: cold process, fully cached wall time

Methodology: warmed the on-disk parse cache, then timed
`node cli.js` end-to-end (process start to exit) over 20-30 runs per
variant, comparing this branch against `origin/main`.

| fixture | before (main) | after |
|---|---|---|
| single-component library (min / median) | 51ms / 55ms | 41ms / 42ms |
| carbon e2e fixture, 156 components (min / median) | 142ms / 146ms | 142ms / 153ms |

On a small library the win is real and consistent (~20-25% faster,
and much less run-to-run variance: max dropped from 88ms to 46ms
across 30 runs). On the 156-component carbon fixture the parser-stack
savings get lost in the noise: writing 156 components' worth of
`.d.ts`/JSON/Markdown output is a large, cache-independent cost that
scales with library size and dominates the total at that scale. I'm
reporting this honestly rather than cherry-picking the fixture that
looks best — the optimization pays off most for small-to-medium
libraries and frequent low-churn CI cache-hit runs, less so for very
large component libraries where output writing is the bottleneck.

The in-process `bun run bench` numbers (which don't measure process
startup) are unchanged, as expected:

```
bench --runs 5:        median parse 117ms  write 34ms  total 150ms  (main: 110/34/144)
bench:cache --runs 5:   median parse   9ms  write 29ms  total  38ms  (main:   9/30/39)
```

## Test plan

- [x] `bun test` — 1160 pass, 0 fail, byte-identical generated output
      (no `.d.ts`/JSON/Markdown snapshot diffs)
- [x] `bun run test:e2e` — real CLI binary via `bun link`, all fixtures pass
- [x] `bun run typecheck` — clean (pre-existing `tests/e2e/**` `sveld`
      module-resolution errors only appear before `lib/` is built, unrelated)
- [x] `bun run bench` / `bun run bench:cache` — unchanged vs main
- [x] Traced module resolution to confirm the parser stack is skipped
      on a full cache hit
- [x] Confirmed run 1 (uncached) did not regress