### PR TITLE
test: extract parser test coverage from the custom-parser branch

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -107,9 +107,11 @@
             "noBannedTypes": "off"
           },
           "suspicious": {
+            "noDoubleEquals": "off",
             "noExplicitAny": "off"
           },
           "style": {
+            "noNonNullAssertion": "off",
             "noUnusedTemplateLiteral": "off",
             "useTemplate": "off"
           },
@@ -133,7 +135,11 @@
       }
     },
     {
-      "includes": ["**/tests/fixtures/fuzz-generics-arrow-type-comma/input.svelte"],
+      "includes": [
+        "**/tests/fixtures/fuzz-generics-arrow-type-comma/input.svelte",
+        "**/tests/fixtures/template-expression-shapes/input.svelte",
+        "**/tests/fixtures/template-expression-shapes-ts/input.svelte"
+      ],
       "formatter": {
         "enabled": false
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bench": "bun scripts/bench.ts",
     "bench:cache": "bun scripts/bench.ts --cache",
     "bench:mitata": "bun scripts/bench-mitata.ts",
+    "fuzz": "bun scripts/fuzz-parser.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/fuzz-parser.ts
+++ b/scripts/fuzz-parser.ts
@@ -1,0 +1,489 @@
+/**
+ * Fuzzes the Svelte component parsing pipeline by mutating fixture sources.
+ *
+ * Each trial runs in its own child (`fuzz-trial.ts`) with a wall-clock kill
+ * timeout and a CPU `ulimit`. Do not run trials in-process or in parallel. The
+ * first in-process run coincided with this machine crashing. Cause was never
+ * confirmed, so isolation stayed.
+ *
+ * Operators hit markup grammar: truncation, bracket imbalance, directive
+ * mangling, deep `{#if}`/`{#each}` nesting, `{#snippet}` generics and params.
+ * JSDoc and script-side cases already live in
+ * `tests/svelte-parse-shim.test.ts` and `tests/fixtures.test.ts`.
+ *
+ * A hang or crash is always a finding. A thrown error is a finding only if
+ * `svelte/compiler` accepts the same source. If both parsers reject, skip it.
+ *
+ * Usage:
+ *   bun run fuzz
+ *   bun run fuzz --iterations 500
+ *   bun run fuzz --seed 12345
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Glob } from "bun";
+
+const FIXTURES_DIR = path.join(import.meta.dir, "..", "tests", "fixtures");
+const FINDINGS_DIR = path.join(import.meta.dir, "..", ".context", "fuzz-findings");
+const TRIAL_SCRIPT = path.join(import.meta.dir, "fuzz-trial.ts");
+const DEFAULT_ITERATIONS = 150;
+const SLOW_MS = 1000;
+const TRIAL_TIMEOUT_MS = 5000;
+const TRIAL_CPU_SECONDS = 10;
+const MINIMIZE_TEST_CAP = 60;
+
+interface FuzzArgs {
+  iterations: number;
+  seed: number;
+}
+
+function parseArgs(argv: string[]): FuzzArgs {
+  const args: FuzzArgs = { iterations: DEFAULT_ITERATIONS, seed: Date.now() };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--iterations") args.iterations = Number(argv[++i]);
+    else if (argv[i] === "--seed") args.seed = Number(argv[++i]);
+  }
+  return args;
+}
+
+/** Seedable PRNG (mulberry32). Reproduce a run with `--seed`. */
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Rng = () => number;
+
+function randInt(rng: Rng, min: number, max: number): number {
+  return min + Math.floor(rng() * (max - min + 1));
+}
+
+function pick<T>(rng: Rng, items: readonly T[]): T {
+  return items[randInt(rng, 0, items.length - 1)];
+}
+
+interface Seed {
+  dir: string;
+  source: string;
+}
+
+async function loadSeeds(): Promise<Seed[]> {
+  const seeds: Seed[] = [];
+  for await (const file of new Glob("**/input.svelte").scan(FIXTURES_DIR)) {
+    const source = await Bun.file(path.join(FIXTURES_DIR, file)).text();
+    const dir = file.replace(/\\/g, "/").split("/")[0];
+    seeds.push({ dir, source });
+  }
+  return seeds;
+}
+
+interface Mutation {
+  source: string;
+  tag: string;
+}
+
+/** Truncates a seed at a random offset. Cheap way to get unbalanced tags. */
+function mutateTruncate(rng: Rng, seeds: Seed[]): Mutation | null {
+  const seed = pick(rng, seeds);
+  if (seed.source.length < 4) return null;
+  const cut = randInt(rng, 1, seed.source.length - 1);
+  return { source: seed.source.slice(0, cut), tag: `truncate:${cut}/${seed.source.length}:${seed.dir}` };
+}
+
+const BRACKET_CHAR_REGEX = /[{}<>]/g;
+
+/** Deletes or duplicates a random `{`, `}`, `<`, or `>`. */
+function mutateBracketImbalance(rng: Rng, seeds: Seed[]): Mutation | null {
+  const seed = pick(rng, seeds);
+  const matches = [...seed.source.matchAll(BRACKET_CHAR_REGEX)];
+  if (matches.length === 0) return null;
+  const match = pick(rng, matches);
+  const idx = match.index as number;
+  const option = pick(rng, ["delete", "duplicate"] as const);
+  const mutated =
+    option === "delete"
+      ? seed.source.slice(0, idx) + seed.source.slice(idx + 1)
+      : seed.source.slice(0, idx + 1) + match[0] + seed.source.slice(idx + 1);
+  return { source: mutated, tag: `bracket-imbalance:${option}:${match[0]}:${seed.dir}` };
+}
+
+const DIRECTIVE_REGEX =
+  /\b(on|bind|class|style|use|animate|transition|in|out|let):([a-zA-Z0-9_-]*)(\|[a-zA-Z0-9_-]*)?/g;
+
+/** Empty directive name, dangling `|`, or an unclosed `{` right after the directive. */
+function mutateDirectiveMangle(rng: Rng, seeds: Seed[]): Mutation | null {
+  const candidates = seeds.filter((s) => DIRECTIVE_REGEX.test(s.source));
+  DIRECTIVE_REGEX.lastIndex = 0;
+  if (candidates.length === 0) return null;
+  const seed = pick(rng, candidates);
+  const matches = [...seed.source.matchAll(DIRECTIVE_REGEX)];
+  if (matches.length === 0) return null;
+  const match = pick(rng, matches);
+  const start = match.index as number;
+  const end = start + match[0].length;
+  const option = pick(rng, ["empty-name", "dangling-pipe", "unclosed-brace-after"] as const);
+  let mutated: string;
+  switch (option) {
+    case "empty-name":
+      mutated = `${seed.source.slice(0, start)}${match[1]}:${seed.source.slice(end)}`;
+      break;
+    case "dangling-pipe":
+      mutated = `${seed.source.slice(0, end)}|${seed.source.slice(end)}`;
+      break;
+    case "unclosed-brace-after":
+      mutated = `${seed.source.slice(0, end)}={${seed.source.slice(end)}`;
+      break;
+  }
+  return { source: mutated, tag: `directive-mangle:${option}:${seed.dir}` };
+}
+
+const TEMPLATE_INSERT_POINT_REGEX = /<\/script>/;
+const SCRIPT_LANG_TS_REGEX = /<script[^>]*\blang\s*=\s*["']ts["']/;
+
+function insertIntoTemplate(source: string, block: string): string | null {
+  const matches = [...source.matchAll(new RegExp(TEMPLATE_INSERT_POINT_REGEX, "g"))];
+  const insertAt = matches.length > 0 ? (matches[matches.length - 1].index as number) + "</script>".length : 0;
+  return `${source.slice(0, insertAt)}\n${block}\n${source.slice(insertAt)}`;
+}
+
+/** Deep `{#if}`/`{#each}` nesting. Recursive descent has to not blow the stack. */
+function mutateBlockNesting(rng: Rng, seeds: Seed[]): Mutation | null {
+  const seed = pick(rng, seeds);
+  const depth = pick(rng, [10, 25, 50, 100]);
+  const kind = pick(rng, ["if", "each"] as const);
+  let block: string;
+  if (kind === "if") {
+    block = `${"{#if true}".repeat(depth)}<span>fuzz</span>${"{/if}".repeat(depth)}`;
+  } else {
+    block = `${"{#each [1] as fuzzItem}".repeat(depth)}<span>fuzz</span>${"{/each}".repeat(depth)}`;
+  }
+  const mutated = insertIntoTemplate(seed.source, block);
+  if (!mutated) return null;
+  return { source: mutated, tag: `block-nesting:${kind}:${depth}:${seed.dir}` };
+}
+
+/** `{#snippet}` with a broken generic or parameter list. */
+function mutateSnippetMangle(rng: Rng, seeds: Seed[]): Mutation | null {
+  const seed = pick(rng, seeds);
+  const isTs = SCRIPT_LANG_TS_REGEX.test(seed.source);
+  const option = pick(
+    rng,
+    (isTs
+      ? ["unclosed-generic", "unclosed-paren", "nested-generic", "empty-generic"]
+      : ["unclosed-paren", "no-parens", "extra-parens"]) as const,
+  );
+  let block: string;
+  switch (option) {
+    case "unclosed-generic":
+      block = "{#snippet fuzzSnippet<T(x)}<span>{x}</span>{/snippet}";
+      break;
+    case "unclosed-paren":
+      block = "{#snippet fuzzSnippet(x, y}<span>{x}</span>{/snippet}";
+      break;
+    case "nested-generic":
+      block = `{#snippet fuzzSnippet${"<T".repeat(20)}${">".repeat(20)}(x)}<span>{x}</span>{/snippet}`;
+      break;
+    case "empty-generic":
+      block = "{#snippet fuzzSnippet<>(x)}<span>{x}</span>{/snippet}";
+      break;
+    case "no-parens":
+      block = "{#snippet fuzzSnippet}<span>fuzz</span>{/snippet}";
+      break;
+    case "extra-parens":
+      block = "{#snippet fuzzSnippet((x), (y))}<span>{x}</span>{/snippet}";
+      break;
+    default:
+      block = "{#snippet fuzzSnippet()}<span>fuzz</span>{/snippet}";
+  }
+  const mutated = insertIntoTemplate(seed.source, block);
+  if (!mutated) return null;
+  return { source: mutated, tag: `snippet-mangle:${option}:${seed.dir}` };
+}
+
+/** `{#each}`/`{#await}` destructuring, TS `as` collision, index/key syntax. */
+function mutateEachAwaitEdge(rng: Rng, seeds: Seed[]): Mutation | null {
+  const seed = pick(rng, seeds);
+  const option = pick(rng, [
+    "each-destructure-unclosed",
+    "each-as-collision-comma",
+    "each-key-unclosed",
+    "await-then-catch-both",
+    "await-nested-destructure",
+  ] as const);
+  let block: string;
+  switch (option) {
+    case "each-destructure-unclosed":
+      block = "{#each fuzzList as { a, b }<span>{a}{b}</span>{/each}";
+      break;
+    case "each-as-collision-comma":
+      block = "{#each fuzzList as fuzzItem, }<span>{fuzzItem}</span>{/each}";
+      break;
+    case "each-key-unclosed":
+      block = "{#each fuzzList as fuzzItem (fuzzItem.id}<span>{fuzzItem}</span>{/each}";
+      break;
+    case "await-then-catch-both":
+      block = "{#await fuzzPromise then fuzzValue catch fuzzError}<span>{fuzzValue}</span>{/await}";
+      break;
+    case "await-nested-destructure":
+      block = "{#await fuzzPromise}...{:then { a: { b } }}<span>{b}</span>{/await}";
+      break;
+    default:
+      block = "{#each fuzzList as fuzzItem}{fuzzItem}{/each}";
+  }
+  const mutated = insertIntoTemplate(seed.source, block);
+  if (!mutated) return null;
+  return { source: mutated, tag: `each-await-edge:${option}:${seed.dir}` };
+}
+
+function mutateWhitespace(rng: Rng, seeds: Seed[]): Mutation | null {
+  const seed = pick(rng, seeds);
+  const option = pick(rng, ["crlf", "bom", "unicode-word", "null-byte"] as const);
+  let mutated: string;
+  switch (option) {
+    case "crlf":
+      mutated = seed.source.replace(/\n/g, "\r\n");
+      break;
+    case "bom":
+      mutated = `﻿${seed.source}`;
+      break;
+    case "unicode-word": {
+      const words = [...seed.source.matchAll(/[A-Za-z]{4,}/g)];
+      if (words.length === 0) return null;
+      const w = pick(rng, words);
+      const idx = w.index as number;
+      mutated = `${seed.source.slice(0, idx)}а${seed.source.slice(idx + 1)}`;
+      break;
+    }
+    case "null-byte": {
+      const idx = randInt(rng, 0, seed.source.length);
+      mutated = `${seed.source.slice(0, idx)}\0${seed.source.slice(idx)}`;
+      break;
+    }
+  }
+  return { source: mutated, tag: `whitespace:${option}:${seed.dir}` };
+}
+
+const OPERATORS: Array<(rng: Rng, seeds: Seed[]) => Mutation | null> = [
+  mutateTruncate,
+  mutateBracketImbalance,
+  mutateDirectiveMangle,
+  mutateBlockNesting,
+  mutateSnippetMangle,
+  mutateEachAwaitEdge,
+  mutateWhitespace,
+];
+
+interface TrialResult {
+  ok: boolean;
+  ms: number;
+  timedOut: boolean;
+  crashed: boolean;
+  svelteAccepts?: boolean;
+  error?: { name: string; message: string };
+}
+
+/** One trial in `fuzz-trial.ts`. A hang kills this child, not the harness. */
+async function runTrial(source: string): Promise<TrialResult> {
+  const proc = Bun.spawn({
+    cmd: ["bash", "-c", `ulimit -t ${TRIAL_CPU_SECONDS}; exec bun "${TRIAL_SCRIPT}"`],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write(source);
+  await proc.stdin.end();
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill(9);
+  }, TRIAL_TIMEOUT_MS);
+
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+
+  if (timedOut) {
+    return {
+      ok: false,
+      ms: TRIAL_TIMEOUT_MS,
+      timedOut: true,
+      crashed: false,
+      error: { name: "Timeout", message: `exceeded ${TRIAL_TIMEOUT_MS}ms` },
+    };
+  }
+
+  const stdout = await new Response(proc.stdout).text();
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    return {
+      ok: false,
+      ms: 0,
+      timedOut: false,
+      crashed: true,
+      error: { name: "ProcessCrash", message: `exit ${exitCode}: ${stderr.slice(0, 300)}` },
+    };
+  }
+
+  try {
+    const lastLine = stdout.trim().split("\n").pop() ?? "{}";
+    const parsed = JSON.parse(lastLine);
+    if (parsed.ok)
+      return { ok: true, ms: parsed.ms, timedOut: false, crashed: false, svelteAccepts: parsed.svelteAccepts };
+    return {
+      ok: false,
+      ms: parsed.ms,
+      timedOut: false,
+      crashed: false,
+      svelteAccepts: parsed.svelteAccepts,
+      error: { name: parsed.errorName, message: parsed.errorMessage },
+    };
+  } catch {
+    return {
+      ok: false,
+      ms: 0,
+      timedOut: false,
+      crashed: false,
+      error: { name: "HarnessOutputError", message: stdout.slice(0, 300) },
+    };
+  }
+}
+
+/**
+ * Hang or crash: always a finding. A thrown error is a finding only if svelte
+ * accepts the same source.
+ */
+function isFinding(result: TrialResult): boolean {
+  if (result.timedOut || result.crashed) return true;
+  if (result.ok) return false;
+  return result.svelteAccepts === true;
+}
+
+function severity(result: TrialResult): "hang" | "crash" | "reject" {
+  if (result.timedOut) return "hang";
+  if (result.crashed) return "crash";
+  return "reject";
+}
+
+function errorSignature(result: TrialResult): string {
+  const name = result.error?.name ?? "Unknown";
+  const message = (result.error?.message ?? "").split("\n")[0].replace(/\d+/g, "N").slice(0, 120);
+  return `${severity(result)}:${name}:${message}`;
+}
+
+async function ddmin(lines: string[], reproduces: (candidate: string[]) => Promise<boolean>): Promise<string[]> {
+  let current = lines;
+  let n = 2;
+  let tests = 0;
+  while (current.length >= 2 && tests < MINIMIZE_TEST_CAP) {
+    const chunkSize = Math.ceil(current.length / n);
+    let reduced = false;
+    for (let start = 0; start < current.length && tests < MINIMIZE_TEST_CAP; start += chunkSize) {
+      const complement = [...current.slice(0, start), ...current.slice(start + chunkSize)];
+      tests++;
+      // biome-ignore lint/performance/noAwaitInLoops: each ddmin step depends on the previous trial's result.
+      if (complement.length > 0 && (await reproduces(complement))) {
+        current = complement;
+        n = Math.max(n - 1, 2);
+        reduced = true;
+        break;
+      }
+    }
+    if (!reduced) {
+      if (n >= current.length) break;
+      n = Math.min(n * 2, current.length);
+    }
+  }
+  return current;
+}
+
+interface Finding {
+  signature: string;
+  tag: string;
+  source: string;
+  result: TrialResult;
+}
+
+async function minimizeFinding(finding: Finding): Promise<string> {
+  const targetSignature = finding.signature;
+  const reproduces = async (candidateLines: string[]) => {
+    const result = await runTrial(candidateLines.join("\n"));
+    return isFinding(result) && errorSignature(result) === targetSignature;
+  };
+  const minimizedLines = await ddmin(finding.source.split("\n"), reproduces);
+  return minimizedLines.join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(`fuzz-parser: iterations=${args.iterations} seed=${args.seed}`);
+
+  const seeds = await loadSeeds();
+  console.log(`loaded ${seeds.length} seed fixtures`);
+
+  const rng = mulberry32(args.seed);
+  const findings = new Map<string, Finding>();
+  let rejected = 0;
+  let slow = 0;
+  let applied = 0;
+
+  for (let i = 0; i < args.iterations; i++) {
+    const operator = pick(rng, OPERATORS);
+    const mutation = operator(rng, seeds);
+    if (!mutation) continue;
+    applied++;
+
+    // biome-ignore lint/performance/noAwaitInLoops: sequential so a hang only ties up one child
+    const result = await runTrial(mutation.source);
+    if (result.ok) {
+      if (result.ms > SLOW_MS) {
+        slow++;
+        console.log(`[slow] ${result.ms.toFixed(0)}ms tag=${mutation.tag}`);
+      }
+      continue;
+    }
+    if (!isFinding(result)) {
+      rejected++;
+      continue;
+    }
+    const signature = errorSignature(result);
+    if (!findings.has(signature)) {
+      findings.set(signature, { signature, tag: mutation.tag, source: mutation.source, result });
+      console.log(`[new finding: ${severity(result)}] ${signature} (from ${mutation.tag})`);
+    }
+
+    if ((i + 1) % 25 === 0) {
+      console.log(
+        `... ${i + 1}/${args.iterations} iterations, ${findings.size} findings, ${rejected} rejected, ${slow} slow`,
+      );
+    }
+  }
+
+  console.log(
+    `\napplied ${applied} mutations, ${rejected} expected rejections, ${slow} slow, ${findings.size} unique findings`,
+  );
+
+  if (findings.size > 0) {
+    mkdirSync(FINDINGS_DIR, { recursive: true });
+    for (const finding of findings.values()) {
+      // biome-ignore lint/performance/noAwaitInLoops: sequential so minimizing doesn't multiply load
+      const minimized = await minimizeFinding(finding);
+      const slug = finding.signature
+        .replace(/[^a-zA-Z0-9]+/g, "-")
+        .toLowerCase()
+        .slice(0, 60);
+      const filePath = path.join(FINDINGS_DIR, `${slug}.svelte`);
+      writeFileSync(filePath, minimized);
+      console.log(`\n=== finding: ${finding.signature} ===`);
+      console.log(`mutation: ${finding.tag}`);
+      console.log(`message: ${finding.result.error?.message}`);
+      console.log(`minimized source written to: ${path.relative(process.cwd(), filePath)}`);
+    }
+  }
+}
+
+await main();

--- a/scripts/fuzz-trial.ts
+++ b/scripts/fuzz-trial.ts
@@ -1,0 +1,55 @@
+/**
+ * One fuzz trial. Reads `.svelte` from stdin, parses and writes it, prints
+ * one JSON line to stdout.
+ *
+ * Spawned by `fuzz-parser.ts` with a kill timeout so a hang only takes down
+ * this child. Also runs `svelte/compiler`'s `parse()`, not `compile()`, so
+ * the parent can tell "both parsers reject this junk" from "sveld rejects
+ * something svelte accepts".
+ */
+import { parse as svelteParse } from "svelte/compiler";
+import ComponentParser from "../src/ComponentParser";
+import { writeTsDefinition } from "../src/writer/writer-ts-definitions";
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of Bun.stdin.stream()) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const source = await readStdin();
+
+let svelteAccepts = true;
+try {
+  svelteParse(source, { modern: true });
+} catch {
+  svelteAccepts = false;
+}
+
+const t0 = performance.now();
+try {
+  const parser = new ComponentParser();
+  const parsed = parser.parseSvelteComponent(source, {
+    filePath: "fuzz-target.svelte",
+    moduleName: "FuzzTarget",
+  } as never);
+  writeTsDefinition({
+    ...parsed,
+    moduleName: "FuzzTarget",
+    filePath: "fuzz-target.svelte",
+  } as never);
+  console.log(JSON.stringify({ ok: true, ms: performance.now() - t0, svelteAccepts }));
+} catch (error) {
+  const err = error as { name?: string; constructor?: { name?: string }; message?: string };
+  console.log(
+    JSON.stringify({
+      ok: false,
+      ms: performance.now() - t0,
+      svelteAccepts,
+      errorName: err?.name ?? err?.constructor?.name ?? "Unknown",
+      errorMessage: err?.message ?? String(error),
+    }),
+  );
+}

--- a/tests/fixtures/template-expression-shapes-ts/input.svelte
+++ b/tests/fixtures/template-expression-shapes-ts/input.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  export let size: "sm" | "lg" = "sm";
+  export let label: string | undefined = undefined;
+  export let items: string[] = [];
+</script>
+
+<!--
+  TypeScript twin of template-expression-shapes: `lang="ts"` switches the
+  fallback to the TS-extended acorn parser, so trivial shapes must still
+  fast-path and TS-only syntax must still reach acorn.
+-->
+
+<div
+  data-ident={label}
+  data-member={items.length}
+  data-eq={size === "sm"}
+  data-nullish={label ?? "none"}
+  data-not={!label}
+  data-int={42}
+>
+  {items[0]}
+</div>
+
+<span
+  data-as={label as string}
+  data-nonnull={label!}
+  data-satisfies={size satisfies string}
+  data-as-const={size as const}
+>
+  {(label as string).length}
+</span>
+
+{#each items as item, i (item)}
+  <i>{item as string}</i>
+{/each}

--- a/tests/fixtures/template-expression-shapes-ts/output-class.d.ts
+++ b/tests/fixtures/template-expression-shapes-ts/output-class.d.ts
@@ -1,0 +1,24 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type TemplateExpressionShapesTsProps = {
+  /**
+   * @default "sm"
+   */
+  size?: "sm" | "lg";
+
+  /**
+   * @default undefined
+   */
+  label?: string | undefined;
+
+  /**
+   * @default []
+   */
+  items?: string[];
+};
+
+export default class TemplateExpressionShapesTs extends SvelteComponentTyped<
+  TemplateExpressionShapesTsProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/template-expression-shapes-ts/output-component.d.ts
+++ b/tests/fixtures/template-expression-shapes-ts/output-component.d.ts
@@ -1,0 +1,27 @@
+import type { Component } from "svelte";
+
+export type TemplateExpressionShapesTsProps = {
+  /**
+   * @default "sm"
+   */
+  size?: "sm" | "lg";
+
+  /**
+   * @default undefined
+   */
+  label?: string | undefined;
+
+  /**
+   * @default []
+   */
+  items?: string[];
+};
+
+export type TemplateExpressionShapesTsExports = Record<string, never>;
+
+declare const TemplateExpressionShapesTs: Component<
+  TemplateExpressionShapesTsProps,
+  TemplateExpressionShapesTsExports,
+  ""
+>;
+export default TemplateExpressionShapesTs;

--- a/tests/fixtures/template-expression-shapes-ts/output.json
+++ b/tests/fixtures/template-expression-shapes-ts/output.json
@@ -1,0 +1,103 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 36,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "size",
+      "kind": "let",
+      "type": "\"sm\" | \"lg\"",
+      "typeSource": "typescript",
+      "value": "\"sm\"",
+      "defaultValue": {
+        "raw": "\"sm\"",
+        "kind": "literal",
+        "value": "sm"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 38
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "type": "string | undefined",
+      "typeSource": "typescript",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 51
+        }
+      }
+    },
+    {
+      "name": "items",
+      "kind": "let",
+      "type": "string[]",
+      "typeSource": "typescript",
+      "value": "[]",
+      "defaultValue": {
+        "raw": "[]",
+        "kind": "array",
+        "value": []
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/template-expression-shapes/input.svelte
+++ b/tests/fixtures/template-expression-shapes/input.svelte
@@ -1,0 +1,89 @@
+<script>
+  export let size = "sm";
+  export let disabled = false;
+  export let items = [];
+  export let refs = [];
+  export let label = undefined;
+</script>
+
+<!--
+  Boundary shapes for the template-expression fast path
+  (src/template-parse/expression.ts). The first two groups parse without
+  acorn; the third must fall back. The shim test compares this whole file
+  against svelte/compiler, and the parser fuzzer mutates it as a seed.
+-->
+
+<div
+  data-ident={label}
+  data-member={items.length}
+  data-deep={a.b.c.d}
+  data-keyword-prop={items.class}
+  data-index={items[0]}
+  data-index-chain={refs[10].id}
+  data-string-key={$$props["aria-label"]}
+  data-single-quote-key={$$props['aria-hidden']}
+  data-true={true}
+  data-false={false}
+  data-null={null}
+  data-undefined={undefined}
+  data-int={42}
+  data-zero={0}
+  data-string={"str"}
+  data-string-single={'str'}
+  data-empty-string={""}
+  data-spaced={ label }
+>
+  {label}
+  {items[0]}
+  {!disabled}
+  {!!disabled}
+  {! disabled}
+  {items.length === 0}
+</div>
+
+<span
+  class:sm={size === "sm"}
+  class:not-lg={size !== "lg"}
+  class:loose-eq={size == "md"}
+  class:tight={size!== "xl"}
+  class:both={!disabled && !label}
+  data-and={disabled && label}
+  data-or={label || "fallback"}
+  data-nullish={label ?? "none"}
+  data-mirrored={"sm" === size}
+>{size === "lg"}</span>
+
+<button
+  {...$$restProps}
+  bind:this={refs[0]}
+  on:click={() => label}
+  on:keydown={(e) => e.key}
+  data-ternary={disabled ? "y" : "n"}
+  data-two-ops={size === "sm" || size === "md"}
+  data-call={items.includes(size)}
+  data-optional={label?.length}
+  data-optional-index={items?.[0]}
+  data-template={`size-${size}`}
+  data-escape={"a\nb"}
+  data-float={5.5}
+  data-hex={0x1f}
+  data-exponent={5e3}
+  data-negative={-1}
+  data-paren={(label)}
+  data-comment={label /* trailing */}
+  data-arith={items.length + 1}
+>
+  {disabled ? "on" : "off"}
+</button>
+
+{#if !disabled}
+  <em>enabled</em>
+{:else if size === "sm"}
+  <em>small</em>
+{/if}
+
+{#each items as item, i (item.id)}
+  <i>{item}</i>
+{:else}
+  <i>empty</i>
+{/each}

--- a/tests/fixtures/template-expression-shapes/output-class.d.ts
+++ b/tests/fixtures/template-expression-shapes/output-class.d.ts
@@ -1,0 +1,41 @@
+import { SvelteComponentTyped } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type $RestProps = SvelteHTMLElements["button"];
+
+type $Props = {
+  /**
+   * @default "sm"
+   */
+  size?: string;
+
+  /**
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * @default []
+   */
+  items?: [];
+
+  /**
+   * @default []
+   */
+  refs?: [];
+
+  /**
+   * @default undefined
+   */
+  label?: undefined;
+
+  [key: `data-${string}`]: unknown;
+};
+
+export type TemplateExpressionShapesProps = Omit<$RestProps, keyof $Props> & $Props;
+
+export default class TemplateExpressionShapes extends SvelteComponentTyped<
+  TemplateExpressionShapesProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/template-expression-shapes/output-component.d.ts
+++ b/tests/fixtures/template-expression-shapes/output-component.d.ts
@@ -1,0 +1,44 @@
+import type { Component } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type $RestProps = SvelteHTMLElements["button"];
+
+type $Props = {
+  /**
+   * @default "sm"
+   */
+  size?: string;
+
+  /**
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * @default []
+   */
+  items?: [];
+
+  /**
+   * @default []
+   */
+  refs?: [];
+
+  /**
+   * @default undefined
+   */
+  label?: undefined;
+
+  [key: `data-${string}`]: unknown;
+};
+
+export type TemplateExpressionShapesProps = Omit<$RestProps, keyof $Props> & $Props;
+
+export type TemplateExpressionShapesExports = Record<string, never>;
+
+declare const TemplateExpressionShapes: Component<
+  TemplateExpressionShapesProps,
+  TemplateExpressionShapesExports,
+  ""
+>;
+export default TemplateExpressionShapes;

--- a/tests/fixtures/template-expression-shapes/output.json
+++ b/tests/fixtures/template-expression-shapes/output.json
@@ -1,0 +1,177 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 90,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "size",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"sm\"",
+      "defaultValue": {
+        "raw": "\"sm\"",
+        "kind": "literal",
+        "value": "sm"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 25
+        }
+      }
+    },
+    {
+      "name": "disabled",
+      "kind": "let",
+      "type": "boolean",
+      "typeSource": "default",
+      "value": "false",
+      "defaultValue": {
+        "raw": "false",
+        "kind": "literal",
+        "value": false
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 30
+        }
+      }
+    },
+    {
+      "name": "items",
+      "kind": "let",
+      "type": "[]",
+      "typeSource": "default",
+      "value": "[]",
+      "defaultValue": {
+        "raw": "[]",
+        "kind": "array",
+        "value": []
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 24
+        }
+      }
+    },
+    {
+      "name": "refs",
+      "kind": "let",
+      "type": "[]",
+      "typeSource": "default",
+      "value": "[]",
+      "defaultValue": {
+        "raw": "[]",
+        "kind": "array",
+        "value": []
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 23
+        }
+      }
+    },
+    {
+      "name": "label",
+      "kind": "let",
+      "typeSource": "unknown",
+      "value": "undefined",
+      "defaultValue": {
+        "raw": "undefined",
+        "kind": "expression"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 31
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "rest_props": {
+    "type": "Element",
+    "name": "button"
+  },
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "template-expression-shapes/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "label",
+      "message": "Prop \"label\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 31
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Pulls the parser-agnostic coverage out of the custom-parser branch
(`metonym/custom-svelte-parser`) so it guards main's current parser
stack now and shrinks that branch's eventual diff. The fixtures pack
curly-expression boundary shapes, trivial atoms, every equality and
logical operator including no-space forms like `size!== "xl"`, and
syntax that needs the full JS/TS grammar, into one fixture plus a
`lang="ts"` twin; they pin snapshot output, join the svelte-parse
shim compare, and seed the fuzzer. The fuzzer (`bun run fuzz`)
mutates fixture sources in subprocess-isolated trials with
wall-clock and CPU limits, counting a thrown error as a finding
only when `svelte/compiler` accepts the same source.

Biome's formatter is excluded for both fixture inputs: it would
rewrite `{ label }` to `{label}`, and that exact spacing already
caught a real off-by-one in attribute ExpressionTag offsets on the
parser branch. As a cross-check, the fixture outputs generated by
main's pipeline are byte-identical to the custom parser's.
