### PR TITLE
fix(parser): resolve TS type annotations for context values

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -845,6 +845,15 @@ export default class ComponentParser {
     }
 
     const cached = this.ctx.variableInfoCache.get(varName);
+
+    const explicitType = this.ctx.explicitVariableTypesByName.get(varName);
+    if (explicitType) {
+      return {
+        type: explicitType,
+        description: cached?.description,
+      };
+    }
+
     if (cached) {
       return cached;
     }

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -63,6 +63,7 @@ export interface ParserContext {
   readonly runesPropsDeclarationMetadataByDeclaratorStart: Map<number, RunesPropsDeclarationMetadata>;
   readonly typedRunesPropsDeclarations: RunesPropsDeclarationMetadata[];
   readonly explicitPropTypesByName: Map<string, string>;
+  readonly explicitVariableTypesByName: Map<string, string>;
   readonly typeImportBindingsByLocalName: Map<string, TypeImportBinding>;
   readonly localTypeDeclarationsByName: Map<string, LocalTypeDeclaration>;
   readonly wholePropsLocals: Set<string>;
@@ -123,6 +124,7 @@ export function createParserContext(): ParserContext {
     runesPropsDeclarationMetadataByDeclaratorStart: new Map(),
     typedRunesPropsDeclarations: [],
     explicitPropTypesByName: new Map(),
+    explicitVariableTypesByName: new Map(),
     typeImportBindingsByLocalName: new Map(),
     localTypeDeclarationsByName: new Map(),
     wholePropsLocals: new Set(),

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -180,6 +180,7 @@ export function buildRunesPropTypeMetadataMap(
 export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserContext) {
   ctx.runesPropsDeclarationMetadataByDeclaratorStart.clear();
   ctx.explicitPropTypesByName.clear();
+  ctx.explicitVariableTypesByName.clear();
   ctx.typeImportBindingsByLocalName.clear();
   ctx.localTypeDeclarationsByName.clear();
   ctx.typedRunesPropsDeclarations.length = 0;
@@ -296,6 +297,14 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
         const explicitType = getTypeAnnotationText(ctx, declarator.id.typeAnnotation);
         if (explicitType) {
           ctx.explicitPropTypesByName.set(declarator.id.name, explicitType);
+        }
+      }
+    } else if (statement.type === "VariableDeclaration") {
+      for (const declarator of statement.declarations ?? []) {
+        if (declarator.id?.type !== "Identifier" || !declarator.id.name) continue;
+        const explicitType = getTypeAnnotationText(ctx, declarator.id.typeAnnotation);
+        if (explicitType) {
+          ctx.explicitVariableTypesByName.set(declarator.id.name, explicitType);
         }
       }
     }

--- a/tests/fixtures/context-ts-annotation/input.svelte
+++ b/tests/fixtures/context-ts-annotation/input.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+
+  const ctx: { theme: string } = { theme: "dark" };
+  setContext("app", ctx);
+
+  /** @type {{ label: string }} */
+  const jsdocCtx = { label: "legacy" };
+  setContext("legacy", jsdocCtx);
+</script>
+
+<slot />

--- a/tests/fixtures/context-ts-annotation/output-class.d.ts
+++ b/tests/fixtures/context-ts-annotation/output-class.d.ts
@@ -1,0 +1,19 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type AppContext = {
+  ctx: { theme: string };
+};
+
+export type LegacyContext = {
+  jsdocCtx: { label: string };
+};
+
+export type ContextTsAnnotationProps = {
+  children?: (this: void) => void;
+};
+
+export default class ContextTsAnnotation extends SvelteComponentTyped<
+  ContextTsAnnotationProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/context-ts-annotation/output-component.d.ts
+++ b/tests/fixtures/context-ts-annotation/output-component.d.ts
@@ -1,0 +1,22 @@
+import type { Component } from "svelte";
+
+export type AppContext = {
+  ctx: { theme: string };
+};
+
+export type LegacyContext = {
+  jsdocCtx: { label: string };
+};
+
+export type ContextTsAnnotationProps = {
+  children?: (this: void) => void;
+};
+
+export type ContextTsAnnotationExports = Record<string, never>;
+
+declare const ContextTsAnnotation: Component<
+  ContextTsAnnotationProps,
+  ContextTsAnnotationExports,
+  ""
+>;
+export default ContextTsAnnotation;

--- a/tests/fixtures/context-ts-annotation/output.json
+++ b/tests/fixtures/context-ts-annotation/output.json
@@ -1,0 +1,62 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
+  "props": [],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": null,
+      "default": true,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 8
+        }
+      }
+    }
+  ],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [
+    {
+      "key": "app",
+      "typeName": "AppContext",
+      "properties": [
+        {
+          "name": "ctx",
+          "type": "{ theme: string }",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "key": "legacy",
+      "typeName": "LegacyContext",
+      "properties": [
+        {
+          "name": "jsdocCtx",
+          "type": "{ label: string }",
+          "description": "",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "diagnostics": []
+}


### PR DESCRIPTION
Context values declared with a TypeScript type annotation resolved to
any because variable type lookup only scanned JSDoc comment blocks.
The lookup now reads the declarator's TS type annotation from the AST
first and falls back to JSDoc, matching the precedence props already
use.

## Repro

```svelte
<script lang="ts">
  import { setContext } from "svelte";
  const ctx: { theme: string } = { theme: "dark" };
  setContext("app", ctx);
</script>
```

Before:
```json
"contexts": [
  {
    "key": "app",
    "typeName": "AppContext",
    "properties": [{ "name": "ctx", "type": "any", "optional": false }]
  }
]
```

After:
```json
"contexts": [
  {
    "key": "app",
    "typeName": "AppContext",
    "properties": [{ "name": "ctx", "type": "{ theme: string }", "optional": false }]
  }
]
```

## Test plan
- [x] `bun test tests/fixtures.test.ts` (new fixture `context-ts-annotation` covers both the TS-annotation and JSDoc `@type` paths in one component)
- [x] `bun run test:fixtures-types`
- [x] `bun test` (full suite, 1169 pass)