### PR TITLE
perf(writer): rewrite generated-TS formatter as slice-based passes

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -45,6 +45,7 @@ import {
   createScopeWalkState,
   enterNestedScopeDeclarationNode,
   initComponentScope,
+  isScopeOwner,
   leaveNestedScopeDeclarationNode,
   markReactivePropsFromMutationTarget,
   resolveIdentifierToReactiveProp,
@@ -879,6 +880,10 @@ export default class ComponentParser {
   private static readonly TS_DIRECTIVE_REGEX = /\/\/\s*@ts-[^\n\r]*/g;
 
   private static stripTypeScriptDirectivesFromScripts(source: string): string {
+    // Every directive contains `@ts-`; without it there's nothing to strip,
+    // so skip the script-block regex replace (and the source copy it makes).
+    if (!source.includes("@ts-")) return source;
+
     ComponentParser.SCRIPT_BLOCK_REGEX.lastIndex = 0;
     return source.replace(ComponentParser.SCRIPT_BLOCK_REGEX, (_match, openTag, scriptContent, closeTag) => {
       ComponentParser.TS_DIRECTIVE_REGEX.lastIndex = 0;
@@ -1105,7 +1110,9 @@ export default class ComponentParser {
     let dispatcher_name: undefined | string;
     const hostLocalNames = new Set<string>();
     const hostDispatchedEventNames = new Set<string>();
-    const callees: { name: string; arguments: Array<Expression | unknown>; source?: SourceRange }[] = [];
+    // Source ranges are resolved lazily below: only calls to the dispatcher
+    // need one, and most components' call expressions aren't dispatches.
+    const callees: { name: string; arguments: Array<Expression | unknown>; node: CallExpression }[] = [];
 
     initComponentScope(this, this.ctx);
     this.ctx.activeScopes.push(this.ctx.componentScope);
@@ -1114,12 +1121,16 @@ export default class ComponentParser {
     walk(componentRoot, {
       enter: (node, parent, _prop) => {
         // Fuse scope declaration into this walk (see enterNestedScopeDeclarationNode).
-        enterNestedScopeDeclarationNode(this, this.ctx, scopeWalkState, node);
-
-        const nodeScope = this.ctx.scopeDeclarations.get(node as unknown as object);
+        // Only scope-owner nodes get a scope, so the returned scope is the
+        // same one a `scopeDeclarations.get(node)` lookup would find.
+        const nodeScope = enterNestedScopeDeclarationNode(this, this.ctx, scopeWalkState, node);
         if (nodeScope) {
           this.ctx.activeScopes.push(nodeScope);
         }
+
+        // Svelte template node types aren't in estree's `Node["type"]` union;
+        // read the type once as a plain string for the markup checks below.
+        const type: string = node.type;
 
         if (node.type === "AssignmentExpression") {
           markReactivePropsFromMutationTarget(this.ctx, (node as AssignmentExpression).left);
@@ -1170,7 +1181,7 @@ export default class ComponentParser {
             callees.push({
               name: calleeName,
               arguments: callExpr.arguments,
-              source: sourceRangeFromNode(this.ctx, callExpr),
+              node: callExpr,
             });
           }
 
@@ -1189,7 +1200,7 @@ export default class ComponentParser {
         }
 
         // Svelte spread attribute nodes: `{...$$restProps}` and rest-prop locals.
-        if (node && typeof node === "object" && "type" in node && String(node.type) === "SpreadAttribute") {
+        if (type === "SpreadAttribute") {
           const spreadNode = node as { type: string; expression?: { name?: string } };
           if (
             spreadNode.expression?.name === "$$restProps" ||
@@ -1376,7 +1387,7 @@ export default class ComponentParser {
           });
         }
 
-        if (node && typeof node === "object" && "type" in node && String(node.type) === "Comment") {
+        if (type === "Comment") {
           const commentNode = node as { data?: string };
           const data: string = commentNode?.data?.trim() ?? "";
 
@@ -1386,7 +1397,7 @@ export default class ComponentParser {
           }
         }
 
-        if (node && typeof node === "object" && "type" in node && String(node.type) === "SlotElement") {
+        if (type === "SlotElement") {
           type AttributeValueChunk = {
             type?: string;
             expression?: unknown;
@@ -1479,7 +1490,7 @@ export default class ComponentParser {
           });
         }
 
-        if (node && typeof node === "object" && "type" in node && String(node.type) === "RenderTag") {
+        if (type === "RenderTag") {
           const renderTag = node as { expression?: unknown };
           const renderInfo = extractRenderTagInfo(this.ctx, renderTag.expression);
           if (renderInfo) {
@@ -1531,7 +1542,7 @@ export default class ComponentParser {
         }
 
         // Bare `on:event` handlers forward events; dispatched events win and are reconciled after the walk.
-        if (node && typeof node === "object" && "type" in node && String(node.type) === "OnDirective") {
+        if (type === "OnDirective") {
           const eventHandlerNode = node as { expression?: unknown; name?: string };
           if (eventHandlerNode.expression == null && eventHandlerNode.name) {
             if (parent != null && typeof parent === "object" && "name" in parent) {
@@ -1575,14 +1586,11 @@ export default class ComponentParser {
          * `bind:*` marks props reactive; `bind:this` on elements also narrows the prop type.
          */
         if (
+          type === "BindDirective" &&
           parent &&
           typeof parent === "object" &&
           "type" in parent &&
-          (isElementLikeType(String(parent.type)) || isComponentLikeType(String(parent.type))) &&
-          node &&
-          typeof node === "object" &&
-          "type" in node &&
-          String(node.type) === "BindDirective"
+          (isElementLikeType(String(parent.type)) || isComponentLikeType(String(parent.type)))
         ) {
           const bindingNode = node as { name?: string; expression?: { name?: string } };
           if (bindingNode.expression?.name) {
@@ -1623,10 +1631,12 @@ export default class ComponentParser {
         }
       },
       leave: (node) => {
-        if (this.ctx.scopeDeclarations.has(node as unknown as object)) {
+        // Scopes exist exactly for scope-owner nodes (see `enter` above), and
+        // function-scope owners are a subset, so one type check covers both.
+        if (isScopeOwner(node)) {
           this.ctx.activeScopes.pop();
+          leaveNestedScopeDeclarationNode(scopeWalkState, node);
         }
-        leaveNestedScopeDeclarationNode(scopeWalkState, node);
       },
     });
 
@@ -1647,7 +1657,7 @@ export default class ComponentParser {
               name: String(event_name),
               detail: event_detail == null ? "" : literalDetailToTypeText(event_detail),
               has_argument: Boolean(event_argument),
-              source: callee.source,
+              source: sourceRangeFromNode(this.ctx, callee.node),
             });
           }
         }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -183,10 +183,17 @@ interface GlobbedComponentSource {
  * against symlink cycles via a set of visited real paths. Tolerates a
  * missing `dir` (returns no matches) instead of throwing.
  */
-function findSvelteFiles(dir: string, results: string[] = [], visited = new Set<string>()): string[] {
+function findSvelteFiles(
+  dir: string,
+  results: string[] = [],
+  visited = new Set<string>(),
+  /** `dir`'s real path when the caller already knows it (see the recursion below). */
+  knownRealDir?: string,
+): string[] {
   let entries: Dirent[];
+  let real: string;
   try {
-    const real = realpathSync(dir);
+    real = knownRealDir ?? realpathSync(dir);
     if (visited.has(real)) return results;
     visited.add(real);
     entries = readdirSync(dir, { withFileTypes: true });
@@ -197,11 +204,15 @@ function findSvelteFiles(dir: string, results: string[] = [], visited = new Set<
   for (const entry of entries) {
     if (entry.name.startsWith(".")) continue;
     const entryPath = join(dir, entry.name);
-    const stat = entry.isSymbolicLink() ? statSync(entryPath, { throwIfNoEntry: false }) : entry;
+    const isSymbolicLink = entry.isSymbolicLink();
+    const stat = isSymbolicLink ? statSync(entryPath, { throwIfNoEntry: false }) : entry;
     if (!stat) continue; // Broken symlink.
 
     if (stat.isDirectory()) {
-      findSvelteFiles(entryPath, results, visited);
+      // A non-symlink child of a directory whose real path is `real` has real
+      // path `real/name`: no `realpathSync` syscall needed. Only symlinked
+      // directories can point elsewhere and must be resolved.
+      findSvelteFiles(entryPath, results, visited, isSymbolicLink ? undefined : join(real, entry.name));
     } else if (stat.isFile() && entry.name.endsWith(".svelte")) {
       results.push(entryPath);
     }
@@ -329,8 +340,17 @@ export function collectComponents(input: string, glob: boolean, documentExports 
   const isFile = lstatSync(input).isFile();
   const dir = isFile ? dirname(input) : input;
   const rootDir = resolve(dir);
-  const resolveComponentFilePath: ResolveComponentFilePath = (filePath) =>
-    isAbsolute(filePath) ? resolve(filePath) : resolve(rootDir, filePath);
+  // Memoized: the same `source` is resolved several times per run (glob
+  // merge, file-path collection, per-component processing, cache lookup).
+  const resolvedPaths = new Map<string, string>();
+  const resolveComponentFilePath: ResolveComponentFilePath = (filePath) => {
+    let resolved = resolvedPaths.get(filePath);
+    if (resolved === undefined) {
+      resolved = isAbsolute(filePath) ? resolve(filePath) : resolve(rootDir, filePath);
+      resolvedPaths.set(filePath, resolved);
+    }
+    return resolved;
+  };
 
   /**
    * Only parse exports if input is a file.

--- a/src/parser/comment-parser.ts
+++ b/src/parser/comment-parser.ts
@@ -67,38 +67,30 @@ export interface JSDocComment {
 }
 
 const BLOCK_OPEN = "/**";
-const BLOCK_OPEN_IGNORE = "/***";
 const GUTTER = "*";
 const BLOCK_CLOSE = "*/";
 const FENCE = "```";
 
-const NEWLINE_REGEX = /\n/;
-const TRAILING_CR_REGEX = /\r$/;
 const LEADING_WS_REGEX = /^\s+/;
 const WHITESPACE_CHAR_REGEX = /\s/;
 const TAG_SECTION_START_REGEX = /^@[^\s/]+(?=\s|$)/;
 const TAG_PREFIX_REGEX = /^@(\S+)\s*/;
 
-interface PhysicalLine {
-  /** `\r`-stripped text of this line. */
-  text: string;
-  /** Absolute character offset where this line begins in the scanned source. */
-  start: number;
-}
-
-function splitSourceLines(source: string): PhysicalLine[] {
-  const lines: PhysicalLine[] = [];
-  let offset = 0;
-  for (const segment of source.split(NEWLINE_REGEX)) {
-    lines.push({ text: segment.replace(TRAILING_CR_REGEX, ""), start: offset });
-    offset += segment.length + 1;
+/** Length of the leading `\s` run in `text`; same set of characters as `LEADING_WS_REGEX`. */
+function leadingWhitespaceLength(text: string): number {
+  let index = 0;
+  while (index < text.length) {
+    const code = text.charCodeAt(index);
+    // Fast checks for space/tab/CR/LF; anything else goes through the regex's `\s` class.
+    if (code !== 32 && code !== 9 && code !== 13 && code !== 10 && !WHITESPACE_CHAR_REGEX.test(text[index])) break;
+    index++;
   }
-  return lines;
+  return index;
 }
 
 /** Strips the comment gutter from one physical line, splitting what's left into `indent`/`separator` + `content`. */
 function tokenizeLine(text: string, isOpeningLine: boolean): { indent: string; separator: string; content: string } {
-  let rest = text.replace(LEADING_WS_REGEX, "");
+  let rest = text.slice(leadingWhitespaceLength(text));
   let hasMarker = false;
 
   if (isOpeningLine) {
@@ -109,7 +101,7 @@ function tokenizeLine(text: string, isOpeningLine: boolean): { indent: string; s
     hasMarker = true;
   }
 
-  const separator = rest.match(LEADING_WS_REGEX)?.[0] ?? "";
+  const separator = rest.slice(0, leadingWhitespaceLength(rest));
   rest = rest.slice(separator.length);
 
   const trimmedEnd = rest.trimEnd();
@@ -121,34 +113,62 @@ function tokenizeLine(text: string, isOpeningLine: boolean): { indent: string; s
   return { indent, separator, content };
 }
 
-/** Finds every `/** ... *\/` block in `source`, tokenizing each line's gutter as it goes. */
+/** `\r`-stripped text of the physical line spanning `[lineStart, lineEnd)`. */
+function physicalLineText(source: string, lineStart: number, lineEnd: number): string {
+  const end = lineEnd > lineStart && source.charCodeAt(lineEnd - 1) === 13 /* \r */ ? lineEnd - 1 : lineEnd;
+  return source.slice(lineStart, end);
+}
+
+/**
+ * Finds every `/** ... *\/` block in `source`, tokenizing each line's gutter as it goes.
+ *
+ * Jumps between `/**` occurrences with `indexOf` and only materializes the lines inside a block,
+ * rather than splitting the whole source (mostly markup and code) into per-line objects. A block
+ * opens on a line whose first non-whitespace text is `/**` (but not `/***`), and closes on the
+ * first line from there whose trimmed text ends with `*\/`; a block still open at end of input is
+ * dropped.
+ */
 function findCommentBlocks(source: string): Array<{ start: number; lines: CommentLine[] }> {
-  // Every block starts with `/**`. If that substring is absent, skip
-  // splitting the source into lines. `/***` starts with the same three
-  // characters, so this can't miss an ignore-block either.
-  if (!source.includes(BLOCK_OPEN)) return [];
-
   const blocks: Array<{ start: number; lines: CommentLine[] }> = [];
-  const physicalLines = splitSourceLines(source);
+  let searchFrom = 0;
 
-  let current: CommentLine[] | null = null;
-  let blockStart = 0;
+  while (true) {
+    const openIndex = source.indexOf(BLOCK_OPEN, searchFrom);
+    if (openIndex === -1) break;
 
-  for (const line of physicalLines) {
-    if (current === null) {
-      const trimmed = line.text.replace(LEADING_WS_REGEX, "");
-      if (!trimmed.startsWith(BLOCK_OPEN) || trimmed.startsWith(BLOCK_OPEN_IGNORE)) continue;
-      current = [];
-      blockStart = line.start + (line.text.length - trimmed.length);
+    const lineStart = source.lastIndexOf("\n", openIndex - 1) + 1;
+    if (
+      source.charCodeAt(openIndex + BLOCK_OPEN.length) === 42 /* `*`: this is `/***`, an ignore-block */ ||
+      source.slice(lineStart, openIndex).trim() !== ""
+    ) {
+      searchFrom = openIndex + 1;
+      continue;
     }
 
-    const { indent, separator, content } = tokenizeLine(line.text, current.length === 0);
-    current.push({ raw: line.text, start: line.start, number: current.length, indent, separator, content });
+    const lines: CommentLine[] = [];
+    let currentLineStart = lineStart;
+    let closed = false;
 
-    if (line.text.trimEnd().endsWith(BLOCK_CLOSE)) {
-      blocks.push({ start: blockStart, lines: current });
-      current = null;
+    while (currentLineStart <= source.length) {
+      const newlineIndex = source.indexOf("\n", currentLineStart);
+      const lineEnd = newlineIndex === -1 ? source.length : newlineIndex;
+      const text = physicalLineText(source, currentLineStart, lineEnd);
+
+      const { indent, separator, content } = tokenizeLine(text, lines.length === 0);
+      lines.push({ raw: text, start: currentLineStart, number: lines.length, indent, separator, content });
+
+      if (text.trimEnd().endsWith(BLOCK_CLOSE)) {
+        closed = true;
+        searchFrom = lineEnd;
+        break;
+      }
+      if (newlineIndex === -1) break;
+      currentLineStart = newlineIndex + 1;
     }
+
+    // Unterminated block: nothing after it can open another one.
+    if (!closed) break;
+    blocks.push({ start: openIndex, lines });
   }
 
   return blocks;
@@ -173,10 +193,21 @@ function splitIntoSections(lines: CommentLine[]): CommentLine[][] {
     } else {
       sections[sections.length - 1].push(line);
     }
-    if (line.content.split(FENCE).length % 2 === 0) fenced = !fenced;
+    if (countOccurrences(line.content, FENCE) % 2 === 1) fenced = !fenced;
   }
 
   return sections;
+}
+
+/** Number of non-overlapping `needle` occurrences in `text`; no per-line `split` allocation. */
+function countOccurrences(text: string, needle: string): number {
+  let count = 0;
+  let index = text.indexOf(needle);
+  while (index !== -1) {
+    count++;
+    index = text.indexOf(needle, index + needle.length);
+  }
+  return count;
 }
 
 function joinLines(lines: CommentLine[]): string {

--- a/src/parser/runes-detection.ts
+++ b/src/parser/runes-detection.ts
@@ -57,6 +57,43 @@ function isValueReference(node: { type: string }, parent: { type: string } | und
   }
 }
 
+const RUNE_NAME_LIST = Array.from(RUNE_NAMES);
+
+/** ASCII `[A-Za-z0-9_$]`: a rune name touching one of these is part of a longer identifier (e.g. `$$props`). */
+function isAsciiIdentifierChar(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    code === 95 /* _ */ ||
+    code === 36 /* $ */
+  );
+}
+
+/**
+ * Cheap textual pre-check: false only when no rune name appears in `source`
+ * as a standalone token (not glued to other ASCII identifier characters, as
+ * in `$$props`), and no `\u` escape could be spelling one. Any other case,
+ * including a rune name inside a string or comment, falls back to the walk.
+ */
+function mayContainRuneReference(source: string): boolean {
+  if (source.includes("\\u")) return true;
+  for (const name of RUNE_NAME_LIST) {
+    let index = source.indexOf(name);
+    while (index !== -1) {
+      // `charCodeAt(-1)` / past-the-end is NaN, which counts as a boundary.
+      if (
+        !isAsciiIdentifierChar(source.charCodeAt(index - 1)) &&
+        !isAsciiIdentifierChar(source.charCodeAt(index + name.length))
+      ) {
+        return true;
+      }
+      index = source.indexOf(name, index + 1);
+    }
+  }
+  return false;
+}
+
 type ScopeStack = Array<Set<string>>;
 
 function isShadowed(name: string, scopeStack: ScopeStack): boolean {
@@ -219,6 +256,13 @@ export function detectSyntaxMode(ctx: ParserContext): SyntaxMode {
 
   const root = ctx.parsed;
   if (!root) return "legacy";
+
+  // An `Identifier` named `$state` etc. can only come from that text in the
+  // source, so a component whose text has no rune name can't be in runes
+  // mode. Skips three full AST walks for every legacy component. (A `\u`
+  // escape could spell a rune name without the literal substring, so fall
+  // back to the walk when one is present.)
+  if (ctx.source !== undefined && !mayContainRuneReference(ctx.source)) return "legacy";
 
   const moduleScope = new Set<string>();
   collectDirectBlockNames(getScriptProgramBody(root.module), moduleScope);

--- a/src/parser/scopes.ts
+++ b/src/parser/scopes.ts
@@ -69,9 +69,18 @@ export function markReactivePropsFromMutationTarget(
   ctx: ParserContext,
   target: Pattern | Expression | null | undefined,
 ) {
-  const identifiers = collectPatternIdentifiers(target);
+  if (!target || typeof target !== "object" || !("type" in target)) return;
 
-  if (!identifiers) return;
+  // `x = ...` / `x++`: by far the most common target; skip the Set allocation.
+  if (target.type === "Identifier") {
+    const publicPropName = resolveIdentifierToReactiveProp(ctx, target.name);
+    if (publicPropName) {
+      ctx.reactive_vars.add(publicPropName);
+    }
+    return;
+  }
+
+  const identifiers = collectPatternIdentifiers(target);
 
   for (const identifier of identifiers) {
     const publicPropName = resolveIdentifierToReactiveProp(ctx, identifier);
@@ -355,8 +364,8 @@ export function enterNestedScopeDeclarationNode(
   ctx: ParserContext,
   state: ScopeWalkState,
   node: unknown,
-) {
-  if (!isScopeOwner(node)) return;
+): LexicalScope | undefined {
+  if (!isScopeOwner(node)) return undefined;
 
   const scope = getOrCreateScope(ctx, node as unknown as object);
   const currentVarScope = state.varScopeStack[state.varScopeStack.length - 1] ?? ctx.componentScope;
@@ -408,6 +417,8 @@ export function enterNestedScopeDeclarationNode(
   if (isFunctionScopeOwner(node)) {
     state.varScopeStack.push(scope);
   }
+
+  return scope;
 }
 
 /** Per-node `leave` step counterpart to {@link enterNestedScopeDeclarationNode}. */

--- a/src/template-parse/comments.ts
+++ b/src/template-parse/comments.ts
@@ -112,8 +112,28 @@ function walkAndAttach(
   // Nothing left to attach. Skip walking the rest of this script AST.
   if (cursor.index >= comments.length) return;
 
-  for (const child of childNodes(node)) {
-    walkAndAttach(child, node, comments, cursor, source);
+  // Direct object/array-of-node children that have a `.type`, same walk rule
+  // as zimmerframe, visited in place rather than collected into an array
+  // first. `Object.keys` instead of `for...in`: acorn nodes don't put
+  // enumerable properties on the prototype. Stops as soon as every comment
+  // is claimed (the trailing-comment step below is a no-op by then).
+  const keys = Object.keys(node);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (key === "type" || key === "leadingComments") continue;
+    const value = node[key];
+    if (!value || typeof value !== "object") continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item && typeof item === "object" && typeof (item as WalkableNode).type === "string") {
+          walkAndAttach(item as WalkableNode, node, comments, cursor, source);
+          if (cursor.index >= comments.length) return;
+        }
+      }
+    } else if (typeof (value as WalkableNode).type === "string") {
+      walkAndAttach(value as WalkableNode, node, comments, cursor, source);
+      if (cursor.index >= comments.length) return;
+    }
   }
 
   // Claim trailing comments the same way svelte does, so they aren't left
@@ -142,26 +162,4 @@ function walkAndAttach(
 
 function isLastOf(list: unknown[] | undefined, node: unknown): boolean {
   return !!list && list.indexOf(node) === list.length - 1;
-}
-
-/** Direct object/array-of-node children that have a `.type`. Same walk rule as zimmerframe. */
-function childNodes(node: WalkableNode): WalkableNode[] {
-  const children: WalkableNode[] = [];
-  // `Object.keys` instead of `for...in`. Acorn nodes don't put enumerable
-  // properties on the prototype, and this runs once per node.
-  for (const key of Object.keys(node)) {
-    if (key === "type" || key === "leadingComments") continue;
-    const value = node[key];
-    if (!value || typeof value !== "object") continue;
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (item && typeof item === "object" && typeof (item as WalkableNode).type === "string") {
-          children.push(item as WalkableNode);
-        }
-      }
-    } else if (typeof (value as WalkableNode).type === "string") {
-      children.push(value as WalkableNode);
-    }
-  }
-  return children;
 }

--- a/src/template-parse/elements.ts
+++ b/src/template-parse/elements.ts
@@ -179,7 +179,16 @@ function getDirectiveType(name: string): AST.Directive["type"] | false {
 }
 
 /** Text/ExpressionTag chunks until `done()`. From svelte's `read_sequence` in `state/element.js`. */
-function readSequence(state: TemplateParserState, done: () => boolean): Array<AST.Text | AST.ExpressionTag> {
+function readSequence(
+  state: TemplateParserState,
+  done: () => boolean,
+  /**
+   * For quoted attribute values: the quote's char code. `done` is then just
+   * "at that quote", so the text between `{` tags and the closing quote can be
+   * skipped in one scan instead of one `done()` call per character.
+   */
+  quoteCode?: number,
+): Array<AST.Text | AST.ExpressionTag> {
   let currentChunk: AST.Text = { start: state.index, end: -1, type: "Text", raw: "", data: "" };
   const chunks: Array<AST.Text | AST.ExpressionTag> = [];
 
@@ -215,7 +224,17 @@ function readSequence(state: TemplateParserState, done: () => boolean): Array<AS
       chunks.push({ type: "ExpressionTag", start: expressionStart, end: state.index, expression });
       currentChunk = { start: state.index, end: -1, type: "Text", raw: "", data: "" };
     } else {
-      state.index++;
+      let index = state.index + 1;
+      if (quoteCode !== undefined) {
+        // Plain text up to the next `{` or closing quote.
+        const source = state.source;
+        while (index < source.length) {
+          const code = source.charCodeAt(index);
+          if (code === 123 /* { */ || code === quoteCode) break;
+          index++;
+        }
+      }
+      state.index = index;
     }
   }
 
@@ -230,10 +249,14 @@ function readAttributeValue(
     return [{ start: state.index - 1, end: state.index - 1, type: "Text", raw: "", data: "" }];
   }
 
-  const value = readSequence(state, () => {
-    if (quoteMark) return state.match(quoteMark);
-    return !!state.matchRegex(REGEX_INVALID_UNQUOTED_ATTRIBUTE_VALUE);
-  });
+  const value = readSequence(
+    state,
+    () => {
+      if (quoteMark) return state.match(quoteMark);
+      return !!state.matchRegex(REGEX_INVALID_UNQUOTED_ATTRIBUTE_VALUE);
+    },
+    quoteMark === null ? undefined : quoteMark.charCodeAt(0),
+  );
 
   if (value.length === 0 && !quoteMark) {
     throw new Error("sveld: expected attribute value");

--- a/src/writer/format-generated-ts.ts
+++ b/src/writer/format-generated-ts.ts
@@ -1,26 +1,61 @@
 const INDENT_UNIT = "  ";
-const CLOSER_START_REGEX = /^[}\])>]/;
-const OPENERS = new Set(["{", "(", "["]);
-const CLOSERS = new Set(["}", ")", "]"]);
 // Conservative width for collapsing `{...}` onto one line; ignores surrounding indent.
 const INLINE_WIDTH_BUDGET = 120;
 // `interface` bodies always expand, unlike plain `{...}` type literals.
 const INTERFACE_HEADER_REGEX = /\binterface\s+[A-Za-z_$][\w$]*(\s*<[^{};]*>)?\s*$/;
+const INTERFACE_HEADER_TAIL_LENGTH = 200;
 const TRAILING_TAB_SPACE_REGEX = /[ \t]+$/;
-const TRAILING_WHITESPACE_REGEX = /\s+$/;
-const OPENS_BLOCK_AT_END_REGEX = /[{([]$/;
 const WHITESPACE_CHAR_REGEX = /\s/;
+// Two consecutive whitespace chars, or any whitespace that isn't a plain space.
+const NEEDS_FLATTEN_REGEX = /\s{2}|[^\S ]/;
+
+// Character codes. The scanners below compare codes rather than one-char
+// strings so the hot loops don't allocate.
+const CH_TAB = 9;
+const CH_LF = 10;
+const CH_SPACE = 32;
+const CH_DOUBLE_QUOTE = 34;
+const CH_SINGLE_QUOTE = 39;
+const CH_OPEN_PAREN = 40;
+const CH_CLOSE_PAREN = 41;
+const CH_STAR = 42;
+const CH_SLASH = 47;
+const CH_SEMICOLON = 59;
+const CH_LT = 60;
+const CH_EQUALS = 61;
+const CH_GT = 62;
+const CH_OPEN_BRACKET = 91;
+const CH_BACKSLASH = 92;
+const CH_CLOSE_BRACKET = 93;
+const CH_BACKTICK = 96;
+const CH_OPEN_BRACE = 123;
+const CH_CLOSE_BRACE = 125;
+
+// Scanner states shared by `computeBraceMatches` and `expandRange`.
+const STATE_NORMAL = 0;
+const STATE_DOUBLE = 1;
+const STATE_SINGLE = 2;
+const STATE_TEMPLATE = 3;
+const STATE_BLOCK_COMMENT = 4;
 
 function endsWithInterfaceHeader(text: string): boolean {
   return INTERFACE_HEADER_REGEX.test(text.slice(-200));
 }
 
-const INTERFACE_HEADER_TAIL_LENGTH = 200;
+const indentCache: string[] = [""];
+
+function indentString(depth: number): string {
+  let indent = indentCache[depth];
+  if (indent === undefined) {
+    indent = INDENT_UNIT.repeat(depth);
+    indentCache[depth] = indent;
+  }
+  return indent;
+}
 
 // Reconstructs just enough of the accumulated buffer's tail to answer
 // `endsWithInterfaceHeader`, without joining the whole (potentially huge)
-// output array. `out` entries are always either a single character or a
-// short fixed string, so walking backwards a few entries is enough.
+// output array.
 function tailString(out: string[], maxLen: number): string {
   let result = "";
   for (let i = out.length - 1; i >= 0 && result.length < maxLen; i--) {
@@ -29,8 +64,47 @@ function tailString(out: string[], maxLen: number): string {
   return result.length > maxLen ? result.slice(-maxLen) : result;
 }
 
-function popTrailing(out: string[], regex: RegExp): void {
-  while (out.length > 0 && regex.test(out[out.length - 1])) out.pop();
+function endsWithNewline(out: string[]): boolean {
+  if (out.length === 0) return false;
+  const last = out[out.length - 1];
+  return last.charCodeAt(last.length - 1) === CH_LF;
+}
+
+/** Removes trailing spaces/tabs from the end of the accumulated buffer. */
+function popTrailingSpacesAndTabs(out: string[]): void {
+  while (out.length > 0) {
+    const last = out[out.length - 1];
+    let end = last.length;
+    while (end > 0) {
+      const c = last.charCodeAt(end - 1);
+      if (c !== CH_SPACE && c !== CH_TAB) break;
+      end--;
+    }
+    if (end === last.length) return;
+    if (end === 0) {
+      out.pop();
+      continue;
+    }
+    out[out.length - 1] = last.slice(0, end);
+    return;
+  }
+}
+
+/** Removes all trailing whitespace (including newlines) from the end of the accumulated buffer. */
+function popTrailingWhitespace(out: string[]): void {
+  while (out.length > 0) {
+    const last = out[out.length - 1];
+    // Common case: the buffer ends in a non-whitespace char; skip the `trimEnd` copy.
+    if (!WHITESPACE_CHAR_REGEX.test(last[last.length - 1])) return;
+    const trimmed = last.trimEnd();
+    if (trimmed.length === last.length) return;
+    if (trimmed.length === 0) {
+      out.pop();
+      continue;
+    }
+    out[out.length - 1] = trimmed;
+    return;
+  }
 }
 
 /**
@@ -38,48 +112,44 @@ function popTrailing(out: string[], regex: RegExp): void {
  * nested `{` and 2+ statement-terminating `;` outside quotes is guaranteed
  * to expand onto multiple lines (each such `;` forces a following newline
  * once the character scan reaches it), so the speculative recursive
- * `expandStatements` call that exists only to answer "would this collapse?"
- * can be skipped for this common flat multi-member case (e.g. a `{ id:
- * string; value: string; meta?: Record<string, unknown> }` object literal
- * repeated across many prop types) instead of running - and discarding - a
- * full recursive pass over the same content. A single trailing `;` (one
- * member) is deliberately left to the general path since it may still
- * collapse; content with a nested `{` is also left to the general path,
- * since a collapsing inner block can change the outer decision.
+ * expansion that exists only to answer "would this collapse?" can be
+ * skipped for this common flat multi-member case (e.g. a `{ id: string;
+ * value: string; meta?: Record<string, unknown> }` object literal repeated
+ * across many prop types). A single trailing `;` (one member) is
+ * deliberately left to the general path since it may still collapse;
+ * content with a nested `{` is also left to the general path, since a
+ * collapsing inner block can change the outer decision.
  */
 function hasMultipleFlatStatements(content: string): boolean {
   if (content.includes("{")) return false;
 
-  let quote: "double" | "single" | "template" | null = null;
+  let quote = 0;
   let semicolons = 0;
 
   for (let i = 0; i < content.length; i++) {
-    const c = content[i];
-    const prev = content[i - 1];
+    const c = content.charCodeAt(i);
 
-    if (quote) {
-      if (
-        (quote === "double" && c === '"' && prev !== "\\") ||
-        (quote === "single" && c === "'" && prev !== "\\") ||
-        (quote === "template" && c === "`" && prev !== "\\")
-      ) {
-        quote = null;
-      }
+    if (quote !== 0) {
+      if (c === quote && content.charCodeAt(i - 1) !== CH_BACKSLASH) quote = 0;
       continue;
     }
 
-    if (c === '"' || c === "'" || c === "`") {
-      quote = c === '"' ? "double" : c === "'" ? "single" : "template";
+    if (c === CH_DOUBLE_QUOTE || c === CH_SINGLE_QUOTE || c === CH_BACKTICK) {
+      quote = c;
       continue;
     }
 
-    if (c === ";" && ++semicolons >= 2) return true;
+    if (c === CH_SEMICOLON && ++semicolons >= 2) return true;
   }
 
   return false;
 }
 
+/** Collapses whitespace runs outside quotes to a single space and trims the end. */
 function flattenToOneLine(content: string): string {
+  // Already flat: nothing to collapse.
+  if (!NEEDS_FLATTEN_REGEX.test(content)) return content.trimEnd();
+
   let out = "";
   let quote: "double" | "single" | "template" | null = null;
   let lastWasSpace = false;
@@ -124,44 +194,52 @@ function flattenToOneLine(content: string): string {
 }
 
 /**
- * Finds the index of the `}` matching the `{` at `openIndex`, skipping over
- * nested brackets and string/comment contents so those never get mistaken
- * for structural braces. Returns -1 if unmatched (shouldn't happen for
- * well-formed generator output).
+ * One pass over `raw` recording, for every `{` reached outside strings and
+ * block comments, the index of its matching `}` (or -1 if unmatched). This
+ * replaces a per-`{` forward scan, which re-walked every nested block once
+ * per enclosing level.
  */
-function findMatchingClose(raw: string, openIndex: number): number {
-  let depth = 0;
-  let state: "normal" | "double" | "single" | "template" | "blockComment" = "normal";
+function computeBraceMatches(raw: string): Int32Array {
+  const matches = new Int32Array(raw.length).fill(-1);
+  const stack: number[] = [];
+  let state = STATE_NORMAL;
 
-  for (let i = openIndex; i < raw.length; i++) {
-    const c = raw[i];
-    const prev = raw[i - 1];
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw.charCodeAt(i);
 
-    if (state === "blockComment") {
-      if (prev === "*" && c === "/") state = "normal";
+    if (state === STATE_BLOCK_COMMENT) {
+      if (c === CH_SLASH && raw.charCodeAt(i - 1) === CH_STAR) state = STATE_NORMAL;
       continue;
     }
-    if (state === "double" || state === "single") {
-      if (c === (state === "double" ? '"' : "'") && prev !== "\\") state = "normal";
+    if (state === STATE_DOUBLE) {
+      if (c === CH_DOUBLE_QUOTE && raw.charCodeAt(i - 1) !== CH_BACKSLASH) state = STATE_NORMAL;
       continue;
     }
-    if (state === "template") {
-      if (c === "`" && prev !== "\\") state = "normal";
+    if (state === STATE_SINGLE) {
+      if (c === CH_SINGLE_QUOTE && raw.charCodeAt(i - 1) !== CH_BACKSLASH) state = STATE_NORMAL;
+      continue;
+    }
+    if (state === STATE_TEMPLATE) {
+      if (c === CH_BACKTICK && raw.charCodeAt(i - 1) !== CH_BACKSLASH) state = STATE_NORMAL;
       continue;
     }
 
-    if (c === "/" && raw[i + 1] === "*") state = "blockComment";
-    else if (c === '"') state = "double";
-    else if (c === "'") state = "single";
-    else if (c === "`") state = "template";
-    else if (c === "{") depth++;
-    else if (c === "}") {
-      depth--;
-      if (depth === 0) return i;
+    if (c === CH_SLASH) {
+      if (raw.charCodeAt(i + 1) === CH_STAR) state = STATE_BLOCK_COMMENT;
+    } else if (c === CH_DOUBLE_QUOTE) {
+      state = STATE_DOUBLE;
+    } else if (c === CH_SINGLE_QUOTE) {
+      state = STATE_SINGLE;
+    } else if (c === CH_BACKTICK) {
+      state = STATE_TEMPLATE;
+    } else if (c === CH_OPEN_BRACE) {
+      stack.push(i);
+    } else if (c === CH_CLOSE_BRACE && stack.length > 0) {
+      matches[stack.pop() as number] = i;
     }
   }
 
-  return -1;
+  return matches;
 }
 
 /**
@@ -176,167 +254,191 @@ function findMatchingClose(raw: string, openIndex: number): number {
  * `{ id: string }` has nothing to separate onto its own line, so it's copied
  * through verbatim (matching how import specifier lists and small inline
  * object types read best on one line).
+ *
+ * Operates on the `[from, to)` range of `raw` so nested blocks recurse
+ * without slicing, and copies unchanged runs of characters through as single
+ * slices rather than one array entry per character.
  */
-function expandStatements(raw: string): string {
+function expandRange(raw: string, from: number, to: number, matches: Int32Array): string {
   const out: string[] = [];
-  let state: "normal" | "double" | "single" | "template" | "blockComment" = "normal";
+  let state = STATE_NORMAL;
+  let runStart = from;
 
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw[i];
-    const prev = raw[i - 1];
+  for (let i = from; i < to; i++) {
+    const c = raw.charCodeAt(i);
 
-    if (state === "blockComment") {
-      out.push(c);
-      if (prev === "*" && c === "/") state = "normal";
+    if (state === STATE_BLOCK_COMMENT) {
+      if (c === CH_SLASH && raw.charCodeAt(i - 1) === CH_STAR) state = STATE_NORMAL;
+      continue;
+    }
+    if (state === STATE_DOUBLE) {
+      if (c === CH_DOUBLE_QUOTE && raw.charCodeAt(i - 1) !== CH_BACKSLASH) state = STATE_NORMAL;
+      continue;
+    }
+    if (state === STATE_SINGLE) {
+      if (c === CH_SINGLE_QUOTE && raw.charCodeAt(i - 1) !== CH_BACKSLASH) state = STATE_NORMAL;
+      continue;
+    }
+    if (state === STATE_TEMPLATE) {
+      if (c === CH_BACKTICK && raw.charCodeAt(i - 1) !== CH_BACKSLASH) state = STATE_NORMAL;
       continue;
     }
 
-    if (state === "double" || state === "single") {
-      out.push(c);
-      if (c === (state === "double" ? '"' : "'") && prev !== "\\") state = "normal";
+    // state === STATE_NORMAL
+    if (c === CH_SLASH) {
+      if (raw.charCodeAt(i + 1) === CH_STAR) state = STATE_BLOCK_COMMENT;
+      continue;
+    }
+    if (c === CH_DOUBLE_QUOTE) {
+      state = STATE_DOUBLE;
+      continue;
+    }
+    if (c === CH_SINGLE_QUOTE) {
+      state = STATE_SINGLE;
+      continue;
+    }
+    if (c === CH_BACKTICK) {
+      state = STATE_TEMPLATE;
       continue;
     }
 
-    if (state === "template") {
-      out.push(c);
-      if (c === "`" && prev !== "\\") state = "normal";
-      continue;
-    }
+    if (c === CH_OPEN_BRACE) {
+      const closeIndex = matches[i];
+      // Unmatched: copy the brace through as ordinary text.
+      if (closeIndex === -1 || closeIndex >= to) continue;
 
-    // state === "normal"
-    if (c === "/" && raw[i + 1] === "*") {
-      state = "blockComment";
-      out.push(c);
-      continue;
-    }
-    if (c === '"') {
-      state = "double";
-      out.push(c);
-      continue;
-    }
-    if (c === "'") {
-      state = "single";
-      out.push(c);
-      continue;
-    }
-    if (c === "`") {
-      state = "template";
-      out.push(c);
-      continue;
-    }
-
-    if (c === "{") {
-      const closeIndex = findMatchingClose(raw, i);
-
-      if (closeIndex === -1) {
-        out.push(c);
-        continue;
-      }
-
-      const content = raw.slice(i + 1, closeIndex);
+      if (runStart < i) out.push(raw.slice(runStart, i));
+      const contentStart = i + 1;
+      const content = raw.slice(contentStart, closeIndex);
 
       if (content.trim() === "") {
         // Empty block; keep braces adjacent instead of splitting across lines.
         out.push("{}");
         i = closeIndex;
+        runStart = closeIndex + 1;
         continue;
       }
 
+      const nextIsNewline = raw.charCodeAt(contentStart) === CH_LF;
+
       // Expand interface bodies always; collapse other single-line `{...}` blocks under INLINE_WIDTH_BUDGET.
       if (
+        !nextIsNewline &&
         !content.includes("/*") &&
-        raw[i + 1] !== "\n" &&
         !hasMultipleFlatStatements(content) &&
         !endsWithInterfaceHeader(tailString(out, INTERFACE_HEADER_TAIL_LENGTH))
       ) {
         // Recurse so nested blocks get their own collapse decision.
-        const normalized = expandStatements(content).trim();
+        const inner = expandRange(raw, contentStart, closeIndex, matches);
+        const normalized = inner.trim();
         if (!normalized.includes("\n")) {
           const body = normalized.endsWith(";") ? normalized.slice(0, -1) : normalized;
           const candidate = `{ ${flattenToOneLine(body)} }`;
           if (candidate.length <= INLINE_WIDTH_BUDGET) {
             out.push(candidate);
             i = closeIndex;
+            runStart = closeIndex + 1;
             continue;
           }
         }
+
+        // The block stays expanded. The recursive pass already produced
+        // exactly what rescanning `content` here would, so splice it in and
+        // resume at the closing brace instead of walking the content again.
+        // (A leading `;` would have consumed the newline after `{`, so skip it.)
+        out.push("{");
+        if (inner.charCodeAt(0) !== CH_SEMICOLON) out.push("\n");
+        if (inner.length > 0) out.push(inner);
+        i = closeIndex - 1;
+        runStart = closeIndex;
+        continue;
       }
 
-      out.push(c);
-      if (raw[i + 1] !== "\n") out.push("\n");
+      out.push("{");
+      if (!nextIsNewline) out.push("\n");
+      runStart = contentStart;
       continue;
     }
 
-    if (c === "}") {
-      popTrailing(out, TRAILING_TAB_SPACE_REGEX);
-      if (out[out.length - 1] !== "\n") out.push("\n");
-      out.push(c);
+    if (c === CH_CLOSE_BRACE) {
+      if (runStart < i) out.push(raw.slice(runStart, i));
+      popTrailingSpacesAndTabs(out);
+      if (!endsWithNewline(out)) out.push("\n");
+      out.push("}");
+      runStart = i + 1;
       continue;
     }
 
-    if (c === ";") {
+    if (c === CH_SEMICOLON) {
+      if (runStart < i) out.push(raw.slice(runStart, i));
       // A `;` always terminates whatever precedes it; attach it directly
       // rather than let it dangle alone on a line (which the generator's
       // own templates sometimes leave a blank line or two before).
-      popTrailing(out, TRAILING_WHITESPACE_REGEX);
+      popTrailingWhitespace(out);
       out.push(";");
-      if (raw[i + 1] !== "\n") out.push("\n");
-      continue;
+      if (raw.charCodeAt(i + 1) !== CH_LF) out.push("\n");
+      runStart = i + 1;
     }
-
-    out.push(c);
   }
 
+  if (runStart < to) out.push(raw.slice(runStart, to));
   return out.join("");
 }
 
+function expandStatements(raw: string): string {
+  return expandRange(raw, 0, raw.length, computeBraceMatches(raw));
+}
+
+/** Collapses runs of spaces outside quotes to a single space. */
 function collapseSpaces(line: string): string {
+  // No consecutive spaces anywhere: nothing to collapse.
+  if (!line.includes("  ")) return line;
+
   let out = "";
-  let quote: "double" | "single" | "template" | null = null;
+  let quote = 0;
 
   for (let i = 0; i < line.length; i++) {
-    const c = line[i];
-    const prev = line[i - 1];
+    const c = line.charCodeAt(i);
 
-    if (quote) {
-      out += c;
-      if (
-        (quote === "double" && c === '"' && prev !== "\\") ||
-        (quote === "single" && c === "'" && prev !== "\\") ||
-        (quote === "template" && c === "`" && prev !== "\\")
-      ) {
-        quote = null;
-      }
+    if (quote !== 0) {
+      out += line[i];
+      if (c === quote && line.charCodeAt(i - 1) !== CH_BACKSLASH) quote = 0;
       continue;
     }
 
-    if (c === '"' || c === "'" || c === "`") {
-      quote = c === '"' ? "double" : c === "'" ? "single" : "template";
-      out += c;
+    if (c === CH_DOUBLE_QUOTE || c === CH_SINGLE_QUOTE || c === CH_BACKTICK) {
+      quote = c;
+      out += line[i];
       continue;
     }
 
-    if (c === " " && out.endsWith(" ")) continue;
-    out += c;
+    if (c === CH_SPACE && out.charCodeAt(out.length - 1) === CH_SPACE) continue;
+    out += line[i];
   }
 
   return out;
 }
 
+function startsWithCloser(line: string): boolean {
+  const first = line.charCodeAt(0);
+  return first === CH_CLOSE_BRACE || first === CH_CLOSE_BRACKET || first === CH_CLOSE_PAREN || first === CH_GT;
+}
+
 /**
  * Recomputes indentation from bracket nesting depth, skipping content inside
  * block comments (JSDoc bodies may themselves contain `{`/`}`, e.g.
- * `{@link Foo}`, which must not perturb the running depth).
+ * `{@link Foo}`, which must not perturb the running depth). Returns the
+ * reindented lines for `tidyBlankLines` to consume without re-splitting.
  */
-function reindent(text: string): string {
+function reindent(text: string): string[] {
   const lines = text.split("\n");
   const out: string[] = [];
   let depth = 0;
   let inBlockComment = false;
   let commentIndent = 0;
 
-  for (const rawLine of lines) {
-    const trimmedLine = rawLine.trim();
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const trimmedLine = lines[lineIndex].trim();
 
     if (trimmedLine === "") {
       out.push("");
@@ -349,73 +451,66 @@ function reindent(text: string): string {
       // spacing is otherwise left untouched — comment bodies may contain
       // authored code examples (e.g. an indented ```svelte fence) whose
       // whitespace is meaningful.
-      out.push(`${INDENT_UNIT.repeat(commentIndent)} ${trimmedLine}`);
+      out.push(`${indentString(commentIndent)} ${trimmedLine}`);
       if (trimmedLine.includes("*/")) inBlockComment = false;
       continue;
     }
 
     if (trimmedLine.startsWith("/**") && !trimmedLine.includes("*/")) {
-      out.push(INDENT_UNIT.repeat(depth) + trimmedLine);
+      out.push(indentString(depth) + trimmedLine);
       inBlockComment = true;
       commentIndent = depth;
       continue;
     }
 
     const line = collapseSpaces(trimmedLine);
-    const startsWithCloser = CLOSER_START_REGEX.test(line);
-    const indent = Math.max(0, depth - (startsWithCloser ? 1 : 0));
-    out.push(INDENT_UNIT.repeat(indent) + line);
+    const indent = Math.max(0, depth - (startsWithCloser(line) ? 1 : 0));
+    out.push(indentString(indent) + line);
 
     // Single-line comments (`/** ... */`) and lines fully inside strings never
     // change bracket depth; everything else is scanned char-by-char.
     if (line.startsWith("/**") && line.includes("*/")) continue;
 
-    let quote: "double" | "single" | "template" | null = null;
+    let quote = 0;
     for (let i = 0; i < line.length; i++) {
-      const c = line[i];
-      const prev = line[i - 1];
+      const c = line.charCodeAt(i);
 
-      if (quote) {
-        if (
-          (quote === "double" && c === '"' && prev !== "\\") ||
-          (quote === "single" && c === "'" && prev !== "\\") ||
-          (quote === "template" && c === "`" && prev !== "\\")
-        ) {
-          quote = null;
-        }
+      if (quote !== 0) {
+        if (c === quote && line.charCodeAt(i - 1) !== CH_BACKSLASH) quote = 0;
         continue;
       }
 
-      if (c === '"') quote = "double";
-      else if (c === "'") quote = "single";
-      else if (c === "`") quote = "template";
-      else if (OPENERS.has(c)) depth++;
-      else if (CLOSERS.has(c)) depth = Math.max(0, depth - 1);
-      else if (c === "<") depth++;
+      if (c === CH_DOUBLE_QUOTE || c === CH_SINGLE_QUOTE || c === CH_BACKTICK) quote = c;
+      else if (c === CH_OPEN_BRACE || c === CH_OPEN_PAREN || c === CH_OPEN_BRACKET || c === CH_LT) depth++;
+      else if (c === CH_CLOSE_BRACE || c === CH_CLOSE_PAREN || c === CH_CLOSE_BRACKET) depth = Math.max(0, depth - 1);
       // Excludes the `>` in `=>`, which isn't a generic-list closer.
-      else if (c === ">" && prev !== "=") depth = Math.max(0, depth - 1);
+      else if (c === CH_GT && line.charCodeAt(i - 1) !== CH_EQUALS) depth = Math.max(0, depth - 1);
     }
   }
 
-  return out.join("\n");
+  return out;
 }
 
-function tidyBlankLines(text: string): string {
-  const lines = text.split("\n").map((line) => line.replace(TRAILING_TAB_SPACE_REGEX, ""));
+function tidyBlankLines(lines: string[]): string {
   const out: string[] = [];
 
-  for (const line of lines) {
-    const isBlank = line === "";
-    const prevBlank = out.length > 0 && out[out.length - 1] === "";
-    const prevOpensBlock = out.length > 0 && OPENS_BLOCK_AT_END_REGEX.test(out[out.length - 1]);
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    let line = lines[lineIndex];
+    const lastCode = line.charCodeAt(line.length - 1);
+    if (lastCode === CH_SPACE || lastCode === CH_TAB) line = line.replace(TRAILING_TAB_SPACE_REGEX, "");
 
-    if (isBlank) {
-      if (out.length === 0 || prevBlank || prevOpensBlock) continue;
+    const prev = out.length > 0 ? out[out.length - 1] : undefined;
+    const prevBlank = prev === "";
+
+    if (line === "") {
+      if (prev === undefined || prevBlank) continue;
+      const prevLast = prev.charCodeAt(prev.length - 1);
+      if (prevLast === CH_OPEN_BRACE || prevLast === CH_OPEN_PAREN || prevLast === CH_OPEN_BRACKET) continue;
       out.push(line);
       continue;
     }
 
-    if (CLOSER_START_REGEX.test(line) && prevBlank) out.pop();
+    if (prevBlank && startsWithCloser(line)) out.pop();
     out.push(line);
   }
 
@@ -432,7 +527,5 @@ function tidyBlankLines(text: string): string {
  * operator spacing.
  */
 export function formatGeneratedTypeScript(raw: string): string {
-  const expanded = expandStatements(raw);
-  const reindented = reindent(expanded);
-  return `${tidyBlankLines(reindented)}\n`;
+  return `${tidyBlankLines(reindent(expandStatements(raw)))}\n`;
 }


### PR DESCRIPTION
Six independent perf commits from a CPU profile of the carbon fixture
(160 components). The formatter was two thirds of the write phase and
the parser was paying for AST walks and source-wide line splits that
most components never needed. Every change keeps generated output
byte-identical; I diffed the `.d.ts`, JSON, and Markdown output for all
160 carbon components plus the 199 fixture components against `main`.

## Benchmark

`bun run bench:ostia` on the same machine, HEAD checkout vs. this
branch, run back to back at the same load (Apple M2, load ~7.5).
Medians:

| Benchmark                                   | main     | branch   |
|---------------------------------------------|----------|----------|
| parseSvelteComponent (small, Row)           | 78.6 us  | 56.5 us  |
| parseSvelteComponent (medium, NumberInput)  | 495 us   | 325 us   |
| parseSvelteComponent (large, DataTable)     | 1.29 ms  | 878 us   |
| parseSvelteComponent (pathological, 200)    | 2.18 ms  | 1.94 ms  |
| template parse (markup-heavy, 150 x 8)      | 1.51 ms  | 1.37 ms  |
| writeTsDefinition (small, Row)              | 59.1 us  | 21.0 us  |
| writeTsDefinition (medium, NumberInput)     | 101 us   | 43.1 us  |
| writeTsDefinition (large, DataTable)        | 219 us   | 81.4 us  |
| writeTsDefinition (pathological, 200)       | 2.72 ms  | 787 us   |
| generateBundle (160 components, no cache)   | 33.9 ms  | 27.1 ms  |

Peak RSS for a one-shot parse-plus-write of the fixture dropped from
about 92-98 MB to 87-91 MB (`/usr/bin/time -l`); most of that is Bun's
own baseline, so the memory win is modest.

What's left is mostly acorn (about half of template-parse time, one
`Parser` per `{expr}`), estree-walker's generic visit loop, and
`JSON.stringify` in the JSON writer.
