### PR TITLE
fix(writer): key colliding JSON output files by source path

### DIFF
--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -32,13 +32,46 @@ function withNormalizedFilePaths(components: ComponentDocApi[], inputDir: string
   }));
 }
 
+const SVELTE_EXT_REGEX = /\.svelte$/;
+
+/**
+ * JSON output file name for one component.
+ *
+ * Two `--glob`-discovered components can share a `moduleName` across
+ * directories, e.g. `Menu/Menu.svelte` and `icons/Menu.svelte`. Writing
+ * both to `${moduleName}.api.json` would silently overwrite one. On
+ * collision, name the file from the source path and warn once per colliding
+ * name. Unique names keep `${moduleName}.api.json`.
+ */
+function jsonFileName(component: ComponentDocApi, hasCollision: boolean, warnedModuleNames: Set<string>): string {
+  if (!hasCollision) return `${component.moduleName}.api.json`;
+
+  if (!warnedModuleNames.has(component.moduleName)) {
+    warnedModuleNames.add(component.moduleName);
+    console.warn(
+      `Warning: multiple components named "${component.moduleName}" found. ` +
+        "Their JSON files are keyed by source path instead of name to avoid overwriting each other.",
+    );
+  }
+
+  return component.filePath.replace(SVELTE_EXT_REGEX, ".api.json");
+}
+
 async function writeJsonComponents(components: ComponentDocs, options: WriteJsonOptions) {
   const document = buildComponentApiDocument(components);
   const output = withNormalizedFilePaths(document.components, options.inputDir);
 
+  const moduleNameCounts = new Map<string, number>();
+  for (const component of output) {
+    moduleNameCounts.set(component.moduleName, (moduleNameCounts.get(component.moduleName) ?? 0) + 1);
+  }
+  const warnedModuleNames = new Set<string>();
+
   await Promise.all(
     output.map(async (c) => {
-      const outFile = path.resolve(path.join(options.outDir || "", `${c.moduleName}.api.json`));
+      const hasCollision = (moduleNameCounts.get(c.moduleName) ?? 0) > 1;
+      const fileName = jsonFileName(c, hasCollision, warnedModuleNames);
+      const outFile = path.resolve(path.join(options.outDir || "", fileName));
       const writer = new Writer({ dryRun: options.dryRun });
       const wasWritten = await writer.write(outFile, formatJsonOutput(c));
       if (!options.dryRun) info(`${wasWritten ? "created" : "unchanged"} "${outFile}".`);

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -149,6 +149,68 @@ describe("writeJson", () => {
   });
 });
 
+describe("writeJson (outDir mode, one file per component)", () => {
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("names each file after moduleName when names are unique", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-outdir-"));
+    const outDir = path.relative(process.cwd(), tempDir);
+    const components: ComponentDocs = new Map([
+      ["Zeta", createComponent("Zeta", "Zeta.svelte")],
+      ["Alpha", createComponent("Alpha", "Alpha.svelte")],
+    ]);
+
+    try {
+      await writeJson(components, { input: "src", inputDir: "src", outFile: "COMPONENT_API.json", outDir });
+
+      expect(JSON.parse(readFileSync(path.join(tempDir, "Zeta.api.json"), "utf-8")).moduleName).toBe("Zeta");
+      expect(JSON.parse(readFileSync(path.join(tempDir, "Alpha.api.json"), "utf-8")).moduleName).toBe("Alpha");
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("keys colliding moduleNames by source path instead of silently overwriting", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-outdir-"));
+    const outDir = path.relative(process.cwd(), tempDir);
+    // Same basename in different dirs; the collision #402 fixed elsewhere.
+    const components: ComponentDocs = new Map([
+      ["Menu/Menu.svelte", createComponent("Menu", "Menu/Menu.svelte")],
+      ["icons/Menu.svelte", createComponent("Menu", "icons/Menu.svelte")],
+    ]);
+
+    try {
+      await writeJson(components, { input: "src", inputDir: "src", outFile: "COMPONENT_API.json", outDir });
+
+      // Flat Menu.api.json must not exist; each file lives under its source path.
+      expect(() => readFileSync(path.join(tempDir, "Menu.api.json"), "utf-8")).toThrow();
+
+      const realMenu = JSON.parse(readFileSync(path.join(tempDir, "src", "Menu", "Menu.api.json"), "utf-8"));
+      const iconMenu = JSON.parse(readFileSync(path.join(tempDir, "src", "icons", "Menu.api.json"), "utf-8"));
+      expect(realMenu.moduleName).toBe("Menu");
+      expect(realMenu.filePath).toBe("src/Menu/Menu.svelte");
+      expect(iconMenu.moduleName).toBe("Menu");
+      expect(iconMenu.filePath).toBe("src/icons/Menu.svelte");
+
+      const duplicateWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes('multiple components named "Menu"'),
+      );
+      expect(duplicateWarnings).toHaveLength(1);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("renderJsonDocument", () => {
   test("matches the document writeJson writes to disk, without touching disk", async () => {
     const components: ComponentDocs = new Map([


### PR DESCRIPTION
`writeJsonComponents`'s outDir mode named every file
`${moduleName}.api.json`, so the same basename collision #402 fixed for
`allComponentsForTypes`/`checkExamples` would let one component silently
overwrite another's JSON. Only reachable through a custom
`registerWriter` entry using `componentSet: "all"`, since the built-in
json writer always gets the exported-only, unique-by-name `components`
map.