### PR TITLE
perf(bundle): stop re-parsing components to strip the style block

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -82,6 +82,7 @@ export interface LegacyAstRoot {
   module?: Node;
   html?: Node;
   instance?: Node;
+  css?: { start?: number; end?: number };
 }
 
 export interface SourcePosition {
@@ -878,7 +879,24 @@ export default class ComponentParser {
 
     this.ctx.syntaxMode = detectSyntaxMode(this.ctx);
 
-    parseCustomTypes(this.ctx, this);
+    /**
+     * `parseCustomTypes` scans the raw source text for `/** *\/`-style comment blocks
+     * (via `comment-parser`), which has no notion of Svelte's markup structure - a
+     * `/** ... *\/`-shaped comment inside a top-level `<style>` block would otherwise be
+     * misread as a JSDoc block and could produce a spurious typedef/event/etc. Blank out
+     * the style block's own text (same length, so it doesn't shift any offsets) for this
+     * scan only; `this.ctx.source` itself stays the untouched parsed source so every other
+     * offset computation (source ranges, `sourceAtPos`, ...) is unaffected.
+     */
+    const cssBlock = this.ctx.parsed.css;
+    const scanSource =
+      cssBlock?.start !== undefined && cssBlock?.end !== undefined
+        ? cleanedSource.slice(0, cssBlock.start) +
+          " ".repeat(cssBlock.end - cssBlock.start) +
+          cleanedSource.slice(cssBlock.end)
+        : cleanedSource;
+
+    parseCustomTypes(this.ctx, this, scanSource);
 
     /**
      * Not fused with the componentRoot walk below: `module` (`<script context="module">`) is a

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -122,30 +122,7 @@ export interface ProcessComponentOptions {
   memo?: Map<string, ParsedComponent>;
 }
 
-const STYLE_TAG_REGEX = /<style.+?<\/style>/gims;
 const HYPHEN_REGEX = /-/g;
-
-export function stripTopLevelStyleBlock(source: string) {
-  // Skip compiler parse when no `<style>`; false positives in strings/comments fall through to regex.
-  if (!source.includes("<style")) return source;
-
-  try {
-    const parsed = getParserStack().parseSvelte(source, { modern: false }) as {
-      css?: { start?: number; end?: number };
-    };
-    const start = parsed.css?.start;
-    const end = parsed.css?.end;
-
-    if (start === undefined || end === undefined) {
-      return source;
-    }
-
-    return `${source.slice(0, start)}${source.slice(end)}`;
-  } catch {
-    // Regex fallback when the compiler cannot parse the source.
-    return source.replace(STYLE_TAG_REGEX, "");
-  }
-}
 
 /**
  * Discovered component sources for an entry point, before parsing.
@@ -288,9 +265,11 @@ export async function readFileMap(filePaths: Iterable<string>): Promise<Map<stri
 /**
  * Parses a single component entry into its documentation API.
  *
- * Reads the component contents from `fileMap`, removes top-level styles for
- * metadata parsing, and parses it to extract component metadata. Returns `null`
- * for non-Svelte entries or files that could not be read.
+ * Reads the component contents from `fileMap` and parses it to extract
+ * component metadata (a top-level `<style>` block, if present, is masked out
+ * of the text scanned for JSDoc comments inside `ComponentParser`, without a
+ * separate parse). Returns `null` for non-Svelte entries or files that could
+ * not be read.
  *
  * A component that throws while parsing is captured via `options.onParseError`
  * (and `null` is returned) so callers can continue with the rest, unless
@@ -345,7 +324,7 @@ export function processComponent(
     } else {
       const parser = new (getParserStack().ComponentParser)();
       try {
-        parsed = parser.parseSvelteComponent(stripTopLevelStyleBlock(source), {
+        parsed = parser.parseSvelteComponent(source, {
           moduleName,
           filePath: normalizedFilePath,
         });

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -349,14 +349,18 @@ export function processJSDocComment(
   return { type, params, returnType, description, binding, deprecated, tags };
 }
 
-export function parseCustomTypes(ctx: ParserContext, parser: ComponentParser) {
-  if (!ctx.source) return;
+export function parseCustomTypes(
+  ctx: ParserContext,
+  parser: ComponentParser,
+  scanSource: string | undefined = ctx.source,
+) {
+  if (!scanSource) return;
   let commentSearchOffset = 0;
-  for (const { tags, description: commentDescription, source: blockSource } of parseComment(ctx.source, {
+  for (const { tags, description: commentDescription, source: blockSource } of parseComment(scanSource, {
     spacing: "preserve",
   })) {
     const blockText = blockSource.map((line) => line.source).join("\n");
-    const blockStartOffset = ctx.source.indexOf(blockText, commentSearchOffset);
+    const blockStartOffset = scanSource.indexOf(blockText, commentSearchOffset);
     const commentBlockStartOffset = blockStartOffset === -1 ? undefined : blockStartOffset;
     if (blockStartOffset !== -1) {
       commentSearchOffset = blockStartOffset + blockText.length;

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,9 +1,8 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { generateBundle, stripTopLevelStyleBlock } from "../src/bundle";
+import { generateBundle } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
-import { loadParserStack } from "../src/parser-stack";
 import { TypeResolver } from "../src/resolve-types";
 
 const BUTTON = `<script>
@@ -167,50 +166,5 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
 
     const exampleCheck = result.allComponentsForTypes.get("ExampleCheck");
     expect(exampleCheck?.diagnostics ?? []).toEqual([]);
-  });
-});
-
-describe("stripTopLevelStyleBlock", () => {
-  beforeAll(async () => {
-    await loadParserStack();
-  });
-
-  test("returns the identical source when it has no <style> substring", () => {
-    const source = `<script>
-  export let label = "hello";
-</script>
-
-<span>{label}</span>`;
-
-    expect(stripTopLevelStyleBlock(source)).toBe(source);
-  });
-
-  test("strips a top-level <style> block", () => {
-    const source = `<script>
-  export let label = "hello";
-</script>
-
-<span>{label}</span>
-
-<style>
-  span {
-    color: red;
-  }
-</style>`;
-
-    const result = stripTopLevelStyleBlock(source);
-
-    expect(result).not.toContain("<style");
-    expect(result).toContain("<span>{label}</span>");
-  });
-
-  test("still parses when <style> only appears inside a string", () => {
-    const source = `<script>
-  const s = "<style>";
-</script>
-
-<span>{s}</span>`;
-
-    expect(stripTopLevelStyleBlock(source)).toBe(source);
   });
 });

--- a/tests/fixtures/style-block-jsdoc-comment-ignored/input.svelte
+++ b/tests/fixtures/style-block-jsdoc-comment-ignored/input.svelte
@@ -1,0 +1,24 @@
+<script>
+  /**
+   * @typedef {object} RealTypedef
+   * @property {string} name
+   */
+
+  /** @type {RealTypedef} */
+  export let real = { name: "hello" };
+</script>
+
+<span>{real.name}</span>
+
+<style>
+  /**
+   * A comment shaped like a JSDoc block, sitting inside a top-level <style>
+   * block. It must not be picked up as a custom-type declaration.
+   *
+   * @typedef {object} FakeTypedef
+   * @property {string} name
+   */
+  span {
+    color: red;
+  }
+</style>

--- a/tests/fixtures/style-block-jsdoc-comment-ignored/output-class.d.ts
+++ b/tests/fixtures/style-block-jsdoc-comment-ignored/output-class.d.ts
@@ -1,0 +1,18 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RealTypedef = {
+  name: string;
+};
+
+export type StyleBlockJsdocCommentIgnoredProps = {
+  /**
+   * @default { name: "hello" }
+   */
+  real?: RealTypedef;
+};
+
+export default class StyleBlockJsdocCommentIgnored extends SvelteComponentTyped<
+  StyleBlockJsdocCommentIgnoredProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/style-block-jsdoc-comment-ignored/output-component.d.ts
+++ b/tests/fixtures/style-block-jsdoc-comment-ignored/output-component.d.ts
@@ -1,0 +1,21 @@
+import type { Component } from "svelte";
+
+export type RealTypedef = {
+  name: string;
+};
+
+export type StyleBlockJsdocCommentIgnoredProps = {
+  /**
+   * @default { name: "hello" }
+   */
+  real?: RealTypedef;
+};
+
+export type StyleBlockJsdocCommentIgnoredExports = Record<string, never>;
+
+declare const StyleBlockJsdocCommentIgnored: Component<
+  StyleBlockJsdocCommentIgnoredProps,
+  StyleBlockJsdocCommentIgnoredExports,
+  ""
+>;
+export default StyleBlockJsdocCommentIgnored;

--- a/tests/fixtures/style-block-jsdoc-comment-ignored/output.json
+++ b/tests/fixtures/style-block-jsdoc-comment-ignored/output.json
@@ -1,0 +1,58 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 25,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "real",
+      "kind": "let",
+      "type": "RealTypedef",
+      "typeSource": "jsdoc",
+      "value": "{ name: \"hello\" }",
+      "defaultValue": {
+        "raw": "{ name: \"hello\" }",
+        "kind": "object",
+        "value": {
+          "name": "hello"
+        }
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 8,
+          "column": 38
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{\n  name: string;\n}",
+      "name": "RealTypedef",
+      "ts": "type RealTypedef = {\n  name: string;\n};"
+    }
+  ],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}


