### PR TITLE
fix(bundle): keep both components when --glob finds duplicate basenames

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -54,11 +54,13 @@ export interface GenerateBundleResult {
    */
   cache?: ParseCache;
   /**
-   * @internal moduleName -> resolved source path, matching `cache`'s entry
-   * identity, so the write phase can key its text cache lookups without
-   * redoing path-alias resolution. Undefined when the parse cache is disabled.
+   * @internal filePath -> resolved source path, matching `cache` entry
+   * identity so the write phase can look up text cache without redoing
+   * path-alias resolution. Uses filePath because moduleName is not unique
+   * when two components share a basename. Undefined when the parse cache
+   * is disabled.
    */
-  resolvedPathByModule?: Map<string, string>;
+  resolvedPathByFilePath?: Map<string, string>;
 }
 
 export interface GenerateBundleOptions {
@@ -140,19 +142,20 @@ const HYPHEN_REGEX = /-/g;
 /**
  * Discovered component sources for an entry point, before parsing.
  *
- * `exports` holds explicitly exported components (used for JSON/Markdown);
- * `allComponents` additionally includes glob-discovered components (used for
- * `.d.ts` generation). `resolveComponentFilePath` maps a component `source`
- * to its absolute path on disk.
+ * `exports` holds explicitly exported components for JSON/Markdown.
+ * `allComponentEntries` is a flat list that also includes glob-discovered
+ * components for `.d.ts` generation. A map keyed by `moduleName` would drop
+ * one of two `.svelte` files that share a basename. `resolveComponentFilePath`
+ * maps a component `source` to its absolute path on disk.
  */
 export interface CollectedComponents {
   exports: ParsedExports;
-  allComponents: ParsedExports;
+  allComponentEntries: Array<[string, ParsedExports[string]]>;
   rootDir: string;
   resolveComponentFilePath: ResolveComponentFilePath;
 }
 
-/** A `.svelte` file discovered on disk, before it's merged into `exports`/`allComponents`. */
+/** A `.svelte` file discovered on disk, before it's merged into `exports`/`allComponentEntries`. */
 export interface GlobbedComponentSource {
   moduleName: string;
   source: ReturnType<typeof asRelativeSourcePath>;
@@ -192,13 +195,110 @@ function findSvelteFiles(dir: string, results: string[] = [], visited = new Set<
   return results;
 }
 
-/** Globs every `.svelte` file under `rootDir`, resolving each to its module name and source path. */
+/**
+ * Globs every `.svelte` file under `rootDir`, resolving each to its module name and source path.
+ *
+ * Sorted by `source` so walk order does not depend on `readdirSync`, which
+ * varies by OS.
+ */
 export function globComponentSources(rootDir: string): GlobbedComponentSource[] {
-  return findSvelteFiles(rootDir).map((file) => {
-    const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
-    const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
-    return { moduleName, source };
-  });
+  return findSvelteFiles(rootDir)
+    .map((file) => {
+      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
+      const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
+      return { moduleName, source };
+    })
+    .sort((a, b) => a.source.localeCompare(b.source));
+}
+
+/** True when an export `source` still needs glob resolution, like `export { X } from "./dir"`. */
+function isUnresolvedBarrelSource(source: string): boolean {
+  return parse(source).ext !== ".svelte";
+}
+
+/** Whether `candidateSource` is a file located under the directory `dirSource` points at. */
+function isWithinSourceDir(dirSource: string, candidateSource: string): boolean {
+  const dir = dirSource.endsWith("/") ? dirSource : `${dirSource}/`;
+  return candidateSource.startsWith(dir);
+}
+
+/**
+ * State shared across {@link mergeGlobbedComponents} calls. Dedupes by
+ * resolved path, and warns once per colliding basename. Watch mode keeps
+ * one instance across re-globs; a one-shot build creates one and drops it.
+ */
+export interface GlobMergeState {
+  seenPaths: Set<string>;
+  seenModuleNamePaths: Map<string, string>;
+  warnedModuleNames: Set<string>;
+}
+
+export function createGlobMergeState(
+  entries: Array<[string, ParsedExports[string]]>,
+  resolveComponentFilePath: ResolveComponentFilePath,
+): GlobMergeState {
+  return {
+    seenPaths: new Set(entries.map(([, entry]) => resolveComponentFilePath(entry.source))),
+    seenModuleNamePaths: new Map(
+      entries.map(([moduleName, entry]) => [moduleName, resolveComponentFilePath(entry.source)]),
+    ),
+    warnedModuleNames: new Set(),
+  };
+}
+
+/**
+ * Merges every glob-discovered `.svelte` file under `rootDir` into `exports`
+ * and `allComponentEntries`.
+ *
+ * When a barrel export still points at a directory, like
+ * `export { Button } from "./button"`, match it to the glob hit under that
+ * directory with the same basename.
+ *
+ * Other glob hits each get their own `allComponentEntries` row, tracked in
+ * `state` by resolved file path. Files that share a basename both stay in
+ * `.d.ts` output. A colliding basename is logged once.
+ *
+ * Safe to call again with the same `state`. Watch mode re-globs on every
+ * edit and skips paths already seen.
+ */
+export function mergeGlobbedComponents(
+  rootDir: string,
+  exports: ParsedExports,
+  allComponentEntries: Array<[string, ParsedExports[string]]>,
+  resolveComponentFilePath: ResolveComponentFilePath,
+  state: GlobMergeState,
+): void {
+  for (const { moduleName, source } of globComponentSources(rootDir)) {
+    const resolvedPath = resolveComponentFilePath(source);
+
+    const exportEntry = exports[moduleName];
+    if (exportEntry && isUnresolvedBarrelSource(exportEntry.source) && isWithinSourceDir(exportEntry.source, source)) {
+      // Same object sits in `allComponentEntries`, so updating `source` is
+      // enough. Swap the old directory path out of `state.seenPaths` for the
+      // resolved file path, or the next pass treats it as a basename collision.
+      state.seenPaths.delete(resolveComponentFilePath(exportEntry.source));
+      exportEntry.source = source;
+      state.seenPaths.add(resolvedPath);
+      state.seenModuleNamePaths.set(moduleName, resolvedPath);
+      continue;
+    }
+
+    if (state.seenPaths.has(resolvedPath)) continue;
+    state.seenPaths.add(resolvedPath);
+
+    const priorPath = state.seenModuleNamePaths.get(moduleName);
+    if (priorPath === undefined) {
+      state.seenModuleNamePaths.set(moduleName, resolvedPath);
+    } else if (priorPath !== resolvedPath && !state.warnedModuleNames.has(moduleName)) {
+      state.warnedModuleNames.add(moduleName);
+      console.warn(
+        `Warning: multiple components named "${moduleName}" found (${normalizeSeparators(relative(rootDir, priorPath))} and ${normalizeSeparators(relative(rootDir, resolvedPath))}). ` +
+          "Both are included in TypeScript definitions, but only one can be the named export.",
+      );
+    }
+
+    allComponentEntries.push([moduleName, { source, default: false }]);
+  }
 }
 
 /**
@@ -234,23 +334,14 @@ export function collectComponents(input: string, glob: boolean, documentExports 
     }
   }
 
-  const allComponents: ParsedExports = { ...exports };
+  const allComponentEntries: Array<[string, ParsedExports[string]]> = Object.entries(exports);
 
   if (glob) {
-    for (const { moduleName, source } of globComponentSources(rootDir)) {
-      if (exports[moduleName]) {
-        exports[moduleName].source = source;
-      }
-
-      if (allComponents[moduleName]) {
-        allComponents[moduleName].source = source;
-      } else {
-        allComponents[moduleName] = { source, default: false };
-      }
-    }
+    const state = createGlobMergeState(allComponentEntries, resolveComponentFilePath);
+    mergeGlobbedComponents(rootDir, exports, allComponentEntries, resolveComponentFilePath, state);
   }
 
-  return { exports, allComponents, rootDir, resolveComponentFilePath };
+  return { exports, allComponentEntries, rootDir, resolveComponentFilePath };
 }
 
 /**
@@ -436,14 +527,17 @@ export async function generateBundle(
   options: GenerateBundleOptions = {},
 ): Promise<GenerateBundleResult> {
   const documentExports = options.documentExports === true;
-  const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
+  const { exports, allComponentEntries, rootDir, resolveComponentFilePath } = collectComponents(
+    input,
+    glob,
+    documentExports,
+  );
 
   // File entry only; directory inputs have no barrel.
   const entryExports: EntryExports =
     documentExports && lstatSync(input).isFile() ? await parseEntryExports(resolve(input)) : [];
 
   const exportEntries = Object.entries(exports);
-  const allComponentEntries = Object.entries(allComponents);
 
   const uniqueFilePaths = collectSvelteFilePaths([exportEntries, allComponentEntries], resolveComponentFilePath);
   const fileMap = await readFileMap(uniqueFilePaths);
@@ -454,10 +548,10 @@ export async function generateBundle(
   // `cache` is on by default; only an explicit `false` disables it.
   const cache =
     options.cache === false ? undefined : new ParseCache(resolveCacheFilePath(rootDir, options.cache ?? true));
-  // moduleName -> resolved source path, so the write phase can key a
-  // generated-text cache against the same identity as `cache` without
-  // redoing path-alias resolution. Only worth building when there's a cache.
-  const resolvedPathByModule = cache ? new Map<string, string>() : undefined;
+  // filePath -> resolved source path for the write-phase text cache, keyed
+  // like `cache` so path-alias resolution is not redone. filePath stays
+  // unique when two components share a basename. Built only when caching.
+  const resolvedPathByFilePath = cache ? new Map<string, string>() : undefined;
 
   const misses = new Set<string>();
   const hashes = new Map<string, string>();
@@ -513,8 +607,8 @@ export async function generateBundle(
   for (const entry of allComponentEntries) {
     const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath, processOptions);
     if (result) {
-      allComponentsForTypes.set(result.moduleName, result);
-      resolvedPathByModule?.set(result.moduleName, resolveComponentFilePath(entry[1].source));
+      allComponentsForTypes.set(result.filePath, result);
+      resolvedPathByFilePath?.set(result.filePath, resolveComponentFilePath(entry[1].source));
     }
   }
 
@@ -540,8 +634,8 @@ export async function generateBundle(
       if (!affected.has(resolvedPath) || misses.has(resolvedPath)) continue;
       const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath, processOptions);
       if (result) {
-        allComponentsForTypes.set(result.moduleName, result);
-        resolvedPathByModule?.set(result.moduleName, resolvedPath);
+        allComponentsForTypes.set(result.filePath, result);
+        resolvedPathByFilePath?.set(result.filePath, resolvedPath);
       }
     }
   }
@@ -586,7 +680,7 @@ export async function generateBundle(
     errors,
     diagnostics,
     cache,
-    resolvedPathByModule,
+    resolvedPathByFilePath,
   };
 }
 
@@ -652,7 +746,9 @@ async function checkComponentExamples(
 ): Promise<void> {
   if (!resolver) return;
 
-  const diagnosticsByModule = await resolver.checkExamples(
+  // Keyed by resolved filePath, not moduleName: two components discovered via
+  // `--glob` can share a basename, and moduleName alone isn't unique.
+  const diagnosticsByFilePath = await resolver.checkExamples(
     candidates.map(({ component, sources }) => ({
       moduleName: component.moduleName,
       filePath: resolveComponentFilePath(component.filePath),
@@ -661,7 +757,7 @@ async function checkComponentExamples(
   );
 
   for (const { component, sources } of candidates) {
-    const found = diagnosticsByModule.get(component.moduleName);
+    const found = diagnosticsByFilePath.get(resolveComponentFilePath(component.filePath));
     if (!found || found.length === 0) continue;
 
     const sourceById = new Map(sources.map((source) => [source.id, source.source]));

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -221,7 +221,7 @@ export async function writeOutput(
       inputDir,
       dryRun,
       cache: result.cache,
-      resolvedPathByModule: result.resolvedPathByModule,
+      resolvedPathByFilePath: result.resolvedPathByFilePath,
     } satisfies WriteTsDefinitionsOptions);
   }
 

--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -209,15 +209,17 @@ export class TypeResolver {
    * depend on the rest of the component's types.
    */
   async checkExamples(targets: ExampleCheckTarget[]): Promise<Map<string, ExampleCheckDiagnostic[]>> {
+    // Keyed by `filePath`. Glob can find two components with the same
+    // basename, so `moduleName` alone is not unique.
     const results = new Map<string, ExampleCheckDiagnostic[]>();
     if (targets.length === 0) return results;
 
-    const examples: Array<{ moduleName: string; source: ExampleCheckSource; file: string }> = [];
+    const examples: Array<{ filePath: string; source: ExampleCheckSource; file: string }> = [];
     for (const target of targets) {
       for (const source of target.sources) {
         const file = this.exampleFileName(target.filePath, target.moduleName, source.id);
         this.overlay.set(file, buildExampleModule(source));
-        examples.push({ moduleName: target.moduleName, source, file });
+        examples.push({ filePath: target.filePath, source, file });
       }
     }
 
@@ -234,7 +236,7 @@ export class TypeResolver {
       if (!project) return results;
 
       await Promise.all(
-        examples.map(async ({ moduleName, source, file }) => {
+        examples.map(async ({ filePath, source, file }) => {
           const [syntactic, semantic]: [TS[], TS[]] = await Promise.all([
             project.program.getSyntacticDiagnostics(file),
             project.program.getSemanticDiagnostics(file),
@@ -249,9 +251,9 @@ export class TypeResolver {
             .map((entry) => `Line ${entry.line}: ${entry.text}`)
             .join("\n");
 
-          const list = results.get(moduleName) ?? [];
+          const list = results.get(filePath) ?? [];
           list.push({ id: source.id, name: source.name, message });
-          results.set(moduleName, list);
+          results.set(filePath, list);
         }),
       );
     } finally {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,12 +1,14 @@
 import { lstatSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  type ComponentDocApi,
   type ComponentDocs,
   type ComponentParseError,
   collectComponents,
   collectSvelteFilePaths,
+  createGlobMergeState,
   type GenerateBundleResult,
-  globComponentSources,
+  mergeGlobbedComponents,
   type ProcessComponentOptions,
   processComponent,
   readFileMap,
@@ -55,14 +57,21 @@ export interface SveldBundle {
  * @param documentExports - Record consts, functions, and types from the entry barrel
  */
 export async function createSveldBundle(input: string, glob: boolean, documentExports = false): Promise<SveldBundle> {
-  // Export map is stable per edit; re-glob `allComponents` in `update()` when files are added.
-  const { exports, allComponents, rootDir, resolveComponentFilePath } = collectComponents(input, glob, documentExports);
+  // Export map is stable per edit; re-glob `allComponentEntries` in `update()` when files are added.
+  const { exports, allComponentEntries, rootDir, resolveComponentFilePath } = collectComponents(
+    input,
+    glob,
+    documentExports,
+  );
 
   const entryExports: EntryExports =
     documentExports && lstatSync(input).isFile() ? await parseEntryExports(resolve(input)) : [];
 
   const exportEntries = Object.entries(exports);
-  const allComponentEntries = Object.entries(allComponents);
+
+  // Dedupes re-glob adds in `update()` by resolved path, including when two
+  // components share a basename.
+  const globMergeState = createGlobMergeState(allComponentEntries, resolveComponentFilePath);
 
   const components: ComponentDocs = new Map();
   const allComponentsForTypes: ComponentDocs = new Map();
@@ -99,7 +108,7 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
     }
     for (const entry of allComponentEntries) {
       const result = processComponent(entry, allComponentEntries, fileMap, resolveComponentFilePath, processOptions);
-      if (result) allComponentsForTypes.set(result.moduleName, result);
+      if (result) allComponentsForTypes.set(result.filePath, result);
     }
     reportParseErrors(buildResult().errors);
   }
@@ -110,9 +119,14 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
   /**
    * Re-parses only the entries whose resolved source is in `affected`, writing
    * results back into `target`. Returns the set of paths that were re-parsed.
+   *
+   * `keyFor` chooses the map key. `components` uses `moduleName` from the
+   * barrel export. `allComponentsForTypes` uses `filePath` so two globbed
+   * components that share a basename stay distinct.
    */
   const reparseInto = (
     target: ComponentDocs,
+    keyFor: (result: ComponentDocApi) => string,
     entries: Array<[string, ParsedExports[string]]>,
     affected: Set<string>,
     fileMap: Map<string, string | null>,
@@ -124,13 +138,13 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
 
       const result = processComponent(entry, entries, fileMap, resolveComponentFilePath, processOptions);
       if (result) {
-        target.set(result.moduleName, result);
+        target.set(keyFor(result), result);
         reparsed.add(resolvedPath);
       } else {
         // Drop stale entry when the source vanished or failed to parse.
-        for (const [moduleName, api] of target) {
+        for (const [key, api] of target) {
           if (resolveComponentFilePath(api.filePath) === resolvedPath) {
-            target.delete(moduleName);
+            target.delete(key);
           }
         }
       }
@@ -147,16 +161,7 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
 
     // Pick up components created since the last parse.
     if (glob) {
-      for (const { moduleName, source } of globComponentSources(rootDir)) {
-        const existing = allComponents[moduleName];
-        if (existing) {
-          existing.source = source;
-        } else {
-          const newEntry = { source, default: false };
-          allComponents[moduleName] = newEntry;
-          allComponentEntries.push([moduleName, newEntry]);
-        }
-      }
+      mergeGlobbedComponents(rootDir, exports, allComponentEntries, resolveComponentFilePath, globMergeState);
     }
 
     const affected = expandAffected(changed, reverseDeps);
@@ -172,10 +177,16 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
     const fileMap = await readFileMap(affected);
 
     const reparsed = new Set<string>();
-    for (const path of reparseInto(components, exportEntries, affected, fileMap)) {
+    for (const path of reparseInto(components, (result) => result.moduleName, exportEntries, affected, fileMap)) {
       reparsed.add(path);
     }
-    for (const path of reparseInto(allComponentsForTypes, allComponentEntries, affected, fileMap)) {
+    for (const path of reparseInto(
+      allComponentsForTypes,
+      (result) => result.filePath,
+      allComponentEntries,
+      affected,
+      fileMap,
+    )) {
       reparsed.add(path);
     }
 

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -46,11 +46,11 @@ export interface WriteTsDefinitionsOptions extends WriteTsDefinitionOptions {
   /**
    * @internal Reuses generated `.d.ts` text across runs for components whose
    * source (and the effective `format` option) hasn't changed. Requires
-   * `resolvedPathByModule` to key lookups; both come from `GenerateBundleResult`.
+   * `resolvedPathByFilePath` to key lookups; both come from `GenerateBundleResult`.
    */
   cache?: ParseCache;
-  /** @internal See `cache`. */
-  resolvedPathByModule?: Map<string, string>;
+  /** @internal See `cache`. Lookups use `component.filePath`. */
+  resolvedPathByFilePath?: Map<string, string>;
 }
 
 /**
@@ -75,7 +75,7 @@ export default async function writeTsDefinitions(components: ComponentDocs, opti
   const cacheFormatKey = options.format ?? "class";
   const writePromises = document.components.map(async (component) => {
     const ts_filepath = convertSvelteExt(join(options.outDir, component.filePath));
-    const resolvedPath = options.resolvedPathByModule?.get(component.moduleName);
+    const resolvedPath = options.resolvedPathByFilePath?.get(component.filePath);
     let text = resolvedPath ? options.cache?.getGeneratedText(resolvedPath, cacheFormatKey) : undefined;
     if (text === undefined) {
       text = writeTsDefinition(component, { format: options.format });

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,9 +1,14 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { generateBundle } from "../src/bundle";
+import { type ComponentDocApi, type ComponentDocs, generateBundle } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
 import { TypeResolver } from "../src/resolve-types";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
 
 const BUTTON = `<script>
   export let label = "button";
@@ -83,7 +88,7 @@ describe("generateBundle in-run parse dedupe", () => {
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(result.components.has("Button")).toBe(true);
-    expect(result.allComponentsForTypes.has("Button")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "Button")).toBeDefined();
   });
 
   test("dedupes the same way when the on-disk cache is enabled", async () => {
@@ -94,7 +99,7 @@ describe("generateBundle in-run parse dedupe", () => {
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(result.components.has("Button")).toBe(true);
-    expect(result.allComponentsForTypes.has("Button")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "Button")).toBeDefined();
   });
 });
 
@@ -164,7 +169,7 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     const propsImported = result.components.get("PropsImported");
     expect(propsImported?.props).toEqual([]);
 
-    const exampleCheck = result.allComponentsForTypes.get("ExampleCheck");
+    const exampleCheck = byModuleName(result.allComponentsForTypes, "ExampleCheck");
     expect(exampleCheck?.diagnostics ?? []).toEqual([]);
   });
 });

--- a/tests/duplicate-basename.test.ts
+++ b/tests/duplicate-basename.test.ts
@@ -1,0 +1,129 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, resolve } from "node:path";
+import { generateBundle } from "../src/bundle";
+import writeTsDefinitions from "../src/writer/writer-ts-definitions";
+
+/**
+ * `--glob` used to index by basename, so two `Menu.svelte` files in different
+ * folders collapsed into one `.d.ts` entry. Walk order decided the winner and
+ * varied by OS.
+ */
+describe("duplicate basenames discovered via glob", () => {
+  let dir: string;
+  let outDirAbs: string;
+  let outDir: string;
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-dup-basename-"));
+    // writeTsDefinitions joins its index.d.ts path onto process.cwd() regardless
+    // of whether outDir is already absolute, so outDir must be relative to cwd.
+    outDirAbs = mkdtempSync(join(process.cwd(), ".tmp-sveld-dup-basename-out-"));
+    outDir = relative(process.cwd(), outDirAbs);
+
+    mkdirSync(join(dir, "Menu"), { recursive: true });
+    mkdirSync(join(dir, "icons"), { recursive: true });
+
+    writeFileSync(join(dir, "index.js"), `export { default as Menu } from "./Menu/Menu.svelte";\n`);
+    writeFileSync(
+      join(dir, "Menu", "Menu.svelte"),
+      "<script>\n  export let anchor = null;\n</script>\n\n<nav>{anchor}</nav>\n",
+    );
+    writeFileSync(
+      join(dir, "icons", "Menu.svelte"),
+      "<script>\n  export let size = 16;\n</script>\n\n<svg width={size} height={size} />\n",
+    );
+
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outDirAbs, { recursive: true, force: true });
+  });
+
+  test("both components survive in allComponentsForTypes, not just the last one walked", async () => {
+    const result = await generateBundle(join(dir, "index.js"), true);
+
+    const menus = Array.from(result.allComponentsForTypes.values()).filter((c) => c.moduleName === "Menu");
+    expect(menus).toHaveLength(2);
+
+    const realMenu = menus.find((c) => c.filePath.endsWith("Menu/Menu.svelte"));
+    const iconMenu = menus.find((c) => c.filePath.endsWith("icons/Menu.svelte"));
+
+    expect(realMenu?.props.map((p) => p.name)).toEqual(["anchor"]);
+    expect(iconMenu?.props.map((p) => p.name)).toEqual(["size"]);
+  });
+
+  test("the barrel export's source still points at the real component, not the icon", async () => {
+    const result = await generateBundle(join(dir, "index.js"), true);
+
+    expect(result.exports.Menu.source).toBe("./Menu/Menu.svelte");
+
+    const exportedMenu = result.components.get("Menu");
+    expect(exportedMenu?.filePath).toBe("./Menu/Menu.svelte");
+    expect(exportedMenu?.props.map((p) => p.name)).toEqual(["anchor"]);
+  });
+
+  test("warns once about the duplicate name", async () => {
+    await generateBundle(join(dir, "index.js"), true);
+
+    const duplicateWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes('multiple components named "Menu"'),
+    );
+    expect(duplicateWarnings).toHaveLength(1);
+  });
+
+  test("writes a .d.ts file for both components", async () => {
+    const result = await generateBundle(join(dir, "index.js"), true);
+    await writeTsDefinitions(result.allComponentsForTypes, {
+      outDir,
+      inputDir: dir,
+      preamble: "",
+      exports: result.exports,
+    });
+
+    const realMenuDts = resolve(outDirAbs, "Menu", "Menu.svelte.d.ts");
+    const iconMenuDts = resolve(outDirAbs, "icons", "Menu.svelte.d.ts");
+
+    expect(existsSync(realMenuDts)).toBe(true);
+    expect(existsSync(iconMenuDts)).toBe(true);
+
+    expect(readFileSync(realMenuDts, "utf-8")).toContain("anchor");
+    expect(readFileSync(iconMenuDts, "utf-8")).toContain("size");
+  });
+});
+
+/**
+ * Directory barrel re-exports like `export { X } from "./dir"` still resolve
+ * through the glob walk to the real `.svelte` file. A same-named file in
+ * another folder must not steal that resolution.
+ */
+describe("directory-style barrel re-exports still resolve via glob", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-dir-reexport-"));
+    mkdirSync(join(dir, "button"), { recursive: true });
+
+    writeFileSync(join(dir, "index.js"), `export { Button } from "./button/";\n`);
+    writeFileSync(join(dir, "button", "index.js"), `export { default as Button } from "./Button.svelte";\n`);
+    writeFileSync(
+      join(dir, "button", "Button.svelte"),
+      `<script>\n  export let label = "button";\n</script>\n\n<button>{label}</button>\n`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("resolves the directory export to the concrete file found by glob", async () => {
+    const result = await generateBundle(join(dir, "index.js"), true);
+
+    expect(result.exports.Button.source).toBe("./button/Button.svelte");
+    expect(result.components.get("Button")?.props.map((p) => p.name)).toEqual(["label"]);
+  });
+});

--- a/tests/example-check.test.ts
+++ b/tests/example-check.test.ts
@@ -39,11 +39,11 @@ describe("opt-in @example compile checking", () => {
     if (!resolver) return;
 
     try {
-      const diagnosticsByModule = await resolver.checkExamples([
+      const diagnosticsByFilePath = await resolver.checkExamples([
         { moduleName: "ExampleCheck", filePath: COMPONENT_PATH, sources },
       ]);
 
-      const diagnostics = diagnosticsByModule.get("ExampleCheck") ?? [];
+      const diagnostics = diagnosticsByFilePath.get(COMPONENT_PATH) ?? [];
       const byId = Object.fromEntries(diagnostics.map((d) => [d.id, d]));
 
       expect(byId["prop:formatValue"]).toBeUndefined();

--- a/tests/generate-bundle-errors.test.ts
+++ b/tests/generate-bundle-errors.test.ts
@@ -1,7 +1,13 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
 import { generateBundle } from "../src/plugin";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
 
 const VALID_COMPONENT = `<script>
   /** @type {string} */
@@ -39,9 +45,9 @@ describe("generateBundle per-component error isolation", () => {
     const result = await generateBundle(dir, true);
 
     // The valid component is parsed and present in the output.
-    expect(result.allComponentsForTypes.has("Valid")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "Valid")).toBeDefined();
     // The broken component is absent from the output but recorded as an error.
-    expect(result.allComponentsForTypes.has("Broken")).toBe(false);
+    expect(byModuleName(result.allComponentsForTypes, "Broken")).toBeUndefined();
     expect(result.errors).toHaveLength(1);
 
     const [error] = result.errors;
@@ -74,7 +80,7 @@ describe("generateBundle per-component error isolation", () => {
     const result = await generateBundle(dir, true);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.allComponentsForTypes.has("Valid")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "Valid")).toBeDefined();
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -1,10 +1,16 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
+import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
 import { generateBundle } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
 import { DEFAULT_CACHE_FILE } from "../src/parse-cache";
 import writeTsDefinitions from "../src/writer/writer-ts-definitions";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
 
 const BUTTON = `<script>
   /** @restProps {button} */
@@ -66,8 +72,8 @@ describe("parse cache", () => {
     expect(Array.from(second.allComponentsForTypes.keys()).sort()).toEqual(
       Array.from(first.allComponentsForTypes.keys()).sort(),
     );
-    expect(second.allComponentsForTypes.get("Button")?.props.map((p) => p.name)).toEqual(
-      first.allComponentsForTypes.get("Button")?.props.map((p) => p.name),
+    expect(byModuleName(second.allComponentsForTypes, "Button")?.props.map((p) => p.name)).toEqual(
+      byModuleName(first.allComponentsForTypes, "Button")?.props.map((p) => p.name),
     );
   });
 
@@ -79,7 +85,7 @@ describe("parse cache", () => {
     const result = await generateBundle(dir, true, { cache: cacheFile });
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
-    expect(result.allComponentsForTypes.get("Standalone")?.props.find((p) => p.name === "label")?.value).toBe(
+    expect(byModuleName(result.allComponentsForTypes, "Standalone")?.props.find((p) => p.name === "label")?.value).toBe(
       '"changed"',
     );
   });
@@ -113,7 +119,7 @@ describe("parse cache", () => {
     // The dependent must be re-parsed once, not once per pass.
     expect(reparsedPaths.sort()).toEqual(["./Button.svelte", "./SecondaryButton.svelte"].sort());
     expect(result.components.has("SecondaryButton")).toBe(true);
-    expect(result.allComponentsForTypes.has("SecondaryButton")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "SecondaryButton")).toBeDefined();
   });
 
   test("a stale cache from an unrelated project root doesn't leak into a new one", async () => {
@@ -127,7 +133,7 @@ describe("parse cache", () => {
       const result = await generateBundle(otherDir, true, { cache: cacheFile });
 
       expect(parseSpy).toHaveBeenCalledTimes(1);
-      expect(result.allComponentsForTypes.has("Standalone")).toBe(true);
+      expect(byModuleName(result.allComponentsForTypes, "Standalone")).toBeDefined();
     } finally {
       rmSync(otherDir, { recursive: true, force: true });
     }
@@ -169,7 +175,7 @@ describe("generated .d.ts text cache", () => {
       preamble: "",
       exports: first.exports,
       cache: first.cache,
-      resolvedPathByModule: first.resolvedPathByModule,
+      resolvedPathByFilePath: first.resolvedPathByFilePath,
     });
     first.cache?.save();
 
@@ -200,7 +206,7 @@ describe("generated .d.ts text cache", () => {
       exports: first.exports,
       format: "class",
       cache: first.cache,
-      resolvedPathByModule: first.resolvedPathByModule,
+      resolvedPathByFilePath: first.resolvedPathByFilePath,
     });
     first.cache?.save();
 
@@ -234,7 +240,7 @@ describe("cache default", () => {
     const second = await generateBundle(dir, true);
 
     expect(parseSpy).not.toHaveBeenCalled();
-    expect(second.allComponentsForTypes.has("Standalone")).toBe(true);
+    expect(byModuleName(second.allComponentsForTypes, "Standalone")).toBeDefined();
   });
 
   test("cache: false disables the cache entirely", async () => {

--- a/tests/rollup-plugin-preprocess.test.ts
+++ b/tests/rollup-plugin-preprocess.test.ts
@@ -1,8 +1,14 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
 import { generateBundle } from "../src/plugin";
 import { writeTsDefinition } from "../src/writer/writer-ts-definitions";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
 
 describe("metadata source preservation", () => {
   test("preserves TypeScript annotations while stripping only the top-level style block", async () => {
@@ -33,7 +39,7 @@ describe("metadata source preservation", () => {
       );
 
       const result = await generateBundle(componentDir, true);
-      const component = result.allComponentsForTypes.get("Button");
+      const component = byModuleName(result.allComponentsForTypes, "Button");
 
       expect(component).toBeDefined();
       expect(component?.props.find((prop) => prop.name === "message")?.type).toBe("string");

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,8 +1,14 @@
 import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
 import pluginSveld from "../src/plugin";
 import { createSveldBundle } from "../src/watch";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
 
 const BUTTON = `<script>
   /** @restProps {button} */
@@ -44,7 +50,7 @@ describe("watch mode (createSveldBundle)", () => {
 
   test("initial bundle parses every component", async () => {
     const bundle = await createSveldBundle(dir, true);
-    const names = Array.from(bundle.result.allComponentsForTypes.keys()).sort();
+    const names = Array.from(bundle.result.allComponentsForTypes.values(), (c) => c.moduleName).sort();
     expect(names).toEqual(["Button", "SecondaryButton", "Standalone"]);
   });
 
@@ -83,7 +89,7 @@ describe("watch mode (createSveldBundle)", () => {
     const { result, reparsed } = await bundle.update([newPath]);
 
     expect(reparsed).toContain(newPath);
-    expect(result.allComponentsForTypes.has("NewOne")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "NewOne")).toBeDefined();
   });
 
   test("picks up a deleted component file", async () => {
@@ -94,7 +100,7 @@ describe("watch mode (createSveldBundle)", () => {
 
     const { result } = await bundle.update([standalonePath]);
 
-    expect(result.allComponentsForTypes.has("Standalone")).toBe(false);
+    expect(byModuleName(result.allComponentsForTypes, "Standalone")).toBeUndefined();
   });
 
   test("deleting an @extendProps dependency reparses its dependent without crashing", async () => {
@@ -106,7 +112,7 @@ describe("watch mode (createSveldBundle)", () => {
     const { result, reparsed } = await bundle.update([buttonPath]);
 
     expect(reparsed).toContain(resolve(dir, "SecondaryButton.svelte"));
-    expect(result.allComponentsForTypes.has("Button")).toBe(false);
+    expect(byModuleName(result.allComponentsForTypes, "Button")).toBeUndefined();
   });
 
   test("ignores non-svelte changes", async () => {
@@ -122,7 +128,7 @@ describe("watch mode (createSveldBundle)", () => {
     writeFileSync(buttonPath, BUTTON.replace("export let primary = false;", "export let danger = false;"));
 
     const { result } = await bundle.update([buttonPath]);
-    const button = result.allComponentsForTypes.get("Button");
+    const button = byModuleName(result.allComponentsForTypes, "Button");
     const propNames = button?.props.map((p) => p.name) ?? [];
     expect(propNames).toContain("danger");
     expect(propNames).not.toContain("primary");


### PR DESCRIPTION
Fixes silent data loss when two .svelte files share a basename in
different directories under --glob (e.g. a real component and an
unrelated icon with the same name). Which file won used to depend on
readdirSync order, so it could pass on macOS and break on Linux CI.