### PR TITLE
fix(resolve-types): key resolved prop types by filePath, not moduleName

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -708,7 +708,9 @@ async function resolveImportedPropTypes(
 ): Promise<void> {
   if (!resolver) return;
 
-  const resolvedByModule = await resolver.expandAll(
+  // Keyed by resolved filePath, not moduleName: two components discovered via
+  // `--glob` can share a basename, and moduleName alone isn't unique.
+  const resolvedByFilePath = await resolver.expandAll(
     candidates.map(({ component, metadata }) => ({
       moduleName: component.moduleName,
       metadata,
@@ -717,7 +719,7 @@ async function resolveImportedPropTypes(
   );
 
   for (const { component } of candidates) {
-    const resolved = resolvedByModule.get(component.moduleName);
+    const resolved = resolvedByFilePath.get(resolveComponentFilePath(component.filePath));
     if (resolved) applyResolvedProps(component, resolved);
   }
 }

--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -82,7 +82,13 @@ export class TypeResolver {
     return resolver;
   }
 
-  /** Resolves every target in one program snapshot. */
+  /**
+   * Resolves every target in one program snapshot.
+   *
+   * Keyed by `filePath`, not `moduleName`: two components discovered via
+   * `--glob` can share a basename (e.g. `Menu/Menu.svelte` and
+   * `icons/Menu.svelte`), and `moduleName` alone is not unique.
+   */
   async expandAll(targets: ResolveTarget[]): Promise<Map<string, ResolvedComponentProp[]>> {
     const results = new Map<string, ResolvedComponentProp[]>();
     if (targets.length === 0) return results;
@@ -143,7 +149,7 @@ export class TypeResolver {
             }
           }
 
-          return { moduleName: target.moduleName, groups: Array.from(groups.values()) };
+          return { filePath: target.filePath, groups: Array.from(groups.values()) };
         }),
       );
 
@@ -190,7 +196,7 @@ export class TypeResolver {
           return { name: group.name, type: Array.from(new Set(texts)).join(" | "), isRequired };
         });
         resolved.sort((a, b) => a.name.localeCompare(b.name));
-        results.set(entry.moduleName, resolved);
+        results.set(entry.filePath, resolved);
       });
     } finally {
       await snapshot.dispose?.();

--- a/tests/resolve-types.test.ts
+++ b/tests/resolve-types.test.ts
@@ -65,7 +65,7 @@ describe("opt-in TypeScript semantic resolution", () => {
         },
       ]);
 
-      applyResolvedProps(parsed, resolved.get("RunesWholePropsImported") ?? []);
+      applyResolvedProps(parsed, resolved.get(COMPONENT_PATH) ?? []);
     } finally {
       await resolver.dispose();
     }
@@ -100,7 +100,7 @@ describe("opt-in TypeScript semantic resolution", () => {
         },
       ]);
 
-      applyResolvedProps(parsed, resolved.get("RunesWholePropsUnionResolveTypes") ?? []);
+      applyResolvedProps(parsed, resolved.get(UNION_COMPONENT_PATH) ?? []);
     } finally {
       await resolver.dispose();
     }
@@ -136,14 +136,45 @@ describe("opt-in TypeScript semantic resolution", () => {
 
       // No entry: the resolver must not fabricate types for a generic it
       // can't bind, rather than guessing at (and getting wrong) unions.
-      expect(resolved.has("RunesWholePropsGenericResolveTypes")).toBe(false);
+      expect(resolved.has(GENERIC_COMPONENT_PATH)).toBe(false);
 
-      applyResolvedProps(parsed, resolved.get("RunesWholePropsGenericResolveTypes") ?? []);
+      applyResolvedProps(parsed, resolved.get(GENERIC_COMPONENT_PATH) ?? []);
     } finally {
       await resolver.dispose();
     }
 
     // Falls back to the same opaque, AST-derived shape the default path produces.
     expect(parsed.props).toEqual([]);
+  }, 30_000);
+
+  test("expandAll keys results by filePath so two targets sharing a moduleName resolve independently", async () => {
+    const importedParsed = await parseFixture();
+    const importedMetadata = getParsedComponentTypeScriptMetadata(importedParsed);
+    if (!importedMetadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
+
+    const unionParsed = await parseUnionFixture();
+    const unionMetadata = getParsedComponentTypeScriptMetadata(unionParsed);
+    if (!unionMetadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
+
+    const resolver = await TypeResolver.create(FIXTURE_DIR);
+    expect(resolver).not.toBeNull();
+    if (!resolver) return;
+
+    try {
+      // Simulates two `--glob`-discovered `.svelte` files sharing a basename
+      // in different directories (e.g. `Menu/Menu.svelte` and `icons/Menu.svelte`).
+      const resolved = await resolver.expandAll([
+        { moduleName: "Duplicate", metadata: importedMetadata, filePath: COMPONENT_PATH },
+        { moduleName: "Duplicate", metadata: unionMetadata, filePath: UNION_COMPONENT_PATH },
+      ]);
+
+      applyResolvedProps(importedParsed, resolved.get(COMPONENT_PATH) ?? []);
+      applyResolvedProps(unionParsed, resolved.get(UNION_COMPONENT_PATH) ?? []);
+    } finally {
+      await resolver.dispose();
+    }
+
+    expect(importedParsed.props.map((prop) => prop.name).sort()).toEqual(["disabled", "href", "variant"]);
+    expect(unionParsed.props.map((prop) => prop.name).sort()).toEqual(["duration", "kind", "target"]);
   }, 30_000);
 });


### PR DESCRIPTION
Two `--glob`-discovered components can share a basename in different
directories, so keying by moduleName can silently drop one component's
resolved types in favor of the other. Not reachable today since
`resolveImportedPropTypes` only ever sees the exported-only `components`
map, but it's the same shape of bug #402 fixed for `checkExamples` right
next to it in this file.