### PR TITLE
fix(parser): infer concise @default for function-identifier props

### DIFF
--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -93,7 +93,7 @@ export function processInitializer(
 
     if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
       type = inferFunctionTypeFromNode(init as ArrowFunctionExpression | FunctionExpression);
-      value = undefined;
+      value = conciseFunctionDefaultText(ctx, init as ArrowFunctionExpression | FunctionExpression);
     }
   } else if (init.type === "UnaryExpression") {
     const unaryExpr = init as UnaryExpression;
@@ -185,9 +185,10 @@ export function processInitializer(
         const resolvedJSDoc = parser.resolveLocalVarJSDoc(ident.name);
         const funcNode = ctx.funcDecls.get(ident.name);
         return {
-          value: undefined,
+          value: funcNode ? conciseFunctionDefaultText(ctx, funcNode) : undefined,
           type: undefined,
           isFunction: true,
+          defaultValue: funcNode ? classifyDefaultValue(parser, ctx, funcNode) : undefined,
           resolvedType: resolvedJSDoc?.type ?? buildFunctionTypeFromParts(resolvedJSDoc, funcNode),
           resolvedDescription: resolvedJSDoc?.description,
           resolvedParams: resolvedJSDoc?.params,
@@ -467,6 +468,74 @@ export function unwrapBindableInitializer(init: unknown): { init?: unknown; bind
   };
 }
 
+/**
+ * Source text of a function default's parameter list, verbatim (names only
+ * matter for a value default; `inferParamsFromNode`'s `: any` annotations
+ * are for the prop's *type*, not this).
+ */
+function paramsSourceText(
+  ctx: ParserContext,
+  node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
+): string {
+  const params = node.params;
+  if (!Array.isArray(params) || params.length === 0) return "";
+  const first = params[0] as { start?: number };
+  const last = params[params.length - 1] as { end?: number };
+  if (typeof first.start !== "number" || typeof last.end !== "number") return "";
+  return sourceAtPos(ctx, first.start, last.end) ?? "";
+}
+
+/**
+ * A concise arrow-shorthand default value for a function default (e.g.
+ * `() => true`, `(value) => String(value)`), or `undefined` when the body
+ * isn't trivial enough to show without clutter. Only an expression-bodied
+ * arrow, an empty block, or a block with exactly one `return <expr>;`
+ * qualify; anything with side effects, control flow, or multiple statements
+ * is intentionally omitted from `@default` (see #203).
+ */
+function conciseFunctionDefaultText(
+  ctx: ParserContext,
+  node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
+): string | undefined {
+  // Generators can't be represented as an arrow shorthand without losing
+  // `function*`/`yield` semantics; leave those to the description instead.
+  if (node.generator) return undefined;
+
+  const body = node.body;
+  if (!body || typeof body !== "object" || !("type" in body)) return undefined;
+
+  const params = paramsSourceText(ctx, node);
+  const asyncPrefix = node.async ? "async " : "";
+
+  // An object-literal arrow body needs parens (`() => ({ a: 1 })`) or it
+  // reads as a block statement instead of an expression.
+  const arrowBody = (expr: unknown, exprText: string) =>
+    expr && typeof expr === "object" && "type" in expr && expr.type === "ObjectExpression" ? `(${exprText})` : exprText;
+
+  if (body.type !== "BlockStatement") {
+    const exprText = sourceForExpression(ctx, body);
+    return exprText === undefined ? undefined : `${asyncPrefix}(${params}) => ${arrowBody(body, exprText)}`;
+  }
+
+  const statements = (body as { body: unknown[] }).body;
+  if (statements.length === 0) {
+    return `${asyncPrefix}(${params}) => {}`;
+  }
+
+  if (statements.length === 1) {
+    const stmt = statements[0];
+    if (stmt && typeof stmt === "object" && "type" in stmt && stmt.type === "ReturnStatement") {
+      const arg = (stmt as { argument?: unknown }).argument;
+      if (arg) {
+        const exprText = sourceForExpression(ctx, arg);
+        if (exprText !== undefined) return `${asyncPrefix}(${params}) => ${arrowBody(arg, exprText)}`;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 function classifyDefaultValue(
   parser: ComponentParser,
   ctx: ParserContext,
@@ -484,7 +553,11 @@ function classifyDefaultValue(
     kind = "array";
   } else if (init.type === "ObjectExpression") {
     kind = "object";
-  } else if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
+  } else if (
+    init.type === "ArrowFunctionExpression" ||
+    init.type === "FunctionExpression" ||
+    init.type === "FunctionDeclaration"
+  ) {
     kind = "function";
   }
 

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -336,15 +336,19 @@ function genPropDef(
 
       const descriptionHasDefault = DESCRIPTION_DEFAULT_TAG_REGEX.test(prop.description ?? "");
 
+      /**
+       * Function props only get `@default` when a concise value was inferred
+       * (a trivial single-expression body, e.g. `() => true` - see
+       * `conciseFunctionDefaultText`); anything more elaborate is omitted so
+       * docs aren't cluttered with function bodies (#203). An explicit
+       * `@default` in the description always wins either way.
+       */
+      const suppressDefault = descriptionHasDefault || (prop.isFunction && prop.value === undefined);
+
       const prop_comments = [
         createPropComment(prop.description, prop.deprecated, prop.tags),
         addCommentLine(prop.constant, "@constant"),
-        /**
-         * Don't add @default for functions - they don't have meaningful default values.
-         * Function props are callbacks, not values with defaults.
-         * Also skip if the description already contains an explicit @default annotation.
-         */
-        prop.isFunction || descriptionHasDefault ? null : `* @default ${defaultValue}\n`,
+        suppressDefault ? null : `* @default ${defaultValue}\n`,
       ]
         .filter(Boolean)
         .join("");

--- a/tests/fixtures/arrow-function-with-jsdoc/output-class.d.ts
+++ b/tests/fixtures/arrow-function-with-jsdoc/output-class.d.ts
@@ -5,6 +5,9 @@ export type ArrowFunctionWithJsdocProps = {
 
   processItems?: (items: string[], callback: (item: string, index: number) => void) => Promise<void>;
 
+  /**
+   * @default (id) => ({ id, created: new Date() })
+   */
   createRecord?: (id: string) => {
     id: string;
     created: Date

--- a/tests/fixtures/arrow-function-with-jsdoc/output-component.d.ts
+++ b/tests/fixtures/arrow-function-with-jsdoc/output-component.d.ts
@@ -5,6 +5,9 @@ export type ArrowFunctionWithJsdocProps = {
 
   processItems?: (items: string[], callback: (item: string, index: number) => void) => Promise<void>;
 
+  /**
+   * @default (id) => ({ id, created: new Date() })
+   */
   createRecord?: (id: string) => {
     id: string;
     created: Date

--- a/tests/fixtures/arrow-function-with-jsdoc/output.json
+++ b/tests/fixtures/arrow-function-with-jsdoc/output.json
@@ -67,6 +67,7 @@
       "kind": "let",
       "type": "(id: string) => { id: string; created: Date }",
       "typeSource": "jsdoc",
+      "value": "(id) => ({ id, created: new Date() })",
       "defaultValue": {
         "raw": "(id) => ({ id, created: new Date() })",
         "kind": "function"

--- a/tests/fixtures/async-function-props/output-class.d.ts
+++ b/tests/fixtures/async-function-props/output-class.d.ts
@@ -1,6 +1,9 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type AsyncFunctionPropsProps = {
+  /**
+   * @default async (id) => id > 0
+   */
   validate?: (id: number) => Promise<boolean>;
 };
 

--- a/tests/fixtures/async-function-props/output-component.d.ts
+++ b/tests/fixtures/async-function-props/output-component.d.ts
@@ -1,6 +1,9 @@
 import type { Component } from "svelte";
 
 export type AsyncFunctionPropsProps = {
+  /**
+   * @default async (id) => id > 0
+   */
   validate?: (id: number) => Promise<boolean>;
 };
 

--- a/tests/fixtures/async-function-props/output.json
+++ b/tests/fixtures/async-function-props/output.json
@@ -69,6 +69,7 @@
       "kind": "let",
       "type": "(id: number) => Promise<boolean>",
       "typeSource": "jsdoc",
+      "value": "async (id) => id > 0",
       "defaultValue": {
         "raw": "async (id) => id > 0",
         "kind": "function"

--- a/tests/fixtures/callback-typedef/output-class.d.ts
+++ b/tests/fixtures/callback-typedef/output-class.d.ts
@@ -10,6 +10,9 @@ export type CallbackTypedefProps = {
    */
   direction?: SortDirection;
 
+  /**
+   * @default (a, b, direction) => 0
+   */
   sort?: SortFn;
 };
 

--- a/tests/fixtures/callback-typedef/output-component.d.ts
+++ b/tests/fixtures/callback-typedef/output-component.d.ts
@@ -10,6 +10,9 @@ export type CallbackTypedefProps = {
    */
   direction?: SortDirection;
 
+  /**
+   * @default (a, b, direction) => 0
+   */
   sort?: SortFn;
 };
 

--- a/tests/fixtures/callback-typedef/output.json
+++ b/tests/fixtures/callback-typedef/output.json
@@ -44,6 +44,7 @@
       "kind": "let",
       "type": "SortFn",
       "typeSource": "jsdoc",
+      "value": "(a, b, direction) => 0",
       "defaultValue": {
         "raw": "(a, b, direction) => 0",
         "kind": "function"

--- a/tests/fixtures/callback/output-class.d.ts
+++ b/tests/fixtures/callback/output-class.d.ts
@@ -15,13 +15,18 @@ export type OnClose = () => void;
 export type CallbackProps = {
   /**
    * Callback fired when the value changes.
+   * @default (value, index) => {}
    */
   onChange?: OnChange;
 
+  /**
+   * @default (a, b) => a - b
+   */
   comparator?: Comparator;
 
   /**
    * No-arg callback.
+   * @default () => {}
    */
   onClose?: OnClose;
 };

--- a/tests/fixtures/callback/output-component.d.ts
+++ b/tests/fixtures/callback/output-component.d.ts
@@ -15,13 +15,18 @@ export type OnClose = () => void;
 export type CallbackProps = {
   /**
    * Callback fired when the value changes.
+   * @default (value, index) => {}
    */
   onChange?: OnChange;
 
+  /**
+   * @default (a, b) => a - b
+   */
   comparator?: Comparator;
 
   /**
    * No-arg callback.
+   * @default () => {}
    */
   onClose?: OnClose;
 };

--- a/tests/fixtures/callback/output.json
+++ b/tests/fixtures/callback/output.json
@@ -18,6 +18,7 @@
       "description": "Callback fired when the value changes.",
       "type": "OnChange",
       "typeSource": "jsdoc",
+      "value": "(value, index) => {}",
       "defaultValue": {
         "raw": "(value, index) => {}",
         "kind": "function"
@@ -43,6 +44,7 @@
       "kind": "let",
       "type": "Comparator",
       "typeSource": "jsdoc",
+      "value": "(a, b) => a - b",
       "defaultValue": {
         "raw": "(a, b) => a - b",
         "kind": "function"
@@ -69,6 +71,7 @@
       "description": "No-arg callback.",
       "type": "OnClose",
       "typeSource": "jsdoc",
+      "value": "() => {}",
       "defaultValue": {
         "raw": "() => {}",
         "kind": "function"

--- a/tests/fixtures/context-module/output.json
+++ b/tests/fixtures/context-module/output.json
@@ -154,6 +154,7 @@
       "kind": "const",
       "type": "(...args: any[]) => any",
       "typeSource": "default",
+      "value": "() => {}",
       "defaultValue": {
         "raw": "() => {}",
         "kind": "function"
@@ -179,6 +180,7 @@
       "kind": "const",
       "type": "(...args: any[]) => any",
       "typeSource": "default",
+      "value": "() => () => {}",
       "defaultValue": {
         "raw": "() => () => {}",
         "kind": "function"
@@ -204,6 +206,7 @@
       "kind": "const",
       "type": "() => () => false",
       "typeSource": "jsdoc",
+      "value": "() => () => false",
       "defaultValue": {
         "raw": "() => () => false",
         "kind": "function"

--- a/tests/fixtures/explicit-default-no-duplicate/output-class.d.ts
+++ b/tests/fixtures/explicit-default-no-duplicate/output-class.d.ts
@@ -34,6 +34,7 @@ export type ExplicitDefaultNoDuplicateProps = {
 
   /**
    * Click handler.
+   * @default () => {}
    */
   onClick?: (e: MouseEvent) => void;
 

--- a/tests/fixtures/explicit-default-no-duplicate/output-component.d.ts
+++ b/tests/fixtures/explicit-default-no-duplicate/output-component.d.ts
@@ -34,6 +34,7 @@ export type ExplicitDefaultNoDuplicateProps = {
 
   /**
    * Click handler.
+   * @default () => {}
    */
   onClick?: (e: MouseEvent) => void;
 

--- a/tests/fixtures/explicit-default-no-duplicate/output.json
+++ b/tests/fixtures/explicit-default-no-duplicate/output.json
@@ -18,6 +18,7 @@
       "description": "Custom filter function.\n@default () => true",
       "type": "(item: string, value: string) => boolean",
       "typeSource": "jsdoc",
+      "value": "() => true",
       "defaultValue": {
         "raw": "() => true",
         "kind": "function"
@@ -156,6 +157,7 @@
       "description": "Click handler.",
       "type": "(e: MouseEvent) => void",
       "typeSource": "jsdoc",
+      "value": "() => {}",
       "defaultValue": {
         "raw": "() => {}",
         "kind": "function"

--- a/tests/fixtures/function-declaration/output-class.d.ts
+++ b/tests/fixtures/function-declaration/output-class.d.ts
@@ -1,6 +1,9 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type FunctionDeclarationProps = {
+  /**
+   * @default () => {}
+   */
   fnA?: (...args: any[]) => any;
 };
 

--- a/tests/fixtures/function-declaration/output-component.d.ts
+++ b/tests/fixtures/function-declaration/output-component.d.ts
@@ -1,6 +1,9 @@
 import type { Component } from "svelte";
 
 export type FunctionDeclarationProps = {
+  /**
+   * @default () => {}
+   */
   fnA?: (...args: any[]) => any;
 };
 

--- a/tests/fixtures/function-declaration/output.json
+++ b/tests/fixtures/function-declaration/output.json
@@ -17,6 +17,7 @@
       "kind": "let",
       "type": "(...args: any[]) => any",
       "typeSource": "default",
+      "value": "() => {}",
       "defaultValue": {
         "raw": "() => {}",
         "kind": "function"
@@ -42,6 +43,7 @@
       "kind": "const",
       "type": "(...args: any[]) => any",
       "typeSource": "default",
+      "value": "() => {}",
       "defaultValue": {
         "raw": "() => {}",
         "kind": "function"

--- a/tests/fixtures/module-reexport-mixed/output.json
+++ b/tests/fixtures/module-reexport-mixed/output.json
@@ -68,6 +68,7 @@
       "description": "A local utility function for formatting",
       "type": "(value: any) => string",
       "typeSource": "jsdoc",
+      "value": "(value) => String(value)",
       "defaultValue": {
         "raw": "(value) => String(value)",
         "kind": "function"

--- a/tests/fixtures/prop-default-identifier-jsdoc/input.svelte
+++ b/tests/fixtures/prop-default-identifier-jsdoc/input.svelte
@@ -39,7 +39,10 @@
   export let label = DEFAULT_LABEL;
 
   /**
-   * Determine if an item should be filtered given the current value.
+   * Determine if an item should be filtered given the current combobox value.
+   * When `typeahead` is enabled and no custom function is provided,
+   * the default case-insensitive prefix matching is used.
+   * When a custom function is provided, it is used even with `typeahead`.
    * @type {(item: string, value: string) => boolean}
    */
   function defaultShouldFilter() {

--- a/tests/fixtures/prop-default-identifier-jsdoc/output-class.d.ts
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output-class.d.ts
@@ -34,24 +34,34 @@ export type PropDefaultIdentifierJsdocProps = {
   label?: string;
 
   /**
-   * Determine if an item should be filtered given the current value.
+   * Determine if an item should be filtered given the current combobox value.
+   * When `typeahead` is enabled and no custom function is provided,
+   * the default case-insensitive prefix matching is used.
+   * When a custom function is provided, it is used even with `typeahead`.
+   * @default () => true
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
+  /**
+   * @default (value) => String(value)
+   */
   format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
+   * @default () => "No results"
    */
   renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.
+   * @default () => ""
    */
   getKey?: (item: string, index: number) => string;
 
   /**
    * Translate a label to the active locale.
+   * @default (key) => key
    */
   translate?: (key: string) => string;
 };

--- a/tests/fixtures/prop-default-identifier-jsdoc/output-component.d.ts
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output-component.d.ts
@@ -34,24 +34,34 @@ export type PropDefaultIdentifierJsdocProps = {
   label?: string;
 
   /**
-   * Determine if an item should be filtered given the current value.
+   * Determine if an item should be filtered given the current combobox value.
+   * When `typeahead` is enabled and no custom function is provided,
+   * the default case-insensitive prefix matching is used.
+   * When a custom function is provided, it is used even with `typeahead`.
+   * @default () => true
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
+  /**
+   * @default (value) => String(value)
+   */
   format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
+   * @default () => "No results"
    */
   renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.
+   * @default () => ""
    */
   getKey?: (item: string, index: number) => string;
 
   /**
    * Translate a label to the active locale.
+   * @default (key) => key
    */
   translate?: (key: string) => string;
 };

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 92,
+      "line": 95,
       "column": 0
     }
   },
@@ -159,9 +159,14 @@
     {
       "name": "shouldFilterItem",
       "kind": "let",
-      "description": "Determine if an item should be filtered given the current value.",
+      "description": "Determine if an item should be filtered given the current combobox value.\nWhen `typeahead` is enabled and no custom function is provided,\nthe default case-insensitive prefix matching is used.\nWhen a custom function is provided, it is used even with `typeahead`.",
       "type": "(item: string, value: string) => boolean",
       "typeSource": "jsdoc",
+      "value": "() => true",
+      "defaultValue": {
+        "raw": "function defaultShouldFilter() {     return true;   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -169,11 +174,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 49,
+          "line": 52,
           "column": 2
         },
         "end": {
-          "line": 49,
+          "line": 52,
           "column": 52
         }
       }
@@ -183,6 +188,11 @@
       "kind": "let",
       "type": "(value: any) => string",
       "typeSource": "jsdoc",
+      "value": "(value) => String(value)",
+      "defaultValue": {
+        "raw": "function defaultFormat(value) {     return String(value);   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -190,11 +200,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 55,
+          "line": 58,
           "column": 2
         },
         "end": {
-          "line": 55,
+          "line": 58,
           "column": 36
         }
       }
@@ -205,6 +215,11 @@
       "description": "Render the message shown when there are no items.",
       "type": "(...args: any[]) => string",
       "typeSource": "jsdoc",
+      "value": "() => \"No results\"",
+      "defaultValue": {
+        "raw": "function defaultRenderEmpty() {     return \"No results\";   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -212,11 +227,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 62,
+          "line": 65,
           "column": 2
         },
         "end": {
-          "line": 62,
+          "line": 65,
           "column": 46
         }
       }
@@ -227,6 +242,11 @@
       "description": "Resolve the unique key for an item.",
       "type": "(item: string, index: number) => string",
       "typeSource": "jsdoc",
+      "value": "() => \"\"",
+      "defaultValue": {
+        "raw": "function defaultGetKey() {     return \"\";   }",
+        "kind": "function"
+      },
       "params": [
         {
           "name": "item",
@@ -249,11 +269,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 74,
+          "line": 77,
           "column": 2
         },
         "end": {
-          "line": 74,
+          "line": 77,
           "column": 36
         }
       }
@@ -264,6 +284,11 @@
       "description": "Translate a label to the active locale.",
       "type": "(key: string) => string",
       "typeSource": "jsdoc",
+      "value": "(key) => key",
+      "defaultValue": {
+        "raw": "function defaultTranslate(key) {     return key;   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -271,11 +296,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 85,
+          "line": 88,
           "column": 2
         },
         "end": {
-          "line": 85,
+          "line": 88,
           "column": 42
         }
       }

--- a/tests/fixtures/prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output-class.d.ts
@@ -32,6 +32,9 @@ export type PropMetadataConsolidatedProps = {
    */
   objectDefault?: { size: "md", count: 2 };
 
+  /**
+   * @default (value: string) => value.toUpperCase()
+   */
   callbackDefault?: (value: any) => any;
 
   /**

--- a/tests/fixtures/prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output-component.d.ts
@@ -32,6 +32,9 @@ export type PropMetadataConsolidatedProps = {
    */
   objectDefault?: { size: "md", count: 2 };
 
+  /**
+   * @default (value: string) => value.toUpperCase()
+   */
   callbackDefault?: (value: any) => any;
 
   /**

--- a/tests/fixtures/prop-metadata-consolidated/output.json
+++ b/tests/fixtures/prop-metadata-consolidated/output.json
@@ -181,6 +181,7 @@
       "kind": "let",
       "type": "(value: any) => any",
       "typeSource": "default",
+      "value": "(value: string) => value.toUpperCase()",
       "defaultValue": {
         "raw": "(value: string) => value.toUpperCase()",
         "kind": "function"

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output-class.d.ts
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output-class.d.ts
@@ -29,23 +29,30 @@ export type RunesPropDefaultIdentifierJsdocProps = {
 
   /**
    * Determine if an item should be filtered given the current value.
+   * @default () => true
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
+  /**
+   * @default (value) => String(value)
+   */
   format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
+   * @default () => "No results"
    */
   renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.
+   * @default () => ""
    */
   getKey?: (item: string, index: number) => string;
 
   /**
    * Translate a label to the active locale.
+   * @default (key) => key
    */
   translate?: (key: string) => string;
 };

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output-component.d.ts
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output-component.d.ts
@@ -29,23 +29,30 @@ export type RunesPropDefaultIdentifierJsdocProps = {
 
   /**
    * Determine if an item should be filtered given the current value.
+   * @default () => true
    */
   shouldFilterItem?: (item: string, value: string) => boolean;
 
+  /**
+   * @default (value) => String(value)
+   */
   format?: (value: any) => string;
 
   /**
    * Render the message shown when there are no items.
+   * @default () => "No results"
    */
   renderEmpty?: (...args: any[]) => string;
 
   /**
    * Resolve the unique key for an item.
+   * @default () => ""
    */
   getKey?: (item: string, index: number) => string;
 
   /**
    * Translate a label to the active locale.
+   * @default (key) => key
    */
   translate?: (key: string) => string;
 };

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
@@ -131,6 +131,11 @@
       "description": "Determine if an item should be filtered given the current value.",
       "type": "(item: string, value: string) => boolean",
       "typeSource": "jsdoc",
+      "value": "() => true",
+      "defaultValue": {
+        "raw": "function defaultShouldFilter() {     return true;   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -152,6 +157,11 @@
       "kind": "let",
       "type": "(value: any) => string",
       "typeSource": "jsdoc",
+      "value": "(value) => String(value)",
+      "defaultValue": {
+        "raw": "function defaultFormat(value) {     return String(value);   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -174,6 +184,11 @@
       "description": "Render the message shown when there are no items.",
       "type": "(...args: any[]) => string",
       "typeSource": "jsdoc",
+      "value": "() => \"No results\"",
+      "defaultValue": {
+        "raw": "function defaultRenderEmpty() {     return \"No results\";   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -196,6 +211,11 @@
       "description": "Resolve the unique key for an item.",
       "type": "(item: string, index: number) => string",
       "typeSource": "jsdoc",
+      "value": "() => \"\"",
+      "defaultValue": {
+        "raw": "function defaultGetKey() {     return \"\";   }",
+        "kind": "function"
+      },
       "params": [
         {
           "name": "item",
@@ -233,6 +253,11 @@
       "description": "Translate a label to the active locale.",
       "type": "(key: string) => string",
       "typeSource": "jsdoc",
+      "value": "(key) => key",
+      "defaultValue": {
+        "raw": "function defaultTranslate(key) {     return key;   }",
+        "kind": "function"
+      },
       "isFunction": true,
       "isFunctionDeclaration": false,
       "isRequired": false,

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
@@ -26,6 +26,9 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   options?: { dense: true };
 
+  /**
+   * @default () => {}
+   */
   onaction?: (...args: any[]) => any;
 
   /**

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
@@ -26,6 +26,9 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   options?: { dense: true };
 
+  /**
+   * @default () => {}
+   */
   onaction?: (...args: any[]) => any;
 
   /**

--- a/tests/fixtures/runes-prop-metadata-consolidated/output.json
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output.json
@@ -153,6 +153,7 @@
       "kind": "let",
       "type": "(...args: any[]) => any",
       "typeSource": "default",
+      "value": "() => {}",
       "defaultValue": {
         "raw": "() => {}",
         "kind": "function"

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -94,7 +94,6 @@ describe("writerTsDefinition", () => {
           name: "fn",
           kind: "function",
           type: "() => {     localBool = !localBool;   }",
-          value: "() => {     localBool = !localBool;   }",
           isFunction: true,
           isFunctionDeclaration: false,
           isRequired: false,


### PR DESCRIPTION
export let x = someFn (a function declaration or const arrow/
function expression) never produced a default value, because the
identifier-resolution path only pulled JSDoc off the declaration and
the .d.ts writer unconditionally suppressed @default for any
function-typed prop. Now a trivial function body (an expression-
bodied arrow, empty block, or single return statement) gets rendered
as arrow shorthand, e.g. () => true; anything more elaborate still
gets no @default.