### PR TITLE
feat(cli): route progress logs to stderr and add --quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,9 @@ npx sveld --json --markdown
 
 If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
 
-Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
+Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
+
+Writer progress lines (`created "..."` / `unchanged "..."`) print to `stderr`, keeping `stdout` reserved for machine-readable data. Pass `--quiet` (or `quiet: true` in `sveld.config.*`) to suppress them; it does not suppress error messages, the diagnostics summary (`--report-diagnostics` / `--strict`), or the `--check` report.
 
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 
@@ -699,6 +701,7 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
 - **`strict`** (boolean, optional, default: `false`): Exit with code `1` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).
 - **`check`** (boolean | string, optional, default: `false`): Diff the parsed component API against a committed snapshot and assign a semver bump to each change. `true` uses the `json` writer's `outFile` (or `COMPONENT_API.json`); a string sets a custom snapshot path. Also available as `--check` / `--check=<path>`. On the CLI this exits `1` on a breaking change; from `sveld()` it's returned on `SveldResult.check` for you to act on. See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check).
+- **`quiet`** (boolean, optional, default: `false`): Suppress writer progress logs (`created "..."` / `unchanged "..."`), which print to `stderr` by default. Does not suppress error messages, the diagnostics summary, or the `--check` report. Also available as `--quiet`.
 
 By default, only TypeScript definitions are generated.
 

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -22,6 +22,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import { generateBundle } from "../src/bundle";
+import { setQuiet } from "../src/logger";
 import { writeOutput } from "../src/plugin";
 
 const DEFAULT_ENTRY = join(import.meta.dir, "..", "tests", "e2e", "carbon", "src", "index.js");
@@ -92,19 +93,6 @@ function formatTiming(timing: RunTiming): string {
   return `${parse}  ${write}  ${total}`;
 }
 
