### PR TITLE
perf(deps): inline tinyglobby and zimmerframe

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,9 +13,7 @@
         "culls": "^0.2.0",
         "estree-walker": "^3.0.3",
         "svelte": "^5.56.3",
-        "tinyglobby": "^0.2.17",
         "typescript": "^7.0.2",
-        "zimmerframe": "^1.1.4",
       },
     },
   },
@@ -166,8 +164,6 @@
 
     "expect": ["expect@30.3.0", "", { "dependencies": { "@jest/expect-utils": "30.3.0", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.3.0", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q=="],
 
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -207,8 +203,6 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
-
-    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
     "culls": "^0.2.0",
     "estree-walker": "^3.0.3",
     "svelte": "^5.56.3",
-    "tinyglobby": "^0.2.17",
-    "typescript": "^7.0.2",
-    "zimmerframe": "^1.1.4"
+    "typescript": "^7.0.2"
   },
   "bin": {
     "sveld": "cli.js"

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,7 +1,7 @@
-import { lstatSync, readFileSync } from "node:fs";
+import type { Dirent } from "node:fs";
+import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, parse, relative, resolve } from "node:path";
-import { globSync } from "tinyglobby";
+import { dirname, isAbsolute, join, parse, relative, resolve } from "node:path";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
 import type { ParsedComponent } from "./ComponentParser";
 import { buildReverseDeps, expandAffected } from "./dependency-graph";
@@ -159,10 +159,43 @@ export interface GlobbedComponentSource {
   source: ReturnType<typeof asRelativeSourcePath>;
 }
 
+/**
+ * Recursively collects absolute paths of every `.svelte` file under `dir`.
+ *
+ * Skips dotfiles/dot-directories and follows symlinked directories, guarding
+ * against symlink cycles via a set of visited real paths. Tolerates a
+ * missing `dir` (returns no matches) instead of throwing.
+ */
+function findSvelteFiles(dir: string, results: string[] = [], visited = new Set<string>()): string[] {
+  let entries: Dirent[];
+  try {
+    const real = realpathSync(dir);
+    if (visited.has(real)) return results;
+    visited.add(real);
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    const entryPath = join(dir, entry.name);
+    const stat = entry.isSymbolicLink() ? statSync(entryPath, { throwIfNoEntry: false }) : entry;
+    if (!stat) continue; // Broken symlink.
+
+    if (stat.isDirectory()) {
+      findSvelteFiles(entryPath, results, visited);
+    } else if (stat.isFile() && entry.name.endsWith(".svelte")) {
+      results.push(entryPath);
+    }
+  }
+
+  return results;
+}
+
 /** Globs every `.svelte` file under `rootDir`, resolving each to its module name and source path. */
 export function globComponentSources(rootDir: string): GlobbedComponentSource[] {
-  return globSync(["**/*.svelte"], { cwd: rootDir, absolute: true }).map((matchedFile) => {
-    const file = resolve(matchedFile);
+  return findSvelteFiles(rootDir).map((file) => {
     const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
     const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
     return { moduleName, source };

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -20,7 +20,6 @@
  * `svelte/compiler`'s across every fixture, so a svelte upgrade that changes
  * this internal shape fails CI instead of silently shipping wrong output.
  */
-import { walk as zimmerframeWalk } from "zimmerframe";
 // @ts-expect-error - internal svelte module, no published types
 import { convert } from "../node_modules/svelte/src/compiler/legacy.js";
 // @ts-expect-error - internal svelte module, no published types
@@ -55,6 +54,32 @@ function stripMetadata(node: InternalAstNode): void {
   delete node.metadata;
 }
 
+/**
+ * Recursively strips `metadata` from every AST node reachable from `node`.
+ *
+ * Mirrors zimmerframe's `walk()` traversal rule: a value is only visited (and
+ * only has its own children recursed into) when it's an object carrying a
+ * `type` string. A child without `type` is left alone and its descendants
+ * are not visited, even if they themselves carry `type` - this is why
+ * `toPublicAst` below special-cases `ast.options.attributes` before calling
+ * this, since `options` itself has no `type`.
+ */
+function stripMetadataDeep(node: unknown): void {
+  if (!node || typeof node !== "object" || typeof (node as InternalAstNode).type !== "string") return;
+  stripMetadata(node as InternalAstNode);
+
+  for (const key in node as InternalAstNode) {
+    if (key === "type") continue;
+    const child = (node as Record<string, unknown>)[key];
+    if (!child || typeof child !== "object") continue;
+    if (Array.isArray(child)) {
+      for (const item of child) stripMetadataDeep(item);
+    } else {
+      stripMetadataDeep(child);
+    }
+  }
+}
+
 /** Mirrors `svelte/compiler`'s own internal `to_public_ast`. */
 function toPublicAst(source: string, ast: InternalAstRoot, modern: boolean | undefined): unknown {
   if (modern) {
@@ -67,12 +92,8 @@ function toPublicAst(source: string, ast: InternalAstRoot, modern: boolean | und
       }
     }
 
-    return zimmerframeWalk(ast, null, {
-      _(node, { next }) {
-        stripMetadata(node);
-        next();
-      },
-    });
+    stripMetadataDeep(ast);
+    return ast;
   }
 
   return convert(source, ast);


### PR DESCRIPTION
Both packages were used for a single narrow purpose, so they're replaced with small hand-written equivalents instead of pulling in the whole dependency. tinyglobby just walked a fixed **/*.svelte pattern in bundle.ts, replaced with a recursive node:fs directory walker that matches its actual defaults (skips dotfiles and dot-directories, follows symlinked directories with a cycle guard, tolerates a missing root directory). zimmerframe just deleted a metadata field off every parsed AST node in svelte-parse.ts, replaced with a function that reproduces its exact type-gated recursion (only descends into a child when it carries a type string, same as the original special-casing around ast.options.attributes).

This drops four packages from the built bundle: tinyglobby plus its fdir and picomatch dependencies, and zimmerframe. Generated output is unchanged.

Risk is mostly around the hand-rolled directory walker in bundle.ts diverging from tinyglobby's globbing semantics in some edge case (unusual symlink topology, case sensitivity, deeply nested cycles). The full test suite passes, including a test that exercises glob discovery against a directory that doesn't exist on disk, and a manual build confirms the removed packages no longer appear anywhere in the output chunks.