### PR TITLE
perf(writer): stop rescanning the output buffer while formatting .d.ts

### DIFF
--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -10,6 +10,11 @@
  *   bun run bench --reuse-outdir   # write every run into the same out dir, so
  *                                  # run 1 populates it and runs 2+ exercise the
  *                                  # writer's skip-unchanged-file path
+ *   bun run bench --stages         # also split the types writer into
+ *                                  # writeTsDefinition generation vs Writer I/O
+ *
+ * The write phase is timed per built-in writer (types/json/markdown) rather
+ * than as one opaque span, since `types` dominates it in practice.
  *
  * All output (types/JSON/Markdown and the parse cache) is written to a temp
  * directory, so benchmarking never touches a fixture's committed files.
@@ -20,10 +25,17 @@
  */
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { generateBundle } from "../src/bundle";
 import { setQuiet } from "../src/logger";
-import { writeOutput } from "../src/plugin";
+// Side-effect import: registers the built-in writers ("types"/"json"/"markdown")
+// with the registry, same as src/plugin.ts does.
+import "../src/writer/built-in-writers";
+import { convertSvelteExt, createExports } from "../src/create-exports";
+import { buildComponentApiDocument } from "../src/writer/document-model";
+import { getWriter } from "../src/writer/registry";
+import Writer from "../src/writer/Writer";
+import { writeTsDefinition } from "../src/writer/writer-ts-definitions-core";
 
 const DEFAULT_ENTRY = join(import.meta.dir, "..", "tests", "e2e", "carbon", "src", "index.js");
 const DEFAULT_RUNS = 3;
@@ -33,16 +45,28 @@ interface BenchArgs {
   cache: boolean;
   entry: string;
   reuseOutDir: boolean;
+  stages: boolean;
 }
 
 interface RunTiming {
   parse: number;
-  write: number;
+  types: number;
+  json: number;
+  markdown: number;
   total: number;
+  /** Only populated with `--stages`: writeTsDefinition generation vs Writer I/O. */
+  typesGenerate?: number;
+  typesIo?: number;
 }
 
 function parseArgs(argv: string[]): BenchArgs {
-  const args: BenchArgs = { runs: DEFAULT_RUNS, cache: false, entry: DEFAULT_ENTRY, reuseOutDir: false };
+  const args: BenchArgs = {
+    runs: DEFAULT_RUNS,
+    cache: false,
+    entry: DEFAULT_ENTRY,
+    reuseOutDir: false,
+    stages: false,
+  };
 
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i];
@@ -62,6 +86,9 @@ function parseArgs(argv: string[]): BenchArgs {
       case "--reuse-outdir":
         args.reuseOutDir = true;
         break;
+      case "--stages":
+        args.stages = true;
+        break;
       case "--entry": {
         const value = argv[++i];
         if (value === undefined) {
@@ -72,7 +99,9 @@ function parseArgs(argv: string[]): BenchArgs {
         break;
       }
       default:
-        console.error(`bench: unknown flag "${flag}". Flags: --runs <n>, --cache, --entry <path>, --reuse-outdir.`);
+        console.error(
+          `bench: unknown flag "${flag}". Flags: --runs <n>, --cache, --entry <path>, --reuse-outdir, --stages.`,
+        );
         process.exit(1);
     }
   }
@@ -86,14 +115,60 @@ function median(values: number[]): number {
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }
 
-function formatTiming(timing: RunTiming): string {
-  const parse = `parse ${timing.parse.toFixed(0)}ms`;
-  const write = `write ${timing.write.toFixed(0)}ms`;
-  const total = `total ${timing.total.toFixed(0)}ms`;
-  return `${parse}  ${write}  ${total}`;
+function formatTiming(timing: RunTiming, stages: boolean): string {
+  const parts = [
+    `parse ${timing.parse.toFixed(0)}ms`,
+    `types ${timing.types.toFixed(0)}ms`,
+    `json ${timing.json.toFixed(0)}ms`,
+    `markdown ${timing.markdown.toFixed(0)}ms`,
+  ];
+  if (stages && timing.typesGenerate !== undefined && timing.typesIo !== undefined) {
+    parts.push(`types-generate ${timing.typesGenerate.toFixed(1)}ms`, `types-io ${timing.typesIo.toFixed(1)}ms`);
+  }
+  parts.push(`total ${timing.total.toFixed(0)}ms`);
+  return parts.join("  ");
 }
 
-async function benchOnce(input: string, cacheFile: string | undefined, outDir: string): Promise<RunTiming> {
+// Mirrors writeTsDefinitions (src/writer/writer-ts-definitions.ts), including
+// its generated-text cache lookup, but times generation separately from I/O
+// (Writer.write) — the boundary the cache moves. Used instead of the "types"
+// writer directly when `--stages` is passed.
+async function timeTypesStages(
+  result: Awaited<ReturnType<typeof generateBundle>>,
+): Promise<{ typesGenerate: number; typesIo: number }> {
+  const writer = new Writer({});
+  const document = buildComponentApiDocument(result.allComponentsForTypes);
+  const cacheFormatKey = "class";
+
+  const generateStart = performance.now();
+  const generated = document.components.map((component) => {
+    const resolvedPath = result.resolvedPathByModule?.get(component.moduleName);
+    let text = resolvedPath ? result.cache?.getGeneratedText(resolvedPath, cacheFormatKey) : undefined;
+    if (text === undefined) {
+      text = writeTsDefinition(component, { format: undefined });
+      if (resolvedPath) result.cache?.setGeneratedText(resolvedPath, cacheFormatKey, text);
+    }
+    return { filePath: convertSvelteExt(join("types", component.filePath)), text };
+  });
+  const indexDts = `${createExports(result.exports)}\n`;
+  const typesGenerate = performance.now() - generateStart;
+
+  const ioStart = performance.now();
+  await Promise.all([
+    ...generated.map((g) => writer.write(g.filePath, g.text)),
+    writer.write(join("types", "index.d.ts"), indexDts),
+  ]);
+  const typesIo = performance.now() - ioStart;
+
+  return { typesGenerate, typesIo };
+}
+
+async function benchOnce(
+  input: string,
+  cacheFile: string | undefined,
+  outDir: string,
+  stages: boolean,
+): Promise<RunTiming> {
   mkdirSync(outDir, { recursive: true });
 
   const start = performance.now();
@@ -112,15 +187,73 @@ async function benchOnce(input: string, cacheFile: string | undefined, outDir: s
   // to `console.error` directly (not through the logger), so parse failures
   // remain visible.
   setQuiet(true);
+  const inputDir = dirname(input);
+  let types = 0;
+  let json = 0;
+  let markdown = 0;
+  let stageTimes: { typesGenerate: number; typesIo: number } | undefined;
   try {
-    await writeOutput(result, { types: true, json: true, markdown: true }, input);
+    if (stages) {
+      // Bypasses the registered "types" writer so generation and I/O are
+      // timed separately instead of double-counted.
+      stageTimes = await timeTypesStages(result);
+      types = stageTimes.typesGenerate + stageTimes.typesIo;
+    } else {
+      const typesWriter = getWriter("types");
+      if (!typesWriter) throw new Error('sveld bench: built-in writer "types" is not registered.');
+      const typesStart = performance.now();
+      await typesWriter.write(result.allComponentsForTypes, {
+        outDir: "types",
+        preamble: "",
+        exports: result.exports,
+        inputDir,
+        dryRun: false,
+        cache: result.cache,
+        resolvedPathByModule: result.resolvedPathByModule,
+      });
+      types = performance.now() - typesStart;
+    }
+    // Persists the generated-text cache populated above, same as a real run
+    // (writeOutput callers save a second time after writing); otherwise the
+    // next run's fresh ParseCache would never see it.
+    result.cache?.save();
+
+    const jsonWriter = getWriter("json");
+    if (!jsonWriter) throw new Error('sveld bench: built-in writer "json" is not registered.');
+    const jsonStart = performance.now();
+    await jsonWriter.write(result.components, {
+      outFile: "COMPONENT_API.json",
+      input,
+      inputDir,
+      entryExports: result.entryExports,
+      dryRun: false,
+    });
+    json = performance.now() - jsonStart;
+
+    const markdownWriter = getWriter("markdown");
+    if (!markdownWriter) throw new Error('sveld bench: built-in writer "markdown" is not registered.');
+    const markdownStart = performance.now();
+    await markdownWriter.write(result.components, {
+      outFile: "COMPONENT_INDEX.md",
+      entryExports: result.entryExports,
+      dryRun: false,
+    });
+    markdown = performance.now() - markdownStart;
   } finally {
     setQuiet(false);
     process.chdir(originalCwd);
   }
   const written = performance.now();
 
-  return { parse: parsed - start, write: written - parsed, total: written - start };
+  return {
+    parse: parsed - start,
+    types,
+    json,
+    markdown,
+    total: written - start,
+    typesGenerate: stageTimes?.typesGenerate,
+    typesIo: stageTimes?.typesIo,
+  };
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -139,9 +272,9 @@ const timings: RunTiming[] = [];
 try {
   for (let run = 1; run <= args.runs; run++) {
     // biome-ignore lint/performance/noAwaitInLoops: runs must execute sequentially so each phase is timed in isolation.
-    const timing = await benchOnce(args.entry, cacheFile, sharedOutDir ?? join(workDir, `run-${run}`));
+    const timing = await benchOnce(args.entry, cacheFile, sharedOutDir ?? join(workDir, `run-${run}`), args.stages);
     timings.push(timing);
-    console.log(`run ${run}  ${formatTiming(timing)}`);
+    console.log(`run ${run}  ${formatTiming(timing, args.stages)}`);
   }
 } finally {
   rmSync(workDir, { recursive: true, force: true });
@@ -150,8 +283,12 @@ try {
 if (timings.length > 1) {
   const summary: RunTiming = {
     parse: median(timings.map((timing) => timing.parse)),
-    write: median(timings.map((timing) => timing.write)),
+    types: median(timings.map((timing) => timing.types)),
+    json: median(timings.map((timing) => timing.json)),
+    markdown: median(timings.map((timing) => timing.markdown)),
     total: median(timings.map((timing) => timing.total)),
+    typesGenerate: args.stages ? median(timings.map((timing) => timing.typesGenerate ?? 0)) : undefined,
+    typesIo: args.stages ? median(timings.map((timing) => timing.typesIo ?? 0)) : undefined,
   };
-  console.log(`median ${formatTiming(summary)}`);
+  console.log(`median ${formatTiming(summary, args.stages)}`);
 }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -46,6 +46,19 @@ export interface GenerateBundleResult {
   errors: ComponentParseError[];
   /** Unknown props, `any` contexts, and orphan `@event` tags across the bundle. */
   diagnostics: SveldDiagnostic[];
+  /**
+   * @internal The parse cache instance for this run (undefined when the parse
+   * cache is disabled). Exposed so the write phase can layer a generated-text
+   * cache on top of it (see `writeTsDefinitions`) and persist the addition
+   * with a second `save()` after writing.
+   */
+  cache?: ParseCache;
+  /**
+   * @internal moduleName -> resolved source path, matching `cache`'s entry
+   * identity, so the write phase can key its text cache lookups without
+   * redoing path-alias resolution. Undefined when the parse cache is disabled.
+   */
+  resolvedPathByModule?: Map<string, string>;
 }
 
 export interface GenerateBundleOptions {
@@ -441,6 +454,10 @@ export async function generateBundle(
   // `cache` is on by default; only an explicit `false` disables it.
   const cache =
     options.cache === false ? undefined : new ParseCache(resolveCacheFilePath(rootDir, options.cache ?? true));
+  // moduleName -> resolved source path, so the write phase can key a
+  // generated-text cache against the same identity as `cache` without
+  // redoing path-alias resolution. Only worth building when there's a cache.
+  const resolvedPathByModule = cache ? new Map<string, string>() : undefined;
 
   const misses = new Set<string>();
   const hashes = new Map<string, string>();
@@ -495,7 +512,10 @@ export async function generateBundle(
    */
   for (const entry of allComponentEntries) {
     const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath, processOptions);
-    if (result) allComponentsForTypes.set(result.moduleName, result);
+    if (result) {
+      allComponentsForTypes.set(result.moduleName, result);
+      resolvedPathByModule?.set(result.moduleName, resolveComponentFilePath(entry[1].source));
+    }
   }
 
   if (cache && misses.size > 0) {
@@ -519,7 +539,10 @@ export async function generateBundle(
       const resolvedPath = resolveComponentFilePath(entry[1].source);
       if (!affected.has(resolvedPath) || misses.has(resolvedPath)) continue;
       const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath, processOptions);
-      if (result) allComponentsForTypes.set(result.moduleName, result);
+      if (result) {
+        allComponentsForTypes.set(result.moduleName, result);
+        resolvedPathByModule?.set(result.moduleName, resolvedPath);
+      }
     }
   }
 
@@ -562,6 +585,8 @@ export async function generateBundle(
     allComponentsForTypes,
     errors,
     diagnostics,
+    cache,
+    resolvedPathByModule,
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -447,6 +447,9 @@ export async function cli(process: NodeJS.Process) {
       await writeStdout(result, options, input);
     } else {
       await writeOutput(result, options, input);
+      // Persists any generated `.d.ts` text writeOutput just cached, on top
+      // of the parse-only save generateBundle() already did.
+      if (!options.dryRun) result.cache?.save();
     }
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -7,7 +7,7 @@ import { PARSED_COMPONENT_TYPE_SCRIPT_METADATA } from "./parsed-component-metada
 import { VERSION as svelteVersion } from "./svelte-version";
 
 /** Bumped whenever the on-disk cache shape changes in a way old caches can't read. */
-const CACHE_FORMAT_VERSION = 1;
+const CACHE_FORMAT_VERSION = 2;
 
 /** Default on-disk location for the persistent parse cache, relative to the project root. */
 export const DEFAULT_CACHE_FILE = join("node_modules", ".cache", "sveld", "parse-cache.json");
@@ -23,6 +23,11 @@ interface ParseCacheEntry {
    * on `parsed` through a disk round-trip.
    */
   typeScriptMetadata?: ParsedComponentTypeScriptMetadata;
+  /**
+   * Generated `.d.ts` text for this entry's `hash`, keyed additionally by the
+   * effective `types-format` option since that changes the output shape.
+   */
+  generatedText?: { format: string; text: string };
 }
 
 interface ParseCacheFile {
@@ -117,6 +122,29 @@ export class ParseCache {
   /** Skip cache for `resolvedPath` this run (e.g. an @extends dependent). */
   invalidate(resolvedPath: string): void {
     this.blocked.add(resolvedPath);
+  }
+
+  /**
+   * Returns the cached generated `.d.ts` text for `resolvedPath`, if this
+   * run's parse entry for it (a fresh parse or a hash-verified hit — see
+   * `get()`/`set()`) already carries text generated for `format`.
+   */
+  getGeneratedText(resolvedPath: string, format: string): string | undefined {
+    const entry = this.next.get(resolvedPath);
+    if (entry?.generatedText === undefined || entry.generatedText.format !== format) return undefined;
+    return entry.generatedText.text;
+  }
+
+  /**
+   * Records generated `.d.ts` text against this run's parse entry for
+   * `resolvedPath`. No-op if that entry hasn't been recorded via `get()`/`set()`
+   * (shouldn't happen: the write phase only runs after every component has
+   * been parsed).
+   */
+  setGeneratedText(resolvedPath: string, format: string, text: string): void {
+    const entry = this.next.get(resolvedPath);
+    if (entry === undefined) return;
+    entry.generatedText = { format, text };
   }
 
   /** Persists this run's cache entries back to disk. */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -151,7 +151,12 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
     },
     async writeBundle() {
       if (watch) return;
-      if (input != null) await writeOutput(result, opts || {}, input);
+      if (input != null) {
+        await writeOutput(result, opts || {}, input);
+        // Persists any generated `.d.ts` text writeOutput just cached, on top
+        // of the parse-only save generateBundle() already did.
+        result.cache?.save();
+      }
     },
     handleHotUpdate(ctx) {
       scheduleUpdate(ctx.file);
@@ -215,6 +220,8 @@ export async function writeOutput(
       exports: result.exports,
       inputDir,
       dryRun,
+      cache: result.cache,
+      resolvedPathByModule: result.resolvedPathByModule,
     } satisfies WriteTsDefinitionsOptions);
   }
 

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -55,6 +55,9 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   }
 
   await writeOutput(result, merged, input);
+  // Persists any generated `.d.ts` text writeOutput just cached, on top of
+  // the parse-only save generateBundle() already did.
+  if (!merged.dryRun) result.cache?.save();
 
   const { diagnostics } = result;
   const shouldReport = merged.reportDiagnostics || merged.strict;

--- a/src/writer/format-generated-ts.ts
+++ b/src/writer/format-generated-ts.ts
@@ -15,6 +15,24 @@ function endsWithInterfaceHeader(text: string): boolean {
   return INTERFACE_HEADER_REGEX.test(text.slice(-200));
 }
 
+const INTERFACE_HEADER_TAIL_LENGTH = 200;
+
+// Reconstructs just enough of the accumulated buffer's tail to answer
+// `endsWithInterfaceHeader`, without joining the whole (potentially huge)
+// output array. `out` entries are always either a single character or a
+// short fixed string, so walking backwards a few entries is enough.
+function tailString(out: string[], maxLen: number): string {
+  let result = "";
+  for (let i = out.length - 1; i >= 0 && result.length < maxLen; i--) {
+    result = out[i] + result;
+  }
+  return result.length > maxLen ? result.slice(-maxLen) : result;
+}
+
+function popTrailing(out: string[], regex: RegExp): void {
+  while (out.length > 0 && regex.test(out[out.length - 1])) out.pop();
+}
+
 function flattenToOneLine(content: string): string {
   let out = "";
   let quote: "double" | "single" | "template" | null = null;
@@ -114,7 +132,7 @@ function findMatchingClose(raw: string, openIndex: number): number {
  * object types read best on one line).
  */
 function expandStatements(raw: string): string {
-  let out = "";
+  const out: string[] = [];
   let state: "normal" | "double" | "single" | "template" | "blockComment" = "normal";
 
   for (let i = 0; i < raw.length; i++) {
@@ -122,19 +140,19 @@ function expandStatements(raw: string): string {
     const prev = raw[i - 1];
 
     if (state === "blockComment") {
-      out += c;
+      out.push(c);
       if (prev === "*" && c === "/") state = "normal";
       continue;
     }
 
     if (state === "double" || state === "single") {
-      out += c;
+      out.push(c);
       if (c === (state === "double" ? '"' : "'") && prev !== "\\") state = "normal";
       continue;
     }
 
     if (state === "template") {
-      out += c;
+      out.push(c);
       if (c === "`" && prev !== "\\") state = "normal";
       continue;
     }
@@ -142,22 +160,22 @@ function expandStatements(raw: string): string {
     // state === "normal"
     if (c === "/" && raw[i + 1] === "*") {
       state = "blockComment";
-      out += c;
+      out.push(c);
       continue;
     }
     if (c === '"') {
       state = "double";
-      out += c;
+      out.push(c);
       continue;
     }
     if (c === "'") {
       state = "single";
-      out += c;
+      out.push(c);
       continue;
     }
     if (c === "`") {
       state = "template";
-      out += c;
+      out.push(c);
       continue;
     }
 
@@ -165,7 +183,7 @@ function expandStatements(raw: string): string {
       const closeIndex = findMatchingClose(raw, i);
 
       if (closeIndex === -1) {
-        out += c;
+        out.push(c);
         continue;
       }
 
@@ -173,35 +191,39 @@ function expandStatements(raw: string): string {
 
       if (content.trim() === "") {
         // Empty block; keep braces adjacent instead of splitting across lines.
-        out += "{}";
+        out.push("{}");
         i = closeIndex;
         continue;
       }
 
       // Expand interface bodies always; collapse other single-line `{...}` blocks under INLINE_WIDTH_BUDGET.
-      if (!content.includes("/*") && raw[i + 1] !== "\n" && !endsWithInterfaceHeader(out)) {
+      if (
+        !content.includes("/*") &&
+        raw[i + 1] !== "\n" &&
+        !endsWithInterfaceHeader(tailString(out, INTERFACE_HEADER_TAIL_LENGTH))
+      ) {
         // Recurse so nested blocks get their own collapse decision.
         const normalized = expandStatements(content).trim();
         if (!normalized.includes("\n")) {
           const body = normalized.endsWith(";") ? normalized.slice(0, -1) : normalized;
           const candidate = `{ ${flattenToOneLine(body)} }`;
           if (candidate.length <= INLINE_WIDTH_BUDGET) {
-            out += candidate;
+            out.push(candidate);
             i = closeIndex;
             continue;
           }
         }
       }
 
-      out += c;
-      if (raw[i + 1] !== "\n") out += "\n";
+      out.push(c);
+      if (raw[i + 1] !== "\n") out.push("\n");
       continue;
     }
 
     if (c === "}") {
-      out = out.replace(TRAILING_TAB_SPACE_REGEX, "");
-      if (!out.endsWith("\n")) out += "\n";
-      out += c;
+      popTrailing(out, TRAILING_TAB_SPACE_REGEX);
+      if (out[out.length - 1] !== "\n") out.push("\n");
+      out.push(c);
       continue;
     }
 
@@ -209,16 +231,16 @@ function expandStatements(raw: string): string {
       // A `;` always terminates whatever precedes it; attach it directly
       // rather than let it dangle alone on a line (which the generator's
       // own templates sometimes leave a blank line or two before).
-      out = out.replace(TRAILING_WHITESPACE_REGEX, "");
-      out += ";";
-      if (raw[i + 1] !== "\n") out += "\n";
+      popTrailing(out, TRAILING_WHITESPACE_REGEX);
+      out.push(";");
+      if (raw[i + 1] !== "\n") out.push("\n");
       continue;
     }
 
-    out += c;
+    out.push(c);
   }
 
-  return out;
+  return out.join("");
 }
 
 function collapseSpaces(line: string): string {

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { convertSvelteExt, createExports } from "../create-exports";
 import { info } from "../logger";
+import type { ParseCache } from "../parse-cache";
 import type { ParsedExports } from "../parse-exports";
 import type { ComponentDocs } from "../plugin";
 import { buildComponentApiDocument } from "./document-model";
@@ -42,6 +43,14 @@ export interface WriteTsDefinitionsOptions extends WriteTsDefinitionOptions {
   exports: ParsedExports;
   /** Report resolved paths instead of writing. Set by `sveld --dry-run`. */
   dryRun?: boolean;
+  /**
+   * @internal Reuses generated `.d.ts` text across runs for components whose
+   * source (and the effective `format` option) hasn't changed. Requires
+   * `resolvedPathByModule` to key lookups; both come from `GenerateBundleResult`.
+   */
+  cache?: ParseCache;
+  /** @internal See `cache`. */
+  resolvedPathByModule?: Map<string, string>;
 }
 
 /**
@@ -62,9 +71,17 @@ export default async function writeTsDefinitions(components: ComponentDocs, opti
   const indexDTs = options.preamble + createExports(options.exports);
 
   const document = buildComponentApiDocument(components);
+  // Must match the default `writeTsDefinition` assumes for `options.format === undefined`.
+  const cacheFormatKey = options.format ?? "class";
   const writePromises = document.components.map(async (component) => {
     const ts_filepath = convertSvelteExt(join(options.outDir, component.filePath));
-    await writer.write(ts_filepath, writeTsDefinition(component, { format: options.format }));
+    const resolvedPath = options.resolvedPathByModule?.get(component.moduleName);
+    let text = resolvedPath ? options.cache?.getGeneratedText(resolvedPath, cacheFormatKey) : undefined;
+    if (text === undefined) {
+      text = writeTsDefinition(component, { format: options.format });
+      if (resolvedPath) options.cache?.setGeneratedText(resolvedPath, cacheFormatKey, text);
+    }
+    await writer.write(ts_filepath, text);
   });
 
   await Promise.all([...writePromises, writer.write(ts_base_path, `${indexDTs}\n`)]);

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -1,9 +1,10 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { generateBundle } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
 import { DEFAULT_CACHE_FILE } from "../src/parse-cache";
+import writeTsDefinitions from "../src/writer/writer-ts-definitions";
 
 const BUTTON = `<script>
   /** @restProps {button} */
@@ -130,6 +131,82 @@ describe("parse cache", () => {
     } finally {
       rmSync(otherDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("generated .d.ts text cache", () => {
+  let dir: string;
+  let outDirAbs: string;
+  let outDir: string;
+  let cacheFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-text-cache-"));
+    // writeTsDefinitions joins its index.d.ts path onto process.cwd() regardless
+    // of whether outDir is already absolute, so (as elsewhere in this test suite)
+    // outDir must be relative to cwd or writes land under a bogus cwd-nested path.
+    outDirAbs = mkdtempSync(join(process.cwd(), ".tmp-sveld-text-cache-out-"));
+    outDir = relative(process.cwd(), outDirAbs);
+    cacheFile = join(dir, ".cache", "parse-cache.json");
+    writeFileSync(join(dir, "Button.svelte"), BUTTON);
+    writeFileSync(join(dir, "SecondaryButton.svelte"), SECONDARY_BUTTON);
+    writeFileSync(join(dir, "Standalone.svelte"), STANDALONE);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outDirAbs, { recursive: true, force: true });
+  });
+
+  test("a component whose @extendProps target changed is regenerated, not served stale cached text", async () => {
+    const secondaryButtonPath = resolve(dir, "SecondaryButton.svelte");
+    const standalonePath = resolve(dir, "Standalone.svelte");
+
+    const first = await generateBundle(dir, true, { cache: cacheFile });
+    await writeTsDefinitions(first.allComponentsForTypes, {
+      outDir,
+      inputDir: dir,
+      preamble: "",
+      exports: first.exports,
+      cache: first.cache,
+      resolvedPathByModule: first.resolvedPathByModule,
+    });
+    first.cache?.save();
+
+    // Both components' generated text is now cached against the first run's parse.
+    expect(first.cache?.getGeneratedText(secondaryButtonPath, "class")).toBeDefined();
+    expect(first.cache?.getGeneratedText(standalonePath, "class")).toBeDefined();
+
+    writeFileSync(join(dir, "Button.svelte"), BUTTON.replace("primary = false", "primary = true"));
+    const second = await generateBundle(dir, true, { cache: cacheFile });
+
+    // SecondaryButton depends on Button via @extendProps, so it's invalidated
+    // and reparsed even though its own source didn't change; its fresh parse
+    // entry must not carry over the stale cached text.
+    expect(second.cache?.getGeneratedText(secondaryButtonPath, "class")).toBeUndefined();
+    // Standalone is unrelated and still a parse-cache hit, so its previously
+    // cached text is legitimately reused.
+    expect(second.cache?.getGeneratedText(standalonePath, "class")).toBeDefined();
+  });
+
+  test("--types-format switch doesn't serve a component's other-format cached text", async () => {
+    const buttonPath = resolve(dir, "Button.svelte");
+
+    const first = await generateBundle(dir, true, { cache: cacheFile });
+    await writeTsDefinitions(first.allComponentsForTypes, {
+      outDir,
+      inputDir: dir,
+      preamble: "",
+      exports: first.exports,
+      format: "class",
+      cache: first.cache,
+      resolvedPathByModule: first.resolvedPathByModule,
+    });
+    first.cache?.save();
+
+    const second = await generateBundle(dir, true, { cache: cacheFile });
+    expect(second.cache?.getGeneratedText(buttonPath, "class")).toBeDefined();
+    expect(second.cache?.getGeneratedText(buttonPath, "component")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fixes the .d.ts formatter's quadratic whole-buffer rescan and adds a
cache for generated .d.ts text so warm runs stop regenerating
unchanged output, plus the bench changes needed to measure both.

Warm-cache run on the carbon fixture (160 components) goes from
~29ms to ~20ms total; the types writer alone from ~28ms to ~2ms on a
fully cached run.