### PR TITLE
fix(writer): define component type parameters in Markdown docs

### DIFF
--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -86,6 +86,14 @@ function renderSectionIfNotEmpty<TItem>(
 function renderComponent(document: MarkdownDocument, component: ComponentDocApi) {
   document.append("h2", `\`${component.moduleName}\``);
 
+  // Prop/slot types can reference the component's own type parameters (e.g. `Row`
+  // from `<script generics="Row extends DataTableRow">`). Markdown has no declaration
+  // context like the generated `.d.ts` does, so without this the name would appear
+  // in the tables below with nothing in the document defining what it means.
+  if (component.generics) {
+    document.append("p", `**Type parameters:** ${formatPropType(`<${component.generics[1]}>`)}`);
+  }
+
   if (component.typedefs.length > 0) {
     document.append("h3", "Types").append(
       "raw",

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -195,6 +195,71 @@ describe("WriterMarkdown", () => {
     expect(output).toContain("| footer | No | -- | -- | -- |");
   });
 
+  test("defines the component's type parameters for generic components", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "DataTable",
+          {
+            filePath: asNormalizedPath("DataTable.svelte"),
+            moduleName: "DataTable",
+            syntaxMode: "runes",
+            props: [
+              {
+                name: "rows",
+                kind: "let",
+                constant: false,
+                type: "ReadonlyArray<Row>",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: true,
+                reactive: false,
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: ["Row", "Row extends DataTableRow = DataTableRow"],
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toMatchSnapshot();
+    // `Row` is used in the prop type below; without this line it would be an
+    // undefined name floating in the document.
+    expect(output).toContain("**Type parameters:** <code><Row extends DataTableRow = DataTableRow></code>");
+    expect(output).toContain("| rows | Yes | <code>let</code> | No | -- | <code>ReadonlyArray<Row></code> | -- | -- |");
+  });
+
+  test("omits the type parameters line for non-generic components", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).not.toContain("Type parameters");
+  });
+
   test("badges deprecated props, events, and slots", () => {
     const output = writeMarkdownCore(
       new Map([

--- a/tests/__snapshots__/WriterMarkdown.test.ts.snap
+++ b/tests/__snapshots__/WriterMarkdown.test.ts.snap
@@ -59,3 +59,33 @@ None.
 
 "
 `;
+
+exports[`WriterMarkdown defines the component's type parameters for generic components 1`] = `
+"# Component Index
+
+## Components
+
+- [\`DataTable\`](#datatable)
+
+---
+
+## \`DataTable\`
+
+**Type parameters:** <code><Row extends DataTableRow = DataTableRow></code>
+
+### Props
+
+| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
+| :- | :- | :- | :- | :- | :- | :- | :- |
+| rows | Yes | <code>let</code> | No | -- | <code>ReadonlyArray<Row></code> | -- | -- |
+
+### Slots
+
+None.
+
+### Events
+
+None.
+
+"
+`;


### PR DESCRIPTION
Props typed from a generic interface rendered a bare T in the Markdown
prop table with nothing in the document defining it. The Markdown
writer now emits the component's type parameter signature under the
component heading, so type params referenced in the table are defined.
The generated .d.ts output is unchanged.

## Before/after

Fixture: `tests/fixtures/runes-script-generics-attribute` (`<script generics="Row extends DataTableRow = DataTableRow">`)

**Before**

\`\`\`markdown
## \`DataTable\`

### Props

| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
| :- | :- | :- | :- | :- | :- | :- | :- |
| headers | Yes | <code>let</code> | No | -- | <code>ReadonlyArray<Row></code> | -- | -- |
| rows | Yes | <code>let</code> | No | -- | <code>ReadonlyArray<Row></code> | -- | -- |
\`\`\`

`Row` appears in the table with nothing in the document defining what it is.

**After**

\`\`\`markdown
## \`DataTable\`

**Type parameters:** <code><Row extends DataTableRow = DataTableRow></code>

### Props

| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
| :- | :- | :- | :- | :- | :- | :- | :- |
| headers | Yes | <code>let</code> | No | -- | <code>ReadonlyArray<Row></code> | -- | -- |
| rows | Yes | <code>let</code> | No | -- | <code>ReadonlyArray<Row></code> | -- | -- |
\`\`\`

## Test plan
- [x] `bun test tests/fixtures.test.ts --update-snapshots` (no fixture output changed; JSON/`.d.ts` unaffected)
- [x] `bun run test:fixtures-types`
- [x] `bun test` (1166 pass)