### PR TITLE
fix(parser): resolve prop defaults that use later imports or functions

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -53,7 +53,11 @@ import { sourceAtPos, sourceRangeFromNode, sourceRangeFromOffsets } from "./pars
 import { buildTypeScriptMetadata } from "./parser/type-resolution";
 import { stripTypeCastWrappers } from "./parser/typescript-casts";
 import { assignValueOrUndefined } from "./parser/utils";
-import { collectValueImportBindings, type ImportDeclarationNode } from "./parser/value-imports";
+import {
+  collectHoistedScriptBindings,
+  collectValueImportBindings,
+  type ImportDeclarationNode,
+} from "./parser/value-imports";
 import { buildVariableJsDocTable } from "./parser/variable-jsdoc";
 import { parseModernAndLegacy } from "./svelte-parse";
 
@@ -926,6 +930,23 @@ export default class ComponentParser {
 
     parseCustomTypes(this.ctx, this, scanSource);
 
+    const componentRoot = {
+      type: "ComponentRoot",
+      instance: this.ctx.parsed.instance,
+      html: this.ctx.parsed.html,
+    } as unknown as Node;
+
+    /**
+     * Imports and function declarations hoist, so `export let id = uniqueId()` must
+     * resolve even when the import or `function uniqueId()` comes later in the script.
+     * See #410. Pre-scan module and instance so those bindings exist before prop defaults run.
+     *
+     * Skip `componentRoot`. Imports and function declarations never appear in `html`,
+     * so walking markup here would re-traverse the largest part of the AST for nothing.
+     */
+    collectHoistedScriptBindings(this.ctx, this.ctx.parsed?.module as unknown as Node | undefined);
+    collectHoistedScriptBindings(this.ctx, this.ctx.parsed?.instance as unknown as Node | undefined);
+
     /**
      * Not fused with the componentRoot walk below: `module` (`<script context="module">`) is a
      * disjoint AST rooted separately from `instance`/`html`, not a subtree reachable from either,
@@ -1071,11 +1092,6 @@ export default class ComponentParser {
     const hostLocalNames = new Set<string>();
     const hostDispatchedEventNames = new Set<string>();
     const callees: { name: string; arguments: Array<Expression | unknown>; source?: SourceRange }[] = [];
-    const componentRoot = {
-      type: "ComponentRoot",
-      instance: this.ctx.parsed.instance,
-      html: this.ctx.parsed.html,
-    } as unknown as Node;
 
     initComponentScope(this, this.ctx);
     this.ctx.activeScopes.push(this.ctx.componentScope);

--- a/src/parser/value-imports.ts
+++ b/src/parser/value-imports.ts
@@ -1,3 +1,6 @@
+import type { FunctionDeclaration } from "estree";
+import type { Node } from "estree-walker";
+import { walk } from "estree-walker";
 import type { ParserContext } from "./context";
 
 /** `ImportDeclaration` fields we read from the Svelte/acorn-typescript AST. */
@@ -33,4 +36,29 @@ export function collectValueImportBindings(ctx: ParserContext, node: ImportDecla
 
     ctx.valueImportBindingsByLocalName.set(localName, { localName, importedName, source });
   }
+}
+
+/**
+ * Collect imports and function declarations from a script root before prop defaults run.
+ * Both hoist, so `export let id = uniqueId()` still resolves when the import or
+ * `function uniqueId()` appears later, the pattern carbon-components-svelte uses.
+ * The main walk records the same bindings again into keyed maps; that is fine.
+ */
+export function collectHoistedScriptBindings(ctx: ParserContext, root: Node | undefined): void {
+  if (!root) return;
+
+  walk(root, {
+    enter(node) {
+      if (node.type === "ImportDeclaration") {
+        collectValueImportBindings(ctx, node as unknown as ImportDeclarationNode);
+      }
+
+      if (node.type === "FunctionDeclaration") {
+        const funcDecl = node as unknown as FunctionDeclaration;
+        if (funcDecl.id?.name) {
+          ctx.funcDecls.set(funcDecl.id.name, funcDecl);
+        }
+      }
+    },
+  });
 }

--- a/tests/fixtures/call-expression-default-hoisted-function/input.svelte
+++ b/tests/fixtures/call-expression-default-hoisted-function/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  export let id = uniqueId();
+
+  /**
+   * @returns {string}
+   */
+  function uniqueId() {
+    return "x";
+  }
+</script>
+
+<div {id} />

--- a/tests/fixtures/call-expression-default-hoisted-function/output-class.d.ts
+++ b/tests/fixtures/call-expression-default-hoisted-function/output-class.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type CallExpressionDefaultHoistedFunctionProps = {
+  /**
+   * @default uniqueId()
+   */
+  id?: string;
+};
+
+export default class CallExpressionDefaultHoistedFunction extends SvelteComponentTyped<
+  CallExpressionDefaultHoistedFunctionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/call-expression-default-hoisted-function/output-component.d.ts
+++ b/tests/fixtures/call-expression-default-hoisted-function/output-component.d.ts
@@ -1,0 +1,17 @@
+import type { Component } from "svelte";
+
+export type CallExpressionDefaultHoistedFunctionProps = {
+  /**
+   * @default uniqueId()
+   */
+  id?: string;
+};
+
+export type CallExpressionDefaultHoistedFunctionExports = Record<string, never>;
+
+declare const CallExpressionDefaultHoistedFunction: Component<
+  CallExpressionDefaultHoistedFunctionProps,
+  CallExpressionDefaultHoistedFunctionExports,
+  ""
+>;
+export default CallExpressionDefaultHoistedFunction;

--- a/tests/fixtures/call-expression-default-hoisted-function/output.json
+++ b/tests/fixtures/call-expression-default-hoisted-function/output.json
@@ -1,0 +1,49 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "id",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "jsdoc",
+      "value": "uniqueId()",
+      "defaultValue": {
+        "raw": "uniqueId()",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/resolve-call-defaults.test.ts
+++ b/tests/resolve-call-defaults.test.ts
@@ -198,6 +198,129 @@ describe("cross-file CallExpression prop-default resolution", () => {
     expect(prop?.type).toBe("string");
   });
 
+  test("F: import after the export let (carbon-components-svelte props-then-imports style)", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "ImportAfter.svelte"),
+      `<script>
+  export let id = uniqueId();
+
+  import { uniqueId } from "./utils.js";
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as ImportAfter } from "./ImportAfter.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "ImportAfter");
+    const prop = component?.props.find((p) => p.name === "id");
+
+    expect(prop?.type).toBe("string");
+    expect(component?.diagnostics?.some((d) => d.name === "id")).toBe(false);
+  });
+
+  test("F: a late import among other imports still resolves", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "LateAmongOthers.svelte"),
+      `<script>
+  export let label = "";
+  export let id = uniqueId();
+  import { createEventDispatcher } from "svelte";
+  import { uniqueId } from "./utils.js";
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(
+      path.join(dir, "index.js"),
+      `export { default as LateAmongOthers } from "./LateAmongOthers.svelte";\n`,
+    );
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "LateAmongOthers")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
+  test("F: a renamed import after the export let still resolves via importedName", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "RenamedAfter.svelte"),
+      `<script>
+  export let id = makeId();
+
+  import { uniqueId as makeId } from "./utils.js";
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as RenamedAfter } from "./RenamedAfter.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "RenamedAfter")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
+  test("F: an import after the export let that cannot be resolved still falls back to any", async () => {
+    writeFileSync(
+      path.join(dir, "Unresolvable2.svelte"),
+      `<script>
+  export let id = uniqueId();
+
+  import { uniqueId } from "./does-not-exist.js";
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Unresolvable2 } from "./Unresolvable2.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "Unresolvable2")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("any");
+  });
+
+  test("F: explicit JSDoc @type still wins when the import comes after the export let", async () => {
+    writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);
+    writeFileSync(
+      path.join(dir, "ExplicitAfter.svelte"),
+      `<script>
+  /** @type {"a" | "b"} */
+  export let id = uniqueId();
+
+  import { uniqueId } from "./utils.js";
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as ExplicitAfter } from "./ExplicitAfter.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "ExplicitAfter")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe('"a" | "b"');
+    expect(prop?.typeSource).toBe("jsdoc");
+  });
+
+  test("F: a same-file function declared after the export let still resolves", async () => {
+    writeFileSync(
+      path.join(dir, "SameFileAfter.svelte"),
+      `<script>
+  export let id = uniqueId();
+
+  function uniqueId() {
+    return "x";
+  }
+</script>
+<div {id} />
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as SameFileAfter } from "./SameFileAfter.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const prop = byModuleName(result.allComponentsForTypes, "SameFileAfter")?.props.find((p) => p.name === "id");
+    expect(prop?.type).toBe("string");
+  });
+
   test("fully cached second run still resolves import call defaults", async () => {
     const cacheFile = path.join(dir, "parse-cache.json");
     writeFileSync(path.join(dir, "utils.js"), UNIQUE_ID_WITH_JSDOC);


### PR DESCRIPTION
Imports and function declarations hoist in JS/Svelte, but sveld only
recorded them as its single AST walk passed each node, so a prop
default like `export let id = uniqueId()` fell back to `any` when the
import or function it calls came after it in source order (the
carbon-components-svelte props-then-imports style), while the same
code with the import first resolved fine. Adds a pre-scan of the
module and instance scripts before any prop default is processed, so
forward references resolve the same as backward ones.

## Benchmark

Ran `scripts/bench.ts --runs 8` against the carbon-components-svelte
fixture (~200 components), before (`bd4df467`) and after, in a
worktree:

| | median parse |
|---|---|
| before | 93ms |
| after | 80ms |

Within run-to-run noise. The pre-scan only walks the module/instance
scripts, not markup, so it doesn't scale with template size.