### PR TITLE
perf(parser): parse each component once instead of twice

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -54,7 +54,7 @@ import { buildTypeScriptMetadata } from "./parser/type-resolution";
 import { stripTypeCastWrappers } from "./parser/typescript-casts";
 import { assignValueOrUndefined } from "./parser/utils";
 import { buildVariableJsDocTable } from "./parser/variable-jsdoc";
-import { parse } from "./svelte-parse";
+import { parseModernAndLegacy } from "./svelte-parse";
 
 /** Structured JSDoc tag (e.g. `{ name: "since", body: "1.2.0" }`). */
 export interface JsDocPassthroughTag {
@@ -854,14 +854,16 @@ export default class ComponentParser {
     this.ctx.componentFilePath = diagnostics.filePath;
     const cleanedSource = ComponentParser.stripTypeScriptDirectivesFromScripts(source);
     this.ctx.source = cleanedSource;
-    buildRunesPropTypeMetadata(this, this.ctx);
 
     /**
-     * Parse once - compile()'s analyze phase roughly doubles the compiler cost per component but
-     * sveld only ever consumed its AST and its runes-metadata flag, so call parse() directly and
-     * determine the syntax mode locally instead.
+     * One `parseFragment` call backs both AST views (see `parseModernAndLegacy`): the modern
+     * view feeds `buildRunesPropTypeMetadata` (type imports, local types, `$props()` metadata),
+     * the legacy view backs the main walk below. Two independent `parse()` calls used to re-lex
+     * and re-parse the same source from scratch for each mode.
      */
-    this.ctx.parsed = parse(cleanedSource, { modern: false }) as LegacyAstRoot;
+    const { modern: modernParsed, legacy: legacyParsed } = parseModernAndLegacy(cleanedSource);
+    buildRunesPropTypeMetadata(this, this.ctx, modernParsed);
+    this.ctx.parsed = legacyParsed as LegacyAstRoot;
 
     /**
      * compile() strips TS-only wrapper expressions (`as`/`satisfies`/`!`/type assertions/explicit

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -9,7 +9,6 @@ import type {
   RunesPropTypeMetadata,
   TypeImportBinding,
 } from "../ComponentParser";
-import { parse } from "../svelte-parse";
 import type { ParserContext } from "./context";
 import { collectGenericsAttributeTypeDependencies } from "./generics";
 import { processLeadingCommentsJSDoc, processNodeJSDoc } from "./jsdoc";
@@ -174,49 +173,25 @@ export function buildRunesPropTypeMetadataMap(
   return metadata;
 }
 
-/**
- * Re-parse `ctx.source` in modern AST mode before the legacy walk: type imports,
- * local types, explicit `export let` annotations, and `$props()` metadata.
- */
-export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserContext) {
-  ctx.runesPropsDeclarationMetadataByDeclaratorStart.clear();
-  ctx.explicitPropTypesByName.clear();
-  ctx.explicitVariableTypesByName.clear();
-  ctx.typeImportBindingsByLocalName.clear();
-  ctx.localTypeDeclarationsByName.clear();
-  ctx.typedRunesPropsDeclarations.length = 0;
-  if (!ctx.source) return;
-
-  const modernParsed = parse(ctx.source, { modern: true }) as {
-    instance?: ModernScriptNode & {
-      content?: {
-        body?: Array<{
+/** The modern-AST shape `buildRunesPropTypeMetadata` reads from. */
+export type ModernParsedRoot = {
+  instance?: ModernScriptNode & {
+    content?: {
+      body?: Array<{
+        type?: string;
+        start?: number;
+        end?: number;
+        importKind?: string;
+        source?: { value?: string };
+        specifiers?: Array<{
           type?: string;
-          start?: number;
-          end?: number;
           importKind?: string;
-          source?: { value?: string };
-          specifiers?: Array<{
-            type?: string;
-            importKind?: string;
-            local?: { name?: string };
-            imported?: { type?: string; name?: string; value?: string };
-          }>;
-          id?: { name?: string };
-          declaration?: {
-            type?: string;
-            declarations?: Array<{
-              id?: {
-                type?: string;
-                name?: string;
-                typeAnnotation?: {
-                  start?: number;
-                  end?: number;
-                  typeAnnotation?: ModernRunesTypeNode;
-                };
-              };
-            }>;
-          };
+          local?: { name?: string };
+          imported?: { type?: string; name?: string; value?: string };
+        }>;
+        id?: { name?: string };
+        declaration?: {
+          type?: string;
           declarations?: Array<{
             id?: {
               type?: string;
@@ -227,15 +202,44 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
                 typeAnnotation?: ModernRunesTypeNode;
               };
             };
-            init?: unknown;
-            start?: number;
           }>;
+        };
+        declarations?: Array<{
+          id?: {
+            type?: string;
+            name?: string;
+            typeAnnotation?: {
+              start?: number;
+              end?: number;
+              typeAnnotation?: ModernRunesTypeNode;
+            };
+          };
+          init?: unknown;
+          start?: number;
         }>;
-      };
+      }>;
     };
-    module?: ModernScriptNode;
-    options?: { customElement?: { tag?: string }; runes?: boolean } | null;
   };
+  module?: ModernScriptNode;
+  options?: { customElement?: { tag?: string }; runes?: boolean } | null;
+};
+
+/**
+ * Reads type imports, local types, explicit `export let` annotations, and
+ * `$props()` metadata off `modernParsed` (the modern-mode AST for the same
+ * source as `ctx.parsed`, parsed once alongside it by the caller - see
+ * `parseModernAndLegacy` in `../svelte-parse`).
+ */
+export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserContext, modernParsedRoot: unknown) {
+  ctx.runesPropsDeclarationMetadataByDeclaratorStart.clear();
+  ctx.explicitPropTypesByName.clear();
+  ctx.explicitVariableTypesByName.clear();
+  ctx.typeImportBindingsByLocalName.clear();
+  ctx.localTypeDeclarationsByName.clear();
+  ctx.typedRunesPropsDeclarations.length = 0;
+  if (!ctx.source) return;
+
+  const modernParsed = modernParsedRoot as ModernParsedRoot;
 
   ctx.scriptLanguage = parser.resolveScriptLanguage(modernParsed);
   ctx.customElementTag = modernParsed.options?.customElement?.tag;

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -105,3 +105,45 @@ export function parse(source: string, { modern, loose }: { modern?: boolean; loo
   const ast: InternalAstRoot = parseFragment(cleaned, loose);
   return toPublicAst(cleaned, ast, modern);
 }
+
+/**
+ * Deep-clones a plain JSON-shaped value (objects/arrays/primitives only - the
+ * AST has neither, as `tests/svelte-parse-shim.test.ts`'s `JSON.stringify`
+ * round-trip already confirms). Plain recursion beats the built-in
+ * `structuredClone`: that API's general-purpose serialization handles many
+ * types this data never contains, and empirically costs about as much as a
+ * fresh `parseFragment` call on ASTs this shape - which would have defeated
+ * the whole point of cloning instead of re-parsing.
+ */
+function cloneAst<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(cloneAst) as T;
+  const out = {} as T;
+  for (const key in value) out[key] = cloneAst(value[key]);
+  return out;
+}
+
+/**
+ * Produces both the modern and legacy AST for the same source from a single
+ * `parseFragment` call, instead of sveld's former two independent `parse()`
+ * calls (one per mode) that each re-lexed and re-parsed the source from
+ * scratch. `convert()` (the legacy path) restructures its input in place, so
+ * it must run on a clone - the modern view is derived first, directly off
+ * the original `parseFragment` output, and only that (already
+ * metadata-stripped, so cheaper to copy) result gets cloned for `convert()`.
+ * `convert()` only ever deletes `.metadata`, never reads it, so pre-stripping
+ * before conversion doesn't change its output (see `tests/svelte-parse-shim.test.ts`,
+ * which byte-compares both branches of this function against the real compiler).
+ */
+export function parseModernAndLegacy(
+  source: string,
+  { loose }: { loose?: boolean } = {},
+): { modern: unknown; legacy: unknown } {
+  const cleaned = removeByteOrderMark(source);
+  resetCompilerState({ warning: () => false, filename: undefined });
+  const ast: InternalAstRoot = parseFragment(cleaned, loose);
+  const modern = toPublicAst(cleaned, ast, true);
+  const legacyInput = cloneAst(modern) as InternalAstRoot;
+  const legacy = toPublicAst(cleaned, legacyInput, false);
+  return { modern, legacy };
+}


### PR DESCRIPTION
Every component's script was parsed twice per run: once in modern
AST mode for runes prop-type metadata (`buildRunesPropTypeMetadata`),
once in legacy AST mode for the main walk in `ComponentParser`. Both
calls went through svelte's internal `parseFragment` from scratch,
re-lexing and re-parsing the identical source text.

Added `parseModernAndLegacy()` in `src/svelte-parse.ts`, which calls
`parseFragment` once and derives both AST views from that single
result. The legacy view still needs svelte's `convert()`, which
restructures its input in place, so it runs on a clone of the modern
view rather than the original. `ComponentParser.ts` and
`runes-props.ts` now share that one parse result instead of each
calling `parse()` independently.

## Clone strategy

The first version cloned with `structuredClone`, but its
general-purpose serialization cost about as much as a fresh parse,
erasing the whole win. Swapped in a hand-rolled recursive
object/array clone instead, safe here since the AST is confirmed
JSON-shaped (no cycles, no exotic types) by the existing
`svelte-parse-shim` drift-guard test, which byte-compares this
module's output against the real `svelte/compiler`. That clone is
roughly 6x cheaper than `structuredClone` on this data.

## Benchmark

`bun run bench`'s wall-clock numbers are too noisy on this machine
to read directly (background load swings runs 2-4x run to run), so
the real signal comes from an isolated in-process microbenchmark:
looping the old two-`parse()`-call path against the new
`parseModernAndLegacy()` path over all 160 components in the carbon
e2e fixture, alternated per iteration to cancel out drift.

| | median (160 components) |
|---|---|
| old (two `parse()` calls) | ~60ms |
| new (`parseModernAndLegacy`) | ~42ms |

About 1.4x faster for this part of the pipeline, consistent across
reruns.

## Risk

Touches the internal svelte-parser shim (`svelte-parse.ts`) and the
per-component parse path that every output (types, JSON, Markdown)
depends on. Guarded by the existing byte-for-byte drift test against
`svelte/compiler` and the full fixture/snapshot suite, both green
with zero diffs.