### PR TITLE
chore(deps-dev): bump ostia to 0.2.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "acorn": "^8.18.0",
         "culls": "^0.2.0",
         "estree-walker": "^3.0.3",
-        "ostia": "^0.1.7",
+        "ostia": "0.2.0",
         "svelte": "^5.56.10",
         "typescript": "^7.0.2",
         "zimmerframe": "1.1.4",
@@ -193,7 +193,7 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "ostia": ["ostia@0.1.7", "", { "bin": { "ostia": "cli.js" } }, "sha512-TVrDTh9H/1xzROyNYQONNfIyT9w8Ki/1RDhJ3Awj8KB0tN8Qbnktqwt0cdElQLiP3TFuq6sTJ4XjTZS05PIDhg=="],
+    "ostia": ["ostia@0.2.0", "", { "bin": { "ostia": "cli.js" } }, "sha512-X+kqTYBmK7r0RgLLy5kqXFxrg0drR39ldOW9+i4H2Nnz4xU1dozsrqaz6pxm6wvlcAoSMIGKWFCYMWMkH+4rmA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "acorn": "^8.18.0",
     "culls": "^0.2.0",
     "estree-walker": "^3.0.3",
-    "ostia": "^0.1.7",
+    "ostia": "0.2.0",
     "svelte": "^5.56.10",
     "typescript": "^7.0.2",
     "zimmerframe": "1.1.4"

--- a/scripts/bench-ostia.ts
+++ b/scripts/bench-ostia.ts
@@ -27,7 +27,7 @@
  *
  * Usage:
  *   bun run bench:ostia
- *   bun run bench:ostia -- --time-budget 1000 --min-samples 50
+ *   bun run bench:ostia -- --budget 1000 --min-samples 50
  *   bun run bench:ostia -- --filter parse   # ostia's name filter (regex, substring match)
  *
  * To establish a baseline and check whether a change actually helped:


### PR DESCRIPTION
Updates the dev dependency to the 0.2.0 breaking release and fixes a
stale --time-budget flag in a bench-ostia.ts comment to --budget. No
source call sites used any of the fields or options removed in this
release.