### PR TITLE
perf(writer): dedupe buildComponentApiDocument() across json/markdown/custom-elements writers

### DIFF
--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -33,6 +33,16 @@ export interface BuildComponentApiDocumentOptions {
 }
 
 /**
+ * Caches by `components` identity, then by `entryExports` identity, so that
+ * `writeOutput()`'s json/markdown/custom-elements writers - which are
+ * commonly called with the same `components` map and the same (or absent)
+ * `entryExports` reference in one run - only pay the sort/strip cost once.
+ * A fresh `components` map (new run, tests) is a fresh WeakMap entry, so
+ * staleness across runs isn't possible.
+ */
+const documentCache = new WeakMap<ComponentDocs, Map<EntryExports | undefined, ComponentApiDocument>>();
+
+/**
  * Builds the canonical document for a component collection: components
  * sorted alphabetically by `moduleName`, with the Node-only `diagnostics`
  * field stripped.
@@ -41,6 +51,10 @@ export function buildComponentApiDocument(
   components: ComponentDocs,
   options: BuildComponentApiDocumentOptions = {},
 ): ComponentApiDocument {
+  let byEntryExports = documentCache.get(components);
+  const cached = byEntryExports?.get(options.entryExports);
+  if (cached) return cached;
+
   const sorted = Array.from(components, ([, component]) => {
     // `diagnostics` is for the Node API only; rendered output skips it.
     const { diagnostics: _diagnostics, ...rest } = component;
@@ -62,6 +76,12 @@ export function buildComponentApiDocument(
     document.totalExports = options.entryExports.length;
     document.exports = options.entryExports;
   }
+
+  if (!byEntryExports) {
+    byEntryExports = new Map();
+    documentCache.set(components, byEntryExports);
+  }
+  byEntryExports.set(options.entryExports, document);
 
   return document;
 }

--- a/tests/document-model.test.ts
+++ b/tests/document-model.test.ts
@@ -1,0 +1,42 @@
+import type { ComponentDocs } from "../src/plugin";
+import { buildComponentApiDocument } from "../src/writer/document-model";
+import { mockComponentDocApi } from "./test-brands";
+
+describe("buildComponentApiDocument caching", () => {
+  test("returns the same document instance for repeat calls with the same components and entryExports", () => {
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+
+    const first = buildComponentApiDocument(components);
+    const second = buildComponentApiDocument(components);
+
+    expect(second).toBe(first);
+  });
+
+  test("does not reuse the document across different entryExports references", () => {
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+    const entryExports = [
+      { name: "VERSION", kind: "const" as const, type: "string", isTypeOnly: false, source: "./constants.ts" },
+    ];
+
+    const withoutExports = buildComponentApiDocument(components);
+    const withExports = buildComponentApiDocument(components, { entryExports });
+
+    expect(withExports).not.toBe(withoutExports);
+    expect(withExports.totalExports).toBe(1);
+    expect(withoutExports.totalExports).toBeUndefined();
+
+    // Same entryExports reference on a later call still hits the cache.
+    expect(buildComponentApiDocument(components, { entryExports })).toBe(withExports);
+  });
+
+  test("does not reuse the document across different components maps", () => {
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+    const otherComponents: ComponentDocs = new Map([["Beta", mockComponentDocApi("Beta", "Beta.svelte")]]);
+
+    const first = buildComponentApiDocument(components);
+    const second = buildComponentApiDocument(otherComponents);
+
+    expect(second).not.toBe(first);
+    expect(second.components.map((c) => c.moduleName)).toEqual(["Beta"]);
+  });
+});


### PR DESCRIPTION
When json, markdown, and custom-elements outputs are all enabled, writeOutput() calls buildComponentApiDocument() once per writer, each on the same components map. Since the function is pure over (components, entryExports), those calls rebuild an identical sorted, diagnostics-stripped document up to three times per run.

This memoizes buildComponentApiDocument() itself, keyed by the components map's identity and then by the entryExports reference, rather than changing any writer's signature. That keeps the OutputWriter contract untouched, so third-party writers registered via registerWriter() aren't affected, and a fresh components map (a new run, or a test) always misses the cache, so there's no risk of stale output across runs.

Generated output is unchanged, the full test suite and e2e fixture suite pass. Added a test asserting the memoization returns the same document instance on repeat calls and correctly misses the cache when either the components map or entryExports reference changes. Risk is low since the change is additive and falls back to the original computation on any cache miss, but it's worth double-checking output correctness if a caller ever mutates the returned document in place, since callers now share the same object across repeat calls with identical inputs.