### PR TITLE
fix(svelte-version): resolve Svelte version via package.json

### DIFF
--- a/src/svelte-version.ts
+++ b/src/svelte-version.ts
@@ -1,10 +1,14 @@
 /**
- * The installed Svelte version, in its own module so callers that only need
- * it for a cache key or document metadata (`parse-cache.ts`,
+ * The Svelte version sveld was built against, in its own module so callers
+ * that only need it for a cache key or document metadata (`parse-cache.ts`,
  * `writer/document-model.ts`) don't have to import the parser stack
  * (`./svelte-parse`) to get it.
+ *
+ * Svelte is a devDependency only (sveld bundles its own parser and doesn't
+ * require consumers to have Svelte installed), so this reads the version via
+ * the bare `svelte/package.json` specifier rather than a path into
+ * `node_modules` - that resolves correctly through Svelte's own `exports`
+ * map regardless of install topology (pnpm, workspaces, Yarn PnP), and gets
+ * inlined to a plain string at sveld's own build time either way.
  */
-// @ts-expect-error - internal svelte module, no published types
-import { VERSION as VERSION_RAW } from "../node_modules/svelte/src/version.js";
-
-export const VERSION: string = VERSION_RAW;
+export { version as VERSION } from "svelte/package.json";


### PR DESCRIPTION
The Svelte version constant reached into an internal, unpublished
module path (../node_modules/svelte/src/version.js) hardcoded
relative to src/, assuming node_modules is a direct sibling. That
assumption breaks under non-hoisted layouts such as Yarn PnP, and it
required a `@ts-expect-error` since the path isn't part of Svelte's
public surface.

Read the version from svelte/package.json instead, via the bare
specifier so it resolves through Svelte's own exports map rather
than a filesystem guess. sveld still bundles this at its own build
time, so the value gets inlined into lib/ as a plain string. It has
no bearing on consumers, who don't need Svelte installed at runtime
either way.

## Risk

Low. Single-file change behind an existing indirection (parse-cache
key, generator metadata); verified the build still inlines the
version as a literal string with no runtime `svelte` import in
lib/.