### PR TITLE
fix(parser): resolve CallExpression prop-default types

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -940,6 +940,24 @@ export default class ComponentParser {
     if (this.ctx.parsed?.module) {
       walk(this.ctx.parsed?.module as unknown as Node, {
         enter: (node) => {
+          // Module bindings are in scope for the instance script. Track the same
+          // import/function/var leads the instance walk does so CallExpression
+          // prop defaults (often in the instance script) can resolve them.
+          if (node.type === "ImportDeclaration") {
+            collectValueImportBindings(this.ctx, node as unknown as ImportDeclarationNode);
+          }
+
+          if (node.type === "FunctionDeclaration") {
+            const funcDecl = node as unknown as FunctionDeclaration;
+            if (funcDecl.id?.name) {
+              this.ctx.funcDecls.set(funcDecl.id.name, funcDecl);
+            }
+          }
+
+          if (node.type === "VariableDeclaration") {
+            this.ctx.vars.add(node as unknown as VariableDeclaration);
+          }
+
           if (node.type === "ExportNamedDeclaration") {
             if (node.declaration == null) {
               return;

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -53,6 +53,7 @@ import { sourceAtPos, sourceRangeFromNode, sourceRangeFromOffsets } from "./pars
 import { buildTypeScriptMetadata } from "./parser/type-resolution";
 import { stripTypeCastWrappers } from "./parser/typescript-casts";
 import { assignValueOrUndefined } from "./parser/utils";
+import { collectValueImportBindings, type ImportDeclarationNode } from "./parser/value-imports";
 import { buildVariableJsDocTable } from "./parser/variable-jsdoc";
 import { parseModernAndLegacy } from "./svelte-parse";
 
@@ -149,6 +150,29 @@ export interface TypeImportBinding {
   specifierType: "default" | "named" | "namespace";
 }
 
+/** A named *value* import binding (`import { x } from "..."`), tracked for cross-file call-default resolution. */
+export interface ValueImportBinding {
+  localName: string;
+  importedName: string;
+  source: string;
+}
+
+/**
+ * A prop whose default is a `CallExpression` (`export let id = uniqueId()`) sveld could not
+ * resolve a return type for during AST-local parsing. When `importSource` is set, the callee
+ * came from a named import and a later, Node-only pass (`resolve-call-defaults.ts`, run from
+ * `bundle.ts`) can still resolve it by reading the target module. Without `importSource` the
+ * callee is a same-file function with no derivable return type, or an unknown identifier - no
+ * further resolution is possible, but the candidate is kept so the diagnostic can name the callee.
+ */
+export interface PendingCallDefaultCandidate {
+  propName: string;
+  location: "props" | "moduleExports";
+  calleeName: string;
+  importSource?: string;
+  importedName?: string;
+}
+
 export interface LocalTypeDeclaration {
   code: string;
   node: ModernRunesTypeNode;
@@ -167,6 +191,8 @@ export interface ParsedComponentTypeScriptMetadata {
    * component's props as their AST-derived text rather than expand them.
    */
   referencesComponentGenerics?: boolean;
+  /** Props with an unresolved `CallExpression` default, for `resolve-call-defaults.ts` to pick up. */
+  pendingCallDefaultCandidates?: PendingCallDefaultCandidate[];
 }
 
 export {
@@ -207,6 +233,13 @@ export interface ProcessedInitializer {
   resolvedDescription?: string;
   resolvedParams?: ComponentPropParam[];
   resolvedReturnType?: string;
+  /**
+   * Set when the initializer is a `CallExpression` whose callee return type
+   * could not be resolved during AST-local parsing (see
+   * {@link PendingCallDefaultCandidate}). The caller fills in `propName`/
+   * `location` and records it on {@link ParserContext.pendingCallDefaultCandidates}.
+   */
+  pendingCallDefault?: Omit<PendingCallDefaultCandidate, "propName" | "location">;
 }
 
 type ModernScriptAttribute = {
@@ -928,7 +961,11 @@ export default class ComponentParser {
             let resolvedJSDoc:
               | Pick<
                   ProcessedInitializer,
-                  "resolvedType" | "resolvedDescription" | "resolvedParams" | "resolvedReturnType"
+                  | "resolvedType"
+                  | "resolvedDescription"
+                  | "resolvedParams"
+                  | "resolvedReturnType"
+                  | "pendingCallDefault"
                 >
               | undefined;
 
@@ -962,6 +999,13 @@ export default class ComponentParser {
               inferredTypeForSource = typeSeed;
               resolvedJSDoc = initResult;
               explicitType = this.getExplicitPropType(localPropName);
+              if (resolvedJSDoc.pendingCallDefault) {
+                this.ctx.pendingCallDefaultCandidates.push({
+                  propName: localPropName,
+                  location: "moduleExports",
+                  ...resolvedJSDoc.pendingCallDefault,
+                });
+              }
             } else {
               return;
             }
@@ -1118,6 +1162,10 @@ export default class ComponentParser {
           }
         }
 
+        if (node.type === "ImportDeclaration") {
+          collectValueImportBindings(this.ctx, node as unknown as ImportDeclarationNode);
+        }
+
         if (node.type === "VariableDeclaration") {
           this.ctx.vars.add(node as unknown as VariableDeclaration);
           if (
@@ -1192,7 +1240,7 @@ export default class ComponentParser {
           let resolvedJSDoc:
             | Pick<
                 ProcessedInitializer,
-                "resolvedType" | "resolvedDescription" | "resolvedParams" | "resolvedReturnType"
+                "resolvedType" | "resolvedDescription" | "resolvedParams" | "resolvedReturnType" | "pendingCallDefault"
               >
             | undefined;
 
@@ -1231,6 +1279,13 @@ export default class ComponentParser {
             ({ value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult);
             inferredTypeForSource = typeSeed;
             resolvedJSDoc = initResult;
+            if (resolvedJSDoc.pendingCallDefault) {
+              this.ctx.pendingCallDefaultCandidates.push({
+                propName: prop_name,
+                location: "props",
+                ...resolvedJSDoc.pendingCallDefault,
+              });
+            }
           } else {
             return;
           }
@@ -1720,15 +1775,35 @@ export default class ComponentParser {
     const typedefsArray = ComponentParser.mapToArray(this.ctx.typedefs);
     const contextsArray = ComponentParser.mapToArray(this.ctx.contexts);
 
+    const pendingCallDefaultsByLocation = {
+      props: new Map(
+        this.ctx.pendingCallDefaultCandidates.filter((c) => c.location === "props").map((c) => [c.propName, c]),
+      ),
+      moduleExports: new Map(
+        this.ctx.pendingCallDefaultCandidates.filter((c) => c.location === "moduleExports").map((c) => [c.propName, c]),
+      ),
+    };
+
     for (const prop of processedProps) {
       if (prop.typeSource === "unknown") {
-        recordDiagnostic(
-          this.ctx,
-          "prop-unknown-type",
-          prop.name,
-          `Prop "${prop.name}" type could not be inferred; falling back to "${prop.type ?? "any"}".`,
-          prop.source,
-        );
+        const callDefault = pendingCallDefaultsByLocation.props.get(prop.name);
+        // A `CallExpression` default's type never stays `undefined`: the writer would render
+        // the literal string `id?: undefined;`, which is worse than `any` for consumers.
+        if (callDefault) prop.type = "any";
+
+        const message = callDefault
+          ? callDefault.importSource
+            ? `Prop "${prop.name}" default calls "${callDefault.calleeName}()" imported from "${callDefault.importSource}"; falling back to "any" pending cross-file resolution.`
+            : `Prop "${prop.name}" default calls "${callDefault.calleeName}()", but its return type could not be inferred; falling back to "any".`
+          : `Prop "${prop.name}" type could not be inferred; falling back to "${prop.type ?? "any"}".`;
+
+        recordDiagnostic(this.ctx, "prop-unknown-type", prop.name, message, prop.source);
+      }
+    }
+
+    for (const moduleExport of moduleExportsArray) {
+      if (moduleExport.typeSource === "unknown" && pendingCallDefaultsByLocation.moduleExports.has(moduleExport.name)) {
+        moduleExport.type = "any";
       }
     }
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -150,7 +150,7 @@ export interface TypeImportBinding {
   specifierType: "default" | "named" | "namespace";
 }
 
-/** A named *value* import binding (`import { x } from "..."`), tracked for cross-file call-default resolution. */
+/** Named value import (`import { x } from "..."`) keyed for cross-file call-default lookup. */
 export interface ValueImportBinding {
   localName: string;
   importedName: string;
@@ -158,12 +158,10 @@ export interface ValueImportBinding {
 }
 
 /**
- * A prop whose default is a `CallExpression` (`export let id = uniqueId()`) sveld could not
- * resolve a return type for during AST-local parsing. When `importSource` is set, the callee
- * came from a named import and a later, Node-only pass (`resolve-call-defaults.ts`, run from
- * `bundle.ts`) can still resolve it by reading the target module. Without `importSource` the
- * callee is a same-file function with no derivable return type, or an unknown identifier - no
- * further resolution is possible, but the candidate is kept so the diagnostic can name the callee.
+ * Prop default is a `CallExpression` whose return type we could not resolve in-parser
+ * (`export let id = uniqueId()`). With `importSource`, `resolve-call-defaults.ts` (from
+ * `generateBundle`) can still read the target module. Without it, keep the candidate so
+ * the diagnostic can name the callee.
  */
 export interface PendingCallDefaultCandidate {
   propName: string;
@@ -191,7 +189,7 @@ export interface ParsedComponentTypeScriptMetadata {
    * component's props as their AST-derived text rather than expand them.
    */
   referencesComponentGenerics?: boolean;
-  /** Props with an unresolved `CallExpression` default, for `resolve-call-defaults.ts` to pick up. */
+  /** Unresolved CallExpression defaults for the cross-file pass in `generateBundle`. */
   pendingCallDefaultCandidates?: PendingCallDefaultCandidate[];
 }
 
@@ -234,10 +232,9 @@ export interface ProcessedInitializer {
   resolvedParams?: ComponentPropParam[];
   resolvedReturnType?: string;
   /**
-   * Set when the initializer is a `CallExpression` whose callee return type
-   * could not be resolved during AST-local parsing (see
-   * {@link PendingCallDefaultCandidate}). The caller fills in `propName`/
-   * `location` and records it on {@link ParserContext.pendingCallDefaultCandidates}.
+   * CallExpression default with no in-parser return type
+   * ({@link PendingCallDefaultCandidate}). Caller adds `propName`/`location`
+   * onto {@link ParserContext.pendingCallDefaultCandidates}.
    */
   pendingCallDefault?: Omit<PendingCallDefaultCandidate, "propName" | "location">;
 }
@@ -940,9 +937,8 @@ export default class ComponentParser {
     if (this.ctx.parsed?.module) {
       walk(this.ctx.parsed?.module as unknown as Node, {
         enter: (node) => {
-          // Module bindings are in scope for the instance script. Track the same
-          // import/function/var leads the instance walk does so CallExpression
-          // prop defaults (often in the instance script) can resolve them.
+          // Module script is in scope for instance. Record imports/funcs/vars
+          // the same way so instance CallExpression defaults can see them.
           if (node.type === "ImportDeclaration") {
             collectValueImportBindings(this.ctx, node as unknown as ImportDeclarationNode);
           }
@@ -1805,8 +1801,7 @@ export default class ComponentParser {
     for (const prop of processedProps) {
       if (prop.typeSource === "unknown") {
         const callDefault = pendingCallDefaultsByLocation.props.get(prop.name);
-        // A `CallExpression` default's type never stays `undefined`: the writer would render
-        // the literal string `id?: undefined;`, which is worse than `any` for consumers.
+        // Never leave type unset: the writer would emit `id?: undefined;`.
         if (callDefault) prop.type = "any";
 
         const message = callDefault

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -682,8 +682,11 @@ export async function generateBundle(
 
   // AST/JSDoc-text only (no tsc), so - unlike resolveTypes - this always runs, keyed on
   // whatever `pendingCallDefaultCandidates` parsing found; a no-op when there are none.
+  // Fully cached component runs skip `loadParserStack()` above, but this pass still parses
+  // sibling modules via `getParserStack()` — load here whenever there is work to do.
   const callDefaultCandidates = collectCallDefaultCandidates(allComponentsForTypes);
   if (callDefaultCandidates.length > 0) {
+    await loadParserStack();
     const callDefaultResolveContext = createCallDefaultResolveContext();
     for (const { component, candidates } of callDefaultCandidates) {
       const resolutions = resolveCallDefaultCandidates(

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -680,10 +680,9 @@ export async function generateBundle(
     }
   }
 
-  // AST/JSDoc-text only (no tsc), so - unlike resolveTypes - this always runs, keyed on
-  // whatever `pendingCallDefaultCandidates` parsing found; a no-op when there are none.
-  // Fully cached component runs skip `loadParserStack()` above, but this pass still parses
-  // sibling modules via `getParserStack()` — load here whenever there is work to do.
+  // AST/JSDoc only (no tsc). Always runs when parsing left pending candidates.
+  // Warm-cache runs skip loadParserStack above, but this pass still needs it to
+  // parse sibling modules.
   const callDefaultCandidates = collectCallDefaultCandidates(allComponentsForTypes);
   if (callDefaultCandidates.length > 0) {
     await loadParserStack();
@@ -720,7 +719,7 @@ interface CallDefaultCandidateGroup {
   candidates: PendingCallDefaultCandidate[];
 }
 
-/** Components with at least one `CallExpression` prop default whose callee came from a named import. */
+/** Components that have a CallExpression prop default from a named import. */
 function collectCallDefaultCandidates(components: ComponentDocs): CallDefaultCandidateGroup[] {
   const groups: CallDefaultCandidateGroup[] = [];
 
@@ -736,10 +735,9 @@ function collectCallDefaultCandidates(components: ComponentDocs): CallDefaultCan
 }
 
 /**
- * Patches `component.props`/`component.moduleExports` with each resolution, and either drops
- * the parse-time `prop-unknown-type` diagnostic (resolved) or replaces it with a more specific
- * one (still unresolved - see {@link describeCallDefaultFailure}). Guarded on `typeSource ===
- * "unknown"`: an explicit JSDoc `@type` on the same prop always wins and must not be overwritten.
+ * Apply each resolution onto props/moduleExports. Drop or rewrite the
+ * parse-time `prop-unknown-type` diagnostic. Skip when `typeSource !==
+ * "unknown"` so an explicit `@type` keeps winning.
  */
 function applyCallDefaultResolutions(component: ComponentDocApi, resolutions: CallDefaultResolution[]): void {
   for (const { candidate, type, failureReason } of resolutions) {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -3,7 +3,7 @@ import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "no
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, parse, relative, resolve } from "node:path";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
-import type { ParsedComponent } from "./ComponentParser";
+import type { ParsedComponent, PendingCallDefaultCandidate } from "./ComponentParser";
 import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
 import { collectExampleSources } from "./example-check";
@@ -13,6 +13,12 @@ import { type ParsedExports, parseExports } from "./parse-exports";
 import { applyResolvedProps, getParsedComponentTypeScriptMetadata } from "./parsed-component-metadata";
 import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
+import {
+  type CallDefaultResolution,
+  createCallDefaultResolveContext,
+  describeCallDefaultFailure,
+  resolveCallDefaultCandidates,
+} from "./resolve-call-defaults";
 import type { TypeResolver } from "./resolve-types";
 
 export interface ComponentDocApi extends ParsedComponent {
@@ -674,6 +680,21 @@ export async function generateBundle(
     }
   }
 
+  // AST/JSDoc-text only (no tsc), so - unlike resolveTypes - this always runs, keyed on
+  // whatever `pendingCallDefaultCandidates` parsing found; a no-op when there are none.
+  const callDefaultCandidates = collectCallDefaultCandidates(allComponentsForTypes);
+  if (callDefaultCandidates.length > 0) {
+    const callDefaultResolveContext = createCallDefaultResolveContext();
+    for (const { component, candidates } of callDefaultCandidates) {
+      const resolutions = resolveCallDefaultCandidates(
+        resolveComponentFilePath(component.filePath),
+        candidates,
+        callDefaultResolveContext,
+      );
+      applyCallDefaultResolutions(component, resolutions);
+    }
+  }
+
   // Dedupe diagnostics from export and all-components passes.
   const diagnostics = dedupeDiagnostics(
     Array.from(allComponentsForTypes.values()).flatMap((component) => component.diagnostics ?? []),
@@ -689,6 +710,58 @@ export async function generateBundle(
     cache,
     resolvedPathByFilePath,
   };
+}
+
+interface CallDefaultCandidateGroup {
+  component: ComponentDocApi;
+  candidates: PendingCallDefaultCandidate[];
+}
+
+/** Components with at least one `CallExpression` prop default whose callee came from a named import. */
+function collectCallDefaultCandidates(components: ComponentDocs): CallDefaultCandidateGroup[] {
+  const groups: CallDefaultCandidateGroup[] = [];
+
+  for (const component of components.values()) {
+    const candidates = getParsedComponentTypeScriptMetadata(component)?.pendingCallDefaultCandidates?.filter(
+      (candidate) => candidate.importSource !== undefined,
+    );
+    if (!candidates || candidates.length === 0) continue;
+    groups.push({ component, candidates });
+  }
+
+  return groups;
+}
+
+/**
+ * Patches `component.props`/`component.moduleExports` with each resolution, and either drops
+ * the parse-time `prop-unknown-type` diagnostic (resolved) or replaces it with a more specific
+ * one (still unresolved - see {@link describeCallDefaultFailure}). Guarded on `typeSource ===
+ * "unknown"`: an explicit JSDoc `@type` on the same prop always wins and must not be overwritten.
+ */
+function applyCallDefaultResolutions(component: ComponentDocApi, resolutions: CallDefaultResolution[]): void {
+  for (const { candidate, type, failureReason } of resolutions) {
+    const list = candidate.location === "props" ? component.props : component.moduleExports;
+    const prop = list.find((entry) => entry.name === candidate.propName);
+    if (prop?.typeSource !== "unknown") continue;
+
+    if (type) {
+      prop.type = type;
+      prop.typeSource = "typescript";
+      if (candidate.location === "props") {
+        component.diagnostics = (component.diagnostics ?? []).filter(
+          (diagnostic) => !(diagnostic.kind === "prop-unknown-type" && diagnostic.name === candidate.propName),
+        );
+      }
+      continue;
+    }
+
+    if (candidate.location === "props" && failureReason) {
+      const existing = component.diagnostics?.find(
+        (diagnostic) => diagnostic.kind === "prop-unknown-type" && diagnostic.name === candidate.propName,
+      );
+      if (existing) existing.message = describeCallDefaultFailure(candidate, failureReason);
+    }
+  }
 }
 
 interface ResolveTypesCandidate {

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -37,10 +37,9 @@ interface AstNode {
 }
 
 /**
- * Internal export record that tracks the absolute declaring file, plus a
- * `returnType` for function-valued exports - used by `resolve-call-defaults.ts`
- * to resolve a `CallExpression` prop default's callee return type. Not part
- * of the public `EntryExport` shape (see `parseEntryExports`, which strips it).
+ * Internal export with absolute `declFile` plus optional `returnType` for
+ * function-valued exports (used by `resolve-call-defaults.ts`). Stripped
+ * before public `EntryExport` output in `parseEntryExports`.
  */
 export interface InternalExport extends Omit<EntryExport, "source"> {
   declFile: string;
@@ -128,7 +127,7 @@ function leadingJsDoc(text: string, start: number): string | undefined {
   return description.join(" ") || undefined;
 }
 
-/** Same anchor as {@link leadingJsDoc}, but returns the raw `/** ... *\/` block instead of just the description. */
+/** Like {@link leadingJsDoc}, but returns the full `/** ... *\/` block. */
 function leadingJsDocBlock(text: string, start: number): string | undefined {
   const before = text.slice(0, start).trimEnd();
   if (!before.endsWith("*/")) return undefined;
@@ -152,10 +151,8 @@ function annotationText(source: ModuleSource, annotated: AstNode | undefined): s
 }
 
 /**
- * A function/arrow/`TSDeclareFunction` node's own TS return-type annotation
- * text (`): T`), if any. Distinct from {@link annotationText}: a function's
- * return type lives on its own `returnType` property, not `typeAnnotation`
- * (which annotates a binding, e.g. a variable or parameter).
+ * Function/arrow/`TSDeclareFunction` return annotation text (`): T`).
+ * Lives on `returnType`, not `typeAnnotation` (that annotates bindings).
  */
 function functionReturnAnnotationText(source: ModuleSource, fn: AstNode): string | undefined {
   const returnAnnotation = asNode(fn.returnType);
@@ -183,7 +180,7 @@ function inferLiteralType(init: AstNode): string | undefined {
   return undefined;
 }
 
-/** Trailing return type from a callable type annotation (`() => string` → `string`). */
+/** Trailing return from a callable type (`() => string` → `string`). */
 function returnTypeFromCallableTypeText(type: string | undefined): string | undefined {
   if (!type) return undefined;
   const idx = type.lastIndexOf("=>");
@@ -193,9 +190,8 @@ function returnTypeFromCallableTypeText(type: string | undefined): string | unde
 }
 
 /**
- * Literal-only return inference for a function/arrow AST node (mirrors
- * same-file `inferReturnTypeFromNode` in props.ts). Template literals and
- * string/number/boolean literals only; anything else → undefined.
+ * Literal-only return inference for a function/arrow (same idea as
+ * `inferReturnTypeFromNode` in props.ts). string/number/boolean/template only.
  */
 function inferAstLiteralReturnType(fn: AstNode): string | undefined {
   if (fn.async || fn.generator) return undefined;
@@ -235,7 +231,7 @@ function collectAstReturnArguments(body: AstNode, out: Array<AstNode | null>): v
       out.push(asNode(statement.argument) ?? null);
       continue;
     }
-    // Shallow walk into nested blocks (if/for/while bodies) without entering nested functions.
+    // Nested blocks (if/for/while) without entering nested functions.
     if (statement.type === "BlockStatement") {
       collectAstReturnArguments(statement, out);
       continue;
@@ -291,8 +287,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
     return results;
   }
 
-  // `TSDeclareFunction`: an ambient/bodyless signature, as written in a `.d.ts`
-  // file (`export function uniqueId(prefix?: string): string;`).
+  // Ambient signature in a `.d.ts`: `export function uniqueId(prefix?: string): string;`
   if (declaration.type === "FunctionDeclaration" || declaration.type === "TSDeclareFunction") {
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
@@ -539,7 +534,7 @@ export async function parseEntryExports(entryFile: string): Promise<EntryExports
 
   const byName = new Map<string, EntryExport>();
   for (const entry of collected) {
-    // `returnType` is internal, for `resolve-call-defaults.ts` only - not part of the public shape.
+    // Drop internal returnType; public EntryExport does not expose it.
     const { declFile, returnType: _returnType, ...rest } = entry;
     const source = normalizeSeparators(`./${relative(entryDir, declFile)}`);
     byName.set(entry.name, { ...rest, source });

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -183,6 +183,74 @@ function inferLiteralType(init: AstNode): string | undefined {
   return undefined;
 }
 
+/** Trailing return type from a callable type annotation (`() => string` → `string`). */
+function returnTypeFromCallableTypeText(type: string | undefined): string | undefined {
+  if (!type) return undefined;
+  const idx = type.lastIndexOf("=>");
+  if (idx === -1) return undefined;
+  const ret = type.slice(idx + 2).trim();
+  return ret || undefined;
+}
+
+/**
+ * Literal-only return inference for a function/arrow AST node (mirrors
+ * same-file `inferReturnTypeFromNode` in props.ts). Template literals and
+ * string/number/boolean literals only; anything else → undefined.
+ */
+function inferAstLiteralReturnType(fn: AstNode): string | undefined {
+  if (fn.async || fn.generator) return undefined;
+
+  const body = asNode(fn.body);
+  if (!body) return undefined;
+
+  const returnArgs: Array<AstNode | null> = [];
+  if (body.type === "BlockStatement") {
+    collectAstReturnArguments(body, returnArgs);
+    if (returnArgs.length === 0) return undefined;
+  } else {
+    returnArgs.push(body);
+  }
+
+  let inferred: string | undefined;
+  for (const arg of returnArgs) {
+    if (!arg) return undefined;
+    const primitive = inferLiteralType(arg);
+    if (!primitive) return undefined;
+    if (inferred === undefined) inferred = primitive;
+    else if (inferred !== primitive) return undefined;
+  }
+  return inferred;
+}
+
+function collectAstReturnArguments(body: AstNode, out: Array<AstNode | null>): void {
+  for (const statement of asNodeArray(body.body)) {
+    if (
+      statement.type === "FunctionDeclaration" ||
+      statement.type === "FunctionExpression" ||
+      statement.type === "ArrowFunctionExpression"
+    ) {
+      continue;
+    }
+    if (statement.type === "ReturnStatement") {
+      out.push(asNode(statement.argument) ?? null);
+      continue;
+    }
+    // Shallow walk into nested blocks (if/for/while bodies) without entering nested functions.
+    if (statement.type === "BlockStatement") {
+      collectAstReturnArguments(statement, out);
+      continue;
+    }
+    const consequent = asNode(statement.consequent);
+    if (consequent?.type === "BlockStatement") collectAstReturnArguments(consequent, out);
+    else if (consequent?.type === "ReturnStatement") out.push(asNode(consequent.argument) ?? null);
+    const alternate = asNode(statement.alternate);
+    if (alternate?.type === "BlockStatement") collectAstReturnArguments(alternate, out);
+    else if (alternate?.type === "ReturnStatement") out.push(asNode(alternate.argument) ?? null);
+    const blockBody = asNode(statement.body);
+    if (blockBody?.type === "BlockStatement") collectAstReturnArguments(blockBody, out);
+  }
+}
+
 function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocStart: number): InternalExport[] {
   const declFile = source.filePath;
   const description = leadingJsDoc(source.text, jsdocStart);
@@ -206,7 +274,11 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
       if (init) {
         if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
           if (!type) type = buildSignature(source, init);
-          returnType = functionReturnAnnotationText(source, init) ?? jsDocReturnType;
+          returnType =
+            functionReturnAnnotationText(source, init) ??
+            jsDocReturnType ??
+            returnTypeFromCallableTypeText(type) ??
+            inferAstLiteralReturnType(init);
         } else {
           value = textOf(source, init);
           if (!type) type = inferLiteralType(init);
@@ -229,7 +301,10 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         name,
         kind: "function",
         type: buildSignature(source, declaration),
-        returnType: functionReturnAnnotationText(source, declaration) ?? jsDocReturnType,
+        returnType:
+          functionReturnAnnotationText(source, declaration) ??
+          jsDocReturnType ??
+          inferAstLiteralReturnType(declaration),
         description,
         declFile,
         isTypeOnly: false,

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -1,6 +1,7 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { isIdentifier } from "./ast-guards";
+import { extractJsDocReturnType } from "./parser/jsdoc";
 import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
 import { resolvePathAliasAbsolute } from "./resolve-alias";
@@ -35,9 +36,15 @@ interface AstNode {
   [key: string]: unknown;
 }
 
-/** Internal export record that tracks the absolute declaring file. */
-interface InternalExport extends Omit<EntryExport, "source"> {
+/**
+ * Internal export record that tracks the absolute declaring file, plus a
+ * `returnType` for function-valued exports - used by `resolve-call-defaults.ts`
+ * to resolve a `CallExpression` prop default's callee return type. Not part
+ * of the public `EntryExport` shape (see `parseEntryExports`, which strips it).
+ */
+export interface InternalExport extends Omit<EntryExport, "source"> {
   declFile: string;
+  returnType?: string;
 }
 
 /** Parsed-source context shared while walking a single module. */
@@ -51,7 +58,7 @@ interface ModuleSource {
 }
 
 /** Resolution state shared across the recursive module walk. */
-interface ResolveContext {
+export interface ResolveContext {
   /** Memoized exports per file so repeated lookups stay cheap. */
   cache: Map<string, InternalExport[]>;
   /** Files currently being resolved, used to break import cycles. */
@@ -81,7 +88,7 @@ function identifierName(node: AstNode | undefined): string | undefined {
  * resolveModuleFile("./utils", "/abs/src") // "/abs/src/utils.ts"
  * ```
  */
-function resolveModuleFile(specifier: string, fromDir: string): string | null {
+export function resolveModuleFile(specifier: string, fromDir: string): string | null {
   const aliased = resolvePathAliasAbsolute(specifier, fromDir);
   const base = resolve(fromDir, aliased);
 
@@ -121,6 +128,18 @@ function leadingJsDoc(text: string, start: number): string | undefined {
   return description.join(" ") || undefined;
 }
 
+/** Same anchor as {@link leadingJsDoc}, but returns the raw `/** ... *\/` block instead of just the description. */
+function leadingJsDocBlock(text: string, start: number): string | undefined {
+  const before = text.slice(0, start).trimEnd();
+  if (!before.endsWith("*/")) return undefined;
+
+  const close = before.length - 2;
+  const open = before.lastIndexOf("/**", close);
+  if (open === -1) return undefined;
+
+  return before.slice(open, close + 2);
+}
+
 function textOf(source: ModuleSource, node: AstNode | undefined): string | undefined {
   if (!node) return undefined;
   return source.text.slice(node.start, node.end);
@@ -132,14 +151,24 @@ function annotationText(source: ModuleSource, annotated: AstNode | undefined): s
   return textOf(source, asNode(annotation.typeAnnotation));
 }
 
+/**
+ * A function/arrow/`TSDeclareFunction` node's own TS return-type annotation
+ * text (`): T`), if any. Distinct from {@link annotationText}: a function's
+ * return type lives on its own `returnType` property, not `typeAnnotation`
+ * (which annotates a binding, e.g. a variable or parameter).
+ */
+function functionReturnAnnotationText(source: ModuleSource, fn: AstNode): string | undefined {
+  const returnAnnotation = asNode(fn.returnType);
+  return returnAnnotation?.type === "TSTypeAnnotation"
+    ? textOf(source, asNode(returnAnnotation.typeAnnotation))
+    : undefined;
+}
+
 function buildSignature(source: ModuleSource, fn: AstNode): string {
   const params = asNodeArray(fn.params)
     .map((param) => textOf(source, param) ?? "")
     .join(", ");
-  // Functions and arrows expose their return type via `returnType`.
-  const returnAnnotation = asNode(fn.returnType);
-  const returnType =
-    returnAnnotation?.type === "TSTypeAnnotation" ? textOf(source, asNode(returnAnnotation.typeAnnotation)) : undefined;
+  const returnType = functionReturnAnnotationText(source, fn);
   return `(${params})${returnType ? ` => ${returnType}` : ""}`;
 }
 
@@ -157,6 +186,8 @@ function inferLiteralType(init: AstNode): string | undefined {
 function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocStart: number): InternalExport[] {
   const declFile = source.filePath;
   const description = leadingJsDoc(source.text, jsdocStart);
+  const rawJsDoc = leadingJsDocBlock(source.text, jsdocStart);
+  const jsDocReturnType = rawJsDoc ? extractJsDocReturnType(rawJsDoc) : undefined;
 
   if (declaration.type === "VariableDeclaration") {
     const kind = (declaration.kind as "const" | "let" | "var") ?? "const";
@@ -169,28 +200,40 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
 
       let type = annotationText(source, id);
       let value: string | undefined;
+      let returnType: string | undefined;
       const init = asNode(declarator.init);
 
       if (init) {
         if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
           if (!type) type = buildSignature(source, init);
+          returnType = functionReturnAnnotationText(source, init) ?? jsDocReturnType;
         } else {
           value = textOf(source, init);
           if (!type) type = inferLiteralType(init);
         }
       }
 
-      results.push({ name, kind, type, value, description, declFile, isTypeOnly: false });
+      results.push({ name, kind, type, value, returnType, description, declFile, isTypeOnly: false });
     }
 
     return results;
   }
 
-  if (declaration.type === "FunctionDeclaration") {
+  // `TSDeclareFunction`: an ambient/bodyless signature, as written in a `.d.ts`
+  // file (`export function uniqueId(prefix?: string): string;`).
+  if (declaration.type === "FunctionDeclaration" || declaration.type === "TSDeclareFunction") {
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
     return [
-      { name, kind: "function", type: buildSignature(source, declaration), description, declFile, isTypeOnly: false },
+      {
+        name,
+        kind: "function",
+        type: buildSignature(source, declaration),
+        returnType: functionReturnAnnotationText(source, declaration) ?? jsDocReturnType,
+        description,
+        declFile,
+        isTypeOnly: false,
+      },
     ];
   }
 
@@ -290,7 +333,7 @@ function findImportSource(body: AstNode[], name: string): { specifier: string; i
  *
  * Walks `export ... from` and `export *` chains. Skips `.svelte` re-exports.
  */
-function collectModuleExports(filePath: string, ctx: ResolveContext): InternalExport[] {
+export function collectModuleExports(filePath: string, ctx: ResolveContext): InternalExport[] {
   const cached = ctx.cache.get(filePath);
   if (cached) return cached;
   // A module currently being resolved is part of an import cycle.
@@ -421,7 +464,8 @@ export async function parseEntryExports(entryFile: string): Promise<EntryExports
 
   const byName = new Map<string, EntryExport>();
   for (const entry of collected) {
-    const { declFile, ...rest } = entry;
+    // `returnType` is internal, for `resolve-call-defaults.ts` only - not part of the public shape.
+    const { declFile, returnType: _returnType, ...rest } = entry;
     const source = normalizeSeparators(`./${relative(entryDir, declFile)}`);
     byName.set(entry.name, { ...rest, source });
   }

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -60,9 +60,9 @@ export interface ParserContext {
   readonly reactive_vars: Set<string>;
   readonly funcDecls: Map<string, FunctionDeclaration>;
   readonly vars: Set<VariableDeclaration>;
-  /** Named value imports (`import { x } from "..."`) by local binding name, for cross-file call-default resolution. */
+  /** Named value imports by local name, for cross-file call-default lookup. */
   readonly valueImportBindingsByLocalName: Map<string, ValueImportBinding>;
-  /** Props whose `CallExpression` default couldn't be resolved during AST-local parsing. */
+  /** CallExpression defaults that still need a return type after AST parsing. */
   readonly pendingCallDefaultCandidates: PendingCallDefaultCandidate[];
 
   readonly runesPropsDeclarationMetadataByDeclaratorStart: Map<number, RunesPropsDeclarationMetadata>;

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -12,6 +12,7 @@ import type {
   LegacyAstRoot,
   LexicalScope,
   LocalTypeDeclaration,
+  PendingCallDefaultCandidate,
   RestProps,
   RunesPropsDeclarationMetadata,
   ScriptLanguage,
@@ -19,6 +20,7 @@ import type {
   SyntaxMode,
   TypeDef,
   TypeImportBinding,
+  ValueImportBinding,
 } from "../ComponentParser";
 import type { SveldDiagnostic } from "../diagnostics";
 
@@ -58,6 +60,10 @@ export interface ParserContext {
   readonly reactive_vars: Set<string>;
   readonly funcDecls: Map<string, FunctionDeclaration>;
   readonly vars: Set<VariableDeclaration>;
+  /** Named value imports (`import { x } from "..."`) by local binding name, for cross-file call-default resolution. */
+  readonly valueImportBindingsByLocalName: Map<string, ValueImportBinding>;
+  /** Props whose `CallExpression` default couldn't be resolved during AST-local parsing. */
+  readonly pendingCallDefaultCandidates: PendingCallDefaultCandidate[];
 
   readonly runesPropsDeclarationMetadataByDeclaratorStart: Map<number, RunesPropsDeclarationMetadata>;
   readonly typedRunesPropsDeclarations: RunesPropsDeclarationMetadata[];
@@ -119,6 +125,8 @@ export function createParserContext(): ParserContext {
     reactive_vars: new Set(),
     funcDecls: new Map(),
     vars: new Set(),
+    valueImportBindingsByLocalName: new Map(),
+    pendingCallDefaultCandidates: [],
     runesPropsDeclarationMetadataByDeclaratorStart: new Map(),
     typedRunesPropsDeclarations: [],
     explicitPropTypesByName: new Map(),

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -145,6 +145,25 @@ function formatComment(comment: string) {
   return formatted_comment;
 }
 
+/** `"*"` becomes `"any"`, otherwise trimmed. Pure counterpart of {@link ComponentParser.aliasType}. */
+export function aliasType(type: string): string {
+  if (type === "*") return "any";
+  return type.trim();
+}
+
+/**
+ * Reads just the `@returns`/`@return` type off a raw JSDoc comment's text
+ * (e.g. `"* @returns {string} the id\n "`, with or without the `/**`/`*\/`
+ * delimiters). No `ComponentParser`/`ParserContext` dependency, so
+ * `parse-entry-exports.ts` can reuse it while parsing an arbitrary sibling
+ * module - not component source, so it has no parser/context of its own.
+ */
+export function extractJsDocReturnType(commentValue: string): string | undefined {
+  const comment = parseComment(formatComment(commentValue), { spacing: "preserve" });
+  const { returns: returnsTag } = getCommentTags(comment);
+  return returnsTag ? aliasType(returnsTag.type) : undefined;
+}
+
 export function getCommentTags(parsed: ReturnType<typeof parseComment>) {
   const tags = parsed[0]?.tags ?? [];
   const excludedTags = new Set([

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -145,18 +145,16 @@ function formatComment(comment: string) {
   return formatted_comment;
 }
 
-/** `"*"` becomes `"any"`, otherwise trimmed. Pure counterpart of {@link ComponentParser.aliasType}. */
+/** Map JSDoc `"*"` to `"any"`; otherwise trim. Same rules as {@link ComponentParser.aliasType}. */
 export function aliasType(type: string): string {
   if (type === "*") return "any";
   return type.trim();
 }
 
 /**
- * Reads just the `@returns`/`@return` type off a raw JSDoc comment's text
- * (e.g. `"* @returns {string} the id\n "`, with or without the `/**`/`*\/`
- * delimiters). No `ComponentParser`/`ParserContext` dependency, so
- * `parse-entry-exports.ts` can reuse it while parsing an arbitrary sibling
- * module - not component source, so it has no parser/context of its own.
+ * `@returns`/`@return` type from raw JSDoc text (with or without `/**` delimiters).
+ * Standalone so `parse-entry-exports.ts` can read sibling modules without a
+ * component parser context.
  */
 export function extractJsDocReturnType(commentValue: string): string | undefined {
   const comment = parseComment(formatComment(commentValue), { spacing: "preserve" });

--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -179,21 +179,23 @@ export function processInitializer(
       return { ...inner, value, defaultValue };
     }
 
-    // A callee that's a same-file function or a named value import may resolve to a
-    // return type below.
+    // A callee that's a same-file function (declaration or const/arrow) or a named
+    // value import may resolve to a return type below.
     if (calleeName) {
-      if (ctx.funcDecls.has(calleeName)) {
-        const sameFileReturnType = resolveSameFileCallReturnType(parser, ctx, calleeName);
-        if (sameFileReturnType) {
-          return {
-            value,
-            type: undefined,
-            isFunction: false,
-            defaultValue,
-            resolvedType: sameFileReturnType,
-            resolvedReturnType: sameFileReturnType,
-          };
-        }
+      const sameFileReturnType = resolveSameFileCallReturnType(parser, ctx, calleeName);
+      if (sameFileReturnType) {
+        // Value props from CallExpression defaults: only `resolvedType`. Setting
+        // `resolvedReturnType` would leak onto `prop.returnType` for non-functions.
+        return {
+          value,
+          type: undefined,
+          isFunction: false,
+          defaultValue,
+          resolvedType: sameFileReturnType,
+        };
+      }
+
+      if (ctx.funcDecls.has(calleeName) || isLocalFunctionValuedBinding(ctx, calleeName)) {
         return { value, type: undefined, isFunction: false, defaultValue, pendingCallDefault: { calleeName } };
       }
 
@@ -361,12 +363,12 @@ function calleeDisplayText(ctx: ParserContext, callee: unknown): string {
 
 /**
  * Return type for a same-file `CallExpression` default's callee (e.g.
- * `export let id = uniqueId()` where `uniqueId` is declared in this file).
- * Tries, in order: the callee's own JSDoc `@returns`, its TS return-type
- * annotation, then a literal-only inference over its `return` statements
- * (see {@link inferReturnTypeFromNode}). Returns `undefined` - not `"any"` -
- * when none of these give a confident answer, so the caller can tell "no
- * lead" apart from "resolved to any".
+ * `export let id = uniqueId()` where `uniqueId` is declared in this file as a
+ * `function` or as `const uniqueId = () => …`). Tries, in order: the callee's
+ * own JSDoc `@returns`, its TS return-type annotation, then a literal-only
+ * inference over its `return` statements (see {@link inferReturnTypeFromNode}).
+ * Returns `undefined` - not `"any"` - when none of these give a confident
+ * answer, so the caller can tell "no lead" apart from "resolved to any".
  */
 function resolveSameFileCallReturnType(
   parser: ComponentParser,
@@ -376,18 +378,81 @@ function resolveSameFileCallReturnType(
   const resolvedJSDoc = parser.resolveLocalVarJSDoc(calleeName);
   if (resolvedJSDoc?.returnType) return resolvedJSDoc.returnType;
 
-  const funcNode = ctx.funcDecls.get(calleeName);
+  const funcNode = ctx.funcDecls.get(calleeName) ?? localFunctionValuedInitializer(ctx, calleeName);
   if (!funcNode) return undefined;
 
   const tsReturnType = functionReturnTypeAnnotationText(ctx, funcNode);
   if (tsReturnType) return tsReturnType;
 
+  const bindingReturnType = bindingCallableReturnTypeText(ctx, calleeName);
+  if (bindingReturnType) return bindingReturnType;
+
   const inferred = inferReturnTypeFromNode(funcNode);
   return inferred === "any" ? undefined : inferred;
 }
 
-/** Source text of a function declaration's explicit TS return-type annotation (`): T`), if any. */
-function functionReturnTypeAnnotationText(ctx: ParserContext, node: FunctionDeclaration): string | undefined {
+/** True when `name` is a local `const`/`let` whose initializer is an arrow or function expression. */
+function isLocalFunctionValuedBinding(ctx: ParserContext, name: string): boolean {
+  return localFunctionValuedInitializer(ctx, name) !== undefined;
+}
+
+/** Arrow/function-expression initializer for a local binding, if any. */
+function localFunctionValuedInitializer(
+  ctx: ParserContext,
+  name: string,
+): FunctionExpression | ArrowFunctionExpression | undefined {
+  const init = resolveLocalVarInitializer(ctx, name);
+  if (!init || typeof init !== "object" || !("type" in init)) return undefined;
+  if (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression") {
+    return init as ArrowFunctionExpression | FunctionExpression;
+  }
+  return undefined;
+}
+
+/**
+ * Return type from a binding-level annotation like `const f: () => string = …`
+ * (the arrow itself may omit `): string`).
+ */
+function bindingCallableReturnTypeText(ctx: ParserContext, name: string): string | undefined {
+  for (const decl of ctx.vars) {
+    for (const declarator of decl.declarations) {
+      const id = declarator.id;
+      if (
+        !id ||
+        typeof id !== "object" ||
+        !("type" in id) ||
+        id.type !== "Identifier" ||
+        !("name" in id) ||
+        id.name !== name
+      ) {
+        continue;
+      }
+      const annotation = (
+        id as unknown as { typeAnnotation?: { type?: string; typeAnnotation?: { start?: number; end?: number } } }
+      ).typeAnnotation;
+      if (annotation?.type !== "TSTypeAnnotation") return undefined;
+      const typeNode = annotation.typeAnnotation;
+      if (!typeNode || typeof typeNode.start !== "number" || typeof typeNode.end !== "number") return undefined;
+      return returnTypeFromCallableTypeText(sourceAtPos(ctx, typeNode.start, typeNode.end));
+    }
+  }
+  return undefined;
+}
+
+/** Trailing return type from a callable type annotation text (`() => string` → `string`). */
+function returnTypeFromCallableTypeText(type: string | undefined): string | undefined {
+  if (!type) return undefined;
+  const idx = type.lastIndexOf("=>");
+  if (idx === -1) return undefined;
+  const ret = type.slice(idx + 2).trim();
+  return ret || undefined;
+}
+
+/** Source text of a function's explicit TS return-type annotation (`): T`), if any. */
+function functionReturnTypeAnnotationText(
+  ctx: ParserContext,
+  node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
+): string | undefined {
   const returnType = (
     node as unknown as { returnType?: { type?: string; typeAnnotation?: { start?: number; end?: number } } }
   ).returnType;

--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -169,23 +169,19 @@ export function processInitializer(
         ? (callee as Identifier).name
         : undefined;
 
-    // `$derived(expr)`/`$state(expr)` wrap a value; the rune call itself has no
-    // meaningful "return type" of its own - the prop's type is whatever `expr` is.
-    // Unwrap and recurse into the argument (mirrors `unwrapBindableInitializer`'s
-    // treatment of `$bindable(...)`), keeping the rune call's own source text as
-    // `value`/`@default`.
+    // `$derived`/`$state` wrap a value. Unwrap like `$bindable`, keep the rune
+    // call text as `@default`.
     if ((calleeName === "$derived" || calleeName === "$state") && callExpr.arguments.length === 1 && depth < 5) {
       const inner = processInitializer(parser, ctx, callExpr.arguments[0], depth + 1);
       return { ...inner, value, defaultValue };
     }
 
-    // A callee that's a same-file function (declaration or const/arrow) or a named
-    // value import may resolve to a return type below.
+    // Same-file function/const-arrow, or a named value import.
     if (calleeName) {
       const sameFileReturnType = resolveSameFileCallReturnType(parser, ctx, calleeName);
       if (sameFileReturnType) {
-        // Value props from CallExpression defaults: only `resolvedType`. Setting
-        // `resolvedReturnType` would leak onto `prop.returnType` for non-functions.
+        // Value prop: only resolvedType. resolvedReturnType would show up on
+        // prop.returnType even when isFunction is false.
         return {
           value,
           type: undefined,
@@ -215,9 +211,8 @@ export function processInitializer(
       }
     }
 
-    // Unresolved: unknown identifier, member call (`x.y()`), IIFE, etc. Still tag as a
-    // pending call default so the finalize pass falls back to `any` - never the literal
-    // string "undefined" for the prop's type - regardless of the callee's shape.
+    // Unknown callee, member call, IIFE, etc. Still pending so finalize uses
+    // "any" instead of the literal type "undefined".
     return {
       value,
       type: undefined,
@@ -346,7 +341,7 @@ export function resolveConstInitializer(ctx: ParserContext, name: string): unkno
   return undefined;
 }
 
-/** Source text of a call's callee (e.g. `now.toISOString`), for a diagnostic naming it. Falls back to `"call"`. */
+/** Callee source text for diagnostics (`now.toISOString`). Falls back to `"call"`. */
 function calleeDisplayText(ctx: ParserContext, callee: unknown): string {
   if (
     callee &&
@@ -362,13 +357,10 @@ function calleeDisplayText(ctx: ParserContext, callee: unknown): string {
 }
 
 /**
- * Return type for a same-file `CallExpression` default's callee (e.g.
- * `export let id = uniqueId()` where `uniqueId` is declared in this file as a
- * `function` or as `const uniqueId = () => …`). Tries, in order: the callee's
- * own JSDoc `@returns`, its TS return-type annotation, then a literal-only
- * inference over its `return` statements (see {@link inferReturnTypeFromNode}).
- * Returns `undefined` - not `"any"` - when none of these give a confident
- * answer, so the caller can tell "no lead" apart from "resolved to any".
+ * Return type for a same-file call default (`export let id = uniqueId()`).
+ * Order: JSDoc `@returns`, TS return annotation, binding `() => T`, then
+ * literal returns via {@link inferReturnTypeFromNode}. Returns `undefined`
+ * (not `"any"`) when nothing confident turns up.
  */
 function resolveSameFileCallReturnType(
   parser: ComponentParser,
@@ -391,12 +383,12 @@ function resolveSameFileCallReturnType(
   return inferred === "any" ? undefined : inferred;
 }
 
-/** True when `name` is a local `const`/`let` whose initializer is an arrow or function expression. */
+/** Local const/let whose initializer is an arrow or function expression. */
 function isLocalFunctionValuedBinding(ctx: ParserContext, name: string): boolean {
   return localFunctionValuedInitializer(ctx, name) !== undefined;
 }
 
-/** Arrow/function-expression initializer for a local binding, if any. */
+/** Arrow or function-expression initializer for a local binding. */
 function localFunctionValuedInitializer(
   ctx: ParserContext,
   name: string,
@@ -410,8 +402,7 @@ function localFunctionValuedInitializer(
 }
 
 /**
- * Return type from a binding-level annotation like `const f: () => string = …`
- * (the arrow itself may omit `): string`).
+ * Return type from `const f: () => string = ...` when the arrow omits `): string`.
  */
 function bindingCallableReturnTypeText(ctx: ParserContext, name: string): string | undefined {
   for (const decl of ctx.vars) {
@@ -439,7 +430,7 @@ function bindingCallableReturnTypeText(ctx: ParserContext, name: string): string
   return undefined;
 }
 
-/** Trailing return type from a callable type annotation text (`() => string` → `string`). */
+/** Trailing return from a callable type (`() => string` → `string`). */
 function returnTypeFromCallableTypeText(type: string | undefined): string | undefined {
   if (!type) return undefined;
   const idx = type.lastIndexOf("=>");
@@ -448,7 +439,7 @@ function returnTypeFromCallableTypeText(type: string | undefined): string | unde
   return ret || undefined;
 }
 
-/** Source text of a function's explicit TS return-type annotation (`): T`), if any. */
+/** Explicit TS return annotation text on a function (`): T`). */
 function functionReturnTypeAnnotationText(
   ctx: ParserContext,
   node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,

--- a/src/parser/props.ts
+++ b/src/parser/props.ts
@@ -162,6 +162,67 @@ export function processInitializer(
     ) {
       value = sourceAtPos(ctx, callExpr.start, callExpr.end);
     }
+
+    const callee = callExpr.callee;
+    const calleeName =
+      callee && typeof callee === "object" && "type" in callee && callee.type === "Identifier"
+        ? (callee as Identifier).name
+        : undefined;
+
+    // `$derived(expr)`/`$state(expr)` wrap a value; the rune call itself has no
+    // meaningful "return type" of its own - the prop's type is whatever `expr` is.
+    // Unwrap and recurse into the argument (mirrors `unwrapBindableInitializer`'s
+    // treatment of `$bindable(...)`), keeping the rune call's own source text as
+    // `value`/`@default`.
+    if ((calleeName === "$derived" || calleeName === "$state") && callExpr.arguments.length === 1 && depth < 5) {
+      const inner = processInitializer(parser, ctx, callExpr.arguments[0], depth + 1);
+      return { ...inner, value, defaultValue };
+    }
+
+    // A callee that's a same-file function or a named value import may resolve to a
+    // return type below.
+    if (calleeName) {
+      if (ctx.funcDecls.has(calleeName)) {
+        const sameFileReturnType = resolveSameFileCallReturnType(parser, ctx, calleeName);
+        if (sameFileReturnType) {
+          return {
+            value,
+            type: undefined,
+            isFunction: false,
+            defaultValue,
+            resolvedType: sameFileReturnType,
+            resolvedReturnType: sameFileReturnType,
+          };
+        }
+        return { value, type: undefined, isFunction: false, defaultValue, pendingCallDefault: { calleeName } };
+      }
+
+      const importBinding = ctx.valueImportBindingsByLocalName.get(calleeName);
+      if (importBinding) {
+        return {
+          value,
+          type: undefined,
+          isFunction: false,
+          defaultValue,
+          pendingCallDefault: {
+            calleeName,
+            importSource: importBinding.source,
+            importedName: importBinding.importedName,
+          },
+        };
+      }
+    }
+
+    // Unresolved: unknown identifier, member call (`x.y()`), IIFE, etc. Still tag as a
+    // pending call default so the finalize pass falls back to `any` - never the literal
+    // string "undefined" for the prop's type - regardless of the callee's shape.
+    return {
+      value,
+      type: undefined,
+      isFunction: false,
+      defaultValue,
+      pendingCallDefault: { calleeName: calleeName ?? calleeDisplayText(ctx, callee) },
+    };
   } else if (init.type === "Identifier") {
     const ident = init as Identifier;
     if (depth < 5) {
@@ -281,6 +342,61 @@ export function resolveConstInitializer(ctx: ParserContext, name: string): unkno
     }
   }
   return undefined;
+}
+
+/** Source text of a call's callee (e.g. `now.toISOString`), for a diagnostic naming it. Falls back to `"call"`. */
+function calleeDisplayText(ctx: ParserContext, callee: unknown): string {
+  if (
+    callee &&
+    typeof callee === "object" &&
+    "start" in callee &&
+    "end" in callee &&
+    typeof callee.start === "number" &&
+    typeof callee.end === "number"
+  ) {
+    return sourceAtPos(ctx, callee.start, callee.end) ?? "call";
+  }
+  return "call";
+}
+
+/**
+ * Return type for a same-file `CallExpression` default's callee (e.g.
+ * `export let id = uniqueId()` where `uniqueId` is declared in this file).
+ * Tries, in order: the callee's own JSDoc `@returns`, its TS return-type
+ * annotation, then a literal-only inference over its `return` statements
+ * (see {@link inferReturnTypeFromNode}). Returns `undefined` - not `"any"` -
+ * when none of these give a confident answer, so the caller can tell "no
+ * lead" apart from "resolved to any".
+ */
+function resolveSameFileCallReturnType(
+  parser: ComponentParser,
+  ctx: ParserContext,
+  calleeName: string,
+): string | undefined {
+  const resolvedJSDoc = parser.resolveLocalVarJSDoc(calleeName);
+  if (resolvedJSDoc?.returnType) return resolvedJSDoc.returnType;
+
+  const funcNode = ctx.funcDecls.get(calleeName);
+  if (!funcNode) return undefined;
+
+  const tsReturnType = functionReturnTypeAnnotationText(ctx, funcNode);
+  if (tsReturnType) return tsReturnType;
+
+  const inferred = inferReturnTypeFromNode(funcNode);
+  return inferred === "any" ? undefined : inferred;
+}
+
+/** Source text of a function declaration's explicit TS return-type annotation (`): T`), if any. */
+function functionReturnTypeAnnotationText(ctx: ParserContext, node: FunctionDeclaration): string | undefined {
+  const returnType = (
+    node as unknown as { returnType?: { type?: string; typeAnnotation?: { start?: number; end?: number } } }
+  ).returnType;
+  if (returnType?.type !== "TSTypeAnnotation") return undefined;
+
+  const annotation = returnType.typeAnnotation;
+  if (!annotation || typeof annotation.start !== "number" || typeof annotation.end !== "number") return undefined;
+
+  return sourceAtPos(ctx, annotation.start, annotation.end);
 }
 
 /**

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -455,6 +455,13 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
       // won; an explicit TS/JSDoc type on the prop itself must not be overridden by it.
       const inheritedType =
         typeMetadata?.type === undefined && propertyJSDoc?.type === undefined ? initResult.resolvedType : undefined;
+      if (initResult.pendingCallDefault) {
+        ctx.pendingCallDefaultCandidates.push({
+          propName,
+          location: "props",
+          ...initResult.pendingCallDefault,
+        });
+      }
 
       const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
         explicitType: typeMetadata?.type,

--- a/src/parser/type-resolution.ts
+++ b/src/parser/type-resolution.ts
@@ -279,10 +279,21 @@ function buildTypeImportStatements(ctx: ParserContext, referencedImportedTypes: 
 }
 
 export function buildTypeScriptMetadata(ctx: ParserContext): ParsedComponentTypeScriptMetadata | undefined {
-  if (ctx.typedRunesPropsDeclarations.length !== 1) return undefined;
+  const pendingCallDefaultCandidates =
+    ctx.pendingCallDefaultCandidates.length > 0 ? ctx.pendingCallDefaultCandidates.slice() : undefined;
+
+  if (ctx.typedRunesPropsDeclarations.length !== 1) {
+    return pendingCallDefaultCandidates
+      ? { canonicalPropNames: [], localTypeDeclarations: [], typeImportStatements: [], pendingCallDefaultCandidates }
+      : undefined;
+  }
 
   const [typedDeclaration] = ctx.typedRunesPropsDeclarations;
-  if (!typedDeclaration.canonicalType) return undefined;
+  if (!typedDeclaration.canonicalType) {
+    return pendingCallDefaultCandidates
+      ? { canonicalPropNames: [], localTypeDeclarations: [], typeImportStatements: [], pendingCallDefaultCandidates }
+      : undefined;
+  }
 
   const localTypeDeclarations = Array.from(typedDeclaration.referencedLocalTypes)
     .map((typeName) => ctx.localTypeDeclarationsByName.get(typeName))
@@ -296,5 +307,6 @@ export function buildTypeScriptMetadata(ctx: ParserContext): ParsedComponentType
     localTypeDeclarations,
     typeImportStatements: buildTypeImportStatements(ctx, typedDeclaration.referencedImportedTypes),
     referencesComponentGenerics: typeTextReferencesGenerics(typedDeclaration.canonicalType, ctx.generics),
+    ...(pendingCallDefaultCandidates ? { pendingCallDefaultCandidates } : {}),
   };
 }

--- a/src/parser/value-imports.ts
+++ b/src/parser/value-imports.ts
@@ -1,6 +1,6 @@
 import type { ParserContext } from "./context";
 
-/** Minimal shape of an `ImportDeclaration` node from the Svelte/acorn-typescript AST. */
+/** `ImportDeclaration` fields we read from the Svelte/acorn-typescript AST. */
 export interface ImportDeclarationNode {
   type: "ImportDeclaration";
   importKind?: "type" | "value";
@@ -14,11 +14,8 @@ export interface ImportDeclarationNode {
 }
 
 /**
- * Tracks named *value* imports (`import { x } from "..."`) by local binding
- * name, so a `CallExpression` prop default calling `x()` can later be
- * resolved cross-file (see `resolve-call-defaults.ts`). Type-only imports
- * (`import type { x }` / `import { type x }`) are skipped; they can't be
- * called at runtime, so they never appear as a prop default's callee.
+ * Record named value imports by local name for later cross-file call-default
+ * resolution. Skips type-only imports; those are not runtime callees.
  */
 export function collectValueImportBindings(ctx: ParserContext, node: ImportDeclarationNode): void {
   const source = node.source?.value;

--- a/src/parser/value-imports.ts
+++ b/src/parser/value-imports.ts
@@ -1,0 +1,39 @@
+import type { ParserContext } from "./context";
+
+/** Minimal shape of an `ImportDeclaration` node from the Svelte/acorn-typescript AST. */
+export interface ImportDeclarationNode {
+  type: "ImportDeclaration";
+  importKind?: "type" | "value";
+  source?: { value?: unknown };
+  specifiers?: Array<{
+    type: string;
+    importKind?: "type" | "value";
+    local?: { name?: string };
+    imported?: { name?: string; value?: unknown };
+  }>;
+}
+
+/**
+ * Tracks named *value* imports (`import { x } from "..."`) by local binding
+ * name, so a `CallExpression` prop default calling `x()` can later be
+ * resolved cross-file (see `resolve-call-defaults.ts`). Type-only imports
+ * (`import type { x }` / `import { type x }`) are skipped; they can't be
+ * called at runtime, so they never appear as a prop default's callee.
+ */
+export function collectValueImportBindings(ctx: ParserContext, node: ImportDeclarationNode): void {
+  const source = node.source?.value;
+  if (typeof source !== "string" || node.importKind === "type") return;
+
+  for (const specifier of node.specifiers ?? []) {
+    if (specifier.type !== "ImportSpecifier" || specifier.importKind === "type") continue;
+
+    const localName = specifier.local?.name;
+    if (!localName) continue;
+
+    const importedName =
+      specifier.imported?.name ??
+      (typeof specifier.imported?.value === "string" ? specifier.imported.value : localName);
+
+    ctx.valueImportBindingsByLocalName.set(localName, { localName, importedName, source });
+  }
+}

--- a/src/resolve-call-defaults.ts
+++ b/src/resolve-call-defaults.ts
@@ -3,25 +3,24 @@ import { dirname } from "node:path";
 import type { PendingCallDefaultCandidate } from "./ComponentParser";
 import { collectModuleExports, type ResolveContext, resolveModuleFile } from "./parse-entry-exports";
 
-/** Why a cross-file call-default candidate's return type couldn't be resolved. */
 export type CallDefaultFailureReason = "module-not-found" | "export-not-found" | "return-type-unresolved";
 
 export interface CallDefaultResolution {
   candidate: PendingCallDefaultCandidate;
-  /** Resolved return type text, present only on success. */
+  /** Present on success. */
   type?: string;
-  /** Present only on failure. */
+  /** Present on failure. */
   failureReason?: CallDefaultFailureReason;
 }
 
-/** Fresh, run-scoped cache/cycle-guard for {@link resolveCallDefaultCandidates}. Share one across a whole `generateBundle()` run. */
+/** Shared cache/cycle set for one `generateBundle()` run. */
 export function createCallDefaultResolveContext(): ResolveContext {
   return { cache: new Map(), computing: new Set() };
 }
 
 const FILE_EXTENSION_REGEX = /\.[^./\\]+$/;
 
-/** `foo.js` -> `foo.d.ts` in the same directory, when it exists. `null` for a `.d.ts` file itself or a missing sibling. */
+/** Sibling `foo.d.ts` for `foo.js` when it exists. */
 function siblingDeclarationFile(resolvedFile: string): string | null {
   if (resolvedFile.endsWith(".d.ts")) return null;
   const dtsPath = resolvedFile.replace(FILE_EXTENSION_REGEX, ".d.ts");
@@ -29,14 +28,10 @@ function siblingDeclarationFile(resolvedFile: string): string | null {
 }
 
 /**
- * Resolves each candidate's callee return type by reading its declaring
- * module (following re-exports - {@link collectModuleExports} already does
- * this) and, when the module itself carries no type info (a plain `.js` file
- * with no JSDoc `@returns`), falling back to a sibling `.d.ts`.
- *
- * AST/JSDoc-text only, no `tsc` - see `PendingCallDefaultCandidate` for why
- * this can't run inline during `ComponentParser` parsing (browser-safe code
- * can't touch `node:fs`).
+ * Read each candidate's callee return type from its declaring module
+ * ({@link collectModuleExports} follows re-exports). If the `.js` has no
+ * `@returns`, try a sibling `.d.ts`. AST/JSDoc only. Not inlined in
+ * `ComponentParser` because the browser build cannot use `node:fs`.
  */
 export function resolveCallDefaultCandidates(
   componentFilePath: string,
@@ -47,8 +42,7 @@ export function resolveCallDefaultCandidates(
 
   return candidates.map((candidate): CallDefaultResolution => {
     if (!candidate.importSource || !candidate.importedName) {
-      // No import lead (same-file function with no derivable return type, or an unknown
-      // callee) - already finalized to "any" with a diagnostic during parsing.
+      // Parse already finalized these to "any".
       return { candidate };
     }
 
@@ -69,7 +63,7 @@ export function resolveCallDefaultCandidates(
   });
 }
 
-/** Diagnostic text for a candidate that stayed unresolved after the cross-file pass. */
+/** Message for a candidate that stayed unresolved after the cross-file pass. */
 export function describeCallDefaultFailure(
   candidate: PendingCallDefaultCandidate,
   reason: CallDefaultFailureReason,

--- a/src/resolve-call-defaults.ts
+++ b/src/resolve-call-defaults.ts
@@ -1,0 +1,85 @@
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+import type { PendingCallDefaultCandidate } from "./ComponentParser";
+import { collectModuleExports, type ResolveContext, resolveModuleFile } from "./parse-entry-exports";
+
+/** Why a cross-file call-default candidate's return type couldn't be resolved. */
+export type CallDefaultFailureReason = "module-not-found" | "export-not-found" | "return-type-unresolved";
+
+export interface CallDefaultResolution {
+  candidate: PendingCallDefaultCandidate;
+  /** Resolved return type text, present only on success. */
+  type?: string;
+  /** Present only on failure. */
+  failureReason?: CallDefaultFailureReason;
+}
+
+/** Fresh, run-scoped cache/cycle-guard for {@link resolveCallDefaultCandidates}. Share one across a whole `generateBundle()` run. */
+export function createCallDefaultResolveContext(): ResolveContext {
+  return { cache: new Map(), computing: new Set() };
+}
+
+const FILE_EXTENSION_REGEX = /\.[^./\\]+$/;
+
+/** `foo.js` -> `foo.d.ts` in the same directory, when it exists. `null` for a `.d.ts` file itself or a missing sibling. */
+function siblingDeclarationFile(resolvedFile: string): string | null {
+  if (resolvedFile.endsWith(".d.ts")) return null;
+  const dtsPath = resolvedFile.replace(FILE_EXTENSION_REGEX, ".d.ts");
+  return existsSync(dtsPath) ? dtsPath : null;
+}
+
+/**
+ * Resolves each candidate's callee return type by reading its declaring
+ * module (following re-exports - {@link collectModuleExports} already does
+ * this) and, when the module itself carries no type info (a plain `.js` file
+ * with no JSDoc `@returns`), falling back to a sibling `.d.ts`.
+ *
+ * AST/JSDoc-text only, no `tsc` - see `PendingCallDefaultCandidate` for why
+ * this can't run inline during `ComponentParser` parsing (browser-safe code
+ * can't touch `node:fs`).
+ */
+export function resolveCallDefaultCandidates(
+  componentFilePath: string,
+  candidates: PendingCallDefaultCandidate[],
+  ctx: ResolveContext,
+): CallDefaultResolution[] {
+  const fromDir = dirname(componentFilePath);
+
+  return candidates.map((candidate): CallDefaultResolution => {
+    if (!candidate.importSource || !candidate.importedName) {
+      // No import lead (same-file function with no derivable return type, or an unknown
+      // callee) - already finalized to "any" with a diagnostic during parsing.
+      return { candidate };
+    }
+
+    const resolvedFile = resolveModuleFile(candidate.importSource, fromDir);
+    if (!resolvedFile) return { candidate, failureReason: "module-not-found" };
+
+    const match = collectModuleExports(resolvedFile, ctx).find((entry) => entry.name === candidate.importedName);
+    if (!match) return { candidate, failureReason: "export-not-found" };
+    if (match.returnType) return { candidate, type: match.returnType };
+
+    const siblingDts = siblingDeclarationFile(resolvedFile);
+    if (siblingDts) {
+      const dtsMatch = collectModuleExports(siblingDts, ctx).find((entry) => entry.name === candidate.importedName);
+      if (dtsMatch?.returnType) return { candidate, type: dtsMatch.returnType };
+    }
+
+    return { candidate, failureReason: "return-type-unresolved" };
+  });
+}
+
+/** Diagnostic text for a candidate that stayed unresolved after the cross-file pass. */
+export function describeCallDefaultFailure(
+  candidate: PendingCallDefaultCandidate,
+  reason: CallDefaultFailureReason,
+): string {
+  switch (reason) {
+    case "module-not-found":
+      return `Prop "${candidate.propName}" default calls "${candidate.calleeName}()", but "${candidate.importSource}" could not be resolved; falling back to "any".`;
+    case "export-not-found":
+      return `Prop "${candidate.propName}" default calls "${candidate.calleeName}()", but "${candidate.importedName}" is not exported from "${candidate.importSource}"; falling back to "any".`;
+    case "return-type-unresolved":
+      return `Prop "${candidate.propName}" default calls "${candidate.calleeName}()" imported from "${candidate.importSource}", but its return type could not be resolved; falling back to "any".`;
+  }
+}

--- a/tests/fixtures/prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output-class.d.ts
@@ -40,7 +40,7 @@ export type PropMetadataConsolidatedProps = {
   /**
    * @default makeDefault()
    */
-  callDefault?: undefined;
+  callDefault?: string;
 
   /**
    * @default Number.MAX_VALUE

--- a/tests/fixtures/prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output-component.d.ts
@@ -40,7 +40,7 @@ export type PropMetadataConsolidatedProps = {
   /**
    * @default makeDefault()
    */
-  callDefault?: undefined;
+  callDefault?: string;
 
   /**
    * @default Number.MAX_VALUE

--- a/tests/fixtures/prop-metadata-consolidated/output.json
+++ b/tests/fixtures/prop-metadata-consolidated/output.json
@@ -212,7 +212,6 @@
         "raw": "makeDefault()",
         "kind": "expression"
       },
-      "returnType": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,

--- a/tests/fixtures/prop-metadata-consolidated/output.json
+++ b/tests/fixtures/prop-metadata-consolidated/output.json
@@ -205,12 +205,14 @@
     {
       "name": "callDefault",
       "kind": "let",
-      "typeSource": "unknown",
+      "type": "string",
+      "typeSource": "jsdoc",
       "value": "makeDefault()",
       "defaultValue": {
         "raw": "makeDefault()",
         "kind": "expression"
       },
+      "returnType": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -307,22 +309,6 @@
   "generics": null,
   "contexts": [],
   "diagnostics": [
-    {
-      "component": "prop-metadata-consolidated/input.svelte",
-      "kind": "prop-unknown-type",
-      "name": "callDefault",
-      "message": "Prop \"callDefault\" type could not be inferred; falling back to \"any\".",
-      "source": {
-        "start": {
-          "line": 21,
-          "column": 2
-        },
-        "end": {
-          "line": 21,
-          "column": 41
-        }
-      }
-    },
     {
       "component": "prop-metadata-consolidated/input.svelte",
       "kind": "prop-unknown-type",

--- a/tests/fixtures/runes-derived-prop-default-resolved/input.svelte
+++ b/tests/fixtures/runes-derived-prop-default-resolved/input.svelte
@@ -1,0 +1,15 @@
+<script>
+  /**
+   * @returns {string}
+   */
+  function uniqueId() {
+    return "x";
+  }
+
+  let id = $derived(uniqueId());
+  let count = $state(0);
+
+  let { theId = id, theCount = count } = $props();
+</script>
+
+<p>{theId}: {theCount}</p>

--- a/tests/fixtures/runes-derived-prop-default-resolved/output-class.d.ts
+++ b/tests/fixtures/runes-derived-prop-default-resolved/output-class.d.ts
@@ -1,0 +1,19 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesDerivedPropDefaultResolvedProps = {
+  /**
+   * @default $derived(uniqueId())
+   */
+  theId?: string;
+
+  /**
+   * @default $state(0)
+   */
+  theCount?: number;
+};
+
+export default class RunesDerivedPropDefaultResolved extends SvelteComponentTyped<
+  RunesDerivedPropDefaultResolvedProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-derived-prop-default-resolved/output-component.d.ts
+++ b/tests/fixtures/runes-derived-prop-default-resolved/output-component.d.ts
@@ -1,0 +1,22 @@
+import type { Component } from "svelte";
+
+export type RunesDerivedPropDefaultResolvedProps = {
+  /**
+   * @default $derived(uniqueId())
+   */
+  theId?: string;
+
+  /**
+   * @default $state(0)
+   */
+  theCount?: number;
+};
+
+export type RunesDerivedPropDefaultResolvedExports = Record<string, never>;
+
+declare const RunesDerivedPropDefaultResolved: Component<
+  RunesDerivedPropDefaultResolvedProps,
+  RunesDerivedPropDefaultResolvedExports,
+  ""
+>;
+export default RunesDerivedPropDefaultResolved;

--- a/tests/fixtures/runes-derived-prop-default-resolved/output.json
+++ b/tests/fixtures/runes-derived-prop-default-resolved/output.json
@@ -1,0 +1,76 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "theId",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "jsdoc",
+      "value": "$derived(uniqueId())",
+      "defaultValue": {
+        "raw": "$derived(uniqueId())",
+        "kind": "expression"
+      },
+      "returnType": "string",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 8
+        },
+        "end": {
+          "line": 12,
+          "column": 18
+        }
+      }
+    },
+    {
+      "name": "theCount",
+      "kind": "let",
+      "type": "number",
+      "typeSource": "default",
+      "value": "$state(0)",
+      "defaultValue": {
+        "raw": "$state(0)",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 20
+        },
+        "end": {
+          "line": 12,
+          "column": 36
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/runes-derived-prop-default-resolved/output.json
+++ b/tests/fixtures/runes-derived-prop-default-resolved/output.json
@@ -22,7 +22,6 @@
         "raw": "$derived(uniqueId())",
         "kind": "expression"
       },
-      "returnType": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,

--- a/tests/fixtures/runes-derived-prop-default/output-class.d.ts
+++ b/tests/fixtures/runes-derived-prop-default/output-class.d.ts
@@ -4,7 +4,7 @@ export type RunesDerivedPropDefaultProps = {
   /**
    * @default $derived(now.toISOString())
    */
-  label?: undefined;
+  label?: any;
 };
 
 export default class RunesDerivedPropDefault extends SvelteComponentTyped<

--- a/tests/fixtures/runes-derived-prop-default/output-component.d.ts
+++ b/tests/fixtures/runes-derived-prop-default/output-component.d.ts
@@ -4,7 +4,7 @@ export type RunesDerivedPropDefaultProps = {
   /**
    * @default $derived(now.toISOString())
    */
-  label?: undefined;
+  label?: any;
 };
 
 export type RunesDerivedPropDefaultExports = Record<string, never>;

--- a/tests/fixtures/runes-derived-prop-default/output.json
+++ b/tests/fixtures/runes-derived-prop-default/output.json
@@ -15,6 +15,7 @@
     {
       "name": "label",
       "kind": "let",
+      "type": "any",
       "typeSource": "unknown",
       "value": "$derived(now.toISOString())",
       "defaultValue": {
@@ -49,7 +50,7 @@
       "component": "runes-derived-prop-default/input.svelte",
       "kind": "prop-unknown-type",
       "name": "label",
-      "message": "Prop \"label\" type could not be inferred; falling back to \"any\".",
+      "message": "Prop \"label\" default calls \"now.toISOString()\", but its return type could not be inferred; falling back to \"any\".",
       "source": {
         "start": {
           "line": 5,

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
@@ -34,7 +34,7 @@ export type RunesPropMetadataConsolidatedProps = {
   /**
    * @default createDefault()
    */
-  computed?: undefined;
+  computed?: string;
 
   /**
    * @default undefined

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
@@ -34,7 +34,7 @@ export type RunesPropMetadataConsolidatedProps = {
   /**
    * @default createDefault()
    */
-  computed?: undefined;
+  computed?: string;
 
   /**
    * @default undefined

--- a/tests/fixtures/runes-prop-metadata-consolidated/output.json
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output.json
@@ -177,12 +177,14 @@
     {
       "name": "computed",
       "kind": "let",
-      "typeSource": "unknown",
+      "type": "string",
+      "typeSource": "jsdoc",
       "value": "createDefault()",
       "defaultValue": {
         "raw": "createDefault()",
         "kind": "expression"
       },
+      "returnType": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,
@@ -240,22 +242,6 @@
         "end": {
           "line": 9,
           "column": 22
-        }
-      }
-    },
-    {
-      "component": "runes-prop-metadata-consolidated/input.svelte",
-      "kind": "prop-unknown-type",
-      "name": "computed",
-      "message": "Prop \"computed\" type could not be inferred; falling back to \"any\".",
-      "source": {
-        "start": {
-          "line": 13,
-          "column": 4
-        },
-        "end": {
-          "line": 13,
-          "column": 30
         }
       }
     },

--- a/tests/fixtures/runes-prop-metadata-consolidated/output.json
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output.json
@@ -184,7 +184,6 @@
         "raw": "createDefault()",
         "kind": "expression"
       },
-      "returnType": "string",
       "isFunction": false,
       "isFunctionDeclaration": false,
       "isRequired": false,

--- a/tests/resolve-call-defaults.test.ts
+++ b/tests/resolve-call-defaults.test.ts
@@ -197,4 +197,151 @@ describe("cross-file CallExpression prop-default resolution", () => {
 
     expect(prop?.type).toBe("string");
   });
+
+  test("fully cached second run still resolves import call defaults", async () => {
+    const cacheFile = path.join(dir, "parse-cache.json");
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "Cached.svelte"),
+      `<script>
+  import { uniqueId } from "./utils.js";
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Cached } from "./Cached.svelte";\n`);
+
+    const first = await generateBundle(path.join(dir, "index.js"), true, { cache: cacheFile });
+    expect(byModuleName(first.allComponentsForTypes, "Cached")?.props.find((p) => p.name === "id")?.type).toBe(
+      "string",
+    );
+
+    // Second run is a full parse-cache hit; must still load the parser stack for the
+    // call-default pass instead of throwing from getParserStack().
+    const second = await generateBundle(path.join(dir, "index.js"), true, { cache: cacheFile });
+    const prop = byModuleName(second.allComponentsForTypes, "Cached")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
+  test("module-script named import resolves an instance CallExpression default", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "ModuleImport.svelte"),
+      `<script context="module">
+  import { uniqueId } from "./utils.js";
+</script>
+<script>
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as ModuleImport } from "./ModuleImport.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "ModuleImport")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
+  test("same-file const arrow callee resolves via literal return", async () => {
+    writeFileSync(
+      path.join(dir, "ConstArrow.svelte"),
+      `<script>
+  const uniqueId = () => "x";
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as ConstArrow } from "./ConstArrow.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "ConstArrow")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+    expect(prop?.returnType).toBeUndefined();
+  });
+
+  test("renamed named import resolves via importedName", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "Renamed.svelte"),
+      `<script>
+  import { uniqueId as makeId } from "./utils.js";
+  export let id = makeId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Renamed } from "./Renamed.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "Renamed")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
+  test("cross-file function without JSDoc/.d.ts still infers a literal return", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_NO_JSDOC);
+    writeFileSync(
+      path.join(dir, "BodyInfer.svelte"),
+      `<script>
+  import { uniqueId } from "./utils.js";
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as BodyInfer } from "./BodyInfer.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "BodyInfer")?.props.find((p) => p.name === "id");
+    // Template-literal return → string via cross-file literal inference.
+    expect(prop?.type).toBe("string");
+  });
+
+  test("binding-annotated const export supplies returnType for call defaults", async () => {
+    writeFileSync(path.join(dir, "utils.ts"), `export const uniqueId: () => string = () => "x";\n`);
+    writeFileSync(
+      path.join(dir, "BindingType.svelte"),
+      `<script lang="ts">
+  import { uniqueId } from "./utils";
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as BindingType } from "./BindingType.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "BindingType")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
+  test("export found but no resolvable return type falls back to any", async () => {
+    writeFileSync(
+      path.join(dir, "utils.js"),
+      `export function uniqueId(prefix = "ccs") {
+  return Math.random();
+}
+`,
+    );
+    writeFileSync(
+      path.join(dir, "NoReturn.svelte"),
+      `<script>
+  import { uniqueId } from "./utils.js";
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as NoReturn } from "./NoReturn.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "NoReturn");
+    const prop = component?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("any");
+    expect(component?.diagnostics?.find((d) => d.name === "id")?.message).toContain(
+      "return type could not be resolved",
+    );
+  });
 });

--- a/tests/resolve-call-defaults.test.ts
+++ b/tests/resolve-call-defaults.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { type ComponentDocApi, type ComponentDocs, generateBundle } from "../src/bundle";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
+
+const UNIQUE_ID_WITH_JSDOC = `/**
+ * @param {string} [prefix]
+ * @returns {string}
+ */
+export function uniqueId(prefix = "ccs") {
+  return \`\${prefix}-\${Math.random().toString(36).slice(2)}\`;
+}
+`;
+
+const UNIQUE_ID_NO_JSDOC = `export function uniqueId(prefix = "ccs") {
+  return \`\${prefix}-\${Math.random().toString(36).slice(2)}\`;
+}
+`;
+
+const UNIQUE_ID_DTS = `export function uniqueId(prefix?: string): string;
+`;
+
+const REEXPORT_BARREL = `export { uniqueId } from "./uniqueId.js";
+`;
+
+describe("cross-file CallExpression prop-default resolution", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-call-defaults-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("A: resolves a return type from a local .js export's JSDoc @returns", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "WithJsdoc.svelte"),
+      `<script>
+  import { uniqueId } from "./utils.js";
+
+  /** Set an id for the input element */
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as WithJsdoc } from "./WithJsdoc.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "WithJsdoc");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("string");
+    expect(prop?.typeSource).toBe("typescript");
+    expect(component?.diagnostics?.some((d) => d.name === "id")).toBe(false);
+  });
+
+  test("B: resolves a return type from a sibling .d.ts when the .js has no JSDoc", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_NO_JSDOC);
+    writeFileSync(path.join(dir, "utils.d.ts"), UNIQUE_ID_DTS);
+    writeFileSync(
+      path.join(dir, "WithDts.svelte"),
+      `<script>
+  import { uniqueId } from "./utils.js";
+
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as WithDts } from "./WithDts.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "WithDts");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("string");
+    expect(prop?.typeSource).toBe("typescript");
+  });
+
+  test("resolves through a re-export barrel", async () => {
+    writeFileSync(path.join(dir, "uniqueId.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(path.join(dir, "reexport.js"), REEXPORT_BARREL);
+    writeFileSync(
+      path.join(dir, "ViaReexport.svelte"),
+      `<script>
+  import { uniqueId } from "./reexport.js";
+
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as ViaReexport } from "./ViaReexport.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "ViaReexport");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("string");
+  });
+
+  test("C: an explicit JSDoc @type on the prop wins over cross-file resolution", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "Explicit.svelte"),
+      `<script>
+  import { uniqueId } from "./utils.js";
+
+  /** @type {"a" | "b"} */
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Explicit } from "./Explicit.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Explicit");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe('"a" | "b"');
+    expect(prop?.typeSource).toBe("jsdoc");
+  });
+
+  test("D: an unresolvable import falls back to any, never the literal string undefined", async () => {
+    writeFileSync(
+      path.join(dir, "Unresolvable.svelte"),
+      `<script>
+  import { uniqueId } from "./does-not-exist.js";
+
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Unresolvable } from "./Unresolvable.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Unresolvable");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("any");
+    expect(prop?.typeSource).toBe("unknown");
+    const diagnostic = component?.diagnostics?.find((d) => d.name === "id");
+    expect(diagnostic?.message).toContain("could not be resolved");
+  });
+
+  test("D: an import that resolves but doesn't export the callee falls back to any", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "MissingExport.svelte"),
+      `<script>
+  import { notExported } from "./utils.js";
+
+  export let id = notExported();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as MissingExport } from "./MissingExport.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "MissingExport");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("any");
+    const diagnostic = component?.diagnostics?.find((d) => d.name === "id");
+    expect(diagnostic?.message).toContain("is not exported from");
+  });
+
+  test("E: a same-file function default still resolves without any import", async () => {
+    writeFileSync(
+      path.join(dir, "SameFile.svelte"),
+      `<script>
+  function uniqueId() {
+    return "x";
+  }
+  export let id = uniqueId();
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as SameFile } from "./SameFile.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "SameFile");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("string");
+  });
+});

--- a/tests/resolve-call-defaults.test.ts
+++ b/tests/resolve-call-defaults.test.ts
@@ -217,8 +217,7 @@ describe("cross-file CallExpression prop-default resolution", () => {
       "string",
     );
 
-    // Second run is a full parse-cache hit; must still load the parser stack for the
-    // call-default pass instead of throwing from getParserStack().
+    // Warm cache: still need the parser stack for the call-default pass.
     const second = await generateBundle(path.join(dir, "index.js"), true, { cache: cacheFile });
     const prop = byModuleName(second.allComponentsForTypes, "Cached")?.props.find((p) => p.name === "id");
     expect(prop?.type).toBe("string");
@@ -295,7 +294,7 @@ describe("cross-file CallExpression prop-default resolution", () => {
 
     const result = await generateBundle(path.join(dir, "index.js"), true);
     const prop = byModuleName(result.allComponentsForTypes, "BodyInfer")?.props.find((p) => p.name === "id");
-    // Template-literal return → string via cross-file literal inference.
+    // Template return → string via cross-file literal inference.
     expect(prop?.type).toBe("string");
   });
 


### PR DESCRIPTION
## Summary

CallExpression prop defaults like `export let id = uniqueId()` used to leave the prop type unset, so generated `.d.ts` emitted the literal type `undefined` (`id?: undefined`). That breaks `svelte-check` for libraries that share runtime helpers across modules (e.g. carbon-components-svelte's `uniqueId()`).

This PR resolves a return type when we can, and falls back to `any` (never `undefined`) when we cannot.

## Cases

### Before (broken)

```svelte
<script>
  import { uniqueId } from "./uniqueId.js";
  export let id = uniqueId();
</script>
```

```ts
// emitted
id?: undefined;
```

### Same-file function / const arrow

```svelte
<script>
  function uniqueId() {
    return "x";
  }
  // also works: const uniqueId = () => "x";
  export let id = uniqueId();
</script>
```

Resolves via JSDoc `@returns`, a TS return annotation, a binding type like `() => string`, or literal return inference → `id?: string`.

### Named import (cross-file)

```js
// uniqueId.js
/** @returns {string} */
export function uniqueId(prefix = "ccs") {
  return `${prefix}-${Math.random().toString(36).slice(2)}`;
}
```

```svelte
<script>
  import { uniqueId } from "./uniqueId.js";
  // renamed imports work too: import { uniqueId as makeId }
  export let id = uniqueId();
</script>
```

Resolved in a Node-only pass from `generateBundle` (`resolve-call-defaults.ts`). Follows re-export barrels and falls back to a sibling `.d.ts` when the `.js` has no `@returns`.

### Module-script import, instance default

```svelte
<script context="module">
  import { uniqueId } from "./uniqueId.js";
</script>
<script>
  export let id = uniqueId();
</script>
```

Module imports/functions/vars are tracked so instance CallExpression defaults can see them.

### `$derived` / `$state` wrappers

```svelte
<script>
  /**
   * @returns {string}
   */
  function uniqueId() {
    return "x";
  }
  let id = $derived(uniqueId());
  let { theId = id } = $props();
</script>
```

Rune wrappers unwrap to the inner expression. `@default` keeps the rune call text.

### Explicit `@type` wins

```svelte
<script>
  import { uniqueId } from "./uniqueId.js";
  /** @type {"a" | "b"} */
  export let id = uniqueId();
</script>
```

Cross-file resolution does not overwrite an explicit prop type.

### Unresolved → `any`

```svelte
<script>
  import { uniqueId } from "./missing.js";
  export let id = uniqueId();
  export let label = now.toISOString(); // member call
</script>
```

```ts
id?: any;
label?: any;
```

Plus a `prop-unknown-type` diagnostic naming the callee / import failure.

## Notes

- Cross-file resolution needs `node:fs`, so it runs in `generateBundle` only (CLI / plugin). `sveld/browser` + `ComponentParser` alone still get same-file resolution and the `any` fallback.
- Warm-cache bundle runs load the parser stack when call-default candidates exist, so the second pass does not throw.

## Test plan

- [x] `tests/resolve-call-defaults.test.ts` (JSDoc, `.d.ts`, re-export, `@type` override, missing module/export, same-file, warm cache, module-script import, const arrow, renamed import, body inference, binding annotation, unresolved return)
- [x] Fixture updates for call defaults / `$derived` / prop metadata
- [ ] Spot-check carbon-style `uniqueId()` component output locally if convenient