### PR TITLE
fix(parser): resolve `setContext` keys imported from another module

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -175,6 +175,18 @@ export interface PendingCallDefaultCandidate {
   importedName?: string;
 }
 
+/**
+ * Named-import `setContext` key (`import { KEY } from "./mod.js"`).
+ * `generateBundle` reads the other file via `resolve-context-keys.ts`.
+ * Properties and description are already filled in from the value argument.
+ */
+export interface PendingContextKeyCandidate {
+  importSource: string;
+  importedName: string;
+  properties: ComponentContextProp[];
+  description?: string;
+}
+
 export interface LocalTypeDeclaration {
   code: string;
   node: ModernRunesTypeNode;
@@ -195,6 +207,8 @@ export interface ParsedComponentTypeScriptMetadata {
   referencesComponentGenerics?: boolean;
   /** Unresolved CallExpression defaults for the cross-file pass in `generateBundle`. */
   pendingCallDefaultCandidates?: PendingCallDefaultCandidate[];
+  /** Unresolved `setContext` import keys for the cross-file pass in `generateBundle`. */
+  pendingContextKeyCandidates?: PendingContextKeyCandidate[];
 }
 
 export {

--- a/src/ast-guards.ts
+++ b/src/ast-guards.ts
@@ -79,3 +79,28 @@ export function isNewExpressionNamed(node: unknown, calleeName: string): node is
 
   return !!node.callee && isObject(node.callee) && node.callee.type === "Identifier" && node.callee.name === calleeName;
 }
+
+/**
+ * String value of a `Literal` or a template with no interpolation.
+ * `1` becomes `"1"`. Returns `null` for `null` literals, interpolated
+ * templates, and anything else.
+ */
+export function resolveStaticStringLiteral(node: unknown): string | null {
+  if (!isObject(node) || typeof node.type !== "string") return null;
+
+  if (node.type === "Literal") {
+    const value = (node as { value?: unknown }).value;
+    if (typeof value === "string") return value;
+    return value == null ? null : String(value);
+  }
+
+  if (node.type === "TemplateLiteral") {
+    const quasis = (node as { quasis?: Array<{ value?: { cooked?: string | null } }> }).quasis;
+    if (quasis?.length === 1) {
+      const cooked = quasis[0]?.value?.cooked;
+      return cooked == null ? null : cooked;
+    }
+  }
+
+  return null;
+}

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -3,7 +3,7 @@ import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "no
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, parse, relative, resolve } from "node:path";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
-import type { ParsedComponent, PendingCallDefaultCandidate } from "./ComponentParser";
+import type { ParsedComponent, PendingCallDefaultCandidate, PendingContextKeyCandidate } from "./ComponentParser";
 import { buildReverseDeps, expandAffected } from "./dependency-graph";
 import { dedupeDiagnostics, type SveldDiagnostic } from "./diagnostics";
 import { collectExampleSources } from "./example-check";
@@ -11,6 +11,7 @@ import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
 import { applyResolvedProps, getParsedComponentTypeScriptMetadata } from "./parsed-component-metadata";
