### PR TITLE
ci: run e2e suite on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Type check fixtures
         run: bun run test:fixtures-types
 
+      - name: Run e2e tests
+        run: bun run test:e2e
+
       - name: Deploy docs
         # Only trigger deploy if previous steps pass on main branch.
         # Only fire once per branch push.

--- a/tests/e2e/carbon/COMPONENT_API.json
+++ b/tests/e2e/carbon/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 156,
   "components": [
@@ -3975,6 +3975,7 @@
           "description": "Override the display of a combobox item",
           "type": "(item: ComboBoxItem) => string",
           "typeSource": "jsdoc",
+          "value": "(item) => item.text || item.id",
           "defaultValue": {
             "raw": "(item) => item.text || item.id",
             "kind": "function"
@@ -4308,6 +4309,7 @@
           "description": "Determine if an item should be filtered given the current combobox value",
           "type": "(item: ComboBoxItem, value: string) => boolean",
           "typeSource": "jsdoc",
+          "value": "() => true",
           "defaultValue": {
             "raw": "() => true",
             "kind": "function"
@@ -7831,6 +7833,7 @@
           "description": "Override the display of a dropdown item\n@required",
           "type": "(item: DropdownItem) => string",
           "typeSource": "jsdoc",
+          "value": "(item) => item.text || item.id",
           "defaultValue": {
             "raw": "(item) => item.text || item.id",
             "kind": "function"
@@ -10010,6 +10013,7 @@
           "description": "Override the default behavior of validating uploaded files\nThe default behavior does not validate files",
           "type": "(files: FileList) => FileList",
           "typeSource": "jsdoc",
+          "value": "(files) => files",
           "defaultValue": {
             "raw": "(files) => files",
             "kind": "function"
@@ -11945,7 +11949,7 @@
           "column": 0
         },
         "end": {
-          "line": 89,
+          "line": 103,
           "column": 0
         }
       },
@@ -12182,7 +12186,7 @@
           "column": 0
         },
         "end": {
-          "line": 36,
+          "line": 44,
           "column": 0
         }
       },
@@ -12320,7 +12324,7 @@
           "column": 0
         },
         "end": {
-          "line": 147,
+          "line": 235,
           "column": 0
         }
       },
@@ -13169,7 +13173,7 @@
           "column": 0
         },
         "end": {
-          "line": 6,
+          "line": 21,
           "column": 0
         }
       },
@@ -13360,7 +13364,7 @@
           "column": 0
         },
         "end": {
-          "line": 178,
+          "line": 311,
           "column": 0
         }
       },
@@ -15288,6 +15292,7 @@
           "description": "Override the default translation ids",
           "type": "(id: ListBoxFieldTranslationId) => string",
           "typeSource": "jsdoc",
