### PR TITLE
build(scripts): add mitata bench

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "acorn": "^8.18.0",
         "culls": "^0.2.0",
         "estree-walker": "^3.0.3",
+        "mitata": "^1.0.34",
         "svelte": "^5.56.8",
         "typescript": "^7.0.2",
       },
@@ -189,6 +190,8 @@
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "bun scripts/build.ts",
     "bench": "bun scripts/bench.ts",
     "bench:cache": "bun scripts/bench.ts --cache",
+    "bench:mitata": "bun scripts/bench-mitata.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
@@ -38,6 +39,7 @@
     "acorn": "^8.18.0",
     "culls": "^0.2.0",
     "estree-walker": "^3.0.3",
+    "mitata": "^1.0.34",
     "svelte": "^5.56.8",
     "typescript": "^7.0.2"
   },

--- a/scripts/bench-mitata.ts
+++ b/scripts/bench-mitata.ts
@@ -1,0 +1,103 @@
+/**
+ * Statistically rigorous microbenchmarks for sveld's hot paths, using mitata
+ * (warmup, batching, outlier-aware percentiles) rather than the wall-clock
+ * medians in `scripts/bench.ts` (which times the full pipeline / stages of
+ * one real invocation instead of many statistically-sampled iterations).
+ *
+ * Covers, from a real fixture (the carbon e2e fixture, ~160 components):
+ *   - parse: parseSvelteComponent on a small/medium/large real component
+ *   - write: writeTsDefinition on the parsed doc for those same components
+ *   - document model: buildComponentApiDocument's sort/strip over all 160
+ *   - pipeline: generateBundle end-to-end, no cache
+ *
+ * Usage:
+ *   bun run bench:mitata
+ *   bun run bench:mitata --filter parse   # mitata's built-in name filter (regex)
+ *
+ * To establish a baseline and check whether a change actually helped:
+ *   bun run bench:mitata > /tmp/before.txt
+ *   ...make a change...
+ *   bun run bench:mitata > /tmp/after.txt
+ *   diff /tmp/before.txt /tmp/after.txt
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { bench, do_not_optimize, group, run } from "mitata";
+import { generateBundle } from "../src/bundle";
+import { setQuiet } from "../src/logger";
+import { getParserStack, loadParserStack } from "../src/parser-stack";
+import { buildComponentApiDocument } from "../src/writer/document-model";
+import { writeTsDefinition } from "../src/writer/writer-ts-definitions-core";
+
+const FIXTURE_DIR = join(import.meta.dir, "..", "tests", "e2e", "carbon", "src");
+const ENTRY = join(FIXTURE_DIR, "index.js");
+
+// One small/medium/large real component, picked by line count, so parse and
+// write costs are measured against realistic (not synthetic) source shapes.
+const SAMPLES = {
+  small: { file: join(FIXTURE_DIR, "Grid", "Row.svelte"), moduleName: "Row" },
+  medium: { file: join(FIXTURE_DIR, "NumberInput", "NumberInput.svelte"), moduleName: "NumberInput" },
+  large: { file: join(FIXTURE_DIR, "DataTable", "DataTable.svelte"), moduleName: "DataTable" },
+} as const;
+
+await loadParserStack();
+const { ComponentParser } = getParserStack();
+const sources = Object.fromEntries(
+  Object.entries(SAMPLES).map(([size, sample]) => [size, readFileSync(sample.file, "utf-8")]),
+) as Record<keyof typeof SAMPLES, string>;
+
+group("parse: single component", () => {
+  for (const [size, sample] of Object.entries(SAMPLES)) {
+    bench(`parseSvelteComponent (${size}, ${sample.moduleName})`, () => {
+      const parser = new ComponentParser();
+      do_not_optimize(
+        parser.parseSvelteComponent(sources[size as keyof typeof SAMPLES], {
+          moduleName: sample.moduleName,
+          filePath: sample.file,
+        }),
+      );
+    });
+  }
+});
+
+// Run the real pipeline once (quietly) to source real ComponentDocApi
+// objects for the write/document-model benchmarks below, instead of
+// hand-rolling fixtures that could drift from what parsing actually produces.
+setQuiet(true);
+const pipelineResult = await generateBundle(ENTRY, true, { cache: false });
+setQuiet(false);
+
+const document = buildComponentApiDocument(pipelineResult.allComponentsForTypes);
+const docsBySize = Object.fromEntries(
+  Object.entries(SAMPLES).map(([size, sample]) => [
+    size,
+    document.components.find((component) => component.moduleName === sample.moduleName),
+  ]),
+);
+
+group("write: types (single component)", () => {
+  for (const [size, doc] of Object.entries(docsBySize)) {
+    if (!doc) continue;
+    bench(`writeTsDefinition (${size}, ${doc.moduleName})`, () => {
+      do_not_optimize(writeTsDefinition(doc));
+    });
+  }
+});
+
+group("write: document model", () => {
+  bench(`buildComponentApiDocument (${document.components.length} components)`, () => {
+    // buildComponentApiDocument caches by `components` Map identity; wrap the
+    // same entries in a fresh Map each iteration so this measures the real
+    // sort/strip cost instead of a cache hit after the first sample.
+    const fresh = new Map(pipelineResult.allComponentsForTypes);
+    do_not_optimize(buildComponentApiDocument(fresh));
+  });
+});
+
+group("pipeline: full carbon fixture", () => {
+  bench(`generateBundle (${document.components.length} components, no cache)`, async () => {
+    do_not_optimize(await generateBundle(ENTRY, true, { cache: false }));
+  });
+});
+
+await run();

--- a/src/parser/source-position.ts
+++ b/src/parser/source-position.ts
@@ -13,10 +13,12 @@ function getSourceLineStartOffsets(ctx: ParserContext) {
 
   const offsets = [0];
   if (ctx.source) {
-    for (let index = 0; index < ctx.source.length; index++) {
-      if (ctx.source[index] === "\n") {
-        offsets.push(index + 1);
-      }
+    // `indexOf` is a native scan; a per-character comparison loop re-does that
+    // scan one JS-level charCodeAt call at a time.
+    let index = ctx.source.indexOf("\n");
+    while (index !== -1) {
+      offsets.push(index + 1);
+      index = ctx.source.indexOf("\n", index + 1);
     }
   }
 


### PR DESCRIPTION
Adds `bun run bench:mitata`, statistically-sampled microbenchmarks
(parse, write, document-model, full pipeline) over the carbon e2e
fixture, for establishing a baseline before parser/writer changes.
Also fixes the one real hotspot the benchmark run turned up:
`getSourceLineStartOffsets` scanned source char-by-char to build the
JSDoc/`@event`/`@slot` line-offset table; swapping to `indexOf` lets
the engine do the scan natively instead.

## Benchmark

Measured with `bun --cpu-prof-md` over a 30x run of the carbon
fixture (160 components), comparing `getSourceLineStartOffsets`'s own
self-time before and after:

| | before | after |
|---|---|---|
| `getSourceLineStartOffsets` self-time | ~56ms | ~15ms |