### PR TITLE
refactor(parser): share prop decision logic across legacy and runes modes

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -31,6 +31,7 @@ import { recordDiagnostic } from "./parser/diagnostics";
 import { addDispatchedEvent, literalDetailToTypeText, parseHostDispatchEventCall } from "./parser/events";
 import { parseGenericsAttribute } from "./parser/generics";
 import { parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
+import { resolvePropTypeAndDocs } from "./parser/prop-shared";
 import { addProp, processInitializer } from "./parser/props";
 import { maybeSetRestProps } from "./parser/rest-props";
 import { detectSyntaxMode } from "./parser/runes-detection";
@@ -239,7 +240,31 @@ export interface ComponentPropParam {
   optional?: boolean;
 }
 
-/** A parsed component prop. */
+/**
+ * A parsed component prop: the shared internal IR that every prop front-end
+ * (legacy `<script context="module">` exports, legacy instance
+ * `export let`/`export function`, and runes `$props()` destructuring)
+ * produces via {@link resolvePropTypeAndDocs}, then hands to `addProp`. The
+ * three front-ends differ only in how they extract the raw signals (type
+ * text, JSDoc, initializer shape) from their respective AST shapes; the
+ * decisions below are shared and, outside the two documented mode
+ * differences, identical across modes.
+ *
+ * - `typeSource` precedence: an explicit TypeScript annotation always wins,
+ *   then JSDoc (`@type`/`@param`/`@returns`), then a type resolved from an
+ *   identifier default's own JSDoc, and only then a bare inferred/initializer
+ *   type. See {@link resolveTypeSource}.
+ * - JSDoc-vs-TS merge: `type`/`params`/`returnType`/`description` each
+ *   independently prefer their JSDoc-sourced value over the identifier
+ *   default's resolved value; an explicit TypeScript type additionally beats
+ *   JSDoc for `type` only.
+ * - Mode difference (preserved, not converged): legacy `export let`/
+ *   `export function` never infers `isFunction` from a function-shaped type
+ *   text; runes `$props()` does (`inferIsFunctionFromTypeSignature`).
+ * - Mode difference (preserved, not converged): legacy falls back to a
+ *   matching `@typedef`'s own description when the prop has none; runes does
+ *   not pass `typedefs` to {@link resolvePropTypeAndDocs} today.
+ */
 export interface ComponentProp {
   /** Public prop name. */
   name: string;
@@ -249,31 +274,38 @@ export interface ComponentProp {
   constant: boolean;
   /** TypeScript type text. */
   type?: string;
-  /** Conservative provenance for the prop type. */
+  /** Conservative provenance for the prop type. See the precedence rule on {@link ComponentProp}. */
   typeSource?: ComponentPropTypeSource;
   /** Local binding when it differs from the public name. */
   localName?: string;
-  /** Default value as source text. */
+  /** Default value as source text; unset when the prop has no initializer/default. */
   value?: string;
-  /** Structured default value metadata for docs UIs. */
+  /** Structured default value metadata for docs UIs; set alongside `value` from the same initializer. */
   defaultValue?: ComponentPropDefaultValue;
-  /** From JSDoc. */
+  /** From JSDoc, or a matching `@typedef`'s own description (legacy only; see {@link ComponentProp}). */
   description?: string;
   /** From JSDoc `@param` on function props. */
   params?: ComponentPropParam[];
   /** From JSDoc `@returns` on function props. */
   returnType?: string;
-  /** True for arrow/function-expression props. */
+  /**
+   * True for arrow/function-expression initializers and bare `function`
+   * declarations in every mode; additionally true for a function-shaped
+   * type/JSDoc signature in runes only (see {@link ComponentProp}).
+   */
   isFunction: boolean;
   /** True for `function` declarations. */
   isFunctionDeclaration: boolean;
   /** True when declared with `let` and no default. */
   isRequired: boolean;
-  /** True when reactive. */
+  /**
+   * True when the prop is mutated locally (legacy, inferred from assignment/
+   * binding targets) or declared with `$bindable()` (runes).
+   */
   reactive: boolean;
   /** Binding direction from `@bindable` JSDoc. */
   binding?: ComponentPropBinding;
-  /** True when declared with Svelte 5 `$bindable()`. */
+  /** True when declared with Svelte 5 `$bindable()` (runes only). */
   bindable?: true;
   /** From `@deprecated` JSDoc. */
   deprecated?: DeprecatedValue;
@@ -512,8 +544,9 @@ export interface ParsedComponent {
   source?: SourceRange;
   syntaxMode: SyntaxMode;
   scriptLanguage?: ScriptLanguage;
+  /** Instance-level props (`export let`/`export function`, or runes `$props()`). See {@link ComponentProp} for the shared IR these are built from. */
   props: ComponentProp[];
-  /** Exports from `<script context="module">`. */
+  /** Exports from `<script context="module">`. Same {@link ComponentProp} shape as `props`, resolved through the same shared decisions. */
   moduleExports: ComponentProp[];
   slots: ComponentSlot[];
   /** Serialized events for JSON/API output. */
@@ -682,24 +715,6 @@ export default class ComponentParser {
     }
 
     return false;
-  }
-
-  resolveTypeSource({
-    hasTypeScriptType,
-    hasJSDocType,
-    inferredType,
-    finalType,
-  }: {
-    hasTypeScriptType?: boolean;
-    hasJSDocType?: boolean;
-    inferredType?: string;
-    finalType?: string;
-  }): ComponentPropTypeSource {
-    if (hasTypeScriptType) return "typescript";
-    if (hasJSDocType) return "jsdoc";
-    if (inferredType !== undefined) return "default";
-    if (finalType !== undefined) return "inferred";
-    return "unknown";
   }
 
   resolveLocalVarJSDoc(name: string) {
@@ -891,16 +906,13 @@ export default class ComponentParser {
 
             let prop_name: string;
             let kind: "let" | "const" | "function";
-            let description: string | undefined;
             let isFunctionDeclaration = false;
             let value: string | undefined;
-            let type: string | undefined;
+            let typeSeed: string | undefined;
             let explicitType: string | undefined;
-            let isFunction = false;
-            let params: ComponentPropParam[] | undefined;
-            let returnType: string | undefined;
+            let initializerIsFunction = false;
             let defaultValue: ComponentPropDefaultValue | undefined;
-            let inferredType: string | undefined;
+            let inferredTypeForSource: string | undefined;
             let resolvedJSDoc:
               | Pick<
                   ProcessedInitializer,
@@ -914,8 +926,8 @@ export default class ComponentParser {
               prop_name = funcDecl.id.name;
               kind = "function";
               value = undefined;
-              type = "() => any";
-              isFunction = true;
+              typeSeed = "() => any";
+              initializerIsFunction = true;
               isFunctionDeclaration = true;
             } else if (node.declaration.type === "VariableDeclaration") {
               const varDecl = node.declaration as VariableDeclaration;
@@ -934,59 +946,31 @@ export default class ComponentParser {
               prop_name = localPropName;
               kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
               const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
-              ({ value, type: inferredType, isFunction, defaultValue } = initResult);
+              ({ value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult);
+              inferredTypeForSource = typeSeed;
               resolvedJSDoc = initResult;
               explicitType = this.getExplicitPropType(localPropName);
-              type = explicitType ?? inferredType;
             } else {
               return;
             }
 
             const jsdocInfo = processNodeJSDoc(this.ctx, this, node);
-            if (jsdocInfo) {
-              if (jsdocInfo.type && explicitType === undefined) type = jsdocInfo.type;
-              params = jsdocInfo.params;
-              returnType = jsdocInfo.returnType;
-              if (jsdocInfo.description) description = jsdocInfo.description;
-            }
 
-            if (explicitType === undefined && jsdocInfo?.type === undefined && resolvedJSDoc?.resolvedType) {
-              type = resolvedJSDoc.resolvedType;
-            }
-            if (description === undefined && resolvedJSDoc?.resolvedDescription) {
-              description = resolvedJSDoc.resolvedDescription;
-            }
-            if (params === undefined && resolvedJSDoc?.resolvedParams) params = resolvedJSDoc.resolvedParams;
-            if (returnType === undefined && resolvedJSDoc?.resolvedReturnType)
-              returnType = resolvedJSDoc.resolvedReturnType;
-
-            // Merge returnType into type for function declarations if not overridden by @type
-            if (isFunctionDeclaration && type === "() => any" && returnType) {
-              if (params && params.length > 0) {
-                const paramStrings = params.map((param) => {
-                  const optional = param.optional ? "?" : "";
-                  return `${param.name}${optional}: ${param.type}`;
-                });
-                const paramsString = paramStrings.join(", ");
-                type = `(${paramsString}) => ${returnType}`;
-              } else {
-                type = `() => ${returnType}`;
-              }
-            }
-
-            if (!description && type && this.ctx.typedefs.has(type)) {
-              description = this.ctx.typedefs.get(type)?.description;
-            }
-
-            const typeSource = this.resolveTypeSource({
-              hasTypeScriptType: explicitType !== undefined,
-              hasJSDocType:
-                jsdocInfo?.type !== undefined ||
-                jsdocInfo?.params !== undefined ||
-                jsdocInfo?.returnType !== undefined ||
-                resolvedJSDoc?.resolvedType !== undefined,
-              inferredType,
-              finalType: type,
+            const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
+              explicitType,
+              typeSeed,
+              inferredTypeForSource,
+              jsdocType: jsdocInfo?.type,
+              jsdocDescription: jsdocInfo?.description,
+              jsdocParams: jsdocInfo?.params,
+              jsdocReturnType: jsdocInfo?.returnType,
+              resolvedType: resolvedJSDoc?.resolvedType,
+              resolvedDescription: resolvedJSDoc?.resolvedDescription,
+              resolvedParams: resolvedJSDoc?.resolvedParams,
+              resolvedReturnType: resolvedJSDoc?.resolvedReturnType,
+              initializerIsFunction,
+              isFunctionDeclaration,
+              typedefs: this.ctx.typedefs,
             });
 
             this.addModuleExport(prop_name, {
@@ -1184,18 +1168,15 @@ export default class ComponentParser {
           }
 
           let kind: "let" | "const" | "function";
-          let description: undefined | string;
           let isFunctionDeclaration = false;
           let value: string | undefined;
-          let type: string | undefined;
+          let typeSeed: string | undefined;
           let explicitType: string | undefined;
-          let isFunction = false;
-          let params: ComponentPropParam[] | undefined;
-          let returnType: string | undefined;
+          let initializerIsFunction = false;
           let isRequired = false;
           let localName: string | undefined;
           let defaultValue: ComponentPropDefaultValue | undefined;
-          let inferredType: string | undefined;
+          let inferredTypeForSource: string | undefined;
           let resolvedJSDoc:
             | Pick<
                 ProcessedInitializer,
@@ -1210,8 +1191,8 @@ export default class ComponentParser {
             localName = funcDecl.id.name;
             kind = "function";
             value = undefined;
-            type = "() => any";
-            isFunction = true;
+            typeSeed = "() => any";
+            initializerIsFunction = true;
             isFunctionDeclaration = true;
             isRequired = false;
           } else if (node.declaration.type === "VariableDeclaration") {
@@ -1235,58 +1216,30 @@ export default class ComponentParser {
             kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
             isRequired = kind === "let" && init == null;
             const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
-            ({ value, type: inferredType, isFunction, defaultValue } = initResult);
+            ({ value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult);
+            inferredTypeForSource = typeSeed;
             resolvedJSDoc = initResult;
-            type = explicitType ?? inferredType;
           } else {
             return;
           }
 
           const jsdocInfo = processNodeJSDoc(this.ctx, this, node);
-          if (jsdocInfo) {
-            if (jsdocInfo.type && explicitType === undefined) type = jsdocInfo.type;
-            params = jsdocInfo.params;
-            returnType = jsdocInfo.returnType;
-            if (jsdocInfo.description) description = jsdocInfo.description;
-          }
 
-          if (explicitType === undefined && jsdocInfo?.type === undefined && resolvedJSDoc?.resolvedType) {
-            type = resolvedJSDoc.resolvedType;
-          }
-          if (description === undefined && resolvedJSDoc?.resolvedDescription) {
-            description = resolvedJSDoc.resolvedDescription;
-          }
-          if (params === undefined && resolvedJSDoc?.resolvedParams) params = resolvedJSDoc.resolvedParams;
-          if (returnType === undefined && resolvedJSDoc?.resolvedReturnType)
-            returnType = resolvedJSDoc.resolvedReturnType;
-
-          // Merge returnType into type for function declarations if not overridden by @type
-          if (isFunctionDeclaration && type === "() => any" && returnType) {
-            if (params && params.length > 0) {
-              const paramStrings = params.map((param) => {
-                const optional = param.optional ? "?" : "";
-                return `${param.name}${optional}: ${param.type}`;
-              });
-              const paramsString = paramStrings.join(", ");
-              type = `(${paramsString}) => ${returnType}`;
-            } else {
-              type = `() => ${returnType}`;
-            }
-          }
-
-          if (!description && type && this.ctx.typedefs.has(type)) {
-            description = this.ctx.typedefs.get(type)?.description;
-          }
-
-          const typeSource = this.resolveTypeSource({
-            hasTypeScriptType: explicitType !== undefined,
-            hasJSDocType:
-              jsdocInfo?.type !== undefined ||
-              jsdocInfo?.params !== undefined ||
-              jsdocInfo?.returnType !== undefined ||
-              resolvedJSDoc?.resolvedType !== undefined,
-            inferredType,
-            finalType: type,
+          const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
+            explicitType,
+            typeSeed,
+            inferredTypeForSource,
+            jsdocType: jsdocInfo?.type,
+            jsdocDescription: jsdocInfo?.description,
+            jsdocParams: jsdocInfo?.params,
+            jsdocReturnType: jsdocInfo?.returnType,
+            resolvedType: resolvedJSDoc?.resolvedType,
+            resolvedDescription: resolvedJSDoc?.resolvedDescription,
+            resolvedParams: resolvedJSDoc?.resolvedParams,
+            resolvedReturnType: resolvedJSDoc?.resolvedReturnType,
+            initializerIsFunction,
+            isFunctionDeclaration,
+            typedefs: this.ctx.typedefs,
           });
 
           addProp(this, this.ctx, prop_name, {

--- a/src/parser/prop-shared.ts
+++ b/src/parser/prop-shared.ts
@@ -1,0 +1,138 @@
+import type { ComponentPropParam, ComponentPropTypeSource } from "../ComponentParser";
+
+/**
+ * Decides a prop's provenance for docs UIs. Order is fixed and mirrors the
+ * precedence used to pick the prop's final `type` text in
+ * {@link resolvePropTypeAndDocs}: an explicit TypeScript annotation always
+ * wins, then JSDoc `@type`/`@param`/`@returns`, then a type resolved from an
+ * identifier default's own JSDoc, and only then a bare inferred/initializer
+ * type. `"unknown"` means none of the above produced any type text at all.
+ */
+export function resolveTypeSource({
+  hasTypeScriptType,
+  hasJSDocType,
+  inferredType,
+  finalType,
+}: {
+  hasTypeScriptType?: boolean;
+  hasJSDocType?: boolean;
+  inferredType?: string;
+  finalType?: string;
+}): ComponentPropTypeSource {
+  if (hasTypeScriptType) return "typescript";
+  if (hasJSDocType) return "jsdoc";
+  if (inferredType !== undefined) return "default";
+  if (finalType !== undefined) return "inferred";
+  return "unknown";
+}
+
+export interface ResolvePropTypeAndDocsInput {
+  /** Explicit TypeScript type text: a legacy `: T` annotation, or the matching `$props()` type-literal member in runes. */
+  explicitType?: string;
+  /**
+   * Lowest-precedence type text, used only when nothing else applies: the
+   * initializer's inferred type, or the literal `"() => any"` seed for a
+   * bare `export function` declaration (which has no initializer).
+   */
+  typeSeed?: string;
+  /**
+   * Value fed to {@link resolveTypeSource}'s `inferredType` bucket. Distinct
+   * from `typeSeed` for function declarations, which have an initializer-less
+   * `typeSeed` placeholder but no actual inferred type.
+   */
+  inferredTypeForSource?: string;
+  jsdocType?: string;
+  jsdocDescription?: string;
+  jsdocParams?: ComponentPropParam[];
+  jsdocReturnType?: string;
+  /**
+   * Type/description/params/returnType resolved from an identifier default's
+   * own JSDoc (e.g. `export let onClick = defaultHandler;` where
+   * `defaultHandler` carries its own doc comment). Callers should gate this
+   * to `undefined` whenever `explicitType`/`jsdocType` is already set, so it
+   * only ever fills a genuine gap (see {@link resolvePropIsFunction}, which
+   * relies on the same gating).
+   */
+  resolvedType?: string;
+  resolvedDescription?: string;
+  resolvedParams?: ComponentPropParam[];
+  resolvedReturnType?: string;
+  /** True when the initializer itself is an arrow/function expression. */
+  initializerIsFunction: boolean;
+  /** True for a bare `export function foo() {}` declaration. */
+  isFunctionDeclaration: boolean;
+  /**
+   * Runes-only: also treat the prop as a function when its resolved type
+   * text looks like a callback signature (`@param`/`@returns`/`=>` from
+   * TypeScript, JSDoc, or an identifier default). Legacy `export let` never
+   * applies this signature check; the mode difference predates this helper
+   * and is preserved here rather than silently converged.
+   */
+  inferIsFunctionFromTypeSignature?: boolean;
+  /**
+   * Legacy-only: fall back to a `@typedef`'s own description when the prop
+   * has none of its own. Runes omits this today (a preserved mode
+   * difference); pass `undefined` there.
+   */
+  typedefs?: Map<string, { description?: string }>;
+}
+
+export interface ResolvedPropTypeAndDocs {
+  type?: string;
+  typeSource: ComponentPropTypeSource;
+  description?: string;
+  params?: ComponentPropParam[];
+  returnType?: string;
+  isFunction: boolean;
+}
+
+/**
+ * Resolves the type/description/params/returnType/isFunction decisions
+ * shared by every prop front-end (legacy module exports, legacy instance
+ * `export let`/`export function`, and runes `$props()` destructuring). The
+ * front-ends differ only in how they extract the raw signals below from
+ * their respective AST shapes; once extracted, the decisions are identical
+ * except where explicitly parameterized above.
+ */
+export function resolvePropTypeAndDocs(input: ResolvePropTypeAndDocsInput): ResolvedPropTypeAndDocs {
+  let type = input.explicitType ?? input.jsdocType ?? input.resolvedType ?? input.typeSeed;
+  const params = input.jsdocParams ?? input.resolvedParams;
+  const returnType = input.jsdocReturnType ?? input.resolvedReturnType;
+
+  // A bare `export function foo() {}` has no `@type` placeholder of its own; if JSDoc
+  // supplies `@param`/`@returns` but no `@type`, build a signature from them.
+  if (input.isFunctionDeclaration && type === "() => any" && returnType) {
+    type =
+      params && params.length > 0
+        ? `(${params.map((param) => `${param.name}${param.optional ? "?" : ""}: ${param.type}`).join(", ")}) => ${returnType}`
+        : `() => ${returnType}`;
+  }
+
+  let description = input.jsdocDescription ?? input.resolvedDescription;
+  if (description === undefined && type !== undefined) {
+    description = input.typedefs?.get(type)?.description;
+  }
+
+  const typeSource = resolveTypeSource({
+    hasTypeScriptType: input.explicitType !== undefined,
+    hasJSDocType:
+      input.jsdocType !== undefined ||
+      input.jsdocParams !== undefined ||
+      input.jsdocReturnType !== undefined ||
+      input.resolvedType !== undefined,
+    inferredType: input.inferredTypeForSource,
+    finalType: type,
+  });
+
+  const isFunction =
+    input.initializerIsFunction ||
+    input.isFunctionDeclaration ||
+    (input.inferIsFunctionFromTypeSignature === true &&
+      (!!input.jsdocParams?.length ||
+        input.jsdocReturnType !== undefined ||
+        !!input.jsdocType?.includes("=>") ||
+        !!input.resolvedType?.includes("=>") ||
+        !!input.explicitType?.includes("=>")));
+
+  return { type, typeSource, description, params, returnType, isFunction };
+}

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -13,6 +13,7 @@ import { parse } from "../svelte-parse";
 import type { ParserContext } from "./context";
 import { collectGenericsAttributeTypeDependencies } from "./generics";
 import { processLeadingCommentsJSDoc, processNodeJSDoc } from "./jsdoc";
+import { resolvePropTypeAndDocs } from "./prop-shared";
 import { addProp, processInitializer, unwrapBindableInitializer } from "./props";
 import { sourceAtPos, sourceRangeFromNode } from "./source-position";
 import {
@@ -445,25 +446,27 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
       );
       const { init: unwrappedInit, bindable } = unwrapBindableInitializer(init);
       const initResult = unwrappedInit == null ? { isFunction: false } : processInitializer(parser, ctx, unwrappedInit);
-      const { value, type: inferredType, isFunction, defaultValue } = initResult;
+      const { value, type: inferredType, isFunction: initializerIsFunction, defaultValue } = initResult;
+      // Only trust the identifier default's own JSDoc type when nothing more explicit already
+      // won; an explicit TS/JSDoc type on the prop itself must not be overridden by it.
       const inheritedType =
         typeMetadata?.type === undefined && propertyJSDoc?.type === undefined ? initResult.resolvedType : undefined;
-      const isFunctionFromJSDoc =
-        !!propertyJSDoc?.params?.length ||
-        propertyJSDoc?.returnType !== undefined ||
-        propertyJSDoc?.type?.includes("=>") ||
-        !!inheritedType?.includes("=>") ||
-        !!typeMetadata?.type?.includes("=>");
-      const type = typeMetadata?.type ?? propertyJSDoc?.type ?? inheritedType ?? inferredType;
-      const typeSource = parser.resolveTypeSource({
-        hasTypeScriptType: typeMetadata?.type !== undefined,
-        hasJSDocType:
-          propertyJSDoc?.type !== undefined ||
-          propertyJSDoc?.params !== undefined ||
-          propertyJSDoc?.returnType !== undefined ||
-          inheritedType !== undefined,
-        inferredType,
-        finalType: type,
+
+      const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
+        explicitType: typeMetadata?.type,
+        typeSeed: inferredType,
+        inferredTypeForSource: inferredType,
+        jsdocType: propertyJSDoc?.type,
+        jsdocDescription: propertyJSDoc?.description,
+        jsdocParams: propertyJSDoc?.params,
+        jsdocReturnType: propertyJSDoc?.returnType,
+        resolvedType: inheritedType,
+        resolvedDescription: initResult.resolvedDescription,
+        resolvedParams: initResult.resolvedParams,
+        resolvedReturnType: initResult.resolvedReturnType,
+        initializerIsFunction,
+        isFunctionDeclaration: false,
+        inferIsFunctionFromTypeSignature: true,
       });
 
       if (bindable) {
@@ -474,7 +477,7 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
         name: propName,
         ...(localName === propName ? {} : { localName }),
         kind: "let",
-        description: propertyJSDoc?.description ?? initResult.resolvedDescription,
+        description,
         binding: propertyJSDoc?.binding,
         deprecated: propertyJSDoc?.deprecated,
         tags: propertyJSDoc?.tags,
@@ -483,9 +486,9 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
         typeSource,
         value,
         defaultValue,
-        params: propertyJSDoc?.params ?? initResult.resolvedParams,
-        returnType: propertyJSDoc?.returnType ?? initResult.resolvedReturnType,
-        isFunction: Boolean(isFunction || isFunctionFromJSDoc),
+        params,
+        returnType,
+        isFunction,
         isFunctionDeclaration: false,
         isRequired: unwrappedInit == null && typeMetadata?.optional !== true,
         constant: false,

--- a/tests/prop-shared.test.ts
+++ b/tests/prop-shared.test.ts
@@ -1,0 +1,235 @@
+import { resolvePropTypeAndDocs, resolveTypeSource } from "../src/parser/prop-shared";
+
+describe("resolveTypeSource", () => {
+  const cases: Array<[string, Parameters<typeof resolveTypeSource>[0], ReturnType<typeof resolveTypeSource>]> = [
+    [
+      "explicit TypeScript wins over everything",
+      { hasTypeScriptType: true, hasJSDocType: true, inferredType: "string", finalType: "string" },
+      "typescript",
+    ],
+    [
+      "JSDoc wins over inferred/final",
+      { hasTypeScriptType: false, hasJSDocType: true, inferredType: "string", finalType: "string" },
+      "jsdoc",
+    ],
+    [
+      "an inferred initializer type is 'default'",
+      { hasTypeScriptType: false, hasJSDocType: false, inferredType: "string", finalType: "string" },
+      "default",
+    ],
+    [
+      "only a final type with no inferred type is 'inferred'",
+      { hasTypeScriptType: false, hasJSDocType: false, finalType: "() => any" },
+      "inferred",
+    ],
+    ["nothing resolved at all is 'unknown'", { hasTypeScriptType: false, hasJSDocType: false }, "unknown"],
+  ];
+
+  for (const [name, input, expected] of cases) {
+    test(name, () => {
+      expect(resolveTypeSource(input)).toBe(expected);
+    });
+  }
+});
+
+describe("resolvePropTypeAndDocs: type precedence", () => {
+  const base = { initializerIsFunction: false, isFunctionDeclaration: false };
+
+  test("explicit TypeScript type beats JSDoc, resolved, and inferred types", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      explicitType: "string",
+      jsdocType: "number",
+      resolvedType: "boolean",
+      typeSeed: "object",
+    });
+    expect(result.type).toBe("string");
+    expect(result.typeSource).toBe("typescript");
+  });
+
+  test("JSDoc type beats resolved and inferred types when there is no explicit type", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      jsdocType: "number",
+      resolvedType: "boolean",
+      typeSeed: "object",
+    });
+    expect(result.type).toBe("number");
+    expect(result.typeSource).toBe("jsdoc");
+  });
+
+  test("a resolved (identifier default JSDoc) type beats a bare inferred type", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      resolvedType: "boolean",
+      typeSeed: "object",
+      inferredTypeForSource: "object",
+    });
+    expect(result.type).toBe("boolean");
+    expect(result.typeSource).toBe("jsdoc");
+  });
+
+  test("falls back to the inferred initializer type when nothing else applies", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      typeSeed: "object",
+      inferredTypeForSource: "object",
+    });
+    expect(result.type).toBe("object");
+    expect(result.typeSource).toBe("default");
+  });
+
+  test("a bare `export function` with no JSDoc @type keeps its () => any placeholder", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: true,
+      isFunctionDeclaration: true,
+      typeSeed: "() => any",
+    });
+    expect(result.type).toBe("() => any");
+    expect(result.typeSource).toBe("inferred");
+  });
+
+  test("a bare `export function` builds its signature from @param/@returns when there is no @type", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: true,
+      isFunctionDeclaration: true,
+      typeSeed: "() => any",
+      jsdocParams: [{ name: "x", type: "number" }],
+      jsdocReturnType: "string",
+    });
+    expect(result.type).toBe("(x: number) => string");
+    expect(result.typeSource).toBe("jsdoc");
+  });
+
+  test("a bare `export function` with @returns but no @param becomes a zero-arg signature", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: true,
+      isFunctionDeclaration: true,
+      typeSeed: "() => any",
+      jsdocReturnType: "string",
+    });
+    expect(result.type).toBe("() => string");
+  });
+
+  test("an explicit @type on a function declaration overrides the () => any placeholder outright", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: true,
+      isFunctionDeclaration: true,
+      typeSeed: "() => any",
+      jsdocType: "(x: number) => void",
+      jsdocReturnType: "string",
+    });
+    expect(result.type).toBe("(x: number) => void");
+  });
+});
+
+describe("resolvePropTypeAndDocs: description/params/returnType merging", () => {
+  const base = { initializerIsFunction: false, isFunctionDeclaration: false };
+
+  test("JSDoc description wins over the resolved (identifier default) description", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      jsdocDescription: "from jsdoc",
+      resolvedDescription: "from resolved",
+    });
+    expect(result.description).toBe("from jsdoc");
+  });
+
+  test("falls back to the resolved description when there is no JSDoc description", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      resolvedDescription: "from resolved",
+    });
+    expect(result.description).toBe("from resolved");
+  });
+
+  test("falls back to a matching @typedef's own description when typedefs are provided", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      explicitType: "MyCallback",
+      typedefs: new Map([["MyCallback", { description: "typedef description" }]]),
+    });
+    expect(result.description).toBe("typedef description");
+  });
+
+  test("does not consult typedefs when none are provided (runes today)", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      explicitType: "MyCallback",
+    });
+    expect(result.description).toBeUndefined();
+  });
+
+  test("JSDoc params/returnType win over resolved params/returnType", () => {
+    const result = resolvePropTypeAndDocs({
+      ...base,
+      jsdocParams: [{ name: "a", type: "string" }],
+      jsdocReturnType: "void",
+      resolvedParams: [{ name: "b", type: "number" }],
+      resolvedReturnType: "boolean",
+    });
+    expect(result.params).toEqual([{ name: "a", type: "string" }]);
+    expect(result.returnType).toBe("void");
+  });
+});
+
+describe("resolvePropTypeAndDocs: isFunction", () => {
+  test("an arrow/function-expression initializer is always a function", () => {
+    const result = resolvePropTypeAndDocs({ initializerIsFunction: true, isFunctionDeclaration: false });
+    expect(result.isFunction).toBe(true);
+  });
+
+  test("a bare `export function` declaration is always a function", () => {
+    const result = resolvePropTypeAndDocs({ initializerIsFunction: false, isFunctionDeclaration: true });
+    expect(result.isFunction).toBe(true);
+  });
+
+  test("legacy export let does not infer isFunction from a function-shaped type (preserved mode difference)", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: false,
+      isFunctionDeclaration: false,
+      explicitType: "() => void",
+    });
+    expect(result.isFunction).toBe(false);
+  });
+
+  test("runes $props() infers isFunction from an explicit function-shaped type when opted in", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: false,
+      isFunctionDeclaration: false,
+      explicitType: "() => void",
+      inferIsFunctionFromTypeSignature: true,
+    });
+    expect(result.isFunction).toBe(true);
+  });
+
+  test("runes $props() infers isFunction from JSDoc @param even without a function-shaped type", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: false,
+      isFunctionDeclaration: false,
+      jsdocParams: [{ name: "x", type: "number" }],
+      inferIsFunctionFromTypeSignature: true,
+    });
+    expect(result.isFunction).toBe(true);
+  });
+
+  test("runes $props() infers isFunction from JSDoc @returns even without a function-shaped type", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: false,
+      isFunctionDeclaration: false,
+      jsdocReturnType: "void",
+      inferIsFunctionFromTypeSignature: true,
+    });
+    expect(result.isFunction).toBe(true);
+  });
+
+  test("a non-function type never infers isFunction, even when opted in", () => {
+    const result = resolvePropTypeAndDocs({
+      initializerIsFunction: false,
+      isFunctionDeclaration: false,
+      explicitType: "string",
+      inferIsFunctionFromTypeSignature: true,
+    });
+    expect(result.isFunction).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Legacy `export let`/`export function` extraction (in `ComponentParser.ts`,
both the module-export and instance-export walks) and runes `$props()`
extraction (`src/parser/runes-props.ts`) each re-implemented the same
decisions for type resolution, `typeSource` precedence, `isFunction`, and
JSDoc-vs-TS merging, and the copies had drifted, producing mode-specific
bugs. Those decisions now live in a single shared module,
`src/parser/prop-shared.ts`, and all three front-ends are syntax-only
adapters over the same component IR (`ComponentProp`), whose invariants are
now documented on the type in `ComponentParser.ts`.

Body (no em dashes):

Legacy export let extraction and runes $props() extraction duplicated
the decisions for type resolution, typeSource precedence, isFunction,
and JSDoc merging, and the copies had drifted, producing mode-specific
bugs. The decisions now live in shared helpers with table-driven unit
tests, and both front-ends are syntax-only adapters over the same
component IR, whose invariants are documented on the type.

## Duplicated decisions found (step 2)

Diffing the legacy module-export walk, the legacy instance-export walk, and
the runes `$props()` destructuring walk turned up the same decisions
reimplemented in each:

- **Type precedence**: explicit TypeScript type > JSDoc `@type` > a type
  resolved from an identifier default's own JSDoc > a bare inferred/
  initializer type (or the `"() => any"` placeholder seed for a bare
  `export function`).
- **`typeSource` provenance**: `parser.resolveTypeSource(...)` was already a
  shared method, but every call site rebuilt its `hasTypeScriptType`/
  `hasJSDocType` inputs by hand from the same four signals.
- **`description`/`params`/`returnType` merging**: each independently
  preferred its JSDoc-sourced value over the identifier-default-resolved
  value.
- **`isFunction` determination**: true for an arrow/function-expression
  initializer or a bare `function` declaration.
- **Function-declaration return-type merge**: for a bare `export function`
  with `@param`/`@returns` but no `@type`, build a signature from them
  (duplicated between the module-export and instance-export legacy walks
  specifically).
- **`@typedef` description fallback**: when a prop has no description of its
  own, look up its type name in `ctx.typedefs` (duplicated between the two
  legacy walks).

These are now one function each in `src/parser/prop-shared.ts`
(`resolveTypeSource`, `resolvePropTypeAndDocs`), called from all three
extraction sites.

## Preserved mode differences (step 3)

Two behavioral differences between legacy and runes proved observable
(verified with ad hoc parses) and are preserved via explicit parameters
rather than silently converged, so this PR stays byte-identical against
existing fixtures:

- **`isFunction` from a function-shaped type signature**: runes infers
  `isFunction: true` for a TS-typed callback prop with no initializer (e.g.
  `let { onClick }: { onClick: () => void } = $props();`); legacy
  `export let onClick: () => void;` does not. Parameterized as
  `inferIsFunctionFromTypeSignature` (`true` for runes, omitted for legacy).
- **`@typedef` description fallback**: legacy falls back to a matching
  `@typedef`'s own description when a prop has none; runes does not apply
  this fallback today. Parameterized as an optional `typedefs` map (passed
  for both legacy walks, omitted for runes).

Both differences are now documented as invariants on `ComponentProp` in
`ComponentParser.ts` rather than living as implicit drift between two
copies of the same logic.

## Test plan

- [x] `bun test` — 1196 pass, 0 fail, zero snapshot changes
- [x] New table-driven unit tests in `tests/prop-shared.test.ts` pin the
      shared helpers' rules (type precedence, description/params/returnType
      merging, `isFunction`, and both preserved mode differences)
      independent of fixtures
- [x] `bunx tsc --noEmit` clean for `src/`
- [x] `bunx biome check` clean