### PR DESCRIPTION
Any component with a top-level `<style>` block paid for a third full
compiler parse per run: `stripTopLevelStyleBlock` parsed the source
just to read `css.start`/`css.end` off the AST, then
`processComponent` parsed the resulting stripped string again from
scratch. That's on top of the single combined parse PR #392 already
does for the modern and legacy views.

The `css` node was already sitting on that same combined parse, so
this reads the bounds from there instead of parsing again, and
deletes `stripTopLevelStyleBlock` entirely. The style block still
needs to be kept out of `parseCustomTypes`' raw-text comment scan
(`comment-parser` has no notion of Svelte's markup structure and
would misread a JSDoc-shaped comment inside `<style>` as a real
typedef or event), so that scan now runs against a same-length masked
copy of the source instead of a separately stripped and re-parsed
one. `ctx.source` itself stays untouched, so every other offset
computation is unaffected.

As a side effect this also fixes a gap in the old approach: the
style-block protection only ever applied via `bundle.ts`'s CLI path,
so calling `ComponentParser.parseSvelteComponent` directly had no
protection against the misfire. Added a fixture covering it.

## Benchmark

Isolated in-process microbenchmark comparing the removed parse
against the new masking step, over the 5 real carbon components that
actually have a top-level `<style>` block (alternating old/new,
median of 5 rounds of 2000 iterations each):

| approach                    | median  |
|------------------------------|---------|
| old (separate compiler parse) | 1.33ms  |
| new (mask from existing AST)  | 0.0018ms |

The absolute win on the full `bun run bench` carbon fixture is small
since only 5/160 components have a style block; the benefit scales
with how common top-level `<style>` blocks are in a given codebase.

Blast radius is limited to components with a top-level `<style>`
block. The main risk is the masking logic mis-locating the block and
either leaving a JSDoc-shaped CSS comment visible to the scanner or
masking real script content; both are covered by the added fixture,
and no existing fixture snapshot changed.