### PR TITLE
feat(writer): add typesOptions.exportTypes to scope .d.ts exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ export default class Button extends SvelteComponentTyped<
 - [Approach](#approach)
 - [Features](#features)
   - [`.d.ts` output format (`typesOptions.format`)](#dts-output-format-typesoptionsformat)
+  - [Restricting `.d.ts` exports (`typesOptions.exportTypes`)](#restricting-dts-exports-typesoptionsexporttypes)
   - [Opt-in semantic resolution (`resolveTypes`)](#opt-in-semantic-resolution-resolvetypes)
   - [Persistent parse cache (`cache`)](#persistent-parse-cache-cache)
   - [Compile-checked `@example` blocks (`checkExamples`)](#compile-checked-example-blocks-checkexamples)
@@ -253,6 +254,30 @@ export default GenericList;
 ```
 
 Both signatures carry their own generic parameter (not the `const` itself), so `Item` is inferred per usage site, e.g. `<GenericList items={numbers} />` infers `Item` from `numbers`. The `new` signature is the one place `"component"` format still touches a legacy type (`SvelteComponent`/`ComponentConstructorOptions`, not the deprecated `SvelteComponentTyped`): the Svelte language server resolves generic inference for `<Comp prop={...} />` template usage through `new`, not the plain call signature, confirmed by comparing against `@sveltejs/package`'s own generated output for the same component. Omitting it silently breaks inference instead of erroring, so it stays in even though it means one legacy import for generic components.
+
+### Restricting `.d.ts` exports (`typesOptions.exportTypes`)
+
+By default, every supporting type sveld generates alongside a component — the `<Name>Props` type, the `<Name>Exports` type (`"component"` format), `@typedef`s, and context types — is exported, so consumers can import them directly (e.g. `import type { ButtonProps } from "my-library"`).
+
+Set `typesOptions.exportTypes: false` to keep the `.d.ts` public surface to just the component itself: every supporting type is still generated (the component's own declaration still references it), but declared without `export`, so it's inaccessible from outside the file.
+
+```ts
+await sveld({ types: true, typesOptions: { exportTypes: false } });
+```
+
+```ts
+import { SvelteComponentTyped } from "svelte";
+
+type ButtonProps = { label?: string };
+
+export default class Button extends SvelteComponentTyped<
+  ButtonProps,
+  { click: WindowEventMap["click"] },
+  { default: Record<string, never> }
+> {}
+```
+
+Exports from `<script context="module">` are unaffected — they mirror `export` statements the component source itself already declares, not a type sveld invented, so they keep whatever export shape the source gives them.
 
 ### Opt-in semantic resolution (`resolveTypes`)
 
@@ -708,8 +733,9 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`glob`** (boolean, optional): Enable glob mode to analyze all `*.svelte` files.
 - **`documentExports`** (boolean, optional): Include consts, functions, and types from the entry barrel in JSON (`exports`) and Markdown ("Exports"). Off by default. See [Documenting Entry Exports](#documenting-entry-exports).
 - **`types`** (boolean, optional, default: `true`): Generate TypeScript definitions.
-- **`typesOptions`** (object, optional): Options for TypeScript definition generation, including `outDir`, `preamble`, and `format`.
+- **`typesOptions`** (object, optional): Options for TypeScript definition generation, including `outDir`, `preamble`, `format`, and `exportTypes`.
   - **`format`** (`"class"` | `"component"`, optional, default: `"class"`): `.d.ts` output shape. `"class"` extends `SvelteComponentTyped`; `"component"` emits the Svelte 5 `Component` type. Also available as `--types-format`. See [`.d.ts` output format](#dts-output-format-typesoptionsformat).
+  - **`exportTypes`** (boolean, optional, default: `true`): Export every supporting type sveld generates (`<Name>Props`, `<Name>Exports`, `@typedef`s, context types). Set to `false` to declare them without `export`, so only the component's own type stays part of the `.d.ts` public surface. See [Restricting `.d.ts` exports](#restricting-dts-exports-typesoptionsexporttypes).
 - **`json`** (boolean, optional): Generate component documentation in JSON format.
 - **`jsonOptions`** (object, optional): Options for JSON output.
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -121,12 +121,13 @@ export function formatTsProps(props?: string) {
   return `${props}\n`;
 }
 
-export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">) {
+export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">, exportTypes = true) {
   if (def.typedefs.length === 0) return EMPTY_STR;
+  const exportKeyword = exportTypes ? "export " : "";
   return def.typedefs
     .map((typedef) => {
       const typedefComment = typedef.description ? `${formatMultiLineComment(typedef.description)}\n` : "";
-      return `${typedefComment}export ${typedef.ts}`;
+      return `${typedefComment}${exportKeyword}${typedef.ts}`;
     })
     .join("\n\n");
 }
@@ -186,8 +187,9 @@ function computeReferencedGenerics(generics: ComponentDocApi["generics"], text: 
  * // };
  * ```
  */
-export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics">) {
+export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics">, exportTypes = true) {
   if (!def.contexts || def.contexts.length === 0) return EMPTY_STR;
+  const exportKeyword = exportTypes ? "export " : "";
 
   /**
    * Pair each generic name with its constraint declaration so the context type
@@ -238,10 +240,10 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
        * This complies with Biome linter rules and Svelte 4 compatibility.
        */
       if (context.properties.length === 0) {
-        return `${contextComment}export type ${context.typeName} = Record<string, never>;`;
+        return `${contextComment}${exportKeyword}type ${context.typeName} = Record<string, never>;`;
       }
 
-      return `${contextComment}export type ${context.typeName}${genericSuffix} = {\n  ${props}\n};`;
+      return `${contextComment}${exportKeyword}type ${context.typeName}${genericSuffix} = {\n  ${props}\n};`;
     })
     .join("\n\n");
 }
@@ -310,7 +312,10 @@ function genPropDef(
      */
     events?: ComponentDocApi["events"];
   },
+  exportTypes = true,
 ) {
+  const exportKeyword = exportTypes ? "export " : "";
+
   /**
    * Collect existing prop names to avoid conflicts with snippet props.
    * Snippet props are generated for slots, but shouldn't conflict with
@@ -530,7 +535,7 @@ function genPropDef(
     };`
     }
 
-    export type ${props_name}${genericsName} = Omit<$RestProps, keyof $Props${genericsNameRef}> & $Props${genericsNameRef};
+    ${exportKeyword}type ${props_name}${genericsName} = Omit<$RestProps, keyof $Props${genericsNameRef}> & $Props${genericsNameRef};
   `;
     } else {
       prop_def = `
@@ -548,7 +553,7 @@ function genPropDef(
     };`
     }
 
-    export type ${props_name}${genericsName} = Omit<$RestProps, keyof ($Props${genericsNameRef} & ${def.extends.interface})> & $Props${genericsNameRef} & ${def.extends.interface};
+    ${exportKeyword}type ${props_name}${genericsName} = Omit<$RestProps, keyof ($Props${genericsNameRef} & ${def.extends.interface})> & $Props${genericsNameRef} & ${def.extends.interface};
   `;
     }
   } else {
@@ -559,16 +564,16 @@ function genPropDef(
      */
     if (props.trim() === "" && def.extends === undefined && !def.canonicalPropsType) {
       prop_def = `
-    export type ${props_name}${genericsName} = ${EMPTY_OBJECT};
+    ${exportKeyword}type ${props_name}${genericsName} = ${EMPTY_OBJECT};
   `;
     } else if (def.canonicalPropsType) {
       prop_def = `
     ${basePropsDef}
-    export type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `${def.extends.interface} & `}$Props${genericsNameRef};
+    ${exportKeyword}type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `${def.extends.interface} & `}$Props${genericsNameRef};
   `;
     } else {
       prop_def = `
-    export type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `${def.extends.interface} & `} {
+    ${exportKeyword}type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `${def.extends.interface} & `} {
       ${props}
     };
   `;
@@ -826,12 +831,17 @@ function genAccessors(def: Pick<ComponentDocApi, "props">) {
  * `exports_ref` is the corresponding reference form (e.g. `FooExports<Row>`)
  * for use at the call site.
  */
-function genExportsDef(def: Pick<ComponentDocApi, "props" | "moduleName" | "generics">) {
+function genExportsDef(def: Pick<ComponentDocApi, "props" | "moduleName" | "generics">, exportTypes = true) {
   const exports_name = `${def.moduleName}Exports`;
   const accessors = genAccessors({ props: def.props });
+  const exportKeyword = exportTypes ? "export " : "";
 
   if (accessors.trim() === "") {
-    return { exports_name, exports_ref: exports_name, exports_def: `export type ${exports_name} = ${EMPTY_OBJECT};` };
+    return {
+      exports_name,
+      exports_ref: exports_name,
+      exports_def: `${exportKeyword}type ${exports_name} = ${EMPTY_OBJECT};`,
+    };
   }
 
   const { declSuffix, refSuffix } = computeReferencedGenerics(def.generics, accessors);
@@ -839,7 +849,7 @@ function genExportsDef(def: Pick<ComponentDocApi, "props" | "moduleName" | "gene
   return {
     exports_name,
     exports_ref: `${exports_name}${refSuffix}`,
-    exports_def: `export type ${exports_name}${declSuffix} = {${accessors}\n  };`,
+    exports_def: `${exportKeyword}type ${exports_name}${declSuffix} = {${accessors}\n  };`,
   };
 }
 
@@ -1048,6 +1058,17 @@ export interface WriteTsDefinitionOptions {
    * parameter (see `genGenericComponentDeclaration`).
    */
   format?: "class" | "component";
+  /**
+   * By default, supporting types generated alongside the component (the
+   * `<Name>Props` type, `<Name>Exports` type, `@typedef`s, and context types)
+   * are all exported. Set to `false` to export only the component's own type
+   * (the `class`/`declare const` shell) and declare everything else without
+   * `export`, keeping the `.d.ts` public surface to just the component itself.
+   * Module exports (from `<script context="module">`) mirror the source's own
+   * `export` statements and are unaffected.
+   * @default true
+   */
+  exportTypes?: boolean;
 }
 
 export function writeTsDefinition(component: ComponentDocApi, options?: WriteTsDefinitionOptions) {
@@ -1069,29 +1090,33 @@ export function writeTsDefinition(component: ComponentDocApi, options?: WriteTsD
 
   const useComponentFormat = options?.format === "component";
   const isGenericComponent = generics !== null;
+  const exportTypes = options?.exportTypes ?? true;
 
-  const { props_name, prop_def } = genPropDef({
-    moduleName,
-    props,
-    rest_props,
-    extends: _extends,
-    generics,
-    slots,
-    canonicalPropNames: new Set(typeScriptMetadata?.canonicalPropNames ?? []),
-    canonicalPropsType: typeScriptMetadata?.canonicalPropsType,
-    events: useComponentFormat && syntaxMode === "legacy" ? events : undefined,
-  });
+  const { props_name, prop_def } = genPropDef(
+    {
+      moduleName,
+      props,
+      rest_props,
+      extends: _extends,
+      generics,
+      slots,
+      canonicalPropNames: new Set(typeScriptMetadata?.canonicalPropNames ?? []),
+      canonicalPropsType: typeScriptMetadata?.canonicalPropsType,
+      events: useComponentFormat && syntaxMode === "legacy" ? events : undefined,
+    },
+    exportTypes,
+  );
 
   const generic = generics ? `<${generics[1]}>` : "";
   const genericProps = generics ? `${props_name}<${generics[0]}>` : props_name;
   const moduleExportsDef = genModuleExports({ moduleExports });
-  const typeDefs = getTypeDefs({ typedefs });
-  const contextDefs = getContextDefs({ contexts, generics });
+  const typeDefs = getTypeDefs({ typedefs }, exportTypes);
+  const contextDefs = getContextDefs({ contexts, generics }, exportTypes);
   const preservedTypeImports = (typeScriptMetadata?.typeImportStatements ?? []).join("\n");
   const preservedLocalTypeDeclarations = (typeScriptMetadata?.localTypeDeclarations ?? []).join("\n\n");
 
   const { exports_ref, exports_def } = useComponentFormat
-    ? genExportsDef({ props, moduleName, generics })
+    ? genExportsDef({ props, moduleName, generics }, exportTypes)
     : { exports_ref: EMPTY_STR, exports_def: EMPTY_STR };
   const bindings = useComponentFormat ? genBindingsUnion({ props }) : EMPTY_STR;
 

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -71,14 +71,14 @@ export default async function writeTsDefinitions(components: ComponentDocs, opti
   const indexDTs = options.preamble + createExports(options.exports);
 
   const document = buildComponentApiDocument(components);
-  // Must match the default `writeTsDefinition` assumes for `options.format === undefined`.
-  const cacheFormatKey = options.format ?? "class";
+  // Must match the defaults `writeTsDefinition` assumes for `options.format`/`options.exportTypes === undefined`.
+  const cacheFormatKey = `${options.format ?? "class"}:${options.exportTypes === false ? "no-export-types" : "export-types"}`;
   const writePromises = document.components.map(async (component) => {
     const ts_filepath = convertSvelteExt(join(options.outDir, component.filePath));
     const resolvedPath = options.resolvedPathByFilePath?.get(component.filePath);
     let text = resolvedPath ? options.cache?.getGeneratedText(resolvedPath, cacheFormatKey) : undefined;
     if (text === undefined) {
-      text = writeTsDefinition(component, { format: options.format });
+      text = writeTsDefinition(component, { format: options.format, exportTypes: options.exportTypes });
       if (resolvedPath) options.cache?.setGeneratedText(resolvedPath, cacheFormatKey, text);
     }
     await writer.write(ts_filepath, text);

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -180,8 +180,8 @@ describe("generated .d.ts text cache", () => {
     first.cache?.save();
 
     // Both components' generated text is now cached against the first run's parse.
-    expect(first.cache?.getGeneratedText(secondaryButtonPath, "class")).toBeDefined();
-    expect(first.cache?.getGeneratedText(standalonePath, "class")).toBeDefined();
+    expect(first.cache?.getGeneratedText(secondaryButtonPath, "class:export-types")).toBeDefined();
+    expect(first.cache?.getGeneratedText(standalonePath, "class:export-types")).toBeDefined();
 
     writeFileSync(join(dir, "Button.svelte"), BUTTON.replace("primary = false", "primary = true"));
     const second = await generateBundle(dir, true, { cache: cacheFile });
@@ -189,10 +189,10 @@ describe("generated .d.ts text cache", () => {
     // SecondaryButton depends on Button via @extendProps, so it's invalidated
     // and reparsed even though its own source didn't change; its fresh parse
     // entry must not carry over the stale cached text.
-    expect(second.cache?.getGeneratedText(secondaryButtonPath, "class")).toBeUndefined();
+    expect(second.cache?.getGeneratedText(secondaryButtonPath, "class:export-types")).toBeUndefined();
     // Standalone is unrelated and still a parse-cache hit, so its previously
     // cached text is legitimately reused.
-    expect(second.cache?.getGeneratedText(standalonePath, "class")).toBeDefined();
+    expect(second.cache?.getGeneratedText(standalonePath, "class:export-types")).toBeDefined();
   });
 
   test("--types-format switch doesn't serve a component's other-format cached text", async () => {
@@ -211,8 +211,28 @@ describe("generated .d.ts text cache", () => {
     first.cache?.save();
 
     const second = await generateBundle(dir, true, { cache: cacheFile });
-    expect(second.cache?.getGeneratedText(buttonPath, "class")).toBeDefined();
-    expect(second.cache?.getGeneratedText(buttonPath, "component")).toBeUndefined();
+    expect(second.cache?.getGeneratedText(buttonPath, "class:export-types")).toBeDefined();
+    expect(second.cache?.getGeneratedText(buttonPath, "component:export-types")).toBeUndefined();
+  });
+
+  test("exportTypes switch doesn't serve a component's other-exportTypes cached text", async () => {
+    const buttonPath = resolve(dir, "Button.svelte");
+
+    const first = await generateBundle(dir, true, { cache: cacheFile });
+    await writeTsDefinitions(first.allComponentsForTypes, {
+      outDir,
+      inputDir: dir,
+      preamble: "",
+      exports: first.exports,
+      exportTypes: true,
+      cache: first.cache,
+      resolvedPathByFilePath: first.resolvedPathByFilePath,
+    });
+    first.cache?.save();
+
+    const second = await generateBundle(dir, true, { cache: cacheFile });
+    expect(second.cache?.getGeneratedText(buttonPath, "class:export-types")).toBeDefined();
+    expect(second.cache?.getGeneratedText(buttonPath, "class:no-export-types")).toBeUndefined();
   });
 });
 

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -990,6 +990,113 @@ export default Button;`,
   });
 });
 
+describe("writeTsDefinition with exportTypes: false", () => {
+  test('"class" format exports only the component; the Props type stays local', () => {
+    const component_api = mockComponentDocApi("Button", "./src/Button.svelte", {
+      props: [
+        {
+          name: "label",
+          kind: "let",
+          type: "string",
+          value: '""',
+          isFunction: false,
+          isFunctionDeclaration: false,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+        },
+      ],
+    });
+
+    const output = writeTsDefinition(component_api, { exportTypes: false });
+    expect(output).toContain("type ButtonProps = {");
+    expect(output).not.toContain("export type ButtonProps");
+    expect(output).toContain("export default class Button extends SvelteComponentTyped<");
+  });
+
+  test('"component" format exports only the component; Props and Exports types stay local', () => {
+    const component_api = mockComponentDocApi("Button", "./src/Button.svelte", {
+      syntaxMode: "runes",
+      props: [
+        {
+          name: "increment",
+          kind: "function",
+          type: "() => any",
+          isFunction: true,
+          isFunctionDeclaration: true,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+        },
+      ],
+    });
+
+    const output = writeTsDefinition(component_api, { format: "component", exportTypes: false });
+    expect(output).toContain("type ButtonProps = Record<string, never>;");
+    expect(output).not.toContain("export type ButtonProps");
+    expect(output).toContain("type ButtonExports = {");
+    expect(output).not.toContain("export type ButtonExports");
+    expect(output).toContain("declare const Button: Component<");
+    expect(output).toContain("export default Button;");
+  });
+
+  test("typedefs and context types are declared without export", () => {
+    const component_api = mockComponentDocApi("Modal", "./src/Modal.svelte", {
+      typedefs: [
+        {
+          type: "{ [key: string]: boolean; }",
+          name: "MyTypedef",
+          ts: "interface MyTypedef { [key: string]: boolean; }",
+        },
+      ],
+      contexts: [
+        {
+          key: "simple-modal",
+          typeName: "SimpleModalContext",
+          properties: [{ name: "close", type: "() => void", optional: false }],
+        },
+      ],
+    });
+
+    const output = writeTsDefinition(component_api, { exportTypes: false });
+    expect(output).toContain("interface MyTypedef {");
+    expect(output).not.toContain("export interface MyTypedef");
+    expect(output).toContain("type SimpleModalContext = {");
+    expect(output).not.toContain("export type SimpleModalContext");
+  });
+
+  test("module exports (script context=module) stay exported regardless", () => {
+    const component_api = mockComponentDocApi("TestComponent", "./src/TestComponent.svelte", {
+      moduleExports: [
+        {
+          name: "computeDepth",
+          kind: "function",
+          type: "() => any",
+          isFunction: true,
+          isFunctionDeclaration: true,
+          isRequired: false,
+          constant: false,
+          reactive: false,
+          returnType: "number",
+        },
+      ],
+    });
+
+    const output = writeTsDefinition(component_api, { exportTypes: false });
+    expect(output).toContain("export declare function computeDepth(): number;");
+  });
+
+  test("getTypeDefs and getContextDefs omit export when passed exportTypes: false directly", () => {
+    expect(getTypeDefs({ typedefs: [{ type: "boolean", name: "Flag", ts: "type Flag = boolean;" }] }, false)).toEqual(
+      "type Flag = boolean;",
+    );
+
+    expect(
+      getContextDefs({ contexts: [{ key: "k", typeName: "KContext", properties: [] }], generics: null }, false),
+    ).toEqual("type KContext = Record<string, never>;");
+  });
+});
+
 describe("writeTsDefinitions", () => {
   let errorSpy: ReturnType<typeof jest.spyOn>;
 


### PR DESCRIPTION
Lets you keep only the component's own type public in generated
.d.ts files. Supporting types (Props, Exports, typedefs, context
types) are still generated and used internally, just declared
without export when the option is off. Module exports from
`<script context="module">` are unaffected since they mirror
explicit source exports rather than sveld-invented types.