### PR TITLE
feat(cli): support --stdout=ndjson for per-component output

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ Writer progress lines (`created "..."` / `unchanged "..."`) print to `stderr`, k
 
 Pass `--stdout` alongside exactly one of `--json`, `--markdown`, or `--custom-elements` to print that single document to `stdout` instead of writing it to disk, e.g. `sveld --json --stdout | jq '.components[].moduleName'`. Zero or more than one of those three flags, `--types`, or `--check` combined with `--stdout` is a usage error that prints to `stderr` and exits `1` without generating anything; the default `.d.ts` generation is skipped in `--stdout` mode since type definitions span multiple files.
 
+`--stdout=ndjson` (only valid with `--json`) prints one minified JSON object per exported component per line instead of the single combined document, in the same order as the combined document's `components` array, e.g. `sveld --json --stdout=ndjson | jq -c 'select(.props | length > 0)'`. Lines are only written after the run completes (component records are only final after cross-component resolution), so this is a line-oriented serialization format, not incremental streaming. Bare `--stdout` (or `--stdout=json`) keeps the single-document behavior; any other value is a usage error.
+
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 
 ### CI: API-drift checks (`--check`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ Options:
   --custom-elements     Generate a Custom Elements Manifest (custom-elements.json)
   --fail-fast           Abort the run when a single component fails to parse
   --quiet               Suppress progress logs (errors, the diagnostics summary, and the --check report are unaffected)
-  --stdout              Print the document from exactly one of --json, --markdown, or --custom-elements to stdout and write nothing to disk (rejects --types and --check)
+  --stdout[=json|ndjson] Print the document from exactly one of --json, --markdown, or --custom-elements to stdout and write nothing to disk (rejects --types and --check); --stdout=ndjson prints one JSON object per component per line and requires --json
   --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (on by default, default path: node_modules/.cache/sveld/parse-cache.json; pass --cache=false to disable)
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
@@ -76,8 +76,14 @@ function parseCliFlag(arg: string): CliFlagResult {
     case "json":
     case "markdown":
     case "quiet":
-    case "stdout":
       return { kind: "option", option: { [flag]: value === true || value === "true" } };
+    case "stdout":
+      // Bare `--stdout` (or `--stdout=true`) keeps the single-document
+      // default; `--stdout=json`/`--stdout=ndjson` select the format
+      // explicitly. Any other value is validated (and rejected) in `cli()`.
+      if (value === true || value === "true") return { kind: "option", option: { stdout: true } };
+      if (value === "false") return { kind: "option", option: { stdout: false } };
+      return { kind: "option", option: { stdout: value as "json" | "ndjson" } };
     case "custom-elements":
       return { kind: "option", option: { customElements: value === true || value === "true" } };
     case "strict":
@@ -177,10 +183,22 @@ export async function cli(process: NodeJS.Process) {
   }
 
   if (options.stdout) {
+    if (options.stdout !== true && options.stdout !== "json" && options.stdout !== "ndjson") {
+      console.error(`sveld: --stdout must be "json" or "ndjson"; got "${options.stdout}".`);
+      process.exitCode = 1;
+      return;
+    }
+
     const selectedOutputs = [options.json, options.markdown, options.customElements].filter(Boolean).length;
 
     if (selectedOutputs !== 1) {
       console.error("sveld: --stdout requires exactly one of --json, --markdown, or --custom-elements.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (options.stdout === "ndjson" && !options.json) {
+      console.error("sveld: --stdout=ndjson is only valid with --json.");
       process.exitCode = 1;
       return;
     }

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -26,9 +26,11 @@ export interface SveldRuntimeOptions extends PluginSveldOptions {
   /**
    * Print the single selected `json` / `markdown` / `customElements` document
    * to stdout instead of writing it to disk. Requires exactly one of those
-   * three outputs; CLI-only (the Vite plugin ignores it).
+   * three outputs; CLI-only (the Vite plugin ignores it). `"ndjson"` is only
+   * valid with `json` and prints one minified JSON object per component per
+   * line instead of the single combined document.
    */
-  stdout?: boolean;
+  stdout?: boolean | "json" | "ndjson";
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,7 +12,7 @@ import { createSveldBundle, type SveldBundle } from "./watch";
 import "./writer/built-in-writers";
 import { getWriter } from "./writer/registry";
 import { renderCustomElementsManifest, type WriteCustomElementsOptions } from "./writer/writer-custom-elements";
-import { renderJsonDocument, type WriteJsonOptions } from "./writer/writer-json";
+import { renderJsonDocument, renderJsonLines, type WriteJsonOptions } from "./writer/writer-json";
 import { renderMarkdownDocument, type WriteMarkdownOptions } from "./writer/writer-markdown";
 import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 
@@ -271,15 +271,25 @@ export async function writeOutput(result: GenerateBundleResult, opts: PluginSvel
  * responsible for enforcing that exactly one of those three options is set
  * before calling this.
  */
-export async function writeStdout(result: GenerateBundleResult, opts: PluginSveldOptions, input: string) {
+export async function writeStdout(
+  result: GenerateBundleResult,
+  opts: PluginSveldOptions & { stdout?: boolean | "json" | "ndjson" },
+  input: string,
+) {
   const inputDir = dirname(input);
 
   if (opts?.json) {
-    const rendered = renderJsonDocument(result.components, {
+    const jsonOptions = {
       ...opts?.jsonOptions,
       inputDir,
       entryExports: result.entryExports,
-    } satisfies Pick<WriteJsonOptions, "inputDir" | "entryExports">);
+    } satisfies Pick<WriteJsonOptions, "inputDir" | "entryExports">;
+
+    const rendered =
+      opts.stdout === "ndjson"
+        ? renderJsonLines(result.components, jsonOptions)
+        : renderJsonDocument(result.components, jsonOptions);
+
     process.stdout.write(rendered);
     return;
   }

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -62,6 +62,21 @@ export function renderJsonDocument(
   return `${JSON.stringify(output, null, 2)}\n`;
 }
 
+/**
+ * Renders one minified JSON object per exported component per line (NDJSON),
+ * in the same order as `renderJsonDocument`'s `components` array. Used by the
+ * CLI's `--stdout=ndjson` mode.
+ */
+export function renderJsonLines(
+  components: ComponentDocs,
+  options: Pick<WriteJsonOptions, "inputDir" | "entryExports">,
+): string {
+  const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
+  const output = withNormalizedFilePaths(document.components, options.inputDir);
+
+  return `${output.map((c) => JSON.stringify(c)).join("\n")}\n`;
+}
+
 async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptions) {
   const raw = renderJsonDocument(components, options);
   const output_path = path.join(process.cwd(), options.outFile);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -105,6 +105,14 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--stdout=false"])).toEqual({ kind: "options", options: { stdout: false } });
   });
 
+  test("--stdout=json sets stdout to json", () => {
+    expect(parseCliOptions(["--stdout=json"])).toEqual({ kind: "options", options: { stdout: "json" } });
+  });
+
+  test("--stdout=ndjson sets stdout to ndjson", () => {
+    expect(parseCliOptions(["--stdout=ndjson"])).toEqual({ kind: "options", options: { stdout: "ndjson" } });
+  });
+
   test("--types-format=component sets typesOptions.format", () => {
     expect(parseCliOptions(["--types-format=component"])).toEqual({
       kind: "options",
@@ -474,5 +482,96 @@ describe("cli() --stdout", () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--stdout cannot be combined with --check"));
     expect(stdoutSpy).not.toHaveBeenCalled();
     expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+  });
+
+  test("--stdout=yaml errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--stdout=yaml"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--stdout must be "json" or "ndjson"'));
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  test("--markdown --stdout=ndjson errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--markdown", "--stdout=ndjson"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--stdout=ndjson is only valid with --json"));
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("cli() --stdout=ndjson", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-stdout-ndjson-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      '<script>\n  export let label = "";\n</script>\n<button>{label}</button>\n',
+    );
+    writeFileSync(
+      join(dir, "src", "Alert.svelte"),
+      '<script>\n  export let message = "";\n</script>\n<div>{message}</div>\n',
+    );
+    writeFileSync(
+      join(dir, "src", "index.js"),
+      'export { default as Button } from "./Button.svelte";\nexport { default as Alert } from "./Alert.svelte";\n',
+    );
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    stdoutSpy = jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("--json --stdout=ndjson prints one JSON object per component per line, in document order", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--stdout=ndjson"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+
+    const printed = stdoutSpy.mock.calls[0][0] as string;
+    const lines = printed.trimEnd().split("\n");
+    expect(lines).toHaveLength(2);
+
+    const documentArgv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--stdout"];
+    process.argv = documentArgv;
+    stdoutSpy.mockClear();
+    await cli(process);
+    const document = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+
+    expect(lines.map((line) => JSON.parse(line))).toEqual(document.components);
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+  });
+
+  test("--json --stdout=json keeps the single-document behavior", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--stdout=json"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(printed).toMatchObject({ schemaVersion: 1, total: 2 });
   });
 });


### PR DESCRIPTION
--stdout=ndjson emits one JSON object per exported component per
line instead of a single document. Line-oriented output composes
with jq, grep, and other stream tooling, and lets consumers of
large libraries process components without parsing one large
document.

Bare --stdout keeps emitting a single JSON document. All lines
are written after the run completes, since component records are
only final after cross-component resolution.