+import { generateContextTypeName } from "./parser/contexts";
 import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
 import {
@@ -19,6 +20,7 @@ import {
   describeCallDefaultFailure,
   resolveCallDefaultCandidates,
 } from "./resolve-call-defaults";
+import { type ContextKeyResolution, resolveContextKeyCandidates } from "./resolve-context-keys";
 import type { TypeResolver } from "./resolve-types";
 
 export interface ComponentDocApi extends ParsedComponent {
@@ -684,16 +686,26 @@ export async function generateBundle(
   // Warm-cache runs skip loadParserStack above, but this pass still needs it to
   // parse sibling modules.
   const callDefaultCandidates = collectCallDefaultCandidates(allComponentsForTypes);
-  if (callDefaultCandidates.length > 0) {
+  const contextKeyCandidates = collectContextKeyCandidates(allComponentsForTypes);
+  if (callDefaultCandidates.length > 0 || contextKeyCandidates.length > 0) {
     await loadParserStack();
-    const callDefaultResolveContext = createCallDefaultResolveContext();
+    // Both passes share this cache and cycle set.
+    const crossFileResolveContext = createCallDefaultResolveContext();
     for (const { component, candidates } of callDefaultCandidates) {
       const resolutions = resolveCallDefaultCandidates(
         resolveComponentFilePath(component.filePath),
         candidates,
-        callDefaultResolveContext,
+        crossFileResolveContext,
       );
       applyCallDefaultResolutions(component, resolutions);
+    }
+    for (const { component, candidates } of contextKeyCandidates) {
+      const resolutions = resolveContextKeyCandidates(
+        resolveComponentFilePath(component.filePath),
+        candidates,
+        crossFileResolveContext,
+      );
+      applyContextKeyResolutions(component, resolutions);
     }
   }
 
@@ -762,6 +774,51 @@ function applyCallDefaultResolutions(component: ComponentDocApi, resolutions: Ca
       );
       if (existing) existing.message = describeCallDefaultFailure(candidate, failureReason);
     }
+  }
+}
+
+interface ContextKeyCandidateGroup {
+  component: ComponentDocApi;
+  candidates: PendingContextKeyCandidate[];
+}
+
+/** Components with a `setContext` key bound to a named import. */
+function collectContextKeyCandidates(components: ComponentDocs): ContextKeyCandidateGroup[] {
+  const groups: ContextKeyCandidateGroup[] = [];
+
+  for (const component of components.values()) {
+    const candidates = getParsedComponentTypeScriptMetadata(component)?.pendingContextKeyCandidates;
+    if (!candidates || candidates.length === 0) continue;
+    groups.push({ component, candidates });
+  }
+
+  return groups;
+}
+
+/**
+ * Append each resolved context to `component.contexts`. Unresolved keys
+ * get the same warning `parseSetContextCall` prints for a local miss.
+ */
+function applyContextKeyResolutions(component: ComponentDocApi, resolutions: ContextKeyResolution[]): void {
+  for (const { candidate, key } of resolutions) {
+    if (!key) {
+      console.warn(
+        `Warning: Could not resolve setContext key in ${component.filePath}. Use a string literal, const-bound string, or Symbol(). Skipping context type generation.`,
+      );
+      continue;
+    }
+
+    if (component.contexts?.some((existing) => existing.key === key)) continue;
+
+    component.contexts = [
+      ...(component.contexts ?? []),
+      {
+        key,
+        typeName: generateContextTypeName(key),
+        description: candidate.description,
+        properties: candidate.properties,
+      },
+    ];
   }
 }
 

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import { isIdentifier } from "./ast-guards";
+import { isIdentifier, resolveStaticStringLiteral } from "./ast-guards";
 import { extractJsDocReturnType } from "./parser/jsdoc";
 import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
@@ -44,6 +44,11 @@ interface AstNode {
 export interface InternalExport extends Omit<EntryExport, "source"> {
   declFile: string;
   returnType?: string;
+  /**
+   * String from a literal or static-template initializer.
+   * `resolve-context-keys.ts` uses this when a `setContext` key is imported.
+   */
+  literalValue?: string;
 }
 
 /** Parsed-source context shared while walking a single module. */
@@ -265,6 +270,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
       let type = annotationText(source, id);
       let value: string | undefined;
       let returnType: string | undefined;
+      let literalValue: string | undefined;
       const init = asNode(declarator.init);
 
       if (init) {
@@ -278,10 +284,11 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         } else {
           value = textOf(source, init);
           if (!type) type = inferLiteralType(init);
+          literalValue = resolveStaticStringLiteral(init) ?? undefined;
         }
       }
 
-      results.push({ name, kind, type, value, returnType, description, declFile, isTypeOnly: false });
+      results.push({ name, kind, type, value, returnType, literalValue, description, declFile, isTypeOnly: false });
     }
 
     return results;

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -13,6 +13,7 @@ import type {
   LexicalScope,
   LocalTypeDeclaration,
   PendingCallDefaultCandidate,
+  PendingContextKeyCandidate,
   RestProps,
   RunesPropsDeclarationMetadata,
   ScriptLanguage,
@@ -64,6 +65,8 @@ export interface ParserContext {
   readonly valueImportBindingsByLocalName: Map<string, ValueImportBinding>;
   /** CallExpression defaults that still need a return type after AST parsing. */
   readonly pendingCallDefaultCandidates: PendingCallDefaultCandidate[];
+  /** Named-import `setContext` keys that need a string value after AST parsing. */
+  readonly pendingContextKeyCandidates: PendingContextKeyCandidate[];
 
   readonly runesPropsDeclarationMetadataByDeclaratorStart: Map<number, RunesPropsDeclarationMetadata>;
   readonly typedRunesPropsDeclarations: RunesPropsDeclarationMetadata[];
@@ -127,6 +130,7 @@ export function createParserContext(): ParserContext {
     vars: new Set(),
     valueImportBindingsByLocalName: new Map(),
     pendingCallDefaultCandidates: [],
+    pendingContextKeyCandidates: [],
     runesPropsDeclarationMetadataByDeclaratorStart: new Map(),
     typedRunesPropsDeclarations: [],
     explicitPropTypesByName: new Map(),

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -1,6 +1,6 @@
 import type { ArrowFunctionExpression, CallExpression, Expression, FunctionExpression, NewExpression } from "estree";
 import type { Node } from "estree-walker";
-import { isIdentifier, isLiteral, isObjectExpression } from "../ast-guards";
+import { isIdentifier, isLiteral, isObjectExpression, resolveStaticStringLiteral } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type { ComponentContext, ComponentContextProp } from "../ComponentParser";
 import type { ParserContext } from "./context";
@@ -12,7 +12,7 @@ import { sourceRangeFromNode } from "./source-position";
 const CONTEXT_KEY_SPLIT_REGEX = /[-_.:/\s]+/;
 
 /** Turn `simple-modal` into `SimpleModalContext`. */
-function generateContextTypeName(key: string): string {
+export function generateContextTypeName(key: string): string {
   const parts = key.split(CONTEXT_KEY_SPLIT_REGEX);
   const capitalized = parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("");
   return `${capitalized}Context`;
@@ -165,35 +165,37 @@ function resolveSymbolKeyDescription(node: CallExpression | NewExpression): stri
   return "";
 }
 
+/** How a `setContext` key expression resolved. */
+type ContextKeyResolution =
+  | { kind: "resolved"; key: string }
+  /** Named import. Resolved later by reading the other file. */
+  | { kind: "pending"; importSource: string; importedName: string }
+  | { kind: "unresolved" };
+
 /**
- * Resolve a `setContext` key to the string used in `{PascalCase}Context`.
- * Accepts literals, static templates, `const` chains (depth 5), and `Symbol()`.
- * Description-less symbols fall back to the binding name.
+ * Resolve a `setContext` key. Literals, static templates, local `const`
+ * chains (depth 5), and `Symbol()` become `{ kind: "resolved" }`. A
+ * `Symbol()` with no description uses the binding name. A named import is
+ * `{ kind: "pending" }` so `generateBundle` can read the other file.
  */
-function resolveContextKey(ctx: ParserContext, keyArg: unknown, depth = 0): string | null {
-  if (!keyArg || typeof keyArg !== "object" || !("type" in keyArg)) return null;
+function resolveContextKey(ctx: ParserContext, keyArg: unknown, depth = 0): ContextKeyResolution {
+  if (!keyArg || typeof keyArg !== "object" || !("type" in keyArg)) return { kind: "unresolved" };
   const node = keyArg as Expression;
 
-  if (node.type === "Literal") {
-    return typeof node.value === "string" ? node.value : node.value == null ? null : String(node.value);
-  }
-
-  if (node.type === "TemplateLiteral") {
-    /** Static template only; interpolated templates return null. */
-    if (node.quasis?.length === 1) {
-      const cooked = node.quasis[0].value.cooked;
-      return cooked == null ? null : cooked;
-    }
-    return null;
+  if (node.type === "Literal" || node.type === "TemplateLiteral") {
+    const value = resolveStaticStringLiteral(node);
+    return value == null ? { kind: "unresolved" } : { kind: "resolved", key: value };
   }
 
   if (node.type === "CallExpression" || node.type === "NewExpression") {
-    return resolveSymbolKeyDescription(node);
+    const description = resolveSymbolKeyDescription(node);
+    return description == null ? { kind: "unresolved" } : { kind: "resolved", key: description };
   }
 
   if (node.type === "Identifier") {
     /** Follow const bindings, same 5-level cap as @default. */
-    if (depth >= 5) return null;
+    if (depth >= 5) return { kind: "unresolved" };
+
     const resolvedInit = resolveConstInitializer(ctx, node.name);
     if (resolvedInit && typeof resolvedInit === "object" && "type" in resolvedInit) {
       const init = resolvedInit as Expression;
@@ -202,17 +204,23 @@ function resolveContextKey(ctx: ParserContext, keyArg: unknown, depth = 0): stri
         (init.type === "CallExpression" || init.type === "NewExpression") &&
         resolveSymbolKeyDescription(init) === ""
       ) {
-        return node.name;
+        return { kind: "resolved", key: node.name };
       }
       return resolveContextKey(ctx, init, depth + 1);
     }
-    return null;
+
+    const importBinding = ctx.valueImportBindingsByLocalName.get(node.name);
+    if (importBinding) {
+      return { kind: "pending", importSource: importBinding.source, importedName: importBinding.importedName };
+    }
+
+    return { kind: "unresolved" };
   }
 
-  return null;
+  return { kind: "unresolved" };
 }
 
-/** Parse `setContext(key, value)` when the key resolves statically. */
+/** Parse `setContext(key, value)`. Imported keys go to `pendingContextKeyCandidates`. */
 export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser, node: Node, _parent?: Node) {
   if (!node || typeof node !== "object" || !("type" in node) || node.type !== "CallExpression") {
     return;
@@ -221,9 +229,9 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
   const keyArg = callExpr.arguments[0];
   if (!keyArg) return;
 
-  const contextKey = resolveContextKey(ctx, keyArg);
+  const resolution = resolveContextKey(ctx, keyArg);
 
-  if (!contextKey) {
+  if (resolution.kind === "unresolved" || (resolution.kind === "resolved" && !resolution.key)) {
     const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
     console.warn(
       `Warning: Could not resolve setContext key${location}. Use a string literal, const-bound string, or Symbol(). Skipping context type generation.`,
@@ -234,6 +242,21 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
   const valueArg = callExpr.arguments[1];
   if (!valueArg) return;
 
+  if (resolution.kind === "pending") {
+    /** Properties come from the local value. The key is resolved later. */
+    const contextInfo = parseContextValue(ctx, parser, valueArg, "");
+    if (contextInfo) {
+      ctx.pendingContextKeyCandidates.push({
+        importSource: resolution.importSource,
+        importedName: resolution.importedName,
+        properties: contextInfo.properties,
+        description: contextInfo.description,
+      });
+    }
+    return;
+  }
+
+  const contextKey = resolution.key;
   const contextInfo = parseContextValue(ctx, parser, valueArg, contextKey);
   if (contextInfo && !ctx.contexts.has(contextKey)) {
     ctx.contexts.set(contextKey, contextInfo);

--- a/src/parser/type-resolution.ts
+++ b/src/parser/type-resolution.ts
@@ -281,17 +281,25 @@ function buildTypeImportStatements(ctx: ParserContext, referencedImportedTypes: 
 export function buildTypeScriptMetadata(ctx: ParserContext): ParsedComponentTypeScriptMetadata | undefined {
   const pendingCallDefaultCandidates =
     ctx.pendingCallDefaultCandidates.length > 0 ? ctx.pendingCallDefaultCandidates.slice() : undefined;
+  const pendingContextKeyCandidates =
+    ctx.pendingContextKeyCandidates.length > 0 ? ctx.pendingContextKeyCandidates.slice() : undefined;
+  const pendingCrossFileCandidates = {
+    ...(pendingCallDefaultCandidates ? { pendingCallDefaultCandidates } : {}),
+    ...(pendingContextKeyCandidates ? { pendingContextKeyCandidates } : {}),
+  };
+  const hasPendingCrossFileCandidates =
+    pendingCallDefaultCandidates !== undefined || pendingContextKeyCandidates !== undefined;
 
   if (ctx.typedRunesPropsDeclarations.length !== 1) {
-    return pendingCallDefaultCandidates
-      ? { canonicalPropNames: [], localTypeDeclarations: [], typeImportStatements: [], pendingCallDefaultCandidates }
+    return hasPendingCrossFileCandidates
+      ? { canonicalPropNames: [], localTypeDeclarations: [], typeImportStatements: [], ...pendingCrossFileCandidates }
       : undefined;
   }
 
   const [typedDeclaration] = ctx.typedRunesPropsDeclarations;
   if (!typedDeclaration.canonicalType) {
-    return pendingCallDefaultCandidates
-      ? { canonicalPropNames: [], localTypeDeclarations: [], typeImportStatements: [], pendingCallDefaultCandidates }
+    return hasPendingCrossFileCandidates
+      ? { canonicalPropNames: [], localTypeDeclarations: [], typeImportStatements: [], ...pendingCrossFileCandidates }
       : undefined;
   }
 
@@ -307,6 +315,6 @@ export function buildTypeScriptMetadata(ctx: ParserContext): ParsedComponentType
     localTypeDeclarations,
     typeImportStatements: buildTypeImportStatements(ctx, typedDeclaration.referencedImportedTypes),
     referencesComponentGenerics: typeTextReferencesGenerics(typedDeclaration.canonicalType, ctx.generics),
-    ...(pendingCallDefaultCandidates ? { pendingCallDefaultCandidates } : {}),
+    ...pendingCrossFileCandidates,
   };
 }

--- a/src/resolve-context-keys.ts
+++ b/src/resolve-context-keys.ts
@@ -1,0 +1,33 @@
+import { dirname } from "node:path";
+import type { PendingContextKeyCandidate } from "./ComponentParser";
+import { collectModuleExports, type ResolveContext, resolveModuleFile } from "./parse-entry-exports";
+
+export interface ContextKeyResolution {
+  candidate: PendingContextKeyCandidate;
+  /** Present on success. */
+  key?: string;
+}
+
+/**
+ * Read each candidate's imported key from its declaring module
+ * ({@link collectModuleExports} follows re-exports). Only `export const`
+ * with a string literal or static template counts. `export let` / `var`
+ * stay unresolved even if the initializer is a literal. AST only, no `tsc`.
+ */
+export function resolveContextKeyCandidates(
+  componentFilePath: string,
+  candidates: PendingContextKeyCandidate[],
+  ctx: ResolveContext,
+): ContextKeyResolution[] {
+  const fromDir = dirname(componentFilePath);
+
+  return candidates.map((candidate): ContextKeyResolution => {
+    const resolvedFile = resolveModuleFile(candidate.importSource, fromDir);
+    if (!resolvedFile) return { candidate };
+
+    const match = collectModuleExports(resolvedFile, ctx).find((entry) => entry.name === candidate.importedName);
+    if (match?.kind !== "const" || match.literalValue === undefined) return { candidate };
+
+    return { candidate, key: match.literalValue };
+  });
+}

--- a/tests/resolve-context-keys.test.ts
+++ b/tests/resolve-context-keys.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { type ComponentDocApi, type ComponentDocs, generateBundle } from "../src/bundle";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
+
+describe("cross-file setContext key resolution", () => {
+  let dir: string;
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-context-keys-"));
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+
+  test("A: resolves a setContext key imported from a plain .js module", async () => {
+    writeFileSync(
+      path.join(dir, "highlightCursor.js"),
+      `export const HIGHLIGHT_CURSOR_KEY = "carbon:ListBoxHighlight";\n`,
+    );
+    writeFileSync(
+      path.join(dir, "ListBoxMenu.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+  import { HIGHLIGHT_CURSOR_KEY } from "./highlightCursor.js";
+
+  /** @type {number} */
+  let highlightCursor = 0;
+
+  setContext(HIGHLIGHT_CURSOR_KEY, { highlightCursor });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as ListBoxMenu } from "./ListBoxMenu.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "ListBoxMenu");
+
+    expect(component?.contexts).toHaveLength(1);
+    expect(component?.contexts?.[0]).toMatchObject({
+      key: "carbon:ListBoxHighlight",
+      typeName: "CarbonListBoxHighlightContext",
+    });
+    expect(component?.contexts?.[0].properties).toMatchObject([
+      { name: "highlightCursor", type: "number", optional: false },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("B: resolves through a re-export barrel", async () => {
+    writeFileSync(path.join(dir, "key.js"), `export const MODAL_KEY = "simple-modal";\n`);
+    writeFileSync(path.join(dir, "reexport.js"), `export { MODAL_KEY } from "./key.js";\n`);
+    writeFileSync(
+      path.join(dir, "Modal.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+  import { MODAL_KEY } from "./reexport.js";
+
+  const close = () => {};
+
+  setContext(MODAL_KEY, { close });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Modal } from "./Modal.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Modal");
+
+    expect(component?.contexts).toHaveLength(1);
+    expect(component?.contexts?.[0].key).toBe("simple-modal");
+  });
+
+  test("C: export let stays unresolved and warns", async () => {
+    writeFileSync(path.join(dir, "key.js"), `export let MODAL_KEY = "simple-modal";\n`);
+    writeFileSync(
+      path.join(dir, "Modal.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+  import { MODAL_KEY } from "./key.js";
+
+  const close = () => {};
+
+  setContext(MODAL_KEY, { close });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Modal } from "./Modal.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Modal");
+
+    expect(component?.contexts ?? []).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Could not resolve setContext key"));
+  });
+
+  test("missing export warns and skips the context", async () => {
+    writeFileSync(path.join(dir, "key.js"), `export const OTHER_KEY = "other";\n`);
+    writeFileSync(
+      path.join(dir, "Modal.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+  import { MODAL_KEY } from "./key.js";
+
+  const close = () => {};
+
+  setContext(MODAL_KEY, { close });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Modal } from "./Modal.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Modal");
+
+    expect(component?.contexts ?? []).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test("missing module warns and skips the context", async () => {
+    writeFileSync(
+      path.join(dir, "Modal.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+  import { MODAL_KEY } from "./does-not-exist.js";
+
+  const close = () => {};
+
+  setContext(MODAL_KEY, { close });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Modal } from "./Modal.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Modal");
+
+    expect(component?.contexts ?? []).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test("renamed import uses importedName", async () => {
+    writeFileSync(path.join(dir, "key.js"), `export const MODAL_KEY = "simple-modal";\n`);
+    writeFileSync(
+      path.join(dir, "Modal.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+  import { MODAL_KEY as KEY } from "./key.js";
+
+  const close = () => {};
+
+  setContext(KEY, { close });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Modal } from "./Modal.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Modal");
+
+    expect(component?.contexts?.[0]?.key).toBe("simple-modal");
+  });
+
+  test("local const resolves without an import", async () => {
+    writeFileSync(
+      path.join(dir, "Modal.svelte"),
+      `<script>
+  import { setContext } from "svelte";
+
+  const MODAL_KEY = "simple-modal";
+  const close = () => {};
+
+  setContext(MODAL_KEY, { close });
+</script>
+<div><slot /></div>
+`,
+    );
+    writeFileSync(path.join(dir, "index.js"), `export { default as Modal } from "./Modal.svelte";\n`);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true);
+    const component = byModuleName(result.allComponentsForTypes, "Modal");
+
+    expect(component?.contexts?.[0]?.key).toBe("simple-modal");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
setContext(KEY, value) only followed local const bindings, so a key
imported from a sibling module (a common pattern for sharing context
keys across components without duplicating strings) silently skipped
context type generation with a warning. Resolution now defers to the
same post-parse cross-file pass generateBundle() already runs for
prop defaults that call an imported function, sharing its module-
export cache.

## Example

```svelte
<!-- highlightCursor.js -->
export const HIGHLIGHT_CURSOR_KEY = "carbon:ListBoxHighlight";

<!-- ListBoxMenu.svelte -->
<script>
  import { setContext } from "svelte";
  import { HIGHLIGHT_CURSOR_KEY } from "./highlightCursor.js";

  setContext(HIGHLIGHT_CURSOR_KEY, highlightCursor);
</script>
```

Before: `Warning: Could not resolve setContext key ... Skipping
context type generation.` and no context type in the .d.ts.

After: the .d.ts gets a `CarbonListBoxHighlightContext` type keyed
on `"carbon:ListBoxHighlight"`, no warning.