### PR TITLE
refactor: dedupe repeated regex constants across modules

### DIFF
--- a/scripts/bundle-dts.ts
+++ b/scripts/bundle-dts.ts
@@ -18,7 +18,7 @@ const EXPORT_DEFAULT_RE = /^export\s+default\b/;
 const EXPORT_DEFAULT_PREFIX_RE = /^export\s+default\s+/;
 const EXPORT_PREFIX_RE = /^export\s+/;
 
-export type EntryName = keyof typeof ENTRY_TO_SUBPATH;
+type EntryName = keyof typeof ENTRY_TO_SUBPATH;
 
 export interface BundleDtsEntry {
   name: EntryName;

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -324,8 +324,6 @@ const CARRIAGE_RETURN_REGEX = /\r/g;
 /** Matches a JSDoc `@slot`/`@snippet` type of an empty object literal, e.g. `{{}}` or `{{ }}`. */
 const EMPTY_OBJECT_TYPE_REGEX = /^\{\s*\}$/;
 
-const _NEWLINE_CR_REGEX = /[\r\n]+/g;
-
 export interface ComponentSlot {
   /** Slot name (`null` for the default slot). */
   name?: string | null;

--- a/src/ast-guards.ts
+++ b/src/ast-guards.ts
@@ -1,8 +1,5 @@
 import type {
-  ArrowFunctionExpression,
   CallExpression,
-  FunctionDeclaration,
-  FunctionExpression,
   Identifier,
   Literal,
   MemberExpression,
@@ -35,7 +32,7 @@ export function isObjectExpression(node: unknown): node is ObjectExpression {
   return isObject(node) && node.type === "ObjectExpression" && Array.isArray(node.properties);
 }
 
-export function isCallExpression(node: unknown): node is CallExpression {
+function isCallExpression(node: unknown): node is CallExpression {
   return isObject(node) && node.type === "CallExpression";
 }
 
@@ -71,7 +68,7 @@ export function getTypeCastAnnotation(node: unknown): unknown {
   return undefined;
 }
 
-export function isNewExpression(node: unknown): node is NewExpression {
+function isNewExpression(node: unknown): node is NewExpression {
   return isObject(node) && node.type === "NewExpression";
 }
 
@@ -81,16 +78,4 @@ export function isNewExpressionNamed(node: unknown, calleeName: string): node is
   }
 
   return !!node.callee && isObject(node.callee) && node.callee.type === "Identifier" && node.callee.name === calleeName;
-}
-
-export function isFunctionDeclaration(node: unknown): node is FunctionDeclaration {
-  return isObject(node) && node.type === "FunctionDeclaration";
-}
-
-export function isFunctionExpression(node: unknown): node is FunctionExpression {
-  return isObject(node) && node.type === "FunctionExpression";
-}
-
-export function isArrowFunctionExpression(node: unknown): node is ArrowFunctionExpression {
-  return isObject(node) && node.type === "ArrowFunctionExpression";
 }

--- a/src/brands.ts
+++ b/src/brands.ts
@@ -1,6 +1,6 @@
 declare const brand: unique symbol;
 
-export type Brand<TBase extends string, TBrand extends string> = TBase & {
+type Brand<TBase extends string, TBrand extends string> = TBase & {
   readonly [brand]: TBrand;
 };
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -163,7 +163,7 @@ export interface CollectedComponents {
 }
 
 /** A `.svelte` file discovered on disk, before it's merged into `exports`/`allComponentEntries`. */
-export interface GlobbedComponentSource {
+interface GlobbedComponentSource {
   moduleName: string;
   source: ReturnType<typeof asRelativeSourcePath>;
 }
@@ -208,7 +208,7 @@ function findSvelteFiles(dir: string, results: string[] = [], visited = new Set<
  * Sorted by `source` so walk order does not depend on `readdirSync`, which
  * varies by OS.
  */
-export function globComponentSources(rootDir: string): GlobbedComponentSource[] {
+function globComponentSources(rootDir: string): GlobbedComponentSource[] {
   return findSvelteFiles(rootDir)
     .map((file) => {
       const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");

--- a/src/create-exports.ts
+++ b/src/create-exports.ts
@@ -1,6 +1,5 @@
 import type { ParsedExports } from "./parse-exports";
-
-const SVELTE_EXT_REGEX = /\.svelte$/;
+import { SVELTE_EXT_REGEX } from "./path";
 
 /**
  * Builds export statements from parsed export metadata.

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -1,7 +1,6 @@
 import { dirname, resolve } from "node:path";
 import type { ComponentDocApi, ComponentDocs, ResolveComponentFilePath } from "./bundle";
-
-const SVELTE_EXT_REGEX = /\.svelte$/;
+import { SVELTE_EXT_REGEX } from "./path";
 
 /** Strips matching surrounding single/double quotes from an import specifier. */
 const SURROUNDING_QUOTES_REGEX = /^(['"])(.*)\1$/;

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -10,7 +10,7 @@ const SURROUNDING_QUOTES_REGEX = /^(['"])(.*)\1$/;
  * or `null` when it doesn't point at a local `.svelte` file (e.g. it references
  * an external package interface like `carbon-components-svelte`).
  */
-export function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): string | null {
+function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): string | null {
   const raw = api.extends?.import;
   if (raw === undefined) return null;
   // `extends.import` is stored verbatim from the JSDoc tag, including any

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -107,7 +107,7 @@ export function formatDiagnosticsSummary(diagnostics: SveldDiagnostic[]): string
 }
 
 /** `SveldDiagnostic[]`, serialized for stream consumers with a `kind` discriminator. */
-export interface DiagnosticsJson {
+interface DiagnosticsJson {
   kind: "diagnostics";
   diagnostics: SveldDiagnostic[];
 }

--- a/src/element-tag-map.ts
+++ b/src/element-tag-map.ts
@@ -133,7 +133,7 @@ const tag_map = {
 
 type ElementTag = keyof typeof tag_map;
 
-export function isElementTag(element: string): element is ElementTag {
+function isElementTag(element: string): element is ElementTag {
   return element in tag_map;
 }
 

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -52,7 +52,7 @@ export interface SveldRuntimeOptions extends PluginSveldOptions {
 export type SveldConfig = SveldRuntimeOptions;
 
 /** Config file names probed at the project root. First existing file wins. */
-export const CONFIG_FILE_NAMES = ["sveld.config.js", "sveld.config.mjs", "sveld.config.ts"] as const;
+const CONFIG_FILE_NAMES = ["sveld.config.js", "sveld.config.mjs", "sveld.config.ts"] as const;
 
 /**
  * Identity helper that fully types a `sveld` config object.

--- a/src/parser/bindings.ts
+++ b/src/parser/bindings.ts
@@ -4,7 +4,7 @@ import type { ParserContext } from "./context";
 /** Matches a single word character; used to reject partial-name matches in {@link extractPropertyType}. */
 const WORD_CHAR_REGEX = /\w/;
 
-export function extractPropertyType(typeStr: string, propName: string): string | undefined {
+function extractPropertyType(typeStr: string, propName: string): string | undefined {
   const trimmed = typeStr.trim();
   if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return undefined;
 

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -12,14 +12,14 @@ import { sourceRangeFromNode } from "./source-position";
 const CONTEXT_KEY_SPLIT_REGEX = /[-_.:/\s]+/;
 
 /** Turn `simple-modal` into `SimpleModalContext`. */
-export function generateContextTypeName(key: string): string {
+function generateContextTypeName(key: string): string {
   const parts = key.split(CONTEXT_KEY_SPLIT_REGEX);
   const capitalized = parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("");
   return `${capitalized}Context`;
 }
 
 /** Build a {@link ComponentContext} from an object literal or variable reference. */
-export function parseContextValue(
+function parseContextValue(
   ctx: ParserContext,
   parser: ComponentParser,
   node: Node,
@@ -138,7 +138,7 @@ export function parseContextValue(
 }
 
 /** Static description from `Symbol()` / `Symbol.for()`, or `""` when unknown. Returns `null` for other calls. */
-export function resolveSymbolKeyDescription(node: CallExpression | NewExpression): string | null {
+function resolveSymbolKeyDescription(node: CallExpression | NewExpression): string | null {
   const callee = node.callee;
   if (!callee || typeof callee !== "object" || !("type" in callee)) return null;
 
@@ -170,7 +170,7 @@ export function resolveSymbolKeyDescription(node: CallExpression | NewExpression
  * Accepts literals, static templates, `const` chains (depth 5), and `Symbol()`.
  * Description-less symbols fall back to the binding name.
  */
-export function resolveContextKey(ctx: ParserContext, keyArg: unknown, depth = 0): string | null {
+function resolveContextKey(ctx: ParserContext, keyArg: unknown, depth = 0): string | null {
   if (!keyArg || typeof keyArg !== "object" || !("type" in keyArg)) return null;
   const node = keyArg as Expression;
 

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -35,7 +35,7 @@ function normalizeGenericNameSpacing(name: string): string {
   return `${base}<${normalizedParams}>`;
 }
 
-const ONLY_WHITESPACE_REGEX = /^\s*$/;
+export const ONLY_WHITESPACE_REGEX = /^\s*$/;
 
 const TRAILING_SEMICOLON_REGEX = /;$/;
 

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -131,7 +131,7 @@ function isSingleObjectLiteral(source: string): boolean {
   return depth === 0;
 }
 
-export function formatComment(comment: string) {
+function formatComment(comment: string) {
   let formatted_comment = comment;
 
   if (!formatted_comment.startsWith("/*")) {
@@ -209,13 +209,13 @@ export function getCommentTags(parsed: ReturnType<typeof parseComment>) {
   };
 }
 
-export function findJSDocComment(leadingComments: unknown[]): { value: string } | undefined {
+function findJSDocComment(leadingComments: unknown[]): { value: string } | undefined {
   if (!leadingComments || leadingComments.length === 0) return undefined;
   const comment = leadingComments[leadingComments.length - 1];
   return comment && typeof comment === "object" && "value" in comment ? (comment as { value: string }) : undefined;
 }
 
-export function findAdjacentJSDocComment(
+function findAdjacentJSDocComment(
   ctx: ParserContext,
   leadingComments: unknown[] | undefined,
   nodeStart: number | undefined,
@@ -270,7 +270,7 @@ export function processLeadingCommentsJSDoc(
   return processNodeJSDoc(ctx, parser, node);
 }
 
-export function processJSDocComment(
+function processJSDocComment(
   parser: ComponentParser,
   leadingComments: unknown[],
 ):

--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -235,7 +235,7 @@ export function processInitializer(
  * Look up a local variable's initializer AST node by name.
  * Returns the init node if found, or undefined.
  */
-export function resolveLocalVarInitializer(ctx: ParserContext, name: string): unknown | undefined {
+function resolveLocalVarInitializer(ctx: ParserContext, name: string): unknown | undefined {
   for (const decl of ctx.vars) {
     for (const declarator of decl.declarations) {
       if (
@@ -288,7 +288,7 @@ export function resolveConstInitializer(ctx: ParserContext, name: string): unkno
  * If JSDoc has no params or return either, try the function `node`, then
  * `(...args: any[]) => any`.
  */
-export function buildFunctionTypeFromParts(
+function buildFunctionTypeFromParts(
   jsdoc?: { params?: ComponentPropParam[]; returnType?: string },
   node?: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
 ): string {
@@ -313,9 +313,7 @@ export function buildFunctionTypeFromParts(
  * A default's body is a weak signal for the prop contract. We only read
  * named params and literal returns. Everything else becomes `any`.
  */
-export function inferFunctionTypeFromNode(
-  node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
-): string {
+function inferFunctionTypeFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
   return `(${inferParamsFromNode(node)}) => ${inferReturnTypeFromNode(node)}`;
 }
 
@@ -323,7 +321,7 @@ export function inferFunctionTypeFromNode(
  * Turn params into `name: any`, or use `...args: any[]` when arity is unclear:
  * no params, destructuring, rest, or defaults.
  */
-export function inferParamsFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
+function inferParamsFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
   const params = node.params;
   if (!Array.isArray(params) || params.length === 0) {
     return "...args: any[]";
@@ -352,9 +350,7 @@ export function inferParamsFromNode(node: FunctionDeclaration | FunctionExpressi
  * the same primitive. Bare `return;`, no returns, identifiers, calls,
  * objects, ternaries, async, or generators all become `any`.
  */
-export function inferReturnTypeFromNode(
-  node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
-): string {
+function inferReturnTypeFromNode(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): string {
   if (node.async || node.generator) {
     return "any";
   }
@@ -396,7 +392,7 @@ export function inferReturnTypeFromNode(
  * otherwise reach these descendant statements. Deferring it to ride along with the outer
  * traversal would mean computing prop types in a second pass instead of inline.
  */
-export function collectReturnArguments(body: unknown): unknown[] {
+function collectReturnArguments(body: unknown): unknown[] {
   const returnArgs: unknown[] = [];
   walk(body as Node, {
     enter(node) {
@@ -420,7 +416,7 @@ export function collectReturnArguments(body: unknown): unknown[] {
  * Map one return expression to `string`, `number`, or `boolean`, or `null`
  * if it isn't a literal, template literal, or `String`/`Number`/`Boolean` call.
  */
-export function inferReturnPrimitive(expr: unknown): "string" | "number" | "boolean" | null {
+function inferReturnPrimitive(expr: unknown): "string" | "number" | "boolean" | null {
   if (!expr || typeof expr !== "object" || !("type" in expr)) {
     return null;
   }

--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -26,10 +26,8 @@ import type {
   ProcessedInitializer,
 } from "../ComponentParser";
 import type { ParserContext } from "./context";
-import { sourceAtPos, sourceForExpression } from "./source-position";
+import { NEWLINE_CR_REGEX, sourceAtPos, sourceForExpression } from "./source-position";
 import { assignValueOrUndefined } from "./utils";
-
-const NEWLINE_CR_REGEX = /[\r\n]+/g;
 
 export function addProp(parser: ComponentParser, ctx: ParserContext, prop_name: string, data: ComponentProp) {
   if (assignValueOrUndefined(prop_name) === undefined) return;

--- a/src/parser/rest-props.ts
+++ b/src/parser/rest-props.ts
@@ -1,7 +1,7 @@
 import type { ComponentElement, RestProps } from "../ComponentParser";
 import type { ParserContext } from "./context";
 
-export function createRestPropsFromParent(parent: unknown): RestProps {
+function createRestPropsFromParent(parent: unknown): RestProps {
   if (!parent || typeof parent !== "object" || !("type" in parent)) return undefined;
 
   const parentType = String(parent.type);

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -60,7 +60,7 @@ function substituteTypeParameters(type: string, substitutions: Map<string, strin
 }
 
 /** Flatten a runes `$props()` type node into prop name -> metadata, following local aliases and intersections. */
-export function buildRunesPropTypeMetadataMap(
+function buildRunesPropTypeMetadataMap(
   parser: ComponentParser,
   ctx: ParserContext,
   typeNode: ModernRunesTypeNode | undefined,
@@ -174,7 +174,7 @@ export function buildRunesPropTypeMetadataMap(
 }
 
 /** The modern-AST shape `buildRunesPropTypeMetadata` reads from. */
-export type ModernParsedRoot = {
+type ModernParsedRoot = {
   instance?: ModernScriptNode & {
     content?: {
       body?: Array<{

--- a/src/parser/scopes.ts
+++ b/src/parser/scopes.ts
@@ -13,7 +13,7 @@ import type ComponentParser from "../ComponentParser";
 import type { LexicalScope, ScopeBinding, ScopeBindingKind } from "../ComponentParser";
 import type { ParserContext } from "./context";
 
-export function declareScopeBinding(scope: LexicalScope, name: string, binding: ScopeBinding) {
+function declareScopeBinding(scope: LexicalScope, name: string, binding: ScopeBinding) {
   if (!name || scope.has(name)) return;
   scope.set(name, binding);
 }
@@ -101,14 +101,14 @@ export function isScopeOwner(node: unknown) {
 }
 
 /** True for node types that introduce a new `var`-hoisting (function) scope. */
-export function isFunctionScopeOwner(node: unknown) {
+function isFunctionScopeOwner(node: unknown) {
   if (!node || typeof node !== "object" || !("type" in node)) return false;
   const type = String(node.type);
   return type === "FunctionDeclaration" || type === "FunctionExpression" || type === "ArrowFunctionExpression";
 }
 
 /** Returns the scope map for `node`, creating and caching an empty one on first access. */
-export function getOrCreateScope(ctx: ParserContext, node: object) {
+function getOrCreateScope(ctx: ParserContext, node: object) {
   let scope = ctx.scopeDeclarations.get(node);
   if (!scope) {
     scope = new Map();
@@ -118,7 +118,7 @@ export function getOrCreateScope(ctx: ParserContext, node: object) {
 }
 
 /** Scope bindings from `const { a, b: c } = $props()`. Destructured props are `prop`; rest is `local`. */
-export function extractRunesScopeBindings(
+function extractRunesScopeBindings(
   parser: ComponentParser,
   _node: VariableDeclaration,
   declarator: VariableDeclarator,
@@ -164,7 +164,7 @@ export function extractRunesScopeBindings(
 }
 
 /** Declares bindings for every declarator in a `var`/`let`/`const` declaration into the appropriate scope. */
-export function declareVariableDeclaration(
+function declareVariableDeclaration(
   parser: ComponentParser,
   declaration: unknown,
   lexicalScope: LexicalScope,
@@ -205,7 +205,7 @@ export function declareVariableDeclaration(
 }
 
 /** Declares a function-like node's own name (if any) and its parameter bindings into `scope`. */
-export function declareFunctionLikeScopeBindings(
+function declareFunctionLikeScopeBindings(
   node: FunctionExpression | ArrowFunctionExpression | FunctionDeclaration,
   scope: LexicalScope,
 ) {
@@ -221,7 +221,7 @@ export function declareFunctionLikeScopeBindings(
 }
 
 /** Declares top-level `var`/`function`/`class` bindings directly within a block's statement list. */
-export function collectDirectBlockDeclarations(
+function collectDirectBlockDeclarations(
   parser: ComponentParser,
   body: unknown,
   lexicalScope: LexicalScope,
@@ -251,7 +251,7 @@ export function collectDirectBlockDeclarations(
 }
 
 /** Declares all component-instance-level (`<script>`) bindings into `ctx.componentScope`. */
-export function collectComponentScopeDeclarations(parser: ComponentParser, ctx: ParserContext, instance: unknown) {
+function collectComponentScopeDeclarations(parser: ComponentParser, ctx: ParserContext, instance: unknown) {
   if (!instance || typeof instance !== "object") return;
 
   const program =

--- a/src/parser/slots.ts
+++ b/src/parser/slots.ts
@@ -8,7 +8,7 @@ import { assignValueOrUndefined } from "./utils";
 
 const DEFAULT_SLOT_NAME = null;
 
-export function inferSlotPropValueFromExpression(
+function inferSlotPropValueFromExpression(
   ctx: ParserContext,
   parser: ComponentParser,
   expression: unknown,
@@ -60,7 +60,7 @@ export function buildSlotPropsFromObjectExpression(
   return slot_props;
 }
 
-export function resolveRenderTagPropReference(
+function resolveRenderTagPropReference(
   ctx: ParserContext,
   callee: unknown,
 ): { publicName: string; trackingName: string } | null {

--- a/src/parser/source-position.ts
+++ b/src/parser/source-position.ts
@@ -1,7 +1,8 @@
 import type { SourcePosition, SourceRange } from "../ComponentParser";
 import type { ParserContext } from "./context";
 
-const NEWLINE_CR_REGEX = /[\r\n]+/g;
+/** Matches one or more consecutive `\r`/`\n` so multiline source can collapse to a single space. */
+export const NEWLINE_CR_REGEX = /[\r\n]+/g;
 
 /**
  * Returns (and lazily computes/caches on `ctx`) the 0-based source offset for

--- a/src/parser/source-position.ts
+++ b/src/parser/source-position.ts
@@ -8,7 +8,7 @@ export const NEWLINE_CR_REGEX = /[\r\n]+/g;
  * Returns (and lazily computes/caches on `ctx`) the 0-based source offset for
  * the start of each line in `ctx.source`.
  */
-export function getSourceLineStartOffsets(ctx: ParserContext) {
+function getSourceLineStartOffsets(ctx: ParserContext) {
   if (ctx.sourceLineStartOffsetsCache) return ctx.sourceLineStartOffsetsCache;
 
   const offsets = [0];
@@ -24,7 +24,7 @@ export function getSourceLineStartOffsets(ctx: ParserContext) {
   return offsets;
 }
 
-export function sourcePositionFromOffset(ctx: ParserContext, offset: number): SourcePosition | undefined {
+function sourcePositionFromOffset(ctx: ParserContext, offset: number): SourcePosition | undefined {
   if (!ctx.source || offset < 0 || offset > ctx.source.length) return undefined;
 
   const offsets = getSourceLineStartOffsets(ctx);

--- a/src/parser/type-resolution.ts
+++ b/src/parser/type-resolution.ts
@@ -56,7 +56,7 @@ export function getTypeReferenceName(typeName: unknown): string | undefined {
   return undefined;
 }
 
-export function getTypeDependencyName(typeName: unknown): string | undefined {
+function getTypeDependencyName(typeName: unknown): string | undefined {
   if (!typeName || typeof typeName !== "object" || !("type" in typeName)) return undefined;
 
   if (typeName.type === "Identifier" && "name" in typeName && typeof typeName.name === "string") {
@@ -228,7 +228,7 @@ export function collectReferencedTypeDependencies(
   }
 }
 
-export function buildTypeImportStatements(ctx: ParserContext, referencedImportedTypes: Set<string>) {
+function buildTypeImportStatements(ctx: ParserContext, referencedImportedTypes: Set<string>) {
   const groupedImports = new Map<
     string,
     { default: string[]; named: Array<{ imported?: string; local: string }>; namespace: string[] }

--- a/src/parser/variable-jsdoc.ts
+++ b/src/parser/variable-jsdoc.ts
@@ -1,7 +1,7 @@
 import { parse as parseComment } from "comment-parser";
 import type ComponentParser from "../ComponentParser";
 import type { ParserContext } from "./context";
-import { getCommentTags } from "./jsdoc";
+import { getCommentTags, ONLY_WHITESPACE_REGEX } from "./jsdoc";
 
 interface ScriptComment {
   /** Offset (into the full component source) right after the closing delimiter. */
@@ -16,8 +16,6 @@ interface TopLevelDeclaration {
   /** Offset of the declaration's (or, for `export`, the export statement's) first token. */
   start: number;
 }
-
-const WHITESPACE_ONLY_REGEX = /^\s*$/;
 
 function skipStringLiteral(source: string, start: number, quote: string): number {
   let i = start + 1;
@@ -162,7 +160,7 @@ function findAttachedComment(comments: ScriptComment[], declStart: number, sourc
   for (const comment of comments) {
     if (comment.end > declStart) break;
     if (!comment.isJsDoc) continue;
-    if (!WHITESPACE_ONLY_REGEX.test(source.slice(comment.end, declStart))) continue;
+    if (!ONLY_WHITESPACE_REGEX.test(source.slice(comment.end, declStart))) continue;
     attached = comment;
   }
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,6 +1,9 @@
 import path, { sep } from "node:path";
 import type { NormalizedPath } from "./brands";
 
+/** Matches a trailing `.svelte` extension. Shared so every module tests/strips it the same way. */
+export const SVELTE_EXT_REGEX = /\.svelte$/;
+
 export function normalizeSeparators(filePath: string): NormalizedPath {
   return (sep === "/" ? filePath : filePath.split(sep).join("/")) as NormalizedPath;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   toGenerateBundleOptions,
 } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
+import { SVELTE_EXT_REGEX } from "./path";
 import { createSveldBundle, type SveldBundle } from "./watch";
 // Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements" writers.
 import "./writer/built-in-writers";
@@ -94,8 +95,6 @@ interface SveldPlugin {
 
 /** Debounce window (ms) for coalescing rapid file changes into one regeneration. */
 const WATCH_DEBOUNCE_MS = 50;
-
-const SVELTE_EXT_REGEX = /\.svelte$/;
 
 export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
   const watch = opts?.watch === true;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,24 +17,8 @@ import { renderJsonDocument, renderJsonLines, type WriteJsonOptions } from "./wr
 import { renderMarkdownDocument, type WriteMarkdownOptions } from "./writer/writer-markdown";
 import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 
-export type {
-  CollectedComponents,
-  ComponentDocApi,
-  ComponentDocs,
-  ComponentParseError,
-  GenerateBundleOptions,
-  GenerateBundleResult,
-  ResolveComponentFilePath,
-} from "./bundle";
-export {
-  collectComponents,
-  collectSvelteFilePaths,
-  generateBundle,
-  processComponent,
-  readFileMap,
-  reportParseErrors,
-  toGenerateBundleOptions,
-} from "./bundle";
+export type { ComponentDocApi, ComponentDocs, GenerateBundleResult } from "./bundle";
+export { generateBundle, toGenerateBundleOptions } from "./bundle";
 
 export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolveTypes" | "cache" | "checkExamples"> {
   /**

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -22,7 +22,7 @@ import { loadParserStack } from "./parser-stack";
 import { SVELTE_EXT_REGEX } from "./path";
 
 /** Result of an incremental update. */
-export interface SveldBundleUpdate {
+interface SveldBundleUpdate {
   /** The full, updated bundle result (all components, with the affected ones re-parsed). */
   result: GenerateBundleResult;
   /**

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -19,8 +19,7 @@ import { dedupeDiagnostics } from "./diagnostics";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import type { ParsedExports } from "./parse-exports";
 import { loadParserStack } from "./parser-stack";
-
-const SVELTE_EXT_REGEX = /\.svelte$/;
+import { SVELTE_EXT_REGEX } from "./path";
 
 /** Result of an incremental update. */
 export interface SveldBundleUpdate {

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -23,7 +23,7 @@ export function formatPropType(type?: string) {
   return `<code>${type.replace(PIPE_REGEX, "&#124;")}</code>`;
 }
 
-export function escapeHtml(text: string) {
+function escapeHtml(text: string) {
   return text.replace(LT_REGEX, "&lt;").replace(GT_REGEX, "&gt;");
 }
 

--- a/src/writer/registry.ts
+++ b/src/writer/registry.ts
@@ -16,7 +16,7 @@ import type { ComponentDocs } from "../plugin";
  * instead, or on `moduleName` only after checking for a collision (see
  * `writer-json.ts`'s `outDir` mode for that pattern).
  */
-export type WriterComponentSet = "exported" | "all";
+type WriterComponentSet = "exported" | "all";
 
 /**
  * A pluggable output format. Built-in writers (`json`, `markdown`, `types`)

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { removeSvelteExt } from "../create-exports";
 import { info } from "../logger";
 import type { EntryExports } from "../parse-entry-exports";
 import { formatJsonOutput, normalizeComponentFilePath } from "../path";
@@ -32,8 +33,6 @@ function withNormalizedFilePaths(components: ComponentDocApi[], inputDir: string
   }));
 }
 
-const SVELTE_EXT_REGEX = /\.svelte$/;
-
 /**
  * JSON output file name for one component.
  *
@@ -54,7 +53,7 @@ function jsonFileName(component: ComponentDocApi, hasCollision: boolean, warnedM
     );
   }
 
-  return component.filePath.replace(SVELTE_EXT_REGEX, ".api.json");
+  return `${removeSvelteExt(component.filePath)}.api.json`;
 }
 
 async function writeJsonComponents(components: ComponentDocs, options: WriteJsonOptions) {

--- a/tests/test-brands.ts
+++ b/tests/test-brands.ts
@@ -1,8 +1,8 @@
-import { asNormalizedPath, asRelativeSourcePath, type NormalizedPath, type RelativeSourcePath } from "../src/brands";
+import { asNormalizedPath, asRelativeSourcePath, type RelativeSourcePath } from "../src/brands";
 import type { ParsedExports } from "../src/parse-exports";
 import type { ComponentDocApi } from "../src/plugin";
 
-export function mockRelativeSourcePath(source: string): RelativeSourcePath {
+function mockRelativeSourcePath(source: string): RelativeSourcePath {
   return asRelativeSourcePath(source);
 }
 
@@ -38,5 +38,3 @@ export function mockComponentDocApi(
     ...overrides,
   };
 }
-
-export type { NormalizedPath, RelativeSourcePath };


### PR DESCRIPTION
Also strips exports and types that nothing outside their own file used,
caught by a one-off `bunx knip` pass. Neither change touches behavior.