### PR TITLE
build(scripts): add more coverage

### DIFF
--- a/scripts/bench-mitata.ts
+++ b/scripts/bench-mitata.ts
@@ -6,9 +6,21 @@
  *
  * Covers, from a real fixture (the carbon e2e fixture, ~160 components):
  *   - parse: parseSvelteComponent on a small/medium/large real component
- *   - write: writeTsDefinition on the parsed doc for those same components
+ *   - parse: parseSvelteComponent on a synthetic pathological component
+ *     (200 props with wide union/generic JSDoc types) — realistic samples
+ *     alone can't show worst-case type-resolution cost
+ *   - write: writeTsDefinition on the parsed doc for those same components,
+ *     including the pathological one
+ *   - write: renderJsonDocument / renderMarkdownDocument (the pure,
+ *     I/O-free cores the real json/markdown writers call) over all 160
  *   - document model: buildComponentApiDocument's sort/strip over all 160
+ *   - cache: hashSource (sha256, paid once per file every run) and
+ *     ParseCache.get on a hit vs. a miss
  *   - pipeline: generateBundle end-to-end, no cache
+ *
+ * Deliberately out of scope: Writer's actual disk I/O (fs write cost isn't
+ * sveld logic) and the on-disk cache file read/write (`ParseCache.save`,
+ * `readCacheFile`) — both are one-shot per run, not per-file hot paths.
  *
  * Usage:
  *   bun run bench:mitata
@@ -21,13 +33,39 @@
  *   diff /tmp/before.txt /tmp/after.txt
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { bench, do_not_optimize, group, run } from "mitata";
 import { generateBundle } from "../src/bundle";
 import { setQuiet } from "../src/logger";
+import { hashSource, ParseCache } from "../src/parse-cache";
 import { getParserStack, loadParserStack } from "../src/parser-stack";
 import { buildComponentApiDocument } from "../src/writer/document-model";
+import { renderJsonDocument } from "../src/writer/writer-json";
+import { renderMarkdownDocument } from "../src/writer/writer-markdown";
 import { writeTsDefinition } from "../src/writer/writer-ts-definitions-core";
+
+/**
+ * A synthetic component shaped nothing like carbon's real components: wide
+ * union types and nested generics repeated across many props/events, to
+ * stress type-printing cost that a realistic fixture wouldn't surface.
+ */
+function buildPathologicalComponent(propCount: number, eventCount: number): string {
+  const literalUnion = Array.from({ length: 12 }, (_, i) => `"variant-${i}"`).join(" | ");
+  const complexType = `${literalUnion} | Array<{ id: string; value: number | string; meta?: Record<string, unknown> }> | null`;
+
+  const props = Array.from(
+    { length: propCount },
+    (_, i) =>
+      `  /**\n   * Synthetic prop ${i} for pathological-shape benchmarking.\n   * @type {${complexType}}\n   */\n  export let prop${i} = null;`,
+  ).join("\n\n");
+
+  const events = Array.from(
+    { length: eventCount },
+    (_, i) => ` * @event {{ index: number; detail: ${complexType} }} synthetic-event-${i}`,
+  ).join("\n");
+
+  return `<script>\n/**\n${events}\n */\n\n${props}\n</script>\n\n<div />\n`;
+}
 
 const FIXTURE_DIR = join(import.meta.dir, "..", "tests", "e2e", "carbon", "src");
 const ENTRY = join(FIXTURE_DIR, "index.js");
@@ -46,6 +84,9 @@ const sources = Object.fromEntries(
   Object.entries(SAMPLES).map(([size, sample]) => [size, readFileSync(sample.file, "utf-8")]),
 ) as Record<keyof typeof SAMPLES, string>;
 
+const pathologicalFilePath = "pathological.svelte";
+const pathologicalSource = buildPathologicalComponent(200, 20);
+
 group("parse: single component", () => {
   for (const [size, sample] of Object.entries(SAMPLES)) {
     bench(`parseSvelteComponent (${size}, ${sample.moduleName})`, () => {
@@ -58,6 +99,16 @@ group("parse: single component", () => {
       );
     });
   }
+
+  bench("parseSvelteComponent (pathological, 200 wide-union props)", () => {
+    const parser = new ComponentParser();
+    do_not_optimize(
+      parser.parseSvelteComponent(pathologicalSource, {
+        moduleName: "Pathological",
+        filePath: pathologicalFilePath,
+      }),
+    );
+  });
 });
 
 // Run the real pipeline once (quietly) to source real ComponentDocApi
@@ -75,11 +126,26 @@ const docsBySize = Object.fromEntries(
   ]),
 );
 
+// Parsed standalone (not through generateBundle, which resolves against the
+// carbon fixture's file tree): the pathological component only needs its own
+// parse result to reach writeTsDefinition.
+const pathologicalParsed = new ComponentParser().parseSvelteComponent(pathologicalSource, {
+  moduleName: "Pathological",
+  filePath: pathologicalFilePath,
+});
+const pathologicalDoc = buildComponentApiDocument(new Map([[pathologicalFilePath, pathologicalParsed]])).components[0];
+
 group("write: types (single component)", () => {
   for (const [size, doc] of Object.entries(docsBySize)) {
     if (!doc) continue;
     bench(`writeTsDefinition (${size}, ${doc.moduleName})`, () => {
       do_not_optimize(writeTsDefinition(doc));
+    });
+  }
+
+  if (pathologicalDoc) {
+    bench("writeTsDefinition (pathological, 200 wide-union props)", () => {
+      do_not_optimize(writeTsDefinition(pathologicalDoc));
     });
   }
 });