-/**
- * The writers log one "created ..." line per emitted file (160+ per run on
- * the carbon fixture), which would drown the timing output. Errors still go
- * to `console.error`, so parse failures remain visible.
- */
-function silenceLogs(): () => void {
-  const original = console.log;
-  console.log = () => {};
-  return () => {
-    console.log = original;
-  };
-}
-
 async function benchOnce(input: string, cacheFile: string | undefined, outDir: string): Promise<RunTiming> {
   mkdirSync(outDir, { recursive: true });
 
@@ -119,11 +107,15 @@ async function benchOnce(input: string, cacheFile: string | undefined, outDir: s
   // write phase from the scratch directory so nothing lands in the fixture.
   const originalCwd = process.cwd();
   process.chdir(outDir);
-  const restoreLogs = silenceLogs();
+  // The writers log one "created ..." line per emitted file (160+ per run on
+  // the carbon fixture), which would drown the timing output. Errors still go
+  // to `console.error` directly (not through the logger), so parse failures
+  // remain visible.
+  setQuiet(true);
   try {
     await writeOutput(result, { types: true, json: true, markdown: true }, input);
   } finally {
-    restoreLogs();
+    setQuiet(false);
     process.chdir(originalCwd);
   }
   const written = performance.now();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { type CheckResult, formatCheckReport, resolveCheckSnapshotFile, runCheck
 import { formatDiagnosticsSummary } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
+import { setQuiet } from "./logger";
 import { normalizeSeparators } from "./path";
 import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
@@ -29,6 +30,7 @@ Options:
   --markdown            Generate component documentation in Markdown format
   --custom-elements     Generate a Custom Elements Manifest (custom-elements.json)
   --fail-fast           Abort the run when a single component fails to parse
+  --quiet               Suppress progress logs (errors, the diagnostics summary, and the --check report are unaffected)
   --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (on by default, default path: node_modules/.cache/sveld/parse-cache.json; pass --cache=false to disable)
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
@@ -72,6 +74,7 @@ function parseCliFlag(arg: string): CliFlagResult {
     case "types":
     case "json":
     case "markdown":
+    case "quiet":
       return { kind: "option", option: { [flag]: value === true || value === "true" } };
     case "custom-elements":
       return { kind: "option", option: { customElements: value === true || value === "true" } };
@@ -170,6 +173,8 @@ export async function cli(process: NodeJS.Process) {
   if (fileConfig.typesOptions || cliOptions.typesOptions) {
     options.typesOptions = { ...fileConfig.typesOptions, ...cliOptions.typesOptions };
   }
+
+  setQuiet(options.quiet === true);
 
   const resolvedEntry = getSvelteEntry(options.entry);
   let input: string;

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -21,6 +21,8 @@ export interface SveldRuntimeOptions extends PluginSveldOptions {
    * string for a custom snapshot path.
    */
   check?: boolean | string;
+  /** Suppress writer progress logs (`created "..."` / `unchanged "..."`). */
+  quiet?: boolean;
 }
 
 /**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,21 @@
+/**
+ * Progress logging for the writers.
+ *
+ * Writers are invoked through the writer registry and don't receive runtime
+ * options today, so threading a `quiet` param through every writer signature
+ * would be a larger refactor than the CLI's `--quiet` flag warrants. A
+ * module-level toggle (set once by `cli()`) is the pragmatic shape instead.
+ */
+let quiet = false;
+
+/** Sets the module-level quiet toggle. Called once by `cli()`. */
+export function setQuiet(value: boolean): void {
+  quiet = value;
+}
+
+/** Writes a progress line to stderr, suppressed when quiet mode is on. */
+export function info(message: string): void {
+  if (!quiet) {
+    console.error(message);
+  }
+}

--- a/src/writer/writer-custom-elements.ts
+++ b/src/writer/writer-custom-elements.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { info } from "../logger";
 import { normalizeSeparators } from "../path";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import { createJsonWriter } from "./Writer";
@@ -48,5 +49,5 @@ export default async function writeCustomElements(components: ComponentDocs, opt
   const writer = createJsonWriter();
   await writer.write(output_path, `${JSON.stringify(manifest, null, 2)}\n`);
 
-  console.log(`created "${options.outFile}".`);
+  info(`created "${options.outFile}".`);
 }

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { info } from "../logger";
 import type { EntryExports } from "../parse-entry-exports";
 import { normalizeSeparators } from "../path";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
@@ -38,7 +39,7 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
       const outFile = path.resolve(path.join(options.outDir || "", `${c.moduleName}.api.json`));
       const writer = createJsonWriter();
       const wasWritten = await writer.write(outFile, `${JSON.stringify(c, null, 2)}\n`);
-      console.log(`${wasWritten ? "created" : "unchanged"} "${outFile}".`);
+      info(`${wasWritten ? "created" : "unchanged"} "${outFile}".`);
     }),
   );
 }
@@ -54,7 +55,7 @@ async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptio
   const writer = createJsonWriter();
   await writer.write(output_path, `${JSON.stringify(output, null, 2)}\n`);
 
-  console.log(`created "${options.outFile}".`);
+  info(`created "${options.outFile}".`);
 }
 
 /**

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { info } from "../logger";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocs } from "../plugin";
 import { renderComponentsToMarkdown } from "./markdown-render-utils";
@@ -37,7 +38,7 @@ export default async function writeMarkdown(components: ComponentDocs, options: 
   if (write) {
     const outFile = join(process.cwd(), options.outFile);
     await document.write(outFile, document.end());
-    console.log(`created "${options.outFile}".`);
+    info(`created "${options.outFile}".`);
   }
 
   return document.end();

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { convertSvelteExt, createExports } from "../create-exports";
+import { info } from "../logger";
 import type { ParsedExports } from "../parse-exports";
 import type { ComponentDocs } from "../plugin";
 import { buildComponentApiDocument } from "./document-model";
@@ -66,5 +67,5 @@ export default async function writeTsDefinitions(components: ComponentDocs, opti
 
   await Promise.all([...writePromises, writer.write(ts_base_path, `${indexDTs}\n`)]);
 
-  console.log("created TypeScript definitions.");
+  info("created TypeScript definitions.");
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,10 +2,26 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cli, parseCliOptions } from "../src/cli";
+import { setQuiet } from "../src/logger";
 
 describe("parseCliOptions", () => {
   test("--fail-fast enables failFast", () => {
     expect(parseCliOptions(["--fail-fast"])).toEqual({ kind: "options", options: { failFast: true } });
+  });
+
+  test("--quiet enables quiet", () => {
+    expect(parseCliOptions(["--quiet"])).toEqual({ kind: "options", options: { quiet: true } });
+  });
+
+  test("--quiet=false disables quiet", () => {
+    expect(parseCliOptions(["--quiet=false"])).toEqual({ kind: "options", options: { quiet: false } });
+  });
+
+  test("quiet is absent by default", () => {
+    expect(parseCliOptions(["--glob", "--types"])).toEqual({
+      kind: "options",
+      options: { glob: true, types: true },
+    });
   });
 
   test("--fail-fast=false disables failFast", () => {
@@ -226,6 +242,77 @@ describe("cli() --cache", () => {
     await cli(process);
 
     expect(existsSync(join(dir, "src", "node_modules", ".cache"))).toBe(false);
+  });
+});
+
+describe("cli() --quiet", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-quiet-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      '<script>\n  export let label = "";\n</script>\n<button>{label}</button>\n',
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    setQuiet(false);
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("a plain run prints writer progress lines to stderr", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements"];
+
+    await cli(process);
+
+    expect(errorSpy).toHaveBeenCalledWith("created TypeScript definitions.");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "COMPONENT_API.json".'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "COMPONENT_INDEX.md".'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "custom-elements.json".'));
+  });
+
+  test("--quiet suppresses writer progress lines but still writes output files", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--quiet"];
+
+    await cli(process);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(dir, "types", "Button.svelte.d.ts"))).toBe(true);
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(true);
+    expect(existsSync(join(dir, "COMPONENT_INDEX.md"))).toBe(true);
+    expect(existsSync(join(dir, "custom-elements.json"))).toBe(true);
+  });
+
+  test("quiet: true in the config file suppresses progress lines", async () => {
+    writeFileSync(join(dir, "sveld.config.js"), "export default { quiet: true };\n");
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json"];
+
+    await cli(process);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test("--quiet does not suppress the fallback-entry warning", async () => {
+    process.argv = ["bun", "cli.js", "--quiet"];
+
+    await cli(process);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('falling back to "src/index.js"'));
   });
 });
 

--- a/tests/writer-custom-elements.test.ts
+++ b/tests/writer-custom-elements.test.ts
@@ -13,6 +13,7 @@ import { readFileSync, rmSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import path from "node:path";
 import type { ComponentProp, ComponentSlot, SerializedComponentEvent } from "../src/ComponentParser";
+import { setQuiet } from "../src/logger";
 import type { ComponentDocs } from "../src/plugin";
 import type { CemModule } from "../src/writer/writer-custom-elements";
 import writeCustomElements from "../src/writer/writer-custom-elements";
@@ -60,11 +61,14 @@ async function runWriter(components: ComponentDocs): Promise<{ module: CemModule
 }
 
 describe("writeCustomElements", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
   beforeEach(() => {
-    jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    setQuiet(false);
     jest.restoreAllMocks();
   });
 
@@ -84,6 +88,33 @@ describe("writeCustomElements", () => {
       // Deterministic ordering: sorted alphabetically by moduleName, same as the JSON writer.
       expect(manifest.modules.map((m: CemModule) => m.declarations[0].name)).toEqual(["Alpha", "Zeta"]);
       expect(manifest.modules[0].kind).toBe("javascript-module");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("prints the progress line to stderr", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "custom-elements.json"));
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+
+    try {
+      await writeCustomElements(components, { inputDir: "src", outFile });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`created "${outFile}".`));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("suppresses the progress line when quiet mode is on", async () => {
+    setQuiet(true);
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "custom-elements.json"));
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+
+    try {
+      await writeCustomElements(components, { inputDir: "src", outFile });
+      expect(errorSpy).not.toHaveBeenCalled();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import path from "node:path";
 import { version as svelteVersion } from "svelte/package.json";
 import { name as packageName, version as packageVersion } from "../package.json";
+import { setQuiet } from "../src/logger";
 import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
 import writeJson from "../src/writer/writer-json";
 import { mockComponentDocApi } from "./test-brands";
@@ -12,11 +13,14 @@ function createComponent(moduleName: string, filePath: string) {
 }
 
 describe("writeJson", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
   beforeEach(() => {
-    jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    setQuiet(false);
     jest.restoreAllMocks();
   });
 
@@ -104,6 +108,41 @@ describe("writeJson", () => {
         },
         { name: "Theme", kind: "type", type: '"light" | "dark"', isTypeOnly: true, source: "./types.ts" },
       ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("prints the progress line to stderr", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+
+    try {
+      await writeJson(new Map([["Alpha", createComponent("Alpha", "Alpha.svelte")]]), {
+        input: "src",
+        inputDir: "src",
+        outFile,
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`created "${outFile}".`));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("suppresses the progress line when quiet mode is on", async () => {
+    setQuiet(true);
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+
+    try {
+      await writeJson(new Map([["Alpha", createComponent("Alpha", "Alpha.svelte")]]), {
+        input: "src",
+        inputDir: "src",
+        outFile,
+      });
+
+      expect(errorSpy).not.toHaveBeenCalled();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/writer-markdown.test.ts
+++ b/tests/writer-markdown.test.ts
@@ -1,0 +1,55 @@
+import { rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
+import { setQuiet } from "../src/logger";
+import type { ComponentDocs } from "../src/plugin";
+import writeMarkdown from "../src/writer/writer-markdown";
+import { mockComponentDocApi } from "./test-brands";
+
+describe("writeMarkdown", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setQuiet(false);
+    jest.restoreAllMocks();
+  });
+
+  test("prints the progress line to stderr", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_INDEX.md"));
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    try {
+      await writeMarkdown(components, { outFile });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`created "${outFile}".`));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("suppresses the progress line when quiet mode is on", async () => {
+    setQuiet(true);
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_INDEX.md"));
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    try {
+      await writeMarkdown(components, { outFile });
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not print a progress line when write is false", async () => {
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    await writeMarkdown(components, { outFile: "unused.md", write: false });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -1,8 +1,18 @@
+import { rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
 import { asNormalizedPath } from "../src/brands";
 import type { ParsedComponent } from "../src/ComponentParser";
 import { PARSED_COMPONENT_TYPE_SCRIPT_METADATA } from "../src/ComponentParser";
-import type { ComponentDocApi } from "../src/plugin";
-import { formatTsProps, getContextDefs, getTypeDefs, writeTsDefinition } from "../src/writer/writer-ts-definitions";
+import { setQuiet } from "../src/logger";
+import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
+import writeTsDefinitions, {
+  formatTsProps,
+  getContextDefs,
+  getTypeDefs,
+  writeTsDefinition,
+} from "../src/writer/writer-ts-definitions";
+import { mockComponentDocApi, mockParsedExports } from "./test-brands";
 
 const DEFAULT_SLOT_SNIPPET_PROP_REGEX = /default\?\s*:\s*\(\)\s*=>\s*void/;
 
@@ -978,5 +988,57 @@ export default Button;`,
     expect(output).toContain("getSelected: () => Row[];");
     expect(output).toContain("props: GenericTreeProps<Row>");
     expect(output).toContain("} & GenericTreeExports<Row>;");
+  });
+});
+
+describe("writeTsDefinitions", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setQuiet(false);
+    jest.restoreAllMocks();
+  });
+
+  test("prints the progress line to stderr", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-ts-defs-"));
+    const outDir = path.relative(process.cwd(), tempDir);
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    try {
+      await writeTsDefinitions(components, {
+        outDir,
+        inputDir: "src",
+        preamble: "",
+        exports: mockParsedExports({}),
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith("created TypeScript definitions.");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("suppresses the progress line when quiet mode is on", async () => {
+    setQuiet(true);
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-ts-defs-"));
+    const outDir = path.relative(process.cwd(), tempDir);
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    try {
+      await writeTsDefinitions(components, {
+        outDir,
+        inputDir: "src",
+        preamble: "",
+        exports: mockParsedExports({}),
+      });
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Writers previously printed progress lines such as created
"COMPONENT_API.json" to stdout, mixing logs with data and making
the CLI unfriendly to pipe. Progress output now goes to stderr,
keeping stdout reserved for machine-readable data.

A new --quiet flag (and quiet runtime option) suppresses progress
logs entirely. Errors, the diagnostics summary, and the --check
report are unaffected.

