### PR TITLE
chore(build): dedupe the parser-stack chunk across index.ts and cli-entry.ts

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -15,9 +15,9 @@ async function emitTypeDeclarations() {
   }
 }
 
-async function buildEntry(entrypoint: string, target: "node" | "browser") {
+async function buildEntry(entrypoints: string[], target: "node" | "browser") {
   const result = await build({
-    entrypoints: [entrypoint],
+    entrypoints,
     outdir: "./lib",
     format: "esm",
     target,
@@ -29,11 +29,13 @@ async function buildEntry(entrypoint: string, target: "node" | "browser") {
     packages: "bundle",
     // Emit the parser stack (behind `./parser-stack`'s dynamic import) as its
     // own chunk instead of inlining it, so a fully cached CLI run never loads it.
+    // index.ts and cli-entry.ts share this dynamic import, so building them
+    // together lets Bun dedupe the chunk instead of emitting it twice.
     splitting: true,
   });
 
   if (!result.success) {
-    console.error(`Build failed for ${entrypoint}`);
+    console.error(`Build failed for ${entrypoints.join(", ")}`);
     for (const log of result.logs) {
       console.error(log);
     }
@@ -47,13 +49,12 @@ async function buildEntry(entrypoint: string, target: "node" | "browser") {
 }
 
 async function buildProject() {
-  const [node, cliEntry, browser] = await Promise.all([
-    buildEntry("./src/index.ts", "node"),
-    buildEntry("./src/cli-entry.ts", "node"),
-    buildEntry("./src/browser.ts", "browser"),
+  const [node, browser] = await Promise.all([
+    buildEntry(["./src/index.ts", "./src/cli-entry.ts"], "node"),
+    buildEntry(["./src/browser.ts"], "browser"),
   ]);
 
-  if (!node || !cliEntry || !browser) return;
+  if (!node || !browser) return;
 
   await emitTypeDeclarations();
   console.log("✓ Build completed");


### PR DESCRIPTION
649d5d2 split the CLI's entry point (cli-entry.ts) out from the library entry (index.ts) and turned on splitting so the parser stack loads lazily. Because each entry point was built with its own separate Bun build() call, and Bun only dedupes split chunks within a single build() invocation, the two builds each got their own full copy of the parser stack (acorn, acorn-typescript, comment-parser, and friends). That doubled the published package size: unpacked went from 1.41MB to 2.18MB and the packed tarball from 0.40MB to 0.61MB.

This change builds index.ts and cli-entry.ts together in one build() call so Bun can dedupe the shared chunk, while browser.ts stays a separate call since it targets a different platform. Package size is back to 1.41MB unpacked / 0.40MB packed, matching the size before the CLI entry point split, and the CLI still lazily loads the parser stack on a cache miss.

Risk is limited to the build script itself. Verified the full test suite still passes and manually inspected the rebuilt lib output to confirm the parser-stack chunk is now shared between index.js and cli-entry.js instead of duplicated.