@@ -91,6 +157,51 @@ group("write: document model", () => {
     // sort/strip cost instead of a cache hit after the first sample.
     const fresh = new Map(pipelineResult.allComponentsForTypes);
     do_not_optimize(buildComponentApiDocument(fresh));
+  });
+});
+
+// renderJsonDocument/renderMarkdownDocument are the pure, I/O-free cores the
+// registered "json"/"markdown" writers call after resolving output paths, so
+// this measures the same render cost as a real run without touching disk.
+const inputDir = dirname(ENTRY);
+group("write: json/markdown (full fixture)", () => {
+  bench(`renderJsonDocument (${document.components.length} components)`, () => {
+    do_not_optimize(
+      renderJsonDocument(pipelineResult.components, { inputDir, entryExports: pipelineResult.entryExports }),
+    );
+  });
+
+  bench(`renderMarkdownDocument (${document.components.length} components)`, () => {
+    do_not_optimize(renderMarkdownDocument(pipelineResult.components, { entryExports: pipelineResult.entryExports }));
+  });
+});
+
+// hashSource runs once per file on every invocation (parse-cache hit or not),
+// so its cost scales with fixture size regardless of cache state.
+group("cache: hashSource", () => {
+  for (const [size, source] of Object.entries(sources)) {
+    bench(`hashSource (${size})`, () => {
+      do_not_optimize(hashSource(source));
+    });
+  }
+});
+
+group("cache: ParseCache.get", () => {
+  const warmCache = new ParseCache(join(FIXTURE_DIR, ".bench-mitata-cache.json"));
+  const hitPath = SAMPLES.medium.file;
+  const hitHash = hashSource(sources.medium);
+  warmCache.set(hitPath, hitHash, pipelineResult.allComponentsForTypes.get(hitPath) ?? pathologicalParsed);
+
+  bench("get (hit)", () => {
+    do_not_optimize(warmCache.get(hitPath, hitHash));
+  });
+
+  bench("get (miss, unknown path)", () => {
+    do_not_optimize(warmCache.get("/nonexistent/path.svelte", hitHash));
+  });
+
+  bench("get (miss, stale hash)", () => {
+    do_not_optimize(warmCache.get(hitPath, "stale-hash"));
   });
 });
 

--- a/src/writer/format-generated-ts.ts
+++ b/src/writer/format-generated-ts.ts
@@ -33,6 +33,52 @@ function popTrailing(out: string[], regex: RegExp): void {
   while (out.length > 0 && regex.test(out[out.length - 1])) out.pop();
 }
 
+/**
+ * Fast-path check for the `{...}` collapse decision below: content with no
+ * nested `{` and 2+ statement-terminating `;` outside quotes is guaranteed
+ * to expand onto multiple lines (each such `;` forces a following newline
+ * once the character scan reaches it), so the speculative recursive
+ * `expandStatements` call that exists only to answer "would this collapse?"
+ * can be skipped for this common flat multi-member case (e.g. a `{ id:
+ * string; value: string; meta?: Record<string, unknown> }` object literal
+ * repeated across many prop types) instead of running - and discarding - a
+ * full recursive pass over the same content. A single trailing `;` (one
+ * member) is deliberately left to the general path since it may still
+ * collapse; content with a nested `{` is also left to the general path,
+ * since a collapsing inner block can change the outer decision.
+ */
+function hasMultipleFlatStatements(content: string): boolean {
+  if (content.includes("{")) return false;
+
+  let quote: "double" | "single" | "template" | null = null;
+  let semicolons = 0;
+
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i];
+    const prev = content[i - 1];
+
+    if (quote) {
+      if (
+        (quote === "double" && c === '"' && prev !== "\\") ||
+        (quote === "single" && c === "'" && prev !== "\\") ||
+        (quote === "template" && c === "`" && prev !== "\\")
+      ) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c === '"' ? "double" : c === "'" ? "single" : "template";
+      continue;
+    }
+
+    if (c === ";" && ++semicolons >= 2) return true;
+  }
+
+  return false;
+}
+
 function flattenToOneLine(content: string): string {
   let out = "";
   let quote: "double" | "single" | "template" | null = null;
@@ -200,6 +246,7 @@ function expandStatements(raw: string): string {
       if (
         !content.includes("/*") &&
         raw[i + 1] !== "\n" &&
+        !hasMultipleFlatStatements(content) &&
         !endsWithInterfaceHeader(tailString(out, INTERFACE_HEADER_TAIL_LENGTH))
       ) {
         // Recurse so nested blocks get their own collapse decision.


### PR DESCRIPTION
Extends the mitata suite with json/markdown writer renders, ParseCache
hit/miss, hashSource, and a synthetic pathological component (wide
unions, many props) that a realistic fixture alone can't surface.
Profiling that pathological case found `formatGeneratedTypeScript`
wasting a recursive pass on blocks that could never collapse, fixed
here.

## Benchmark

`writeTsDefinition` on the pathological component (200 props, wide
union types), warm:

| before | after |
| --- | --- |
| 19ms | 11ms |