### PR TITLE
perf(parser): convert legacy AST in place instead of cloning

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -59,7 +59,7 @@ import {
   type ImportDeclarationNode,
 } from "./parser/value-imports";
 import { buildVariableJsDocTable } from "./parser/variable-jsdoc";
-import { parseModernAndLegacy } from "./svelte-parse";
+import { parseModern } from "./svelte-parse";
 
 /** Structured JSDoc tag (e.g. `{ name: "since", body: "1.2.0" }`). */
 export interface JsDocPassthroughTag {
@@ -889,14 +889,18 @@ export default class ComponentParser {
     this.ctx.source = cleanedSource;
 
     /**
-     * One `parseFragment` call backs both AST views (see `parseModernAndLegacy`): the modern
-     * view feeds `buildRunesPropTypeMetadata` (type imports, local types, `$props()` metadata),
-     * the legacy view backs the main walk below. Two independent `parse()` calls used to re-lex
-     * and re-parse the same source from scratch for each mode.
+     * One `parseFragment` call backs both AST views (see `parseModern`): the modern view feeds
+     * `buildRunesPropTypeMetadata` (type imports, local types, `$props()` metadata) first, and
+     * only once that's fully consumed does `intoLegacy()` convert the same tree in place for the
+     * main walk below - `convert()` restructures its input in place, so calling it any earlier
+     * would corrupt the modern view still being read. Two independent `parse()` calls used to
+     * re-lex and re-parse the same source from scratch for each mode; an earlier version of this
+     * ran both conversions upfront and deep-cloned the modern AST to give `convert()` a safe
+     * input, which this ordering makes unnecessary.
      */
-    const { modern: modernParsed, legacy: legacyParsed } = parseModernAndLegacy(cleanedSource);
+    const { modern: modernParsed, intoLegacy } = parseModern(cleanedSource);
     buildRunesPropTypeMetadata(this, this.ctx, modernParsed);
-    this.ctx.parsed = legacyParsed as LegacyAstRoot;
+    this.ctx.parsed = intoLegacy() as LegacyAstRoot;
 
     /**
      * compile() strips TS-only wrapper expressions (`as`/`satisfies`/`!`/type assertions/explicit

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -226,9 +226,14 @@ type ModernParsedRoot = {
 
 /**
  * Reads type imports, local types, explicit `export let` annotations, and
- * `$props()` metadata off `modernParsed` (the modern-mode AST for the same
- * source as `ctx.parsed`, parsed once alongside it by the caller - see
- * `parseModernAndLegacy` in `../svelte-parse`).
+ * `$props()` metadata off `modernParsed` (the modern-mode AST derived from the
+ * same `parseFragment` call as `ctx.parsed`, before that tree is converted in
+ * place into the legacy shape - see `parseModern` in `../svelte-parse`). Must
+ * run to completion before the caller converts `modernParsed` into legacy:
+ * `localTypeDeclarationsByName` entries retain a live `node` reference into
+ * this tree (read synchronously by `collectReferencedTypeDependencies` and
+ * `collectGenericsAttributeTypeDependencies` during this call only - nothing
+ * reads `.node` afterwards, only the pre-extracted `.code` string).
  */
 export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserContext, modernParsedRoot: unknown) {
   ctx.runesPropsDeclarationMetadataByDeclaratorStart.clear();

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -128,9 +128,17 @@ export function parseModern(
   const cleaned = removeByteOrderMark(source);
   resetCompilerState({ warning: () => false, filename: undefined });
   const ast: InternalAstRoot = parseFragment(cleaned, loose);
-  const modern = toPublicAst(cleaned, ast, true);
+  /**
+   * Unlike the public `parse()`, the modern view here skips `toPublicAst`'s
+   * metadata stripping: its only consumer (`buildRunesPropTypeMetadata`)
+   * extracts strings and offsets and never touches `metadata`, and the legacy
+   * conversion below runs `convert()` on the raw parser output exactly like
+   * upstream's own legacy branch of `to_public_ast` (convert deletes
+   * `metadata` itself, and never reads it). Skipping the strip avoids a full
+   * extra AST walk per component.
+   */
   return {
-    modern,
-    intoLegacy: () => toPublicAst(cleaned, modern as InternalAstRoot, false),
+    modern: ast,
+    intoLegacy: () => toPublicAst(cleaned, ast, false),
   };
 }

--- a/src/svelte-parse.ts
+++ b/src/svelte-parse.ts
@@ -107,43 +107,30 @@ export function parse(source: string, { modern, loose }: { modern?: boolean; loo
 }
 
 /**
- * Deep-clones a plain JSON-shaped value (objects/arrays/primitives only - the
- * AST has neither, as `tests/svelte-parse-shim.test.ts`'s `JSON.stringify`
- * round-trip already confirms). Plain recursion beats the built-in
- * `structuredClone`: that API's general-purpose serialization handles many
- * types this data never contains, and empirically costs about as much as a
- * fresh `parseFragment` call on ASTs this shape - which would have defeated
- * the whole point of cloning instead of re-parsing.
+ * Produces the modern AST for `source` from a single `parseFragment` call,
+ * plus an `intoLegacy()` finalizer that converts that same tree into the
+ * legacy shape - instead of sveld's former two independent `parse()` calls
+ * (one per mode) that each re-lexed and re-parsed the source from scratch.
+ *
+ * `convert()` (the legacy path) restructures its input in place, so
+ * `intoLegacy()` must not be called until every read of the modern AST is
+ * done - the caller (`ComponentParser.parseSvelteComponent`) enforces this by
+ * fully consuming `modern` (via `buildRunesPropTypeMetadata`) before calling
+ * `intoLegacy()`. This two-phase shape (rather than eagerly producing both
+ * views, as an earlier version of this function did with a deep-cloned
+ * `convert()` input) lets `convert()` mutate the original `parseFragment`
+ * output directly, avoiding a clone entirely.
  */
-function cloneAst<T>(value: T): T {
-  if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(cloneAst) as T;
-  const out = {} as T;
-  for (const key in value) out[key] = cloneAst(value[key]);
-  return out;
-}
-
-/**
- * Produces both the modern and legacy AST for the same source from a single
- * `parseFragment` call, instead of sveld's former two independent `parse()`
- * calls (one per mode) that each re-lexed and re-parsed the source from
- * scratch. `convert()` (the legacy path) restructures its input in place, so
- * it must run on a clone - the modern view is derived first, directly off
- * the original `parseFragment` output, and only that (already
- * metadata-stripped, so cheaper to copy) result gets cloned for `convert()`.
- * `convert()` only ever deletes `.metadata`, never reads it, so pre-stripping
- * before conversion doesn't change its output (see `tests/svelte-parse-shim.test.ts`,
- * which byte-compares both branches of this function against the real compiler).
- */
-export function parseModernAndLegacy(
+export function parseModern(
   source: string,
   { loose }: { loose?: boolean } = {},
-): { modern: unknown; legacy: unknown } {
+): { modern: unknown; intoLegacy: () => unknown } {
   const cleaned = removeByteOrderMark(source);
   resetCompilerState({ warning: () => false, filename: undefined });
   const ast: InternalAstRoot = parseFragment(cleaned, loose);
   const modern = toPublicAst(cleaned, ast, true);
-  const legacyInput = cloneAst(modern) as InternalAstRoot;
-  const legacy = toPublicAst(cleaned, legacyInput, false);
-  return { modern, legacy };
+  return {
+    modern,
+    intoLegacy: () => toPublicAst(cleaned, modern as InternalAstRoot, false),
+  };
 }

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -132,12 +132,41 @@ export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">) {
 }
 
 /**
+ * Compiled word-boundary regexes for `referencesGeneric`, keyed by generic
+ * name. A component declares only a handful of generics, so this cache stays
+ * small; it just avoids recompiling the same RegExp on every prop/generic
+ * pairing checked for a component.
+ */
+const referencesGenericRegexCache = new Map<string, RegExp>();
+
+/**
  * Returns whether a property type references a generic type parameter by name,
  * matching on word boundaries so `Value` doesn't match `ValueType`.
  */
 function referencesGeneric(propType: string, name: string): boolean {
-  const escapedName = name.replace(REGEX_METACHARS, "\\$&");
-  return new RegExp(`\\b${escapedName}\\b`).test(propType);
+  let regex = referencesGenericRegexCache.get(name);
+  if (regex === undefined) {
+    const escapedName = name.replace(REGEX_METACHARS, "\\$&");
+    regex = new RegExp(`\\b${escapedName}\\b`);
+    referencesGenericRegexCache.set(name, regex);
+  }
+  return regex.test(propType);
+}
+
+/**
+ * `splitTopLevelCommas` is called with the same `generics[1]` constraint
+ * string from a few sites (`getGenericParams`, `getContextDefs`, and the
+ * `$Props` generics suffix below) while generating a single component, so a
+ * single last-input memo avoids re-splitting the same string repeatedly.
+ */
+let lastSplitTopLevelCommasInput: string | undefined;
+let lastSplitTopLevelCommasResult: string[] = [];
+function splitTopLevelCommasMemo(input: string): string[] {
+  if (input !== lastSplitTopLevelCommasInput) {
+    lastSplitTopLevelCommasInput = input;
+    lastSplitTopLevelCommasResult = splitTopLevelCommas(input);
+  }
+  return lastSplitTopLevelCommasResult;
 }
 
 /**
@@ -150,7 +179,7 @@ function getGenericParams(generics: ComponentDocApi["generics"]): Array<{ name: 
   if (generics === null) return [];
   return generics[0].split(",").map((name, index) => ({
     name: name.trim(),
-    constraint: (splitTopLevelCommas(generics[1] ?? "")[index] ?? name).trim(),
+    constraint: (splitTopLevelCommasMemo(generics[1] ?? "")[index] ?? name).trim(),
   }));
 }
 
@@ -204,7 +233,7 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
       ? []
       : def.generics[0].split(",").map((name, index) => ({
           name: name.trim(),
-          constraint: (splitTopLevelCommas(def.generics?.[1] ?? "")[index] ?? name).trim(),
+          constraint: (splitTopLevelCommasMemo(def.generics?.[1] ?? "")[index] ?? name).trim(),
         }));
 
   return def.contexts
@@ -312,57 +341,63 @@ function genPropDef(
   },
 ) {
   /**
+   * Props that render as regular `$Props` members, i.e. everything except
+   * accessor-style exports (`export function ...` / `export const ...`),
+   * which are handled separately by `genAccessors`. Computed once and reused
+   * below instead of re-filtering `def.props` at each use site.
+   */
+  const nonAccessorProps = def.props.filter((prop) => !prop.isFunctionDeclaration && prop.kind !== "const");
+
+  /**
    * Collect existing prop names to avoid conflicts with snippet props.
    * Snippet props are generated for slots, but shouldn't conflict with
    * actual component props.
    */
   const existingPropNames = new Set([
-    ...def.props.filter((prop) => !prop.isFunctionDeclaration && prop.kind !== "const").map((prop) => prop.name),
+    ...nonAccessorProps.map((prop) => prop.name),
     ...Array.from(def.canonicalPropNames ?? []),
   ]);
 
-  const initial_props = def.props
-    .filter((prop) => !prop.isFunctionDeclaration && prop.kind !== "const")
-    .map((prop) => {
-      let defaultValue = prop.value;
+  const initial_props = nonAccessorProps.map((prop) => {
+    let defaultValue = prop.value;
 
-      if (typeof prop.value === "string") {
-        defaultValue = prop.value.replace(WHITESPACE_REGEX, " ");
-      }
+    if (typeof prop.value === "string") {
+      defaultValue = prop.value.replace(WHITESPACE_REGEX, " ");
+    }
 
-      if (prop.value === undefined) {
-        defaultValue = "undefined";
-      }
+    if (prop.value === undefined) {
+      defaultValue = "undefined";
+    }
 
-      const descriptionHasDefault = DESCRIPTION_DEFAULT_TAG_REGEX.test(prop.description ?? "");
+    const descriptionHasDefault = DESCRIPTION_DEFAULT_TAG_REGEX.test(prop.description ?? "");
 
-      /**
-       * Function props only get `@default` when a concise value was inferred
-       * (a trivial single-expression body, e.g. `() => true` - see
-       * `conciseFunctionDefaultText`); anything more elaborate is omitted so
-       * docs aren't cluttered with function bodies (#203). An explicit
-       * `@default` in the description always wins either way.
-       */
-      const suppressDefault = descriptionHasDefault || (prop.isFunction && prop.value === undefined);
+    /**
+     * Function props only get `@default` when a concise value was inferred
+     * (a trivial single-expression body, e.g. `() => true` - see
+     * `conciseFunctionDefaultText`); anything more elaborate is omitted so
+     * docs aren't cluttered with function bodies (#203). An explicit
+     * `@default` in the description always wins either way.
+     */
+    const suppressDefault = descriptionHasDefault || (prop.isFunction && prop.value === undefined);
 
-      const prop_comments = [
-        createPropComment(prop.description, prop.deprecated, prop.tags),
-        addCommentLine(prop.constant, "@constant"),
-        suppressDefault ? null : `* @default ${defaultValue}\n`,
-      ]
-        .filter(Boolean)
-        .join("");
+    const prop_comments = [
+      createPropComment(prop.description, prop.deprecated, prop.tags),
+      addCommentLine(prop.constant, "@constant"),
+      suppressDefault ? null : `* @default ${defaultValue}\n`,
+    ]
+      .filter(Boolean)
+      .join("");
 
-      const prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
+    const prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
 
-      return `
+    return `
       ${wrapCommentInJSDoc(prop_comments)}
       ${prop.name}${prop.isRequired ? "" : "?"}: ${prop_value};`;
-    });
+  });
 
   const extra_initial_props = def.canonicalPropsType
     ? initial_props.filter((_, index) => {
-        const prop = def.props.filter((item) => !item.isFunctionDeclaration && item.kind !== "const")[index];
+        const prop = nonAccessorProps[index];
         return prop ? !(def.canonicalPropNames?.has(prop.name) ?? false) : true;
       })
     : initial_props;
@@ -431,7 +466,7 @@ function genPropDef(
    * Includes the full generic constraint with extends and default.
    */
   const genericsName = def.generics
-    ? `<${splitTopLevelCommas(def.generics[1])
+    ? `<${splitTopLevelCommasMemo(def.generics[1])
         .map((constraint) => stripConstModifierForTypeAlias(constraint.trim()))
         .join(", ")}>`
     : "";
@@ -1097,9 +1132,12 @@ export function writeTsDefinition(component: ComponentDocApi, options?: WriteTsD
 
   const snippetImportNeeded =
     !PRESERVED_SNIPPET_IMPORT_REGEX.test(preservedTypeImports) &&
-    SNIPPET_TYPE_REFERENCE_REGEX.test(
-      `${prop_def}\n${moduleExportsDef}\n${typeDefs}\n${contextDefs}\n${preservedLocalTypeDeclarations}\n${exports_def}`,
-    );
+    (SNIPPET_TYPE_REFERENCE_REGEX.test(prop_def) ||
+      SNIPPET_TYPE_REFERENCE_REGEX.test(moduleExportsDef) ||
+      SNIPPET_TYPE_REFERENCE_REGEX.test(typeDefs) ||
+      SNIPPET_TYPE_REFERENCE_REGEX.test(contextDefs) ||
+      SNIPPET_TYPE_REFERENCE_REGEX.test(preservedLocalTypeDeclarations) ||
+      SNIPPET_TYPE_REFERENCE_REGEX.test(exports_def));
 
   /**
    * Determine imports needed for rest_props.


### PR DESCRIPTION
Follow-up to #392: the deep clone that made the shared-tree parse safe
is no longer needed, since the modern view is fully consumed before the
legacy conversion runs. The internal path also skips the public-AST
metadata strip, and `.d.ts` generation trims some repeated work.
Generated output is byte-identical throughout.

## Benchmark

Wall-clock bench medians were too noisy to trust on this machine (load
average 5-8, identical code swung 123ms to 234ms between invocations),
so each change was measured with interleaved in-process A/B loops over
all 160 carbon components, 7+ iterations per side, comparing medians:

| Change | Before | After |
|---|---|---|
| parse+convert loop (clone removed) | 80.3ms | 61.8ms |
| metadata strip (work deleted) | ~11ms | 0ms |
| `writeTsDefinition` loop (micro-opts) | 11.4ms | 10.5ms |

For the record, `bun run bench --runs 5 --stages` medians moved from
total 184ms (parse 140, types 36) to total 98ms (parse 70, types 24),
but those absolute numbers are load-confounded in both directions.