### PR TITLE
perf(index): stop eagerly re-exporting ComponentParser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,13 @@
-export { default as ComponentParser, type SerializedComponentEvent } from "./ComponentParser";
+/**
+ * `ComponentParser` itself is intentionally not re-exported here: doing so
+ * would statically pull the parser stack (acorn, `@sveltejs/acorn-typescript`,
+ * estree-walker) into every consumer of this entry point, even ones that only
+ * want `bundle`/`sveld`/`defineConfig` and never parse a component directly.
+ * `bundle()` already defers that cost via `./parser-stack`'s dynamic import.
+ * Node consumers who want direct, low-level parsing access can import
+ * `ComponentParser` from `sveld/browser`, which works fine outside a browser.
+ */
+export type { SerializedComponentEvent } from "./ComponentParser";
 export {
   type ApiChange,
   type CheckReportJson,


### PR DESCRIPTION
The root entry re-exported ComponentParser directly, which statically
pulls in the parser stack (acorn, @sveltejs/acorn-typescript,
estree-walker) the moment anything is imported from "sveld", even
just defineConfig or bundle. bundle() already defers that cost via
parser-stack.ts's dynamic import; this closes the one path around it.
ComponentParser stays available, unchanged, via sveld/browser, which
is where the README already documents it.