### PR TITLE
feat(cli): differentiate exit codes by failure kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ export default class Button extends SvelteComponentTyped<
   - [Installation](#installation)
   - [Vite](#vite)
   - [CLI](#cli)
+  - [Exit codes](#exit-codes)
   - [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check)
   - [Node.js](#nodejs)
   - [Browser](#browser)
@@ -375,7 +376,7 @@ By default, nothing is printed. Opt in when you are working on types or want CI 
 await sveld({ json: true, reportDiagnostics: true });
 ```
 
-Use `strict: true` (or `--strict`) to exit with code `1` when diagnostics exist. `strict` implies `reportDiagnostics`, so CI always shows why the run failed.
+Use `strict: true` (or `--strict`) to exit with code `4` when diagnostics exist. `strict` implies `reportDiagnostics`, so CI always shows why the run failed.
 
 ```ts
 await sveld({ json: true, strict: true });
@@ -483,9 +484,21 @@ Pass `--stdout` alongside exactly one of `--json`, `--markdown`, or `--custom-el
 
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Usage or configuration error (unknown flag, bad flag value, unresolvable entry) |
+| `2` | Generation failure (a component failed to parse under `--fail-fast`, or an unrecoverable pipeline error) |
+| `3` | Breaking API change detected by `--check` |
+| `4` | Diagnostics present under `--strict` |
+
+Every failure is still reported to its usual channel even when more than one applies in a single run (e.g. a breaking change under `--check` alongside diagnostics under `--strict`); the process exits with the lowest applicable code. All failure codes are nonzero, so existing `if sveld; then ...` and `set -e` scripts that only check for success keep working unmodified.
+
 ### CI: API-drift checks (`--check`)
 
-`--check` diffs the parsed component API against a committed `COMPONENT_API.json` snapshot, assigns a semver bump to each change, and exits `1` when it finds a breaking change.
+`--check` diffs the parsed component API against a committed `COMPONENT_API.json` snapshot, assigns a semver bump to each change, and exits `3` when it finds a breaking change.
 
 1. Generate and commit the snapshot once: `npx sveld --json`, then commit `COMPONENT_API.json`.
 2. Add `npx sveld --check` to CI:
@@ -509,7 +522,7 @@ Removed props, events, or slots, and props that become required, are breaking (`
 
 Use `--check=<path>` to diff against a snapshot at a custom location (defaults to `jsonOptions.outFile`, or `COMPONENT_API.json`).
 
-The CLI exits non-zero on any fatal error (an unreadable entry, a config file that throws, etc.), not just on `--strict`/`--check` findings, so it's safe to use either flag as a CI gate.
+The CLI exits non-zero on any fatal error (an unreadable entry, a config file that throws, etc.), not just on `--strict`/`--check` findings, so it's safe to use either flag as a CI gate. See [Exit codes](#exit-codes) for how these are differentiated.
 
 Pass `--format=json` for a machine-readable report on `stdout` instead of the prose above, e.g. `sveld --check --format=json | jq '.bump'` or `sveld --check --format=json | jq '.changes[] | select(.bump == "major")'`.
 
@@ -707,8 +720,8 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`cache`** (boolean | string, optional, default: `true`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. On by default, writing to `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path; pass `false` to disable. Also available as `--cache` / `--cache=<path>` / `--cache=false`. See [Persistent parse cache](#persistent-parse-cache-cache).
 - **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. Also available as `--check-examples` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
-- **`strict`** (boolean, optional, default: `false`): Exit with code `1` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).
-- **`check`** (boolean | string, optional, default: `false`): Diff the parsed component API against a committed snapshot and assign a semver bump to each change. `true` uses the `json` writer's `outFile` (or `COMPONENT_API.json`); a string sets a custom snapshot path. Also available as `--check` / `--check=<path>`. On the CLI this exits `1` on a breaking change; from `sveld()` it's returned on `SveldResult.check` for you to act on. See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check).
+- **`strict`** (boolean, optional, default: `false`): Exit with code `4` when diagnostics exist. Implies `reportDiagnostics`. Also available as `--strict`. See [Type inference diagnostics](#type-inference-diagnostics).
+- **`check`** (boolean | string, optional, default: `false`): Diff the parsed component API against a committed snapshot and assign a semver bump to each change. `true` uses the `json` writer's `outFile` (or `COMPONENT_API.json`); a string sets a custom snapshot path. Also available as `--check` / `--check=<path>`. On the CLI this exits `3` on a breaking change; from `sveld()` it's returned on `SveldResult.check` for you to act on. See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check).
 - **`quiet`** (boolean, optional, default: `false`): Suppress writer progress logs (`created "..."` / `unchanged "..."`), which print to `stderr` by default. Does not suppress error messages, the diagnostics summary, or the `--check` report. Also available as `--quiet`.
 
 By default, only TypeScript definitions are generated.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,19 @@ import { generateBundle, toGenerateBundleOptions, writeOutput, writeStdout } fro
 /** Relative fallback entry used only when entry resolution otherwise fails. */
 const FALLBACK_ENTRY = "src/index.js";
 
+/**
+ * Documented exit code contract so scripts can branch on failure kind
+ * without parsing output. When more than one applies in a single run, the
+ * lowest code wins (1 beats 2 beats 3 beats 4).
+ */
+const EXIT_CODES = {
+  SUCCESS: 0,
+  USAGE_ERROR: 1,
+  GENERATION_FAILURE: 2,
+  BREAKING_CHANGE: 3,
+  DIAGNOSTICS: 4,
+} as const;
+
 /** CLI options: identical surface to the shared runtime options. */
 type CliOptions = SveldRuntimeOptions;
 
@@ -48,6 +61,13 @@ Options:
   --format=<text|json>  Output format for the --check report and the diagnostics summary (default: text)
   --help                Print this help message and exit
   --version             Print the installed sveld version and exit
+
+Exit codes:
+  0  success
+  1  usage or configuration error
+  2  generation failure
+  3  breaking API change detected by --check
+  4  diagnostics present under --strict
 `;
 
 /** Discriminated result of parsing a single CLI argument, kept side-effect free. */
@@ -179,7 +199,7 @@ export async function cli(process: NodeJS.Process) {
   if (parsed.kind === "unknown") {
     console.error(`Unknown flag: ${parsed.arg}`);
     console.error("Run sveld --help for a list of available flags.");
-    process.exitCode = 1;
+    process.exitCode = EXIT_CODES.USAGE_ERROR;
     return;
   }
 
@@ -198,7 +218,7 @@ export async function cli(process: NodeJS.Process) {
   if (options.stdout) {
     if (options.stdout !== true && options.stdout !== "json" && options.stdout !== "ndjson") {
       console.error(`sveld: --stdout must be "json" or "ndjson"; got "${options.stdout}".`);
-      process.exitCode = 1;
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
 
@@ -206,32 +226,32 @@ export async function cli(process: NodeJS.Process) {
 
     if (selectedOutputs !== 1) {
       console.error("sveld: --stdout requires exactly one of --json, --markdown, or --custom-elements.");
-      process.exitCode = 1;
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
 
     if (options.stdout === "ndjson" && !options.json) {
       console.error("sveld: --stdout=ndjson is only valid with --json.");
-      process.exitCode = 1;
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
 
     if (options.types === true) {
       console.error("sveld: --stdout cannot be combined with --types; type definitions span multiple files.");
-      process.exitCode = 1;
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
 
     if (options.check) {
       console.error("sveld: --stdout cannot be combined with --check; both write their document to stdout.");
-      process.exitCode = 1;
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
   }
 
   if (options.format !== undefined && options.format !== "text" && options.format !== "json") {
     console.error(`sveld: --format must be "text" or "json"; got "${options.format}".`);
-    process.exitCode = 1;
+    process.exitCode = EXIT_CODES.USAGE_ERROR;
     return;
   }
 
@@ -248,24 +268,32 @@ export async function cli(process: NodeJS.Process) {
     );
     input = asSvelteEntryPoint(normalizeSeparators(FALLBACK_ENTRY));
   } else {
-    process.exitCode = 1;
+    process.exitCode = EXIT_CODES.USAGE_ERROR;
     return;
   }
 
-  const result = await generateBundle(input, options.glob === true, toGenerateBundleOptions(options));
-
-  // Read the committed snapshot before `writeOutput` can overwrite it.
+  let result: Awaited<ReturnType<typeof generateBundle>>;
   let checkResult: CheckResult | undefined;
-  if (options.check) {
-    checkResult = await runCheck(result.components, resolveCheckSnapshotFile(options), {
-      entryExports: result.entryExports,
-    });
-  }
 
-  if (options.stdout) {
-    await writeStdout(result, options, input);
-  } else {
-    await writeOutput(result, options, input);
+  try {
+    result = await generateBundle(input, options.glob === true, toGenerateBundleOptions(options));
+
+    // Read the committed snapshot before `writeOutput` can overwrite it.
+    if (options.check) {
+      checkResult = await runCheck(result.components, resolveCheckSnapshotFile(options), {
+        entryExports: result.entryExports,
+      });
+    }
+
+    if (options.stdout) {
+      await writeStdout(result, options, input);
+    } else {
+      await writeOutput(result, options, input);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = EXIT_CODES.GENERATION_FAILURE;
+    return;
   }
 
   const { diagnostics } = result;
@@ -285,12 +313,20 @@ export async function cli(process: NodeJS.Process) {
     } else {
       console.log(formatCheckReport(checkResult));
     }
-    if (checkResult.bump === "major") {
-      process.exitCode = 1;
-    }
+  }
+
+  // Lowest applicable code wins (3 beats 4); every failure is still reported above.
+  let exitCode: number | undefined;
+
+  if (checkResult?.bump === "major") {
+    exitCode = EXIT_CODES.BREAKING_CHANGE;
   }
 
   if (options.strict && diagnostics.length > 0) {
-    process.exitCode = 1;
+    exitCode = exitCode === undefined ? EXIT_CODES.DIAGNOSTICS : Math.min(exitCode, EXIT_CODES.DIAGNOSTICS);
+  }
+
+  if (exitCode !== undefined) {
+    process.exitCode = exitCode;
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -671,7 +671,7 @@ describe("cli() --format with --check", () => {
 
     await cli(process);
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(3);
     expect(logSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const printed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
@@ -687,7 +687,7 @@ describe("cli() --format with --check", () => {
 
     await cli(process);
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(3);
     expect(stdoutSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[BREAKING] prop "label" added (required)'));
   });
@@ -697,7 +697,7 @@ describe("cli() --format with --check", () => {
 
     await cli(process);
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(3);
     expect(stdoutSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Suggested semver bump: major."));
   });
@@ -763,5 +763,90 @@ describe("cli() --format with --report-diagnostics", () => {
 
     expect(stderrSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("cli() exit codes", () => {
+  let dir: string;
+  let previousCwd: string;
+  let previousArgv: string[];
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    previousArgv = process.argv;
+    process.exitCode = 0;
+    dir = mkdtempSync(join(tmpdir(), "sveld-cli-exit-codes-"));
+    process.chdir(dir);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    stdoutSpy = jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    process.argv = previousArgv;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("sets exitCode 2 and prints the error to stderr when --fail-fast rethrows a parse failure", async () => {
+    writeFileSync(join(dir, "src", "Broken.svelte"), "<script>\n  export let label = ;\n</script>\n<button>{label}</button>\n");
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Broken } from "./Broken.svelte";\n');
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json", "--fail-fast"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(2);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
+  });
+
+  test("sets exitCode 4 when diagnostics exist under --strict without --check", async () => {
+    writeFileSync(
+      join(dir, "src", "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Phantom } from "./Phantom.svelte";\n');
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json", "--strict"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(4);
+  });
+
+  test("exits 3 (not 4) when a --check breaking change and --strict diagnostics both apply in one run", async () => {
+    writeFileSync(join(dir, "src", "Button.svelte"), "<script></script>\n<button>Click</button>\n");
+    writeFileSync(
+      join(dir, "src", "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(
+      join(dir, "src", "index.js"),
+      'export { default as Button } from "./Button.svelte";\nexport { default as Phantom } from "./Phantom.svelte";\n',
+    );
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json"];
+    await cli(process);
+    stdoutSpy.mockClear();
+    logSpy.mockClear();
+    errorSpy.mockClear();
+
+    // Add a required prop to Button so `--check` has a breaking change to report,
+    // alongside Phantom's pre-existing diagnostic.
+    writeFileSync(
+      join(dir, "src", "Button.svelte"),
+      "<script>\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--check", "--strict"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(3);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Suggested semver bump: major."));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("unresolved type"));
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -795,7 +795,10 @@ describe("cli() exit codes", () => {
   });
 
   test("sets exitCode 2 and prints the error to stderr when --fail-fast rethrows a parse failure", async () => {
-    writeFileSync(join(dir, "src", "Broken.svelte"), "<script>\n  export let label = ;\n</script>\n<button>{label}</button>\n");
+    writeFileSync(
+      join(dir, "src", "Broken.svelte"),
+      "<script>\n  export let label = ;\n</script>\n<button>{label}</button>\n",
+    );
     writeFileSync(join(dir, "src", "index.js"), 'export { default as Broken } from "./Broken.svelte";\n');
     process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json", "--fail-fast"];
 


### PR DESCRIPTION
The CLI previously exited 1 for every failure, so scripts could
not tell a usage error from a breaking API change without
parsing output. Exit codes now distinguish:

  0  success
  1  usage or configuration error
  2  generation failure
  3  breaking API change detected by --check
  4  diagnostics present under --strict

When multiple failures apply, the lowest code wins. All failures
remain nonzero, so existing checks against a nonzero exit are
unaffected. The contract is documented in the README and in
--help.

