### PR TITLE
docs(writer): document componentSet "all" key semantics

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -37,7 +37,14 @@ export interface GenerateBundleResult {
   exports: ParsedExports;
   /** Entry-barrel exports other than components. Empty when `documentExports` is off. */
   entryExports: EntryExports;
+  /** Keyed by `moduleName`, unique here because it comes from the entry barrel's export names. */
   components: ComponentDocs;
+  /**
+   * Every `--glob`-discovered `.svelte` file, keyed by resolved `filePath`
+   * rather than `moduleName`: two files in different directories can share a
+   * basename. See `WriterComponentSet` in `writer/registry.ts` for what this
+   * means for a custom writer that receives this map.
+   */
   allComponentsForTypes: ComponentDocs;
   /**
    * Components that failed to parse. Empty unless `failFast` is disabled and

--- a/src/writer/registry.ts
+++ b/src/writer/registry.ts
@@ -1,6 +1,21 @@
 import type { ComponentDocs } from "../plugin";
 
-/** Which component set a writer expects: exported-only, or every discovered component. */
+/**
+ * Which component set a writer expects.
+ *
+ * `"exported"` gets `result.components`: only components reachable from the
+ * entry barrel, keyed by `moduleName`, which is unique there by construction
+ * (JS export names can't collide).
+ *
+ * `"all"` gets `result.allComponentsForTypes`: every `.svelte` file `--glob`
+ * discovered, keyed by resolved `filePath`, not `moduleName` — two files in
+ * different directories can share a basename (e.g. `Menu/Menu.svelte` and
+ * `icons/Menu.svelte`), so `moduleName` is not unique in this set. A writer
+ * that derives an output location (a file name, a map key) from `moduleName`
+ * alone will silently drop one of the colliding components; key on `filePath`
+ * instead, or on `moduleName` only after checking for a collision (see
+ * `writer-json.ts`'s `outDir` mode for that pattern).
+ */
 export type WriterComponentSet = "exported" | "all";
 
 /**
@@ -10,7 +25,7 @@ export type WriterComponentSet = "exported" | "all";
  */
 export interface OutputWriter<TOptions = unknown> {
   name: string;
-  /** Which component set this writer expects. @default "exported" */
+  /** Which component set this writer expects — see {@link WriterComponentSet}. @default "exported" */
   componentSet?: WriterComponentSet;
   write(components: ComponentDocs, options: TOptions): Promise<unknown> | unknown;
 }

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -2,7 +2,10 @@
 import * as fs from "node:fs";
 // biome-ignore lint/performance/noNamespaceImport: needed for jest.spyOn
 import * as path from "node:path";
-import pluginSveld, { generateBundle } from "../src/plugin";
+import type { ComponentDocs, GenerateBundleResult } from "../src/plugin";
+import pluginSveld, { generateBundle, writeOutput } from "../src/plugin";
+import { registerWriter } from "../src/writer/registry";
+import { mockComponentDocApi } from "./test-brands";
 
 describe("pluginSveld", () => {
   const mockCwd = "/mock/project";
@@ -105,5 +108,79 @@ describe("generateBundle", () => {
       expect(byName.get("clamp")).toMatchObject({ kind: "function" });
       expect(byName.get("Theme")).toMatchObject({ kind: "type", isTypeOnly: true });
     });
+  });
+});
+
+describe("writeOutput additionalWriters", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('componentSet: "all" gets allComponentsForTypes, keyed by filePath so colliding moduleNames both survive', async () => {
+    let received: ComponentDocs | undefined;
+    registerWriter({
+      name: "test-all-componentset-writer",
+      componentSet: "all",
+      write: (components) => {
+        received = components;
+      },
+    });
+
+    // Two --glob-discovered components sharing a basename in different
+    // directories, same shape as the collision #402 fixed.
+    const allComponentsForTypes: ComponentDocs = new Map([
+      ["Menu/Menu.svelte", mockComponentDocApi("Menu", "Menu/Menu.svelte")],
+      ["icons/Menu.svelte", mockComponentDocApi("Menu", "icons/Menu.svelte")],
+    ]);
+
+    const result: GenerateBundleResult = {
+      exports: {},
+      entryExports: [],
+      components: new Map(),
+      allComponentsForTypes,
+      errors: [],
+      diagnostics: [],
+    };
+
+    await writeOutput(
+      result,
+      { types: false, additionalWriters: { "test-all-componentset-writer": {} } },
+      "/mock/src/index.js",
+    );
+
+    // The custom writer sees the same, filePath-keyed map: both "Menu"
+    // components are present, not collapsed into one via moduleName.
+    expect(received).toBe(allComponentsForTypes);
+    expect(received?.size).toBe(2);
+    expect(Array.from(received?.values() ?? []).map((component) => component.moduleName)).toEqual(["Menu", "Menu"]);
+  });
+
+  test('componentSet: "exported" (the default) gets components, not allComponentsForTypes', async () => {
+    let received: ComponentDocs | undefined;
+    registerWriter({
+      name: "test-exported-componentset-writer",
+      write: (components) => {
+        received = components;
+      },
+    });
+
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    const result: GenerateBundleResult = {
+      exports: {},
+      entryExports: [],
+      components,
+      allComponentsForTypes: new Map(),
+      errors: [],
+      diagnostics: [],
+    };
+
+    await writeOutput(
+      result,
+      { types: false, additionalWriters: { "test-exported-componentset-writer": {} } },
+      "/mock/src/index.js",
+    );
+
+    expect(received).toBe(components);
   });
 });

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
@@ -90,6 +90,29 @@ describe("watch mode (createSveldBundle)", () => {
 
     expect(reparsed).toContain(newPath);
     expect(byModuleName(result.allComponentsForTypes, "NewOne")).toBeDefined();
+  });
+
+  test("picks up a newly created component that shares a basename with an existing one", async () => {
+    const bundle = await createSveldBundle(dir, true);
+
+    // Same shape as the collision #402 fixed for the one-shot `generateBundle`
+    // path, but exercised through the incremental `mergeGlobbedComponents`
+    // call in `update()`, which has its own dedupe/collision-warning state.
+    mkdirSync(join(dir, "nested"));
+    const newPath = resolve(dir, "nested", "Button.svelte");
+    writeFileSync(newPath, `<script>\n  export let size = "small";\n</script>\n\n<button>{size}</button>`);
+
+    const { result, reparsed } = await bundle.update([newPath]);
+
+    expect(reparsed).toContain(newPath);
+
+    const buttons = Array.from(result.allComponentsForTypes.values()).filter((c) => c.moduleName === "Button");
+    expect(buttons).toHaveLength(2);
+
+    const original = buttons.find((c) => !c.filePath.includes("nested"));
+    const added = buttons.find((c) => c.filePath.includes("nested"));
+    expect(original?.props.map((p) => p.name)).toEqual(["primary"]);
+    expect(added?.props.map((p) => p.name)).toEqual(["size"]);
   });
 
   test("picks up a deleted component file", async () => {


### PR DESCRIPTION
`componentSet: "all"` hands a custom writer `allComponentsForTypes`
without saying it's keyed by filePath, not moduleName, or that
moduleName can repeat, and `writer-json.ts`'s own outDir mode got that
wrong until #404. Also adds the `additionalWriters` test coverage that
was completely missing, plus a watch-mode duplicate-basename case
mirroring the one-shot `generateBundle` regression test from #402.