### PR TITLE
refactor(parser): build a per-component symbol table for variable info

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -1,4 +1,3 @@
-import { parse as parseComment } from "comment-parser";
 import type {
   AssignmentExpression,
   CallExpression,
@@ -31,7 +30,7 @@ import { parseSetContextCall } from "./parser/contexts";
 import { recordDiagnostic } from "./parser/diagnostics";
 import { addDispatchedEvent, literalDetailToTypeText, parseHostDispatchEventCall } from "./parser/events";
 import { parseGenericsAttribute } from "./parser/generics";
-import { getCommentTags, parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
+import { parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
 import { addProp, processInitializer } from "./parser/props";
 import { maybeSetRestProps } from "./parser/rest-props";
 import { detectSyntaxMode } from "./parser/runes-detection";
@@ -53,10 +52,8 @@ import { sourceAtPos, sourceRangeFromNode, sourceRangeFromOffsets } from "./pars
 import { buildTypeScriptMetadata } from "./parser/type-resolution";
 import { stripTypeCastWrappers } from "./parser/typescript-casts";
 import { assignValueOrUndefined } from "./parser/utils";
+import { buildVariableJsDocTable } from "./parser/variable-jsdoc";
 import { parse } from "./svelte-parse";
-
-/** Matches `const`/`let`/`function` declarations for JSDoc association. */
-const VAR_DECLARATION_REGEX = /(?:const|let|function)\s+(\w+)\s*[=(]/;
 
 export { assignValueOrUndefined as assignValue };
 
@@ -756,66 +753,6 @@ export default class ComponentParser {
     return type.trim();
   }
 
-  private buildVariableInfoCache() {
-    if (!this.ctx.source) return;
-
-    if (!this.ctx.sourceLinesCache) {
-      this.ctx.sourceLinesCache = this.ctx.source.split("\n");
-    }
-    const lines = this.ctx.sourceLinesCache;
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i].trim();
-
-      const varMatch = line.match(VAR_DECLARATION_REGEX);
-      if (varMatch) {
-        const varName = varMatch[1];
-
-        for (let j = i - 1; j >= 0; j--) {
-          const prevLine = lines[j].trim();
-
-          if (prevLine && !prevLine.startsWith("*") && !prevLine.startsWith("/*") && !prevLine.startsWith("//")) {
-            break;
-          }
-
-          if (prevLine.startsWith("/**")) {
-            const commentLines: string[] = [];
-            for (let k = j; k < i; k++) {
-              commentLines.push(lines[k]);
-            }
-            const commentBlock = commentLines.join("\n");
-
-            const parsed = parseComment(commentBlock, { spacing: "preserve" });
-            const { type: typeTag, description } = getCommentTags(parsed);
-            if (typeTag) {
-              this.ctx.variableInfoCache.set(varName, {
-                type: this.aliasType(typeTag.type),
-                description: description || typeTag.description,
-              });
-            }
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  private static readonly VAR_NAME_REGEX_CACHE = new Map<string, [RegExp, RegExp, RegExp]>();
-
-  private static getVarNameRegexes(varName: string): [RegExp, RegExp, RegExp] {
-    let cached = ComponentParser.VAR_NAME_REGEX_CACHE.get(varName);
-    if (!cached) {
-      const escaped = varName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      cached = [
-        new RegExp(`const\\s+${escaped}\\s*=`),
-        new RegExp(`let\\s+${escaped}\\s*=`),
-        new RegExp(`function\\s+${escaped}\\s*\\(`),
-      ];
-      ComponentParser.VAR_NAME_REGEX_CACHE.set(varName, cached);
-    }
-    return cached;
-  }
-
   /**
    * @example
    * ```ts
@@ -840,7 +777,7 @@ export default class ComponentParser {
     }
 
     if (!this.ctx.variableInfoCacheBuilt) {
-      this.buildVariableInfoCache();
+      this.ctx.variableInfoCache = buildVariableJsDocTable(this.ctx, this);
       this.ctx.variableInfoCacheBuilt = true;
     }
 
@@ -854,56 +791,7 @@ export default class ComponentParser {
       };
     }
 
-    if (cached) {
-      return cached;
-    }
-
-    if (!this.ctx.source) return null;
-
-    if (!this.ctx.sourceLinesCache) {
-      this.ctx.sourceLinesCache = this.ctx.source.split("\n");
-    }
-    const lines = this.ctx.sourceLinesCache;
-
-    const [constRegex, letRegex, funcRegex] = ComponentParser.getVarNameRegexes(varName);
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i].trim();
-
-      const constMatch = line.match(constRegex);
-      const letMatch = line.match(letRegex);
-      const funcMatch = line.match(funcRegex);
-
-      if (constMatch || letMatch || funcMatch) {
-        for (let j = i - 1; j >= 0; j--) {
-          const prevLine = lines[j].trim();
-
-          if (prevLine && !prevLine.startsWith("*") && !prevLine.startsWith("/*") && !prevLine.startsWith("//")) {
-            break;
-          }
-
-          if (prevLine.startsWith("/**")) {
-            const commentLines: string[] = [];
-            for (let k = j; k < i; k++) {
-              commentLines.push(lines[k]);
-            }
-            const commentBlock = commentLines.join("\n");
-
-            const parsed = parseComment(commentBlock, { spacing: "preserve" });
-            const { type: typeTag, description } = getCommentTags(parsed);
-            if (typeTag) {
-              return {
-                type: this.aliasType(typeTag.type),
-                description: description || typeTag.description,
-              };
-            }
-            break;
-          }
-        }
-      }
-    }
-
-    return null;
+    return cached ?? null;
   }
 
   accumulateGeneric(name: string, constraint: string): void {

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -34,7 +34,6 @@ export interface ParserContext {
    */
   runesOptionOverride?: boolean;
 
-  sourceLinesCache?: string[];
   sourceLineStartOffsetsCache?: number[];
 
   rest_props?: RestProps;
@@ -92,7 +91,7 @@ export interface ParserContext {
   readonly typedefs: Map<string, TypeDef>;
   variableInfoCache: Map<string, { type: string; description?: string }>;
 
-  /** True after a whole-source scan populates {@link variableInfoCache}. */
+  /** True after the per-component variable/JSDoc symbol table has populated {@link variableInfoCache}. */
   variableInfoCacheBuilt: boolean;
 }
 
@@ -104,7 +103,6 @@ export function createParserContext(): ParserContext {
     source: undefined,
     parsed: undefined,
     runesOptionOverride: undefined,
-    sourceLinesCache: undefined,
     sourceLineStartOffsetsCache: undefined,
     rest_props: undefined,
     extends: undefined,

--- a/src/parser/variable-jsdoc.ts
+++ b/src/parser/variable-jsdoc.ts
@@ -1,0 +1,217 @@
+import { parse as parseComment } from "comment-parser";
+import type ComponentParser from "../ComponentParser";
+import type { ParserContext } from "./context";
+import { getCommentTags } from "./jsdoc";
+
+interface ScriptComment {
+  /** Offset (into the full component source) right after the closing delimiter. */
+  end: number;
+  isJsDoc: boolean;
+  /** Raw comment text, delimiters included. */
+  text: string;
+}
+
+interface TopLevelDeclaration {
+  name: string;
+  /** Offset of the declaration's (or, for `export`, the export statement's) first token. */
+  start: number;
+}
+
+const WHITESPACE_ONLY_REGEX = /^\s*$/;
+
+function skipStringLiteral(source: string, start: number, quote: string): number {
+  let i = start + 1;
+  while (i < source.length) {
+    if (source[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (source[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/** Skips a template literal, including nested `${...}` expressions (which may themselves nest strings/templates). */
+function skipTemplateLiteral(source: string, start: number): number {
+  let i = start + 1;
+  let exprDepth = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (exprDepth === 0) {
+      if (ch === "`") return i + 1;
+      if (ch === "$" && source[i + 1] === "{") {
+        exprDepth = 1;
+        i += 2;
+        continue;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "{") {
+      exprDepth++;
+    } else if (ch === "}") {
+      exprDepth--;
+    } else if (ch === '"' || ch === "'") {
+      i = skipStringLiteral(source, i, ch);
+      continue;
+    } else if (ch === "`") {
+      i = skipTemplateLiteral(source, i);
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Finds every `//` and `/* *\/` comment in `scriptSource`, skipping string and template
+ * literal contents so declaration-like or comment-like text inside them can't be mistaken
+ * for the real thing. `offsetBase` maps positions back into the full component source,
+ * since `scriptSource` is a slice starting there.
+ */
+function buildCommentIndex(scriptSource: string, offsetBase: number): ScriptComment[] {
+  const comments: ScriptComment[] = [];
+  const len = scriptSource.length;
+  let i = 0;
+
+  while (i < len) {
+    const ch = scriptSource[i];
+
+    if (ch === '"' || ch === "'") {
+      i = skipStringLiteral(scriptSource, i, ch);
+      continue;
+    }
+    if (ch === "`") {
+      i = skipTemplateLiteral(scriptSource, i);
+      continue;
+    }
+    if (ch === "/" && scriptSource[i + 1] === "/") {
+      let j = i + 2;
+      while (j < len && scriptSource[j] !== "\n") j++;
+      i = j;
+      continue;
+    }
+    if (ch === "/" && scriptSource[i + 1] === "*") {
+      const start = i;
+      let j = i + 2;
+      while (j < len && !(scriptSource[j] === "*" && scriptSource[j + 1] === "/")) j++;
+      const end = Math.min(j + 2, len);
+      const text = scriptSource.slice(start, end);
+      comments.push({ end: end + offsetBase, isJsDoc: text.startsWith("/**") && text.length > 4, text });
+      i = end;
+      continue;
+    }
+    i++;
+  }
+
+  return comments;
+}
+
+function addDeclarationNames(node: unknown, start: number, declarations: TopLevelDeclaration[]): void {
+  if (!node || typeof node !== "object" || !("type" in node)) return;
+  const decl = node as {
+    type: string;
+    id?: { type?: string; name?: string };
+    declarations?: Array<{ id?: { type?: string; name?: string } }>;
+  };
+
+  if (decl.type === "FunctionDeclaration") {
+    if (decl.id?.type === "Identifier" && decl.id.name) {
+      declarations.push({ name: decl.id.name, start });
+    }
+    return;
+  }
+
+  if (decl.type === "VariableDeclaration") {
+    for (const declarator of decl.declarations ?? []) {
+      if (declarator?.id?.type === "Identifier" && declarator.id.name) {
+        declarations.push({ name: declarator.id.name, start });
+      }
+    }
+  }
+}
+
+/** Every top-level `const`/`let`/`function` (including `export`-ed ones) in a script's Program body. */
+function collectTopLevelDeclarations(body: unknown[]): TopLevelDeclaration[] {
+  const declarations: TopLevelDeclaration[] = [];
+
+  for (const statement of body) {
+    if (!statement || typeof statement !== "object" || !("type" in statement)) continue;
+    const stmt = statement as { type: string; start?: number; declaration?: unknown };
+    if (stmt.start === undefined) continue;
+
+    if (stmt.type === "ExportNamedDeclaration" && stmt.declaration) {
+      addDeclarationNames(stmt.declaration, stmt.start, declarations);
+    } else {
+      addDeclarationNames(stmt, stmt.start, declarations);
+    }
+  }
+
+  return declarations;
+}
+
+/** The closest JSDoc block comment with only whitespace between its end and `declStart`, if any. */
+function findAttachedComment(comments: ScriptComment[], declStart: number, source: string): ScriptComment | undefined {
+  let attached: ScriptComment | undefined;
+
+  for (const comment of comments) {
+    if (comment.end > declStart) break;
+    if (!comment.isJsDoc) continue;
+    if (!WHITESPACE_ONLY_REGEX.test(source.slice(comment.end, declStart))) continue;
+    attached = comment;
+  }
+
+  return attached;
+}
+
+/**
+ * Maps every top-level variable/function name declared in a component's module and instance
+ * scripts to the `@type`/description from its attached JSDoc block. Used by
+ * {@link ComponentParser.findVariableTypeAndDescription} to resolve plain identifiers (e.g. a
+ * value passed to `setContext`) that aren't otherwise typed by a prop or a TS annotation.
+ */
+export function buildVariableJsDocTable(
+  ctx: ParserContext,
+  parser: ComponentParser,
+): Map<string, { type: string; description?: string }> {
+  const table = new Map<string, { type: string; description?: string }>();
+  if (!ctx.source) return table;
+
+  const scripts = [ctx.parsed?.module, ctx.parsed?.instance] as unknown as Array<
+    { content?: { start?: number; end?: number; body?: unknown[] } } | undefined
+  >;
+
+  const allComments: ScriptComment[] = [];
+  const allDeclarations: TopLevelDeclaration[] = [];
+
+  for (const script of scripts) {
+    const program = script?.content;
+    if (!program?.body || program.start === undefined || program.end === undefined) continue;
+
+    allComments.push(...buildCommentIndex(ctx.source.slice(program.start, program.end), program.start));
+    allDeclarations.push(...collectTopLevelDeclarations(program.body));
+  }
+
+  allComments.sort((a, b) => a.end - b.end);
+
+  for (const declaration of allDeclarations) {
+    const comment = findAttachedComment(allComments, declaration.start, ctx.source);
+    if (!comment) continue;
+
+    const parsed = parseComment(comment.text, { spacing: "preserve" });
+    const { type: typeTag, description } = getCommentTags(parsed);
+    if (!typeTag) continue;
+
+    table.set(declaration.name, {
+      type: parser.aliasType(typeTag.type),
+      description: description || typeTag.description,
+    });
+  }
+
+  return table;
+}

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -1511,6 +1511,179 @@ describe("ComponentParser", () => {
     warn.mockRestore();
   });
 
+  describe("findVariableTypeAndDescription's JSDoc symbol table", () => {
+    test("resolves a JSDoc'd variable whose name is on a different line than its keyword", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          /**
+           * @type {number}
+           */
+          const
+            count = 0;
+          setContext("counter", { count });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "count", type: "number" });
+    });
+
+    test("does not mistake comment-like text inside a string literal for a real comment", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          const trap = "look: /* not a real comment";
+          /**
+           * @type {number}
+           */
+          const value = 42;
+          setContext("k", { value });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "value", type: "number" });
+    });
+
+    test("does not mistake a declaration-like string literal for a real declaration", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          const noise = "const value = 1";
+          /**
+           * @type {string}
+           */
+          const value = "real";
+          setContext("k", { value });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "value", type: "string" });
+    });
+
+    test("a trailing same-line comment on a prior statement doesn't block the next declaration's own JSDoc", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          const a = 1; // trailing note about a, not JSDoc
+          /**
+           * @type {number}
+           */
+          const value = 2;
+          setContext("k", { value });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "value", type: "number" });
+    });
+
+    test("resolves a JSDoc'd `export const` from a module script", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script context="module">
+          /**
+           * Shared default count
+           * @type {number}
+           */
+          export const defaultCount = 0;
+        </script>
+        <script>
+          import { setContext } from "svelte";
+          setContext("k", { defaultCount });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({
+        name: "defaultCount",
+        type: "number",
+        description: "Shared default count",
+      });
+    });
+
+    test("resolves a JSDoc'd arrow-function const", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          /**
+           * Closes the modal
+           * @type {() => void}
+           */
+          const close = () => {};
+          setContext("k", { close });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({
+        name: "close",
+        type: "() => void",
+        description: "Closes the modal",
+      });
+    });
+
+    test("tolerates a blank line between the JSDoc block and the declaration", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          /**
+           * @type {number}
+           */
+
+          const value = 5;
+          setContext("k", { value });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "value", type: "number" });
+    });
+
+    test("attaches only the closest of two preceding JSDoc blocks", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          /**
+           * @type {string}
+           */
+          /**
+           * @type {number}
+           */
+          const value = 5;
+          setContext("k", { value });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "value", type: "number" });
+    });
+
+    test("a plain (non-JSDoc) block comment does not supply a type", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          import { setContext } from "svelte";
+          /* @type {string} */
+          const value = 5;
+          setContext("k", { value });
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.contexts?.[0].properties[0]).toMatchObject({ name: "value", type: "any" });
+    });
+  });
+
   test('ignores the generics script attribute without lang="ts" and reports syntax-skipped', () => {
     const parser = new ComponentParser();
     const source = `


### PR DESCRIPTION
Variable types and JSDoc were discovered by rescanning source lines
with regexes, which associated comments with declarations by line
heuristics and missed multi-line declarations and TS annotations. A
symbol table is now built once per component from the AST with a
positional comment index, and all variable-info lookups consume it
with the existing precedence of prop type, then TS annotation, then
JSDoc type.

## Details

- New `src/parser/variable-jsdoc.ts`: `buildVariableJsDocTable()` walks
  the top-level statements of the instance and module script Programs
  (already-parsed legacy AST), collecting every `const`/`let`/`function`
  (including `export`-ed ones). A dedicated tokenizer-level scan of the
  script source (skipping string/template literal contents) builds a
  comment index; each declaration is matched to the closest preceding
  JSDoc (`/**`) block with only whitespace between the comment's end and
  the declaration's start.
- `ComponentParser.findVariableTypeAndDescription()` now consumes this
  table instead of `buildVariableInfoCache()`'s regex scan and the
  duplicate ad hoc regex fallback that followed it. Precedence is
  unchanged: prop type, then the `#379`-introduced TS annotation lookup
  (`explicitVariableTypesByName`, left as-is), then this symbol table's
  JSDoc result.
- Deleted `VAR_DECLARATION_REGEX`, `getVarNameRegexes()`,
  `buildVariableInfoCache()`, and the `sourceLinesCache` context field
  (only used by these scans; `sourceLineStartOffsetsCache`, used for
  diagnostics, is untouched).

## Verification

- Full `bun test` is green (1180 pass, up from 1171 — no snapshot
  changes), confirming byte-identical output across every fixture.
- No latent regex bugs surfaced as snapshot diffs during the switch.
- Added 9 unit tests under a new `findVariableTypeAndDescription's
  JSDoc symbol table` describe block in `tests/ComponentParser.test.ts`,
  covering: a declaration split across lines, comment-like text inside a
  string, declaration-like text inside a string, a trailing same-line
  comment on a prior statement, a JSDoc'd `export const` in a module
  script, a JSDoc'd arrow-function const, a blank line between JSDoc and
  declaration, picking the closest of two stacked JSDoc blocks, and a
  plain (non-JSDoc) block comment correctly *not* supplying a type.

## Notes

- This repo doesn't yet have an `AST_DIFF` differential harness (that's
  part of the still-pending modern-AST migration); verification here
  relies on the existing fixture/snapshot suite instead, per the
  standalone note that this refactor doesn't require that migration.
- Built directly against the current legacy AST (no `astMode`
  awareness needed).