### PR TITLE
feat(cli): add --stdout to emit one output to standard out

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,9 +471,11 @@ npx sveld --json --markdown
 
 If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
 
-Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
+Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`, `--stdout`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
 
 Writer progress lines (`created "..."` / `unchanged "..."`) print to `stderr`, keeping `stdout` reserved for machine-readable data. Pass `--quiet` (or `quiet: true` in `sveld.config.*`) to suppress them; it does not suppress error messages, the diagnostics summary (`--report-diagnostics` / `--strict`), or the `--check` report.
+
+Pass `--stdout` alongside exactly one of `--json`, `--markdown`, or `--custom-elements` to print that single document to `stdout` instead of writing it to disk, e.g. `sveld --json --stdout | jq '.components[].moduleName'`. Zero or more than one of those three flags, `--types`, or `--check` combined with `--stdout` is a usage error that prints to `stderr` and exits `1` without generating anything; the default `.d.ts` generation is skipped in `--stdout` mode since type definitions span multiple files.
 
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
 import { setQuiet } from "./logger";
 import { normalizeSeparators } from "./path";
-import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
+import { generateBundle, toGenerateBundleOptions, writeOutput, writeStdout } from "./plugin";
 
 /** Relative fallback entry used only when entry resolution otherwise fails. */
 const FALLBACK_ENTRY = "src/index.js";
@@ -31,6 +31,7 @@ Options:
   --custom-elements     Generate a Custom Elements Manifest (custom-elements.json)
   --fail-fast           Abort the run when a single component fails to parse
   --quiet               Suppress progress logs (errors, the diagnostics summary, and the --check report are unaffected)
+  --stdout              Print the document from exactly one of --json, --markdown, or --custom-elements to stdout and write nothing to disk (rejects --types and --check)
   --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (on by default, default path: node_modules/.cache/sveld/parse-cache.json; pass --cache=false to disable)
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
@@ -75,6 +76,7 @@ function parseCliFlag(arg: string): CliFlagResult {
     case "json":
     case "markdown":
     case "quiet":
+    case "stdout":
       return { kind: "option", option: { [flag]: value === true || value === "true" } };
     case "custom-elements":
       return { kind: "option", option: { customElements: value === true || value === "true" } };
@@ -174,6 +176,28 @@ export async function cli(process: NodeJS.Process) {
     options.typesOptions = { ...fileConfig.typesOptions, ...cliOptions.typesOptions };
   }
 
+  if (options.stdout) {
+    const selectedOutputs = [options.json, options.markdown, options.customElements].filter(Boolean).length;
+
+    if (selectedOutputs !== 1) {
+      console.error("sveld: --stdout requires exactly one of --json, --markdown, or --custom-elements.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (options.types === true) {
+      console.error("sveld: --stdout cannot be combined with --types; type definitions span multiple files.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (options.check) {
+      console.error("sveld: --stdout cannot be combined with --check; both write their document to stdout.");
+      process.exitCode = 1;
+      return;
+    }
+  }
+
   setQuiet(options.quiet === true);
 
   const resolvedEntry = getSvelteEntry(options.entry);
@@ -201,7 +225,11 @@ export async function cli(process: NodeJS.Process) {
     });
   }
 
-  await writeOutput(result, options, input);
+  if (options.stdout) {
+    await writeStdout(result, options, input);
+  } else {
+    await writeOutput(result, options, input);
+  }
 
   const { diagnostics } = result;
   const shouldReport = options.reportDiagnostics || options.strict;

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -23,6 +23,12 @@ export interface SveldRuntimeOptions extends PluginSveldOptions {
   check?: boolean | string;
   /** Suppress writer progress logs (`created "..."` / `unchanged "..."`). */
   quiet?: boolean;
+  /**
+   * Print the single selected `json` / `markdown` / `customElements` document
+   * to stdout instead of writing it to disk. Requires exactly one of those
+   * three outputs; CLI-only (the Vite plugin ignores it).
+   */
+  stdout?: boolean;
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,9 +11,9 @@ import { createSveldBundle, type SveldBundle } from "./watch";
 // Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements" writers.
 import "./writer/built-in-writers";
 import { getWriter } from "./writer/registry";
-import type { WriteCustomElementsOptions } from "./writer/writer-custom-elements";
-import type { WriteJsonOptions } from "./writer/writer-json";
-import type { WriteMarkdownOptions } from "./writer/writer-markdown";
+import { renderCustomElementsManifest, type WriteCustomElementsOptions } from "./writer/writer-custom-elements";
+import { renderJsonDocument, type WriteJsonOptions } from "./writer/writer-json";
+import { renderMarkdownDocument, type WriteMarkdownOptions } from "./writer/writer-markdown";
 import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 
 export type {
@@ -263,4 +263,41 @@ export async function writeOutput(result: GenerateBundleResult, opts: PluginSvel
   });
 
   await Promise.all(additionalWrites);
+}
+
+/**
+ * Prints the single selected `json` / `markdown` / `customElements` document
+ * to stdout instead of writing it to disk. CLI-only: the caller (`cli()`) is
+ * responsible for enforcing that exactly one of those three options is set
+ * before calling this.
+ */
+export async function writeStdout(result: GenerateBundleResult, opts: PluginSveldOptions, input: string) {
+  const inputDir = dirname(input);
+
+  if (opts?.json) {
+    const rendered = renderJsonDocument(result.components, {
+      ...opts?.jsonOptions,
+      inputDir,
+      entryExports: result.entryExports,
+    } satisfies Pick<WriteJsonOptions, "inputDir" | "entryExports">);
+    process.stdout.write(rendered);
+    return;
+  }
+
+  if (opts?.markdown) {
+    const rendered = renderMarkdownDocument(result.components, {
+      ...opts?.markdownOptions,
+      entryExports: result.entryExports,
+    } satisfies Pick<WriteMarkdownOptions, "entryExports" | "onAppend">);
+    process.stdout.write(rendered);
+    return;
+  }
+
+  if (opts?.customElements) {
+    const rendered = renderCustomElementsManifest(result.components, {
+      ...opts?.customElementsOptions,
+      inputDir,
+    } satisfies Pick<WriteCustomElementsOptions, "inputDir">);
+    process.stdout.write(rendered);
+  }
 }

--- a/src/writer/writer-custom-elements.ts
+++ b/src/writer/writer-custom-elements.ts
@@ -33,6 +33,22 @@ function normalizedModulePath(component: ComponentDocApi, inputDir: string): str
 }
 
 /**
+ * Renders the Custom Elements Manifest document without touching disk. Used
+ * by both `writeCustomElements` and the CLI's `--stdout` mode so the two
+ * channels can't drift.
+ */
+export function renderCustomElementsManifest(
+  components: ComponentDocs,
+  options: Pick<WriteCustomElementsOptions, "inputDir">,
+): string {
+  const manifest = buildCustomElementsManifest(components, {
+    resolveModulePath: (component) => normalizedModulePath(component, options.inputDir),
+  });
+
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+/**
  * Writes component documentation as a Custom Elements Manifest
  * (schemaVersion "1.0.0"). Components without a `customElementTag` (i.e. not
  * compiled with `<svelte:options customElement="..." />`) still emit a plain
@@ -41,13 +57,11 @@ function normalizedModulePath(component: ComponentDocApi, inputDir: string): str
  * `tagName`, `attributes`, and `events`.
  */
 export default async function writeCustomElements(components: ComponentDocs, options: WriteCustomElementsOptions) {
-  const manifest = buildCustomElementsManifest(components, {
-    resolveModulePath: (component) => normalizedModulePath(component, options.inputDir),
-  });
+  const raw = renderCustomElementsManifest(components, options);
 
   const output_path = path.join(process.cwd(), options.outFile);
   const writer = createJsonWriter();
-  await writer.write(output_path, `${JSON.stringify(manifest, null, 2)}\n`);
+  await writer.write(output_path, raw);
 
   info(`created "${options.outFile}".`);
 }

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -44,16 +44,29 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
   );
 }
 
-async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptions) {
+/**
+ * Renders the single combined JSON document (the same shape written to
+ * `COMPONENT_API.json`) without touching disk. Used by both `writeJsonLocal`
+ * and the CLI's `--stdout` mode so the two channels can't drift.
+ */
+export function renderJsonDocument(
+  components: ComponentDocs,
+  options: Pick<WriteJsonOptions, "inputDir" | "entryExports">,
+): string {
   const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
   const output: ComponentApiDocument = {
     ...document,
     components: withNormalizedFilePaths(document.components, options.inputDir),
   };
 
+  return `${JSON.stringify(output, null, 2)}\n`;
+}
+
+async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptions) {
+  const raw = renderJsonDocument(components, options);
   const output_path = path.join(process.cwd(), options.outFile);
   const writer = createJsonWriter();
-  await writer.write(output_path, `${JSON.stringify(output, null, 2)}\n`);
+  await writer.write(output_path, raw);
 
   info(`created "${options.outFile}".`);
 }

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -3,6 +3,7 @@ import { info } from "../logger";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocs } from "../plugin";
 import { renderComponentsToMarkdown } from "./markdown-render-utils";
+import Writer from "./Writer";
 import WriterMarkdown, { type AppendType } from "./WriterMarkdown";
 
 export interface WriteMarkdownOptions {
@@ -11,6 +12,26 @@ export interface WriteMarkdownOptions {
   /** Entry-barrel exports when `documentExports` is on. */
   entryExports?: EntryExports;
   onAppend?: (type: AppendType, document: WriterMarkdown, components: ComponentDocs) => void;
+}
+
+/**
+ * Renders the Markdown document without touching disk. Used by both
+ * `writeMarkdown` and the CLI's `--stdout` mode so the two channels can't
+ * drift.
+ */
+export function renderMarkdownDocument(
+  components: ComponentDocs,
+  options: Pick<WriteMarkdownOptions, "entryExports" | "onAppend">,
+): string {
+  const document = new WriterMarkdown({
+    onAppend: (type, document) => {
+      options.onAppend?.call(null, type, document, components);
+    },
+  });
+
+  renderComponentsToMarkdown(document, components, options.entryExports);
+
+  return document.end();
 }
 
 /**
@@ -27,19 +48,13 @@ export interface WriteMarkdownOptions {
  */
 export default async function writeMarkdown(components: ComponentDocs, options: WriteMarkdownOptions) {
   const write = options?.write !== false;
-  const document = new WriterMarkdown({
-    onAppend: (type, document) => {
-      options.onAppend?.call(null, type, document, components);
-    },
-  });
-
-  renderComponentsToMarkdown(document, components, options.entryExports);
+  const rendered = renderMarkdownDocument(components, options);
 
   if (write) {
     const outFile = join(process.cwd(), options.outFile);
-    await document.write(outFile, document.end());
+    await new Writer().write(outFile, rendered);
     info(`created "${options.outFile}".`);
   }
 
-  return document.end();
+  return rendered;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -97,6 +97,14 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--strict"])).toEqual({ kind: "options", options: { strict: true } });
   });
 
+  test("--stdout enables stdout", () => {
+    expect(parseCliOptions(["--stdout"])).toEqual({ kind: "options", options: { stdout: true } });
+  });
+
+  test("--stdout=false disables stdout", () => {
+    expect(parseCliOptions(["--stdout=false"])).toEqual({ kind: "options", options: { stdout: false } });
+  });
+
   test("--types-format=component sets typesOptions.format", () => {
     expect(parseCliOptions(["--types-format=component"])).toEqual({
       kind: "options",
@@ -351,5 +359,120 @@ describe("cli() --types-format merges with config file typesOptions", () => {
     const outputPath = join(dir, "custom-types", "Button.svelte.d.ts");
     expect(existsSync(outputPath)).toBe(true);
     expect(readFileSync(outputPath, "utf-8")).toContain("declare const Button: Component<");
+  });
+});
+
+describe("cli() --stdout", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-stdout-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      '<script>\n  export let label = "";\n</script>\n<button>{label}</button>\n',
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    stdoutSpy = jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("--json --stdout prints the combined JSON document to stdout and writes nothing to disk", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(printed).toMatchObject({ schemaVersion: 1, total: 1 });
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+    expect(existsSync(join(dir, "types"))).toBe(false);
+  });
+
+  test("--markdown --stdout prints the Markdown document to stdout and writes nothing to disk", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--markdown", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutSpy.mock.calls[0][0]).toContain("Button");
+    expect(existsSync(join(dir, "COMPONENT_INDEX.md"))).toBe(false);
+    expect(existsSync(join(dir, "types"))).toBe(false);
+  });
+
+  test("--custom-elements --stdout prints the manifest to stdout and writes nothing to disk", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--custom-elements", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(printed.schemaVersion).toBe("1.0.0");
+    expect(existsSync(join(dir, "custom-elements.json"))).toBe(false);
+    expect(existsSync(join(dir, "types"))).toBe(false);
+  });
+
+  test("--stdout with no document-producing output errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--stdout requires exactly one of"));
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(dir, "types"))).toBe(false);
+  });
+
+  test("--json --markdown --stdout errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--stdout requires exactly one of"));
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+    expect(existsSync(join(dir, "COMPONENT_INDEX.md"))).toBe(false);
+  });
+
+  test("--json --types --stdout errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--types", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--stdout cannot be combined with --types"));
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(dir, "types"))).toBe(false);
+  });
+
+  test("--json --check --stdout errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--check", "--stdout"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--stdout cannot be combined with --check"));
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
   });
 });

--- a/tests/writer-custom-elements.test.ts
+++ b/tests/writer-custom-elements.test.ts
@@ -16,7 +16,7 @@ import type { ComponentProp, ComponentSlot, SerializedComponentEvent } from "../
 import { setQuiet } from "../src/logger";
 import type { ComponentDocs } from "../src/plugin";
 import type { CemModule } from "../src/writer/writer-custom-elements";
-import writeCustomElements from "../src/writer/writer-custom-elements";
+import writeCustomElements, { renderCustomElementsManifest } from "../src/writer/writer-custom-elements";
 import { mockComponentDocApi } from "./test-brands";
 
 function mockProp(name: string, overrides?: Partial<ComponentProp>): ComponentProp {
@@ -115,6 +115,23 @@ describe("writeCustomElements", () => {
     try {
       await writeCustomElements(components, { inputDir: "src", outFile });
       expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("renderCustomElementsManifest matches the document writeCustomElements writes to disk", async () => {
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+    const rendered = renderCustomElementsManifest(components, { inputDir: "src" });
+
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-render-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "custom-elements.json"));
+
+    try {
+      await writeCustomElements(components, { inputDir: "src", outFile });
+      const written = readFileSync(path.join(tempDir, "custom-elements.json"), "utf-8");
+
+      expect(rendered).toBe(written);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -5,7 +5,7 @@ import { version as svelteVersion } from "svelte/package.json";
 import { name as packageName, version as packageVersion } from "../package.json";
 import { setQuiet } from "../src/logger";
 import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
-import writeJson from "../src/writer/writer-json";
+import writeJson, { renderJsonDocument } from "../src/writer/writer-json";
 import { mockComponentDocApi } from "./test-brands";
 
 function createComponent(moduleName: string, filePath: string) {
@@ -146,5 +146,40 @@ describe("writeJson", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("renderJsonDocument", () => {
+  test("matches the document writeJson writes to disk, without touching disk", async () => {
+    const components: ComponentDocs = new Map([
+      ["Zeta", createComponent("Zeta", "Zeta.svelte")],
+      ["Alpha", createComponent("Alpha", "Alpha.svelte")],
+    ]);
+
+    const rendered = renderJsonDocument(components, { inputDir: "src" });
+
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-render-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+
+    try {
+      await writeJson(components, { input: "src", inputDir: "src", outFile });
+      const written = readFileSync(path.join(tempDir, "COMPONENT_API.json"), "utf-8");
+
+      expect(rendered).toBe(written);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes schemaVersion and generator metadata", () => {
+    const components: ComponentDocs = new Map([["Alpha", createComponent("Alpha", "Alpha.svelte")]]);
+
+    const rendered = JSON.parse(renderJsonDocument(components, { inputDir: "src" }));
+
+    expect(rendered).toMatchObject({
+      schemaVersion: 1,
+      generator: { name: packageName, version: packageVersion, svelteVersion },
+      total: 1,
+    });
   });
 });

--- a/tests/writer-markdown.test.ts
+++ b/tests/writer-markdown.test.ts
@@ -1,9 +1,9 @@
-import { rmSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import path from "node:path";
 import { setQuiet } from "../src/logger";
 import type { ComponentDocs } from "../src/plugin";
-import writeMarkdown from "../src/writer/writer-markdown";
+import writeMarkdown, { renderMarkdownDocument } from "../src/writer/writer-markdown";
 import { mockComponentDocApi } from "./test-brands";
 
 describe("writeMarkdown", () => {
@@ -51,5 +51,22 @@ describe("writeMarkdown", () => {
     await writeMarkdown(components, { outFile: "unused.md", write: false });
 
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test("renderMarkdownDocument matches the document writeMarkdown writes to disk", async () => {
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+    const rendered = renderMarkdownDocument(components, {});
+
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-render-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_INDEX.md"));
+
+    try {
+      await writeMarkdown(components, { outFile });
+      const written = readFileSync(path.join(tempDir, "COMPONENT_INDEX.md"), "utf-8");
+
+      expect(rendered).toBe(written);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Passing --stdout with exactly one of --json, --markdown, or
--custom-elements prints that document to stdout and writes
nothing to disk. This lets scripts and agents consume the
component API in one step without touching the working tree.

--stdout requires a single document-producing output and is
rejected otherwise, including alongside --check, whose report
also occupies stdout. Default .d.ts generation is skipped in
stdout mode since type definitions span multiple files.