+          "value": "(id) => defaultTranslations[id]",
           "defaultValue": {
             "raw": "(id) => defaultTranslations[id]",
             "kind": "function"
@@ -15684,6 +15689,7 @@
           "description": "Override the default translation ids",
           "type": "(id: ListBoxMenuIconTranslationId) => string",
           "typeSource": "jsdoc",
+          "value": "(id) => defaultTranslations[id]",
           "defaultValue": {
             "raw": "(id) => defaultTranslations[id]",
             "kind": "function"
@@ -15992,6 +15998,7 @@
           "description": "Override the default translation ids",
           "type": "(id: ListBoxSelectionTranslationId) => string",
           "typeSource": "jsdoc",
+          "value": "(id) => defaultTranslations[id]",
           "defaultValue": {
             "raw": "(id) => defaultTranslations[id]",
             "kind": "function"
@@ -17698,6 +17705,7 @@
           "description": "Override the display of a multiselect item",
           "type": "(item: MultiSelectItem) => string",
           "typeSource": "jsdoc",
+          "value": "(item) => item.text || item.id",
           "defaultValue": {
             "raw": "(item) => item.text || item.id",
             "kind": "function"
@@ -17919,6 +17927,7 @@
           "description": "Override the filtering logic\nThe default filtering is an exact string comparison",
           "type": "(item: MultiSelectItem, value: string) => string",
           "typeSource": "jsdoc",
+          "value": "(item, value) => item.text.toLowerCase().includes(value.toLowerCase())",
           "defaultValue": {
             "raw": "(item, value) => item.text.toLowerCase().includes(value.toLowerCase())",
             "kind": "function"
@@ -18057,6 +18066,7 @@
           "description": "Override the sorting logic\nThe default sorting compare the item text value",
           "type": "((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) | (() => void)",
           "typeSource": "jsdoc",
+          "value": "(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })",
           "defaultValue": {
             "raw": "(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })",
             "kind": "function"
@@ -19583,6 +19593,7 @@
           "description": "Override the default translation ids",
           "type": "(id: NumberInputTranslationId) => string",
           "typeSource": "jsdoc",
+          "value": "(id) => defaultTranslations[id]",
           "defaultValue": {
             "raw": "(id) => defaultTranslations[id]",
             "kind": "function"
@@ -21254,6 +21265,7 @@
           "description": "Override the item text",
           "type": "(min: number, max: number) => string",
           "typeSource": "jsdoc",
+          "value": "(min, max) => `${min}–${max} items`",
           "defaultValue": {
             "raw": "(min, max) => `${min}–${max} items`",
             "kind": "function"
@@ -21280,6 +21292,7 @@
           "description": "Override the item range text",
           "type": "(min: number, max: number, total: number) => string",
           "typeSource": "jsdoc",
+          "value": "(min, max, total) => `${min}–${max} of ${total} items`",
           "defaultValue": {
             "raw": "(min, max, total) => `${min}–${max} of ${total} items`",
             "kind": "function"
@@ -21448,6 +21461,7 @@
           "description": "Override the page text",
           "type": "(page: number) => string",
           "typeSource": "jsdoc",
+          "value": "(page) => `page ${page}`",
           "defaultValue": {
             "raw": "(page) => `page ${page}`",
             "kind": "function"
@@ -21474,6 +21488,7 @@
           "description": "Override the page range text",
           "type": "(current: number, total: number) => string",
           "typeSource": "jsdoc",
+          "value": "(_current, total) => `of ${total} page${total === 1 ? \"\" : \"s\"}`",
           "defaultValue": {
             "raw": "(_current, total) => `of ${total} page${total === 1 ? \"\" : \"s\"}`",
             "kind": "function"
@@ -30577,6 +30592,7 @@
           "description": "Override the default id translations",
           "type": "() => string",
           "typeSource": "jsdoc",
+          "value": "() => \"\"",
           "defaultValue": {
             "raw": "() => \"\"",
             "kind": "function"
@@ -35780,6 +35796,7 @@
           "description": "Override the total items selected text",
           "type": "(totalSelected: number) => string",
           "typeSource": "jsdoc",
+          "value": "(totalSelected) => `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
           "defaultValue": {
             "raw": "(totalSelected) => `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
             "kind": "function"

--- a/tests/e2e/carbon/COMPONENT_INDEX.md
+++ b/tests/e2e/carbon/COMPONENT_INDEX.md
@@ -608,7 +608,7 @@ export interface ComboBoxItem { id: string; text: string; }
 | value | No | <code>let</code> | Yes | -- | <code>string</code> | <code>""</code> | Specify the selected combobox value |
 | selectedIndex | No | <code>let</code> | Yes | -- | <code>number</code> | <code>-1</code> | Set the selected item by value index |
 | items | No | <code>let</code> | No | -- | <code>ComboBoxItem[]</code> | <code>[]</code> | Set the combobox items |
-| itemToString | No | <code>let</code> | No | -- | <code>(item: ComboBoxItem) => string</code> | -- | Override the display of a combobox item |
+| itemToString | No | <code>let</code> | No | -- | <code>(item: ComboBoxItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a combobox item |
 | size | No | <code>let</code> | No | -- | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Set the size of the combobox |
 | disabled | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to disable the combobox |
 | titleText | No | <code>let</code> | No | -- | <code>string</code> | <code>""</code> | Specify the title text of the combobox |
@@ -617,7 +617,7 @@ export interface ComboBoxItem { id: string; text: string; }
 | invalidText | No | <code>let</code> | No | -- | <code>string</code> | <code>""</code> | Specify the invalid state text |
 | invalid | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state |
 | light | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
-| shouldFilterItem | No | <code>let</code> | No | -- | <code>(item: ComboBoxItem, value: string) => boolean</code> | -- | Determine if an item should be filtered given the current combobox value |
+| shouldFilterItem | No | <code>let</code> | No | -- | <code>(item: ComboBoxItem, value: string) => boolean</code> | <code>() => true</code> | Determine if an item should be filtered given the current combobox value |
 | translateWithId | No | <code>let</code> | No | -- | <code>(id: any) => string</code> | <code>undefined</code> | Override the default translation ids |
 | id | No | <code>let</code> | No | -- | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the list box component |
 | name | No | <code>let</code> | No | -- | <code>string</code> | <code>undefined</code> | Specify a name attribute for the input |
@@ -968,7 +968,7 @@ export interface DropdownItem { id: DropdownItemId; text: DropdownItemText; }
 | open | No | <code>let</code> | Yes | -- | <code>boolean</code> | <code>false</code> | Set to `true` to open the dropdown |
 | selectedIndex | No | <code>let</code> | Yes | -- | <code>number</code> | <code>-1</code> | Specify the selected item index |
 | items | No | <code>let</code> | No | -- | <code>DropdownItem[]</code> | <code>[]</code> | Set the dropdown items |
-| itemToString | No | <code>let</code> | No | -- | <code>(item: DropdownItem) => string</code> | -- | Override the display of a dropdown item<br />@required |
+| itemToString | No | <code>let</code> | No | -- | <code>(item: DropdownItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item<br />@required |
 | type | No | <code>let</code> | No | -- | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Specify the type of dropdown |
 | size | No | <code>let</code> | No | -- | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the dropdown field |
 | light | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
@@ -1145,7 +1145,7 @@ None.
 | ref | No | <code>let</code> | Yes | -- | <code>null &#124; HTMLInputElement</code> | <code>null</code> | Obtain a reference to the input HTML element |
 | accept | No | <code>let</code> | No | -- | <code>string[]</code> | <code>[]</code> | Specify the accepted file types |
 | multiple | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to allow multiple files |
-| validateFiles | No | <code>let</code> | No | -- | <code>(files: FileList) => FileList</code> | -- | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
+| validateFiles | No | <code>let</code> | No | -- | <code>(files: FileList) => FileList</code> | <code>(files) => files</code> | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
 | labelText | No | <code>let</code> | No | -- | <code>string</code> | <code>"Add file"</code> | Specify the label text |
 | role | No | <code>let</code> | No | -- | <code>string</code> | <code>"button"</code> | Specify the `role` attribute of the drop container |
 | disabled | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to disable the input |
@@ -1829,7 +1829,7 @@ export type ListBoxFieldTranslationId = "close" | "open";
 | role | No | <code>let</code> | No | -- | <code>string</code> | <code>"combobox"</code> | Specify the role attribute |
 | tabindex | No | <code>let</code> | No | -- | <code>string</code> | <code>"-1"</code> | Specify the tabindex |
 | translationIds | No | <code>const</code> | No | -- | <code>{ close: "close", open: "open" }</code> | <code>{ close: "close", open: "open" }</code> | Default translation ids |
-| translateWithId | No | <code>let</code> | No | -- | <code>(id: ListBoxFieldTranslationId) => string</code> | -- | Override the default translation ids |
+| translateWithId | No | <code>let</code> | No | -- | <code>(id: ListBoxFieldTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code> | Override the default translation ids |
 | id | No | <code>let</code> | No | -- | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element |
 
 ### Slots
@@ -1884,7 +1884,7 @@ export type ListBoxMenuIconTranslationId = "close" | "open";
 | :- | :- | :- | :- | :- | :- | :- | :- |
 | open | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to open the list box menu icon |
 | translationIds | No | <code>const</code> | No | -- | <code>{ close: "close", open: "open" }</code> | <code>{ close: "close", open: "open" }</code> | Default translation ids |
-| translateWithId | No | <code>let</code> | No | -- | <code>(id: ListBoxMenuIconTranslationId) => string</code> | -- | Override the default translation ids |
+| translateWithId | No | <code>let</code> | No | -- | <code>(id: ListBoxMenuIconTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code> | Override the default translation ids |
 
 ### Slots
 
@@ -1935,7 +1935,7 @@ export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 | selectionCount | No | <code>let</code> | No | -- | <code>any</code> | <code>undefined</code> | Specify the number of selected items |
 | disabled | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to disable the list box selection |
 | translationIds | No | <code>const</code> | No | -- | <code>{     clearAll: "clearAll",     clearSelection: "clearSelection",   }</code> | <code>{     clearAll: "clearAll",     clearSelection: "clearSelection",   }</code> | Default translation ids |
-| translateWithId | No | <code>let</code> | No | -- | <code>(id: ListBoxSelectionTranslationId) => string</code> | -- | Override the default translation ids |
+| translateWithId | No | <code>let</code> | No | -- | <code>(id: ListBoxSelectionTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code> | Override the default translation ids |
 
 ### Slots
 
@@ -2124,17 +2124,17 @@ export interface MultiSelectItem { id: MultiSelectItemId; text: MultiSelectItemT
 | value | No | <code>let</code> | Yes | -- | <code>string</code> | <code>""</code> | Specify the multiselect value |
 | selectedIds | No | <code>let</code> | Yes | -- | <code>MultiSelectItemId[]</code> | <code>[]</code> | Set the selected ids |
 | items | No | <code>let</code> | Yes | -- | <code>MultiSelectItem[]</code> | <code>[]</code> | Set the multiselect items |
-| itemToString | No | <code>let</code> | No | -- | <code>(item: MultiSelectItem) => string</code> | -- | Override the display of a multiselect item |
+| itemToString | No | <code>let</code> | No | -- | <code>(item: MultiSelectItem) => string</code> | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a multiselect item |
 | size | No | <code>let</code> | No | -- | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>undefined</code> | Set the size of the combobox |
 | type | No | <code>let</code> | No | -- | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Specify the type of multiselect |
 | selectionFeedback | No | <code>let</code> | No | -- | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code> | <code>"top-after-reopen"</code> | Specify the selection feedback after selecting items |
 | disabled | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to disable the dropdown |
 | filterable | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to filter items |
-| filterItem | No | <code>let</code> | No | -- | <code>(item: MultiSelectItem, value: string) => string</code> | -- | Override the filtering logic<br />The default filtering is an exact string comparison |
+| filterItem | No | <code>let</code> | No | -- | <code>(item: MultiSelectItem, value: string) => string</code> | <code>(item, value) => item.text.toLowerCase().includes(value.toLowerCase())</code> | Override the filtering logic<br />The default filtering is an exact string comparison |
 | light | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
 | locale | No | <code>let</code> | No | -- | <code>string</code> | <code>"en"</code> | Specify the locale |
 | placeholder | No | <code>let</code> | No | -- | <code>string</code> | <code>""</code> | Specify the placeholder text |
-| sortItem | No | <code>let</code> | No | -- | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | -- | Override the sorting logic<br />The default sorting compare the item text value |
+| sortItem | No | <code>let</code> | No | -- | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code> | <code>(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })</code> | Override the sorting logic<br />The default sorting compare the item text value |
 | translateWithId | No | <code>let</code> | No | -- | <code>(id: any) => string</code> | <code>undefined</code> | Override the default translation ids |
 | titleText | No | <code>let</code> | No | -- | <code>string</code> | <code>""</code> | Specify the title text |
 | useTitleInItem | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to pass the item to `itemToString` in the checkbox |
@@ -2276,7 +2276,7 @@ export type NumberInputTranslationId = "increment" | "decrement";
 | helperText | No | <code>let</code> | No | -- | <code>string</code> | <code>""</code> | Specify the helper text |
 | label | No | <code>let</code> | No | -- | <code>string</code> | <code>""</code> | Specify the label text |
 | hideLabel | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
-| translateWithId | No | <code>let</code> | No | -- | <code>(id: NumberInputTranslationId) => string</code> | -- | Override the default translation ids |
+| translateWithId | No | <code>let</code> | No | -- | <code>(id: NumberInputTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code> | Override the default translation ids |
 | translationIds | No | <code>const</code> | No | -- | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{     increment: "increment",     decrement: "decrement",   }</code> | Default translation ids |
 | id | No | <code>let</code> | No | -- | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the input element |
 | name | No | <code>let</code> | No | -- | <code>string</code> | <code>undefined</code> | Specify a name attribute for the input |
@@ -2443,14 +2443,14 @@ None.
 | forwardText | No | <code>let</code> | No | -- | <code>string</code> | <code>"Next page"</code> | Specify the forward button text |
 | backwardText | No | <code>let</code> | No | -- | <code>string</code> | <code>"Previous page"</code> | Specify the backward button text |
 | itemsPerPageText | No | <code>let</code> | No | -- | <code>string</code> | <code>"Items per page:"</code> | Specify the items per page text |
-| itemText | No | <code>let</code> | No | -- | <code>(min: number, max: number) => string</code> | -- | Override the item text |
-| itemRangeText | No | <code>let</code> | No | -- | <code>(min: number, max: number, total: number) => string</code> | -- | Override the item range text |
+| itemText | No | <code>let</code> | No | -- | <code>(min: number, max: number) => string</code> | <code>(min, max) => \`${min}–${max} items\`</code> | Override the item text |
+| itemRangeText | No | <code>let</code> | No | -- | <code>(min: number, max: number, total: number) => string</code> | <code>(min, max, total) => \`${min}–${max} of ${total} items\`</code> | Override the item range text |
 | pageInputDisabled | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to disable the page input |
 | pageSizeInputDisabled | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` to disable the page size input |
 | pageSizes | No | <code>let</code> | No | -- | <code>number[]</code> | <code>[10]</code> | Specify the available page sizes |
 | pagesUnknown | No | <code>let</code> | No | -- | <code>boolean</code> | <code>false</code> | Set to `true` if the number of pages is unknown |
-| pageText | No | <code>let</code> | No | -- | <code>(page: number) => string</code> | -- | Override the page text |
-| pageRangeText | No | <code>let</code> | No | -- | <code>(current: number, total: number) => string</code> | -- | Override the page range text |
+| pageText | No | <code>let</code> | No | -- | <code>(page: number) => string</code> | <code>(page) => \`page ${page}\`</code> | Override the page text |
+| pageRangeText | No | <code>let</code> | No | -- | <code>(current: number, total: number) => string</code> | <code>(_current, total) => \`of ${total} page${total === 1 ? "" : "s"}\`</code> | Override the page range text |
 | id | No | <code>let</code> | No | -- | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element |
 
 ### Slots
@@ -3513,7 +3513,7 @@ None.
 | Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
 | :- | :- | :- | :- | :- | :- | :- | :- |
 | scope | No | <code>let</code> | No | -- | <code>string</code> | <code>"col"</code> | Specify the `scope` attribute |
-| translateWithId | No | <code>let</code> | No | -- | <code>() => string</code> | -- | Override the default id translations |
+| translateWithId | No | <code>let</code> | No | -- | <code>() => string</code> | <code>() => ""</code> | Override the default id translations |
 | id | No | <code>let</code> | No | -- | <code>string</code> | <code>\`ccs-${Math.random().toString(36)}\`</code> | Set an id for the top-level element |
 
 ### Slots
@@ -4052,7 +4052,7 @@ None.
 
 | Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
 | :- | :- | :- | :- | :- | :- | :- | :- |
-| formatTotalSelected | No | <code>let</code> | No | -- | <code>(totalSelected: number) => string</code> | -- | Override the total items selected text |
+| formatTotalSelected | No | <code>let</code> | No | -- | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text |
 
 ### Slots
 

--- a/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
+++ b/tests/e2e/carbon/types/ComboBox/ComboBox.svelte.d.ts
@@ -17,6 +17,7 @@ type $Props = {
 
   /**
    * Override the display of a combobox item
+   * @default (item) => item.text || item.id
    */
   itemToString?: (item: ComboBoxItem) => string;
 
@@ -88,6 +89,7 @@ type $Props = {
 
   /**
    * Determine if an item should be filtered given the current combobox value
+   * @default () => true
    */
   shouldFilterItem?: (item: ComboBoxItem, value: string) => boolean;
 

--- a/tests/e2e/carbon/types/DataTable/TableHeader.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/TableHeader.svelte.d.ts
@@ -12,6 +12,7 @@ type $Props = {
 
   /**
    * Override the default id translations
+   * @default () => ""
    */
   translateWithId?: () => string;
 

--- a/tests/e2e/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/tests/e2e/carbon/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -6,6 +6,7 @@ type $RestProps = SvelteHTMLElements["div"];
 type $Props = {
   /**
    * Override the total items selected text
+   * @default (totalSelected) => `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`
    */
   formatTotalSelected?: (totalSelected: number) => string;
 

--- a/tests/e2e/carbon/types/Dropdown/Dropdown.svelte.d.ts
+++ b/tests/e2e/carbon/types/Dropdown/Dropdown.svelte.d.ts
@@ -22,6 +22,7 @@ type $Props = {
   /**
    * Override the display of a dropdown item
    * @required
+   * @default (item) => item.text || item.id
    */
   itemToString?: (item: DropdownItem) => string;
 

--- a/tests/e2e/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/tests/e2e/carbon/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -19,6 +19,7 @@ type $Props = {
   /**
    * Override the default behavior of validating uploaded files
    * The default behavior does not validate files
+   * @default (files) => files
    */
   validateFiles?: (files: FileList) => FileList;
 

--- a/tests/e2e/carbon/types/ListBox/ListBoxField.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxField.svelte.d.ts
@@ -26,6 +26,7 @@ type $Props = {
 
   /**
    * Override the default translation ids
+   * @default (id) => defaultTranslations[id]
    */
   translateWithId?: (id: ListBoxFieldTranslationId) => string;
 

--- a/tests/e2e/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -14,6 +14,7 @@ type $Props = {
 
   /**
    * Override the default translation ids
+   * @default (id) => defaultTranslations[id]
    */
   translateWithId?: (id: ListBoxMenuIconTranslationId) => string;
 

--- a/tests/e2e/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/tests/e2e/carbon/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -20,6 +20,7 @@ type $Props = {
 
   /**
    * Override the default translation ids
+   * @default (id) => defaultTranslations[id]
    */
   translateWithId?: (id: ListBoxSelectionTranslationId) => string;
 

--- a/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/tests/e2e/carbon/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -25,6 +25,7 @@ type $Props = {
 
   /**
    * Override the display of a multiselect item
+   * @default (item) => item.text || item.id
    */
   itemToString?: (item: MultiSelectItem) => string;
 
@@ -73,6 +74,7 @@ type $Props = {
   /**
    * Override the filtering logic
    * The default filtering is an exact string comparison
+   * @default (item, value) => item.text.toLowerCase().includes(value.toLowerCase())
    */
   filterItem?: (item: MultiSelectItem, value: string) => string;
 
@@ -103,6 +105,7 @@ type $Props = {
   /**
    * Override the sorting logic
    * The default sorting compare the item text value
+   * @default (a, b) => a.text.localeCompare(b.text, locale, { numeric: true })
    */
   sortItem?: ((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) | (() => void);
 

--- a/tests/e2e/carbon/types/NumberInput/NumberInput.svelte.d.ts
+++ b/tests/e2e/carbon/types/NumberInput/NumberInput.svelte.d.ts
@@ -116,6 +116,7 @@ type $Props = {
 
   /**
    * Override the default translation ids
+   * @default (id) => defaultTranslations[id]
    */
   translateWithId?: (id: NumberInputTranslationId) => string;
 

--- a/tests/e2e/carbon/types/Pagination/Pagination.svelte.d.ts
+++ b/tests/e2e/carbon/types/Pagination/Pagination.svelte.d.ts
@@ -42,11 +42,13 @@ type $Props = {
 
   /**
    * Override the item text
+   * @default (min, max) => `${min}–${max} items`
    */
   itemText?: (min: number, max: number) => string;
 
   /**
    * Override the item range text
+   * @default (min, max, total) => `${min}–${max} of ${total} items`
    */
   itemRangeText?: (min: number, max: number, total: number) => string;
 
@@ -82,11 +84,13 @@ type $Props = {
 
   /**
    * Override the page text
+   * @default (page) => `page ${page}`
    */
   pageText?: (page: number) => string;
 
   /**
    * Override the page range text
+   * @default (_current, total) => `of ${total} page${total === 1 ? "" : "s"}`
    */
   pageRangeText?: (current: number, total: number) => string;
 

--- a/tests/e2e/glob/COMPONENT_API.json
+++ b/tests/e2e/glob/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/multi-export-typed/COMPONENT_API.json
+++ b/tests/e2e/multi-export-typed/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 4,
   "components": [

--- a/tests/e2e/multi-export/COMPONENT_API.json
+++ b/tests/e2e/multi-export/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 5,
   "components": [

--- a/tests/e2e/path-aliases/COMPONENT_API.json
+++ b/tests/e2e/path-aliases/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 2,
   "components": [

--- a/tests/e2e/single-export/COMPONENT_API.json
+++ b/tests/e2e/single-export/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 1,
   "components": [

--- a/tests/e2e/svelte5-vite/COMPONENT_API.json
+++ b/tests/e2e/svelte5-vite/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 3,
   "components": [

--- a/tests/e2e/sveltekit/COMPONENT_API.json
+++ b/tests/e2e/sveltekit/COMPONENT_API.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generator": {
     "name": "sveld",
-    "version": "0.35.2",
-    "svelteVersion": "5.56.3"
+    "version": "0.36.10",
+    "svelteVersion": "5.56.10"
   },
   "total": 1,
   "components": [

--- a/tests/test-e2e.ts
+++ b/tests/test-e2e.ts
@@ -7,8 +7,14 @@ await $`bun link`;
 
 let hasError = false;
 
-for await (const dir of $`find tests/e2e -maxdepth 1 -mindepth 1 -type d`.lines()) {
+const e2eRoot = "tests/e2e";
+const dirs = readdirSync(e2eRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => join(e2eRoot, entry.name));
+
+for (const dir of dirs) {
   const packageJsonPath = `${dir}/package.json`;
+  // biome-ignore lint/performance/noAwaitInLoops: each example links/installs/builds into a shared bun link registry, so they must run one at a time.
   if (!(await Bun.file(packageJsonPath).exists())) continue;
 
   try {


### PR DESCRIPTION
## Summary
- Regenerate the Carbon e2e goldens, which had drifted since the parser rewrite (sveld 0.35.2/Svelte 5.56.3 -> 0.36.10/5.56.10) with nothing in CI catching it.
- Add a `Run e2e tests` step to CI on all three matrix legs (measured ~15s locally, well under budget).

## Test plan
- [x] `bun run test:e2e` passes locally with fresh goldens
- [x] `bun test` green
- [x] New CI step runs on this PR