### PR TITLE
feat(cli): add --format=json for check and diagnostics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,13 +471,15 @@ npx sveld --json --markdown
 
 If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
 
-Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`, `--stdout`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
+Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--fail-fast`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`, `--stdout`, `--format`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; sveld takes no positional arguments, so any non-flag argument errors the same way.
 
 Writer progress lines (`created "..."` / `unchanged "..."`) print to `stderr`, keeping `stdout` reserved for machine-readable data. Pass `--quiet` (or `quiet: true` in `sveld.config.*`) to suppress them; it does not suppress error messages, the diagnostics summary (`--report-diagnostics` / `--strict`), or the `--check` report.
 
 Pass `--stdout` alongside exactly one of `--json`, `--markdown`, or `--custom-elements` to print that single document to `stdout` instead of writing it to disk, e.g. `sveld --json --stdout | jq '.components[].moduleName'`. Zero or more than one of those three flags, `--types`, or `--check` combined with `--stdout` is a usage error that prints to `stderr` and exits `1` without generating anything; the default `.d.ts` generation is skipped in `--stdout` mode since type definitions span multiple files.
 
 `--stdout=ndjson` (only valid with `--json`) prints one minified JSON object per exported component per line instead of the single combined document, in the same order as the combined document's `components` array, e.g. `sveld --json --stdout=ndjson | jq -c 'select(.props | length > 0)'`. Lines are only written after the run completes (component records are only final after cross-component resolution), so this is a line-oriented serialization format, not incremental streaming. Bare `--stdout` (or `--stdout=json`) keeps the single-document behavior; any other value is a usage error.
+
+`--format=json` switches the `--check` report and the `--report-diagnostics` / `--strict` diagnostics summary from prose to JSON, so scripts and agents don't have to regex the text output, e.g. `sveld --json --check --format=json | jq '.bump'`. Channels are unchanged: the check report prints to `stdout` and the diagnostics summary to `stderr`, same as the text format. The default remains `--format=text`; an unrecognized value (e.g. `--format=yaml`) is a usage error that prints to `stderr` and exits `1` without generating anything.
 
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 
@@ -508,6 +510,8 @@ Removed props, events, or slots, and props that become required, are breaking (`
 Use `--check=<path>` to diff against a snapshot at a custom location (defaults to `jsonOptions.outFile`, or `COMPONENT_API.json`).
 
 The CLI exits non-zero on any fatal error (an unreadable entry, a config file that throws, etc.), not just on `--strict`/`--check` findings, so it's safe to use either flag as a CI gate.
+
+Pass `--format=json` for a machine-readable report on `stdout` instead of the prose above, e.g. `sveld --check --format=json | jq '.bump'` or `sveld --check --format=json | jq '.changes[] | select(.bump == "major")'`.
 
 ### Node.js
 

--- a/src/check.ts
+++ b/src/check.ts
@@ -437,3 +437,12 @@ export function formatCheckReport(result: CheckResult): string {
 
   return lines.join("\n");
 }
+
+/** `CheckResult`, serialized for stream consumers with a `kind` discriminator. */
+export type CheckReportJson = CheckResult & { kind: "check-report" };
+
+/** Serializes a `CheckResult` as JSON, for `--format=json --check`. */
+export function formatCheckReportJson(result: CheckResult): string {
+  const document: CheckReportJson = { kind: "check-report", ...result };
+  return `${JSON.stringify(document, null, 2)}\n`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,14 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import pkg from "../package.json" with { type: "json" };
 import { asSvelteEntryPoint } from "./brands";
-import { type CheckResult, formatCheckReport, resolveCheckSnapshotFile, runCheck } from "./check";
-import { formatDiagnosticsSummary } from "./diagnostics";
+import {
+  type CheckResult,
+  formatCheckReport,
+  formatCheckReportJson,
+  resolveCheckSnapshotFile,
+  runCheck,
+} from "./check";
+import { formatDiagnosticsSummary, formatDiagnosticsSummaryJson } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
 import { setQuiet } from "./logger";
@@ -39,6 +45,7 @@ Options:
   --strict              Exit with code 1 when diagnostics exist (implies --report-diagnostics)
   --types-format=<format>  ".d.ts" output format: "class" (default) or "component" (Svelte 5 Component<...>)
   --check[=<path>]      Diff the parsed API against a committed snapshot; exit 1 on a breaking change (default path: COMPONENT_API.json)
+  --format=<text|json>  Output format for the --check report and the diagnostics summary (default: text)
   --help                Print this help message and exit
   --version             Print the installed sveld version and exit
 `;
@@ -111,6 +118,12 @@ function parseCliFlag(arg: string): CliFlagResult {
     case "types-format":
       return typeof value === "string"
         ? { kind: "option", option: { typesOptions: { format: value as "class" | "component" } } }
+        : { kind: "option", option: {} };
+    case "format":
+      // The value is validated in `cli()` once it can be reported as a usage
+      // error (`--format=yaml`); a bare `--format` is silently ignored.
+      return typeof value === "string"
+        ? { kind: "option", option: { format: value as "text" | "json" } }
         : { kind: "option", option: {} };
     default:
       return { kind: "unknown", arg };
@@ -216,6 +229,12 @@ export async function cli(process: NodeJS.Process) {
     }
   }
 
+  if (options.format !== undefined && options.format !== "text" && options.format !== "json") {
+    console.error(`sveld: --format must be "text" or "json"; got "${options.format}".`);
+    process.exitCode = 1;
+    return;
+  }
+
   setQuiet(options.quiet === true);
 
   const resolvedEntry = getSvelteEntry(options.entry);
@@ -253,11 +272,19 @@ export async function cli(process: NodeJS.Process) {
   const shouldReport = options.reportDiagnostics || options.strict;
 
   if (shouldReport && diagnostics.length > 0) {
-    console.error(formatDiagnosticsSummary(diagnostics));
+    if (options.format === "json") {
+      process.stderr.write(formatDiagnosticsSummaryJson(diagnostics));
+    } else {
+      console.error(formatDiagnosticsSummary(diagnostics));
+    }
   }
 
   if (checkResult) {
-    console.log(formatCheckReport(checkResult));
+    if (options.format === "json") {
+      process.stdout.write(formatCheckReportJson(checkResult));
+    } else {
+      console.log(formatCheckReport(checkResult));
+    }
     if (checkResult.bump === "major") {
       process.exitCode = 1;
     }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -104,3 +104,15 @@ export function formatDiagnosticsSummary(diagnostics: SveldDiagnostic[]): string
 
   return lines.join("\n");
 }
+
+/** `SveldDiagnostic[]`, serialized for stream consumers with a `kind` discriminator. */
+export interface DiagnosticsJson {
+  kind: "diagnostics";
+  diagnostics: SveldDiagnostic[];
+}
+
+/** Serializes deduped diagnostics as JSON, for `--format=json --report-diagnostics` / `--strict`. */
+export function formatDiagnosticsSummaryJson(diagnostics: SveldDiagnostic[]): string {
+  const document: DiagnosticsJson = { kind: "diagnostics", diagnostics };
+  return `${JSON.stringify(document, null, 2)}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 export { default as ComponentParser, type SerializedComponentEvent } from "./ComponentParser";
 export {
   type ApiChange,
+  type CheckReportJson,
   type CheckResult,
   diffApiDocuments,
   formatCheckReport,
+  formatCheckReportJson,
   runCheck,
   type SemverBump,
 } from "./check";

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -31,6 +31,12 @@ export interface SveldRuntimeOptions extends PluginSveldOptions {
    * line instead of the single combined document.
    */
   stdout?: boolean | "json" | "ndjson";
+  /**
+   * Output format for the `--check` report and the `--report-diagnostics` /
+   * `--strict` diagnostics summary: `"text"` (default) or `"json"`. Channels
+   * are unchanged, the check report on stdout and diagnostics on stderr.
+   */
+  format?: "text" | "json";
 }
 
 /**

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import path from "node:path";
 import { version as svelteVersion } from "svelte/package.json";
 import { name as packageName, version as packageVersion } from "../package.json";
-import { diffApiDocuments, formatCheckReport, runCheck } from "../src/check";
+import { diffApiDocuments, formatCheckReport, formatCheckReportJson, runCheck } from "../src/check";
 import type { ComponentDocApi, ComponentDocs } from "../src/plugin";
 import type { ComponentApiDocument } from "../src/writer/document-model";
 import { mockComponentDocApi } from "./test-brands";
@@ -359,5 +359,27 @@ describe("formatCheckReport", () => {
     expect(report).toContain('[BREAKING] prop "href" removed');
     expect(report).toContain("Card");
     expect(report).toContain('[additive] component "Card" added');
+  });
+});
+
+describe("formatCheckReportJson", () => {
+  test("serializes the CheckResult with a kind discriminator", () => {
+    const result = {
+      snapshotExists: true,
+      snapshotFile: "COMPONENT_API.json",
+      bump: "major" as const,
+      changes: [{ component: "Button", kind: "prop" as const, name: "href", bump: "major" as const, message: 'prop "href" removed' }],
+    };
+
+    const json = formatCheckReportJson(result);
+
+    expect(json.endsWith("\n")).toBe(true);
+    expect(JSON.parse(json)).toEqual({ kind: "check-report", ...result });
+  });
+
+  test("serializes a missing snapshot the same as any other result", () => {
+    const result = { snapshotExists: false, snapshotFile: "COMPONENT_API.json", changes: [], bump: "none" as const };
+
+    expect(JSON.parse(formatCheckReportJson(result))).toEqual({ kind: "check-report", ...result });
   });
 });

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -368,7 +368,15 @@ describe("formatCheckReportJson", () => {
       snapshotExists: true,
       snapshotFile: "COMPONENT_API.json",
       bump: "major" as const,
-      changes: [{ component: "Button", kind: "prop" as const, name: "href", bump: "major" as const, message: 'prop "href" removed' }],
+      changes: [
+        {
+          component: "Button",
+          kind: "prop" as const,
+          name: "href",
+          bump: "major" as const,
+          message: 'prop "href" removed',
+        },
+      ],
     };
 
     const json = formatCheckReportJson(result);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -120,6 +120,18 @@ describe("parseCliOptions", () => {
     });
   });
 
+  test("--format=json sets format to json", () => {
+    expect(parseCliOptions(["--format=json"])).toEqual({ kind: "options", options: { format: "json" } });
+  });
+
+  test("--format=text sets format to text", () => {
+    expect(parseCliOptions(["--format=text"])).toEqual({ kind: "options", options: { format: "text" } });
+  });
+
+  test("a bare --format is ignored", () => {
+    expect(parseCliOptions(["--format"])).toEqual({ kind: "options", options: {} });
+  });
+
   test("unknown flag surfaces as an unknown result", () => {
     expect(parseCliOptions(["--markdwon"])).toEqual({ kind: "unknown", arg: "--markdwon" });
   });
@@ -573,5 +585,199 @@ describe("cli() --stdout=ndjson", () => {
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const printed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
     expect(printed).toMatchObject({ schemaVersion: 1, total: 2 });
+  });
+});
+
+describe("cli() --format usage error", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-format-error-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "Button.svelte"), "<script></script>\n<button>Click</button>\n");
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("--format=yaml errors and generates nothing", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--format=yaml"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--format must be "text" or "json"; got "yaml"'));
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+    expect(existsSync(join(dir, "types"))).toBe(false);
+  });
+});
+
+describe("cli() --format with --check", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(async () => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-format-check-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    stdoutSpy = jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    // Snapshot a prop-less Button, then add a required prop so `--check` has a breaking change to report.
+    writeFileSync(join(dir, "src", "Button.svelte"), "<script></script>\n<button>Click</button>\n");
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json"];
+    await cli(process);
+    stdoutSpy.mockClear();
+    logSpy.mockClear();
+
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      '<script>\n  export let label;\n</script>\n<button>{label}</button>\n',
+    );
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("--format=json prints the CheckResult as JSON to stdout", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--check", "--format=json"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(printed.kind).toBe("check-report");
+    expect(printed.bump).toBe("major");
+    expect(printed.changes).toContainEqual(
+      expect.objectContaining({ component: "Button", kind: "prop", name: "label", bump: "major" }),
+    );
+  });
+
+  test("--format=text keeps the text report on stdout (default behavior unchanged)", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--check", "--format=text"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[BREAKING] prop "label" added (required)'));
+  });
+
+  test("omitting --format keeps the text report on stdout", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--check"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Suggested semver bump: major."));
+  });
+});
+
+describe("cli() --format with --report-diagnostics", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-format-diagnostics-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Phantom } from "./Phantom.svelte";\n');
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    stderrSpy = jest.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("--format=json prints the diagnostics as JSON to stderr", async () => {
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--types=false",
+      "--report-diagnostics",
+      "--format=json",
+    ];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(stderrSpy.mock.calls[0][0] as string);
+    expect(printed.kind).toBe("diagnostics");
+    expect(printed.diagnostics).toContainEqual(
+      expect.objectContaining({ kind: "event-no-source", name: "phantom" }),
+    );
+  });
+
+  test("--format=text keeps the text summary on stderr (default behavior unchanged)", async () => {
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--report-diagnostics", "--format=text"];
+
+    await cli(process);
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("unresolved type"));
+  });
+
+  test("--format=json with no diagnostics prints nothing, same as text", async () => {
+    writeFileSync(join(dir, "src", "Phantom.svelte"), "<script></script>\n<button>Click</button>\n");
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--types=false",
+      "--report-diagnostics",
+      "--format=json",
+    ];
+
+    await cli(process);
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -654,7 +654,7 @@ describe("cli() --format with --check", () => {
 
     writeFileSync(
       join(dir, "src", "Button.svelte"),
-      '<script>\n  export let label;\n</script>\n<button>{label}</button>\n',
+      "<script>\n  export let label;\n</script>\n<button>{label}</button>\n",
     );
   });
 
@@ -735,14 +735,7 @@ describe("cli() --format with --report-diagnostics", () => {
   });
 
   test("--format=json prints the diagnostics as JSON to stderr", async () => {
-    process.argv = [
-      "bun",
-      "cli.js",
-      "--entry=src/index.js",
-      "--types=false",
-      "--report-diagnostics",
-      "--format=json",
-    ];
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--report-diagnostics", "--format=json"];
 
     await cli(process);
 
@@ -750,9 +743,7 @@ describe("cli() --format with --report-diagnostics", () => {
     expect(stderrSpy).toHaveBeenCalledTimes(1);
     const printed = JSON.parse(stderrSpy.mock.calls[0][0] as string);
     expect(printed.kind).toBe("diagnostics");
-    expect(printed.diagnostics).toContainEqual(
-      expect.objectContaining({ kind: "event-no-source", name: "phantom" }),
-    );
+    expect(printed.diagnostics).toContainEqual(expect.objectContaining({ kind: "event-no-source", name: "phantom" }));
   });
 
   test("--format=text keeps the text summary on stderr (default behavior unchanged)", async () => {
@@ -766,14 +757,7 @@ describe("cli() --format with --report-diagnostics", () => {
 
   test("--format=json with no diagnostics prints nothing, same as text", async () => {
     writeFileSync(join(dir, "src", "Phantom.svelte"), "<script></script>\n<button>Click</button>\n");
-    process.argv = [
-      "bun",
-      "cli.js",
-      "--entry=src/index.js",
-      "--types=false",
-      "--report-diagnostics",
-      "--format=json",
-    ];
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--report-diagnostics", "--format=json"];
 
     await cli(process);
 

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,7 +1,12 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import ComponentParser from "../src/ComponentParser";
-import { dedupeDiagnostics, formatDiagnosticsSummary, type SveldDiagnostic } from "../src/diagnostics";
+import {
+  dedupeDiagnostics,
+  formatDiagnosticsSummary,
+  formatDiagnosticsSummaryJson,
+  type SveldDiagnostic,
+} from "../src/diagnostics";
 import { sveld } from "../src/sveld";
 
 const parseContext = { moduleName: "TestComponent", filePath: "./TestComponent.svelte" };
@@ -196,6 +201,19 @@ describe("diagnostics helpers", () => {
 
     expect(summary).toContain("- prop fallback");
     expect(summary).not.toContain("prop fallback (");
+  });
+
+  test("formatDiagnosticsSummaryJson serializes the diagnostics list with a kind discriminator", () => {
+    const diagnostics = [make({ name: "value", message: "prop fallback" })];
+
+    const json = formatDiagnosticsSummaryJson(diagnostics);
+
+    expect(json.endsWith("\n")).toBe(true);
+    expect(JSON.parse(json)).toEqual({ kind: "diagnostics", diagnostics });
+  });
+
+  test("formatDiagnosticsSummaryJson serializes an empty list", () => {
+    expect(JSON.parse(formatDiagnosticsSummaryJson([]))).toEqual({ kind: "diagnostics", diagnostics: [] });
   });
 });
 


### PR DESCRIPTION
The --check report and the diagnostics summary previously
rendered only as human-readable text, forcing scripts to parse
prose. With --format=json, the check report is emitted as
structured JSON on stdout and the diagnostics summary as
structured JSON on stderr, mirroring the existing channels and
serializing the existing CheckResult and SveldDiagnostic shapes.

The default remains text output. Exit code behavior is
unchanged.

