### PR TITLE
fix(types): emit any and no @default for untyped props

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ Needs `typescript` and a `tsconfig.json`, same as `resolveTypes`. Use `--strict`
 
 `sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, `$props()`/`{@render}` syntax sveld can't model, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`. Each diagnostic carries an optional `source` range (the same `{ start: { line, column }, end: { line, column } }` shape as JSON output source ranges) whenever the parser holds a stable position for it.
 
+A prop with no type annotation, no `@type` JSDoc, and no initializer has nothing to infer a type or a default from: its JSON `type` stays absent (`"typeSource": "unknown"`), it triggers a `prop-unknown-type` diagnostic, and the emitted `.d.ts` types it as `any` with no `@default` line (rather than the literal type `undefined`).
+
 With `reportDiagnostics` or `strict`, the grouped summary looks like this:
 
 ```

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -502,7 +502,7 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
         returnType,
         isFunction,
         isFunctionDeclaration: false,
-        isRequired: unwrappedInit == null && typeMetadata?.optional !== true,
+        isRequired: !bindable && unwrappedInit == null && typeMetadata?.optional !== true,
         constant: false,
         reactive: bindable,
         source: sourceRangeFromNode(ctx, property),

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -359,15 +359,7 @@ function genPropDef(
   ]);
 
   const initial_props = nonAccessorProps.map((prop) => {
-    let defaultValue = prop.value;
-
-    if (typeof prop.value === "string") {
-      defaultValue = prop.value.replace(WHITESPACE_REGEX, " ");
-    }
-
-    if (prop.value === undefined) {
-      defaultValue = "undefined";
-    }
+    const defaultValue = typeof prop.value === "string" ? prop.value.replace(WHITESPACE_REGEX, " ") : prop.value;
 
     const descriptionHasDefault = DESCRIPTION_DEFAULT_TAG_REGEX.test(prop.description ?? "");
 
@@ -376,9 +368,10 @@ function genPropDef(
      * (a trivial single-expression body, e.g. `() => true` - see
      * `conciseFunctionDefaultText`); anything more elaborate is omitted so
      * docs aren't cluttered with function bodies (#203). An explicit
-     * `@default` in the description always wins either way.
+     * `@default` in the description always wins either way. Props with no
+     * initializer at all never get a `@default` line.
      */
-    const suppressDefault = descriptionHasDefault || (prop.isFunction && prop.value === undefined);
+    const suppressDefault = descriptionHasDefault || prop.value === undefined;
 
     const prop_comments = [
       createPropComment(prop.description, prop.deprecated, prop.tags),
@@ -388,7 +381,7 @@ function genPropDef(
       .filter(Boolean)
       .join("");
 
-    const prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type;
+    const prop_value = prop.constant && !prop.isFunction ? prop.value : prop.type || ANY_TYPE;
 
     return `
       ${wrapCommentInJSDoc(prop_comments)}

--- a/tests/__snapshots__/writer-ts-definitions.test.ts.snap
+++ b/tests/__snapshots__/writer-ts-definitions.test.ts.snap
@@ -14,9 +14,6 @@ export type ModuleNameProps = {
    */
   propString?: string;
 
-  /**
-   * @default undefined
-   */
   name?: string;
 
   /**

--- a/tests/fixtures/bind-this-multiple/output-class.d.ts
+++ b/tests/fixtures/bind-this-multiple/output-class.d.ts
@@ -1,14 +1,8 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type BindThisMultipleProps = {
-  /**
-   * @default undefined
-   */
   ref: null | HTMLButtonElement | HTMLHeadingElement;
 
-  /**
-   * @default undefined
-   */
   ref2: null | HTMLDivElement;
 
   /**

--- a/tests/fixtures/bind-this-multiple/output-component.d.ts
+++ b/tests/fixtures/bind-this-multiple/output-component.d.ts
@@ -1,14 +1,8 @@
 import type { Component } from "svelte";
 
 export type BindThisMultipleProps = {
-  /**
-   * @default undefined
-   */
   ref: null | HTMLButtonElement | HTMLHeadingElement;
 
-  /**
-   * @default undefined
-   */
   ref2: null | HTMLDivElement;
 
   /**

--- a/tests/fixtures/bind-this/output-class.d.ts
+++ b/tests/fixtures/bind-this/output-class.d.ts
@@ -1,9 +1,6 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type BindThisProps = {
-  /**
-   * @default undefined
-   */
   ref: null | HTMLButtonElement;
 
   children?: (this: void) => void;

--- a/tests/fixtures/bind-this/output-component.d.ts
+++ b/tests/fixtures/bind-this/output-component.d.ts
@@ -1,9 +1,6 @@
 import type { Component } from "svelte";
 
 export type BindThisProps = {
-  /**
-   * @default undefined
-   */
   ref: null | HTMLButtonElement;
 
   children?: (this: void) => void;

--- a/tests/fixtures/bindable-direction-legacy/output-class.d.ts
+++ b/tests/fixtures/bindable-direction-legacy/output-class.d.ts
@@ -5,7 +5,7 @@ export type BindableDirectionLegacyProps = {
    * Bind to the current value emitted by the component.
    * @default undefined
    */
-  size?: undefined;
+  size?: any;
 
   /**
    * Bind to state controlled by either the consumer or component.

--- a/tests/fixtures/bindable-direction-legacy/output-component.d.ts
+++ b/tests/fixtures/bindable-direction-legacy/output-component.d.ts
@@ -5,7 +5,7 @@ export type BindableDirectionLegacyProps = {
    * Bind to the current value emitted by the component.
    * @default undefined
    */
-  size?: undefined;
+  size?: any;
 
   /**
    * Bind to state controlled by either the consumer or component.

--- a/tests/fixtures/bindable-direction-runes/output-class.d.ts
+++ b/tests/fixtures/bindable-direction-runes/output-class.d.ts
@@ -5,7 +5,7 @@ export type BindableDirectionRunesProps = {
    * Bind to the current value emitted by the component.
    * @default undefined
    */
-  size?: undefined;
+  size?: any;
 
   /**
    * Bind to state controlled by either the consumer or component.

--- a/tests/fixtures/bindable-direction-runes/output-component.d.ts
+++ b/tests/fixtures/bindable-direction-runes/output-component.d.ts
@@ -5,7 +5,7 @@ export type BindableDirectionRunesProps = {
    * Bind to the current value emitted by the component.
    * @default undefined
    */
-  size?: undefined;
+  size?: any;
 
   /**
    * Bind to state controlled by either the consumer or component.

--- a/tests/fixtures/infer-basic/output-class.d.ts
+++ b/tests/fixtures/infer-basic/output-class.d.ts
@@ -4,7 +4,7 @@ export type InferBasicProps = {
   /**
    * @default null
    */
-  ref?: undefined;
+  ref?: any;
 
   /**
    * @default true
@@ -16,10 +16,7 @@ export type InferBasicProps = {
    */
   propString?: string;
 
-  /**
-   * @default undefined
-   */
-  name: undefined;
+  name: any;
 
   /**
    * @default "" + Math.random().toString(36)

--- a/tests/fixtures/infer-basic/output-component.d.ts
+++ b/tests/fixtures/infer-basic/output-component.d.ts
@@ -4,7 +4,7 @@ export type InferBasicProps = {
   /**
    * @default null
    */
-  ref?: undefined;
+  ref?: any;
 
   /**
    * @default true
@@ -16,10 +16,7 @@ export type InferBasicProps = {
    */
   propString?: string;
 
-  /**
-   * @default undefined
-   */
-  name: undefined;
+  name: any;
 
   /**
    * @default "" + Math.random().toString(36)

--- a/tests/fixtures/infer-with-types/output-class.d.ts
+++ b/tests/fixtures/infer-with-types/output-class.d.ts
@@ -11,9 +11,6 @@ export type InferWithTypesProps = {
    */
   propString?: string;
 
-  /**
-   * @default undefined
-   */
   name: string;
 
   /**

--- a/tests/fixtures/infer-with-types/output-component.d.ts
+++ b/tests/fixtures/infer-with-types/output-component.d.ts
@@ -11,9 +11,6 @@ export type InferWithTypesProps = {
    */
   propString?: string;
 
-  /**
-   * @default undefined
-   */
   name: string;
 
   /**

--- a/tests/fixtures/legacy-export-typed/output-class.d.ts
+++ b/tests/fixtures/legacy-export-typed/output-class.d.ts
@@ -1,9 +1,6 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type LegacyExportTypedProps = {
-  /**
-   * @default undefined
-   */
   title: string;
 
   /**

--- a/tests/fixtures/legacy-export-typed/output-component.d.ts
+++ b/tests/fixtures/legacy-export-typed/output-component.d.ts
@@ -1,9 +1,6 @@
 import type { Component } from "svelte";
 
 export type LegacyExportTypedProps = {
-  /**
-   * @default undefined
-   */
   title: string;
 
   /**

--- a/tests/fixtures/legacy-untyped-no-default/input.svelte
+++ b/tests/fixtures/legacy-untyped-no-default/input.svelte
@@ -1,0 +1,8 @@
+<script>
+  export let a;
+
+  /** @type {string} */
+  export let b;
+
+  export let c = 1;
+</script>

--- a/tests/fixtures/legacy-untyped-no-default/output-class.d.ts
+++ b/tests/fixtures/legacy-untyped-no-default/output-class.d.ts
@@ -1,0 +1,18 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type LegacyUntypedNoDefaultProps = {
+  a: any;
+
+  b: string;
+
+  /**
+   * @default 1
+   */
+  c?: number;
+};
+
+export default class LegacyUntypedNoDefault extends SvelteComponentTyped<
+  LegacyUntypedNoDefaultProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/legacy-untyped-no-default/output-component.d.ts
+++ b/tests/fixtures/legacy-untyped-no-default/output-component.d.ts
@@ -1,0 +1,21 @@
+import type { Component } from "svelte";
+
+export type LegacyUntypedNoDefaultProps = {
+  a: any;
+
+  b: string;
+
+  /**
+   * @default 1
+   */
+  c?: number;
+};
+
+export type LegacyUntypedNoDefaultExports = Record<string, never>;
+
+declare const LegacyUntypedNoDefault: Component<
+  LegacyUntypedNoDefaultProps,
+  LegacyUntypedNoDefaultExports,
+  ""
+>;
+export default LegacyUntypedNoDefault;

--- a/tests/fixtures/legacy-untyped-no-default/output.json
+++ b/tests/fixtures/legacy-untyped-no-default/output.json
@@ -1,0 +1,108 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "a",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
+      }
+    },
+    {
+      "name": "b",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 15
+        }
+      }
+    },
+    {
+      "name": "c",
+      "kind": "let",
+      "type": "number",
+      "typeSource": "default",
+      "value": "1",
+      "defaultValue": {
+        "raw": "1",
+        "kind": "literal",
+        "value": 1
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 19
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "legacy-untyped-no-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "a",
+      "message": "Prop \"a\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/module-reexport-mixed/output-class.d.ts
+++ b/tests/fixtures/module-reexport-mixed/output-class.d.ts
@@ -18,15 +18,14 @@ export declare function log(msg: string): void;
 export type ModuleReexportMixedProps = {
   /**
    * Item name to display
-   * @default undefined
    */
-  name: undefined;
+  name: any;
 
   /**
    * Optional item value
    * @default null
    */
-  value?: undefined;
+  value?: any;
 };
 
 export default class ModuleReexportMixed extends SvelteComponentTyped<

--- a/tests/fixtures/module-reexport-mixed/output-component.d.ts
+++ b/tests/fixtures/module-reexport-mixed/output-component.d.ts
@@ -18,15 +18,14 @@ export declare function log(msg: string): void;
 export type ModuleReexportMixedProps = {
   /**
    * Item name to display
-   * @default undefined
    */
-  name: undefined;
+  name: any;
 
   /**
    * Optional item value
    * @default null
    */
-  value?: undefined;
+  value?: any;
 };
 
 export type ModuleReexportMixedExports = Record<string, never>;

--- a/tests/fixtures/module-reexport/output-class.d.ts
+++ b/tests/fixtures/module-reexport/output-class.d.ts
@@ -5,7 +5,7 @@ export type ModuleReexportProps = {
    * Chart data to display
    * @default null
    */
-  data?: undefined;
+  data?: any;
 
   /**
    * Chart title

--- a/tests/fixtures/module-reexport/output-component.d.ts
+++ b/tests/fixtures/module-reexport/output-component.d.ts
@@ -5,7 +5,7 @@ export type ModuleReexportProps = {
    * Chart data to display
    * @default null
    */
-  data?: undefined;
+  data?: any;
 
   /**
    * Chart title

--- a/tests/fixtures/non-literal-defaults/output-class.d.ts
+++ b/tests/fixtures/non-literal-defaults/output-class.d.ts
@@ -67,7 +67,7 @@ export type NonLiteralDefaultsProps = {
    * Optional handler with undefined
    * @default undefined
    */
-  handler?: undefined;
+  handler?: any;
 
   /**
    * Append to element

--- a/tests/fixtures/non-literal-defaults/output-component.d.ts
+++ b/tests/fixtures/non-literal-defaults/output-component.d.ts
@@ -67,7 +67,7 @@ export type NonLiteralDefaultsProps = {
    * Optional handler with undefined
    * @default undefined
    */
-  handler?: undefined;
+  handler?: any;
 
   /**
    * Append to element

--- a/tests/fixtures/prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output-class.d.ts
@@ -1,9 +1,6 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type PropMetadataConsolidatedProps = {
-  /**
-   * @default undefined
-   */
   typed: string;
 
   /**
@@ -52,10 +49,7 @@ export type PropMetadataConsolidatedProps = {
    */
   expressionDefault?: number;
 
-  /**
-   * @default undefined
-   */
-  unknown: undefined;
+  unknown: any;
 };
 
 export default class PropMetadataConsolidated extends SvelteComponentTyped<

--- a/tests/fixtures/prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/prop-metadata-consolidated/output-component.d.ts
@@ -1,9 +1,6 @@
 import type { Component } from "svelte";
 
 export type PropMetadataConsolidatedProps = {
-  /**
-   * @default undefined
-   */
   typed: string;
 
   /**
@@ -52,10 +49,7 @@ export type PropMetadataConsolidatedProps = {
    */
   expressionDefault?: number;
 
-  /**
-   * @default undefined
-   */
-  unknown: undefined;
+  unknown: any;
 };
 
 export type PropMetadataConsolidatedExports = Record<string, never>;

--- a/tests/fixtures/required/output-class.d.ts
+++ b/tests/fixtures/required/output-class.d.ts
@@ -14,14 +14,8 @@ export type RequiredProps = {
    */
   prop1?: boolean | string;
 
-  /**
-   * @default undefined
-   */
-  prop2: undefined;
+  prop2: any;
 
-  /**
-   * @default undefined
-   */
   prop3: boolean;
 
   children?: (this: void, ...args: [{

--- a/tests/fixtures/required/output-component.d.ts
+++ b/tests/fixtures/required/output-component.d.ts
@@ -14,14 +14,8 @@ export type RequiredProps = {
    */
   prop1?: boolean | string;
 
-  /**
-   * @default undefined
-   */
-  prop2: undefined;
+  prop2: any;
 
-  /**
-   * @default undefined
-   */
   prop3: boolean;
 
   children?: (this: void, ...args: [{

--- a/tests/fixtures/resolve-default-chained/output-class.d.ts
+++ b/tests/fixtures/resolve-default-chained/output-class.d.ts
@@ -17,7 +17,7 @@ export type ResolveDefaultChainedProps = {
    * Six levels deep: BEYOND -> Z -> Y -> X -> W -> V -> true. Exceeds the depth limit.
    * @default V
    */
-  deep6?: undefined;
+  deep6?: any;
 };
 
 export default class ResolveDefaultChained extends SvelteComponentTyped<

--- a/tests/fixtures/resolve-default-chained/output-component.d.ts
+++ b/tests/fixtures/resolve-default-chained/output-component.d.ts
@@ -17,7 +17,7 @@ export type ResolveDefaultChainedProps = {
    * Six levels deep: BEYOND -> Z -> Y -> X -> W -> V -> true. Exceeds the depth limit.
    * @default V
    */
-  deep6?: undefined;
+  deep6?: any;
 };
 
 export type ResolveDefaultChainedExports = Record<string, never>;

--- a/tests/fixtures/runes-bindable-no-default/input.svelte
+++ b/tests/fixtures/runes-bindable-no-default/input.svelte
@@ -1,0 +1,5 @@
+<script>
+  let { value = $bindable(0), open = $bindable(), onclick } = $props();
+</script>
+
+<button {onclick}>{value} {open}</button>

--- a/tests/fixtures/runes-bindable-no-default/output-class.d.ts
+++ b/tests/fixtures/runes-bindable-no-default/output-class.d.ts
@@ -1,0 +1,18 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesBindableNoDefaultProps = {
+  /**
+   * @default 0
+   */
+  value?: number;
+
+  open?: any;
+
+  onclick: any;
+};
+
+export default class RunesBindableNoDefault extends SvelteComponentTyped<
+  RunesBindableNoDefaultProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/runes-bindable-no-default/output-component.d.ts
+++ b/tests/fixtures/runes-bindable-no-default/output-component.d.ts
@@ -1,0 +1,21 @@
+import type { Component } from "svelte";
+
+export type RunesBindableNoDefaultProps = {
+  /**
+   * @default 0
+   */
+  value?: number;
+
+  open?: any;
+
+  onclick: any;
+};
+
+export type RunesBindableNoDefaultExports = Record<string, never>;
+
+declare const RunesBindableNoDefault: Component<
+  RunesBindableNoDefaultProps,
+  RunesBindableNoDefaultExports,
+  "value" | "open"
+>;
+export default RunesBindableNoDefault;

--- a/tests/fixtures/runes-bindable-no-default/output.json
+++ b/tests/fixtures/runes-bindable-no-default/output.json
@@ -1,0 +1,125 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "bindable": true,
+      "type": "number",
+      "typeSource": "default",
+      "value": "0",
+      "defaultValue": {
+        "raw": "0",
+        "kind": "literal",
+        "value": 0
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": true,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 28
+        }
+      }
+    },
+    {
+      "name": "open",
+      "kind": "let",
+      "bindable": true,
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": true,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 30
+        },
+        "end": {
+          "line": 2,
+          "column": 48
+        }
+      }
+    },
+    {
+      "name": "onclick",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 50
+        },
+        "end": {
+          "line": 2,
+          "column": 57
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-bindable-no-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "open",
+      "message": "Prop \"open\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 30
+        },
+        "end": {
+          "line": 2,
+          "column": 48
+        }
+      }
+    },
+    {
+      "component": "runes-bindable-no-default/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "onclick",
+      "message": "Prop \"onclick\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 50
+        },
+        "end": {
+          "line": 2,
+          "column": 57
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/runes-dispatched-events/output-class.d.ts
+++ b/tests/fixtures/runes-dispatched-events/output-class.d.ts
@@ -1,15 +1,9 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesDispatchedEventsProps = {
-  /**
-   * @default undefined
-   */
-  value: undefined;
+  value: any;
 
-  /**
-   * @default undefined
-   */
-  onchange: undefined;
+  onchange: any;
 };
 
 export default class RunesDispatchedEvents extends SvelteComponentTyped<

--- a/tests/fixtures/runes-dispatched-events/output-component.d.ts
+++ b/tests/fixtures/runes-dispatched-events/output-component.d.ts
@@ -1,15 +1,9 @@
 import type { Component } from "svelte";
 
 export type RunesDispatchedEventsProps = {
-  /**
-   * @default undefined
-   */
-  value: undefined;
+  value: any;
 
-  /**
-   * @default undefined
-   */
-  onchange: undefined;
+  onchange: any;
 };
 
 export type RunesDispatchedEventsExports = Record<string, never>;

--- a/tests/fixtures/runes-host-custom-element/output-class.d.ts
+++ b/tests/fixtures/runes-host-custom-element/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesHostCustomElementProps = {
-  /**
-   * @default undefined
-   */
-  value: undefined;
+  value: any;
 };
 
 export default class RunesHostCustomElement extends SvelteComponentTyped<

--- a/tests/fixtures/runes-host-custom-element/output-component.d.ts
+++ b/tests/fixtures/runes-host-custom-element/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesHostCustomElementProps = {
-  /**
-   * @default undefined
-   */
-  value: undefined;
+  value: any;
 };
 
 export type RunesHostCustomElementExports = Record<string, never>;

--- a/tests/fixtures/runes-internal-noleak/output-class.d.ts
+++ b/tests/fixtures/runes-internal-noleak/output-class.d.ts
@@ -1,15 +1,9 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesInternalNoleakProps = {
-  /**
-   * @default undefined
-   */
-  value: undefined;
+  value: any;
 
-  /**
-   * @default undefined
-   */
-  onchange: undefined;
+  onchange: any;
 };
 
 export default class RunesInternalNoleak extends SvelteComponentTyped<

--- a/tests/fixtures/runes-internal-noleak/output-component.d.ts
+++ b/tests/fixtures/runes-internal-noleak/output-component.d.ts
@@ -1,15 +1,9 @@
 import type { Component } from "svelte";
 
 export type RunesInternalNoleakProps = {
-  /**
-   * @default undefined
-   */
-  value: undefined;
+  value: any;
 
-  /**
-   * @default undefined
-   */
-  onchange: undefined;
+  onchange: any;
 };
 
 export type RunesInternalNoleakExports = Record<string, never>;

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
@@ -11,7 +11,7 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   value?: number;
 
-  open: any;
+  open?: any;
 
   /**
    * @default [1, 2]

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-class.d.ts
@@ -11,10 +11,7 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   value?: number;
 
-  /**
-   * @default undefined
-   */
-  open: undefined;
+  open: any;
 
   /**
    * @default [1, 2]
@@ -36,10 +33,7 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   computed?: string;
 
-  /**
-   * @default undefined
-   */
-  bare: undefined;
+  bare: any;
 };
 
 export default class RunesPropMetadataConsolidated extends SvelteComponentTyped<

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
@@ -11,7 +11,7 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   value?: number;
 
-  open: any;
+  open?: any;
 
   /**
    * @default [1, 2]

--- a/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output-component.d.ts
@@ -11,10 +11,7 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   value?: number;
 
-  /**
-   * @default undefined
-   */
-  open: undefined;
+  open: any;
 
   /**
    * @default [1, 2]
@@ -36,10 +33,7 @@ export type RunesPropMetadataConsolidatedProps = {
    */
   computed?: string;
 
-  /**
-   * @default undefined
-   */
-  bare: undefined;
+  bare: any;
 };
 
 export type RunesPropMetadataConsolidatedExports = Record<string, never>;

--- a/tests/fixtures/runes-prop-metadata-consolidated/output.json
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output.json
@@ -75,7 +75,7 @@
       "typeSource": "unknown",
       "isFunction": false,
       "isFunctionDeclaration": false,
-      "isRequired": true,
+      "isRequired": false,
       "constant": false,
       "reactive": true,
       "source": {

--- a/tests/fixtures/runes-props-basic/output-class.d.ts
+++ b/tests/fixtures/runes-props-basic/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesPropsBasicProps = {
-  /**
-   * @default undefined
-   */
-  title: undefined;
+  title: any;
 
   /**
    * @default 0

--- a/tests/fixtures/runes-props-basic/output-component.d.ts
+++ b/tests/fixtures/runes-props-basic/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesPropsBasicProps = {
-  /**
-   * @default undefined
-   */
-  title: undefined;
+  title: any;
 
   /**
    * @default 0

--- a/tests/fixtures/runes-props-id-default/output-class.d.ts
+++ b/tests/fixtures/runes-props-id-default/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesPropsIdDefaultProps = {
-  /**
-   * @default undefined
-   */
-  label: undefined;
+  label: any;
 };
 
 export default class RunesPropsIdDefault extends SvelteComponentTyped<

--- a/tests/fixtures/runes-props-id-default/output-component.d.ts
+++ b/tests/fixtures/runes-props-id-default/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesPropsIdDefaultProps = {
-  /**
-   * @default undefined
-   */
-  label: undefined;
+  label: any;
 };
 
 export type RunesPropsIdDefaultExports = Record<string, never>;

--- a/tests/fixtures/runes-props-renamed/output-class.d.ts
+++ b/tests/fixtures/runes-props-renamed/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesPropsRenamedProps = {
-  /**
-   * @default undefined
-   */
-  class: undefined;
+  class: any;
 };
 
 export default class RunesPropsRenamed extends SvelteComponentTyped<

--- a/tests/fixtures/runes-props-renamed/output-component.d.ts
+++ b/tests/fixtures/runes-props-renamed/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesPropsRenamedProps = {
-  /**
-   * @default undefined
-   */
-  class: undefined;
+  class: any;
 };
 
 export type RunesPropsRenamedExports = Record<string, never>;

--- a/tests/fixtures/runes-render-skipped-argument/output-class.d.ts
+++ b/tests/fixtures/runes-render-skipped-argument/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesRenderSkippedArgumentProps = {
-  /**
-   * @default undefined
-   */
-  title: undefined;
+  title: any;
 };
 
 export default class RunesRenderSkippedArgument extends SvelteComponentTyped<

--- a/tests/fixtures/runes-render-skipped-argument/output-component.d.ts
+++ b/tests/fixtures/runes-render-skipped-argument/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesRenderSkippedArgumentProps = {
-  /**
-   * @default undefined
-   */
-  title: undefined;
+  title: any;
 };
 
 export type RunesRenderSkippedArgumentExports = Record<string, never>;

--- a/tests/fixtures/runes-rest-props/output-class.d.ts
+++ b/tests/fixtures/runes-rest-props/output-class.d.ts
@@ -4,10 +4,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
-  /**
-   * @default undefined
-   */
-  variant: undefined;
+  variant: any;
 
   [key: `data-${string}`]: unknown;
 };

--- a/tests/fixtures/runes-rest-props/output-component.d.ts
+++ b/tests/fixtures/runes-rest-props/output-component.d.ts
@@ -4,10 +4,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 type $RestProps = SvelteHTMLElements["button"];
 
 type $Props = {
-  /**
-   * @default undefined
-   */
-  variant: undefined;
+  variant: any;
 
   [key: `data-${string}`]: unknown;
 };

--- a/tests/fixtures/runes-snippet-description-hyphens/output-class.d.ts
+++ b/tests/fixtures/runes-snippet-description-hyphens/output-class.d.ts
@@ -1,15 +1,9 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesSnippetDescriptionHyphensProps = {
-  /**
-   * @default undefined
-   */
-  row: undefined;
+  row: any;
 
-  /**
-   * @default undefined
-   */
-  col: undefined;
+  col: any;
 
   /**
    * First line documents `row-id` binding.

--- a/tests/fixtures/runes-snippet-description-hyphens/output-component.d.ts
+++ b/tests/fixtures/runes-snippet-description-hyphens/output-component.d.ts
@@ -1,15 +1,9 @@
 import type { Component } from "svelte";
 
 export type RunesSnippetDescriptionHyphensProps = {
-  /**
-   * @default undefined
-   */
-  row: undefined;
+  row: any;
 
-  /**
-   * @default undefined
-   */
-  col: undefined;
+  col: any;
 
   /**
    * First line documents `row-id` binding.

--- a/tests/fixtures/runes-snippets-default/output-class.d.ts
+++ b/tests/fixtures/runes-snippets-default/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesSnippetsDefaultProps = {
-  /**
-   * @default undefined
-   */
-  item: undefined;
+  item: any;
 
   children?: (this: void, ...args: [{ item: any }]) => void;
 };

--- a/tests/fixtures/runes-snippets-default/output-component.d.ts
+++ b/tests/fixtures/runes-snippets-default/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesSnippetsDefaultProps = {
-  /**
-   * @default undefined
-   */
-  item: undefined;
+  item: any;
 
   children?: (this: void, ...args: [{ item: any }]) => void;
 };

--- a/tests/fixtures/runes-snippets-named/output-class.d.ts
+++ b/tests/fixtures/runes-snippets-named/output-class.d.ts
@@ -1,10 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export type RunesSnippetsNamedProps = {
-  /**
-   * @default undefined
-   */
-  item: undefined;
+  item: any;
 
   header?: (this: void, ...args: [{ title: any }]) => void;
 };

--- a/tests/fixtures/runes-snippets-named/output-component.d.ts
+++ b/tests/fixtures/runes-snippets-named/output-component.d.ts
@@ -1,10 +1,7 @@
 import type { Component } from "svelte";
 
 export type RunesSnippetsNamedProps = {
-  /**
-   * @default undefined
-   */
-  item: undefined;
+  item: any;
 
   header?: (this: void, ...args: [{ title: any }]) => void;
 };

--- a/tests/fixtures/template-expression-shapes/output-class.d.ts
+++ b/tests/fixtures/template-expression-shapes/output-class.d.ts
@@ -27,7 +27,7 @@ type $Props = {
   /**
    * @default undefined
    */
-  label?: undefined;
+  label?: any;
 
   [key: `data-${string}`]: unknown;
 };

--- a/tests/fixtures/template-expression-shapes/output-component.d.ts
+++ b/tests/fixtures/template-expression-shapes/output-component.d.ts
@@ -27,7 +27,7 @@ type $Props = {
   /**
    * @default undefined
    */
-  label?: undefined;
+  label?: any;
 
   [key: `data-${string}`]: unknown;
 };

--- a/tests/fixtures/typed-props/output-class.d.ts
+++ b/tests/fixtures/typed-props/output-class.d.ts
@@ -4,7 +4,6 @@ export type TypedPropsProps = {
   /**
    * prop1 description 1
    * prop1 description 2
-   * @default undefined
    */
   prop1: string;
 
@@ -13,7 +12,7 @@ export type TypedPropsProps = {
    * prop2 description 2
    * @default null
    */
-  prop2?: undefined;
+  prop2?: any;
 
   /**
    * @default 4

--- a/tests/fixtures/typed-props/output-component.d.ts
+++ b/tests/fixtures/typed-props/output-component.d.ts
@@ -4,7 +4,6 @@ export type TypedPropsProps = {
   /**
    * prop1 description 1
    * prop1 description 2
-   * @default undefined
    */
   prop1: string;
 
@@ -13,7 +12,7 @@ export type TypedPropsProps = {
    * prop2 description 2
    * @default null
    */
-  prop2?: undefined;
+  prop2?: any;
 
   /**
    * @default 4

--- a/tests/fixtures/typedef-branded-types/output-class.d.ts
+++ b/tests/fixtures/typedef-branded-types/output-class.d.ts
@@ -15,13 +15,11 @@ export type TypedefBrandedTypesProps = {
   /**
    * A branded string. At runtime it is a plain `string`, but the brand makes it
    * a distinct domain type that other strings cannot be assigned to.
-   * @default undefined
    */
   userId: UserId;
 
   /**
    * A branded number representing a monetary amount in cents.
-   * @default undefined
    */
   amount: Cents;
 };

--- a/tests/fixtures/typedef-branded-types/output-component.d.ts
+++ b/tests/fixtures/typedef-branded-types/output-component.d.ts
@@ -15,13 +15,11 @@ export type TypedefBrandedTypesProps = {
   /**
    * A branded string. At runtime it is a plain `string`, but the brand makes it
    * a distinct domain type that other strings cannot be assigned to.
-   * @default undefined
    */
   userId: UserId;
 
   /**
    * A branded number representing a monetary amount in cents.
-   * @default undefined
    */
   amount: Cents;
 };

--- a/tests/fixtures/typedef-import-type/output-class.d.ts
+++ b/tests/fixtures/typedef-import-type/output-class.d.ts
@@ -13,33 +13,28 @@ export type TypedefImportTypeProps = {
   /**
    * A store imported from `svelte/store`. The `import(...)` type is resolved at
    * type level and emitted verbatim — no top-level `import` statement required.
-   * @default undefined
    */
   value: import("svelte/store").Writable<string>;
 
   /**
    * A read-only store.
-   * @default undefined
    */
   count: import("svelte/store").Readable<number>;
 
   /**
    * `typeof import(...)` references the type of a value export — here the
    * `writable` factory itself, rather than a type it exports.
-   * @default undefined
    */
   createStore: typeof import("svelte/store").writable;
 
   /**
    * Reuse another component's props with Svelte's `ComponentProps` utility.
-   * @default undefined
    */
   buttonProps: import("svelte").ComponentProps<import("svelte").SvelteComponent>;
 
   /**
    * The value stored under a Svelte context key, typed with imported store
    * types. `import(...)` works inside a `@typedef` too.
-   * @default undefined
    */
   context: TableContext;
 };

--- a/tests/fixtures/typedef-import-type/output-component.d.ts
+++ b/tests/fixtures/typedef-import-type/output-component.d.ts
@@ -13,33 +13,28 @@ export type TypedefImportTypeProps = {
   /**
    * A store imported from `svelte/store`. The `import(...)` type is resolved at
    * type level and emitted verbatim — no top-level `import` statement required.
-   * @default undefined
    */
   value: import("svelte/store").Writable<string>;
 
   /**
    * A read-only store.
-   * @default undefined
    */
   count: import("svelte/store").Readable<number>;
 
   /**
    * `typeof import(...)` references the type of a value export — here the
    * `writable` factory itself, rather than a type it exports.
-   * @default undefined
    */
   createStore: typeof import("svelte/store").writable;
 
   /**
    * Reuse another component's props with Svelte's `ComponentProps` utility.
-   * @default undefined
    */
   buttonProps: import("svelte").ComponentProps<import("svelte").SvelteComponent>;
 
   /**
    * The value stored under a Svelte context key, typed with imported store
    * types. `import(...)` works inside a `@typedef` too.
-   * @default undefined
    */
   context: TableContext;
 };

--- a/tests/fixtures/typedef-type-predicate/output-class.d.ts
+++ b/tests/fixtures/typedef-type-predicate/output-class.d.ts
@@ -14,13 +14,11 @@ export type TypedefTypePredicateProps = {
   /**
    * A type guard. It accepts an `unknown` value and returns a type predicate,
    * so callers can narrow `unknown` to `User` before accessing its fields.
-   * @default undefined
    */
   isUser: (value: unknown) => value is User;
 
   /**
    * A type guard expressed as a `@callback`.
-   * @default undefined
    */
   validate: UserGuard;
 };

--- a/tests/fixtures/typedef-type-predicate/output-component.d.ts
+++ b/tests/fixtures/typedef-type-predicate/output-component.d.ts
@@ -14,13 +14,11 @@ export type TypedefTypePredicateProps = {
   /**
    * A type guard. It accepts an `unknown` value and returns a type predicate,
    * so callers can narrow `unknown` to `User` before accessing its fields.
-   * @default undefined
    */
   isUser: (value: unknown) => value is User;
 
   /**
    * A type guard expressed as a `@callback`.
-   * @default undefined
    */
   validate: UserGuard;
 };

--- a/tests/fixtures/typedef-unknown-type/output-class.d.ts
+++ b/tests/fixtures/typedef-unknown-type/output-class.d.ts
@@ -4,14 +4,12 @@ export type TypedefUnknownTypeProps = {
   /**
    * A value of unknown shape. Prefer `unknown` over `any`: consumers must
    * narrow it before use instead of silently opting out of type checking.
-   * @default undefined
    */
   payload: unknown;
 
   /**
    * An escape hatch typed as `any`, shown for contrast. `any` disables type
    * checking everywhere it flows, so reach for `unknown` at boundaries instead.
-   * @default undefined
    */
   raw: any;
 };

--- a/tests/fixtures/typedef-unknown-type/output-component.d.ts
+++ b/tests/fixtures/typedef-unknown-type/output-component.d.ts
@@ -4,14 +4,12 @@ export type TypedefUnknownTypeProps = {
   /**
    * A value of unknown shape. Prefer `unknown` over `any`: consumers must
    * narrow it before use instead of silently opting out of type checking.
-   * @default undefined
    */
   payload: unknown;
 
   /**
    * An escape hatch typed as `any`, shown for contrast. `any` disables type
    * checking everywhere it flows, so reach for `unknown` at boundaries instead.
-   * @default undefined
    */
   raw: any;
 };

--- a/tests/fixtures/typedef-utility-types/output-class.d.ts
+++ b/tests/fixtures/typedef-utility-types/output-class.d.ts
@@ -18,25 +18,21 @@ export type Factory = () => Options;
 export type TypedefUtilityTypesProps = {
   /**
    * A read-only subset of `Options`.
-   * @default undefined
    */
   summary: Pick<Options, "id" | "size">;
 
   /**
    * Everything in `Options` except `disabled`.
-   * @default undefined
    */
   editable: Omit<Options, "disabled">;
 
   /**
    * Derived from the factory's return type rather than restated.
-   * @default undefined
    */
   defaults: ReturnType<Factory>;
 
   /**
    * The resolved value of an async source.
-   * @default undefined
    */
   resolved: Awaited<Promise<Options>>;
 };

--- a/tests/fixtures/typedef-utility-types/output-component.d.ts
+++ b/tests/fixtures/typedef-utility-types/output-component.d.ts
@@ -18,25 +18,21 @@ export type Factory = () => Options;
 export type TypedefUtilityTypesProps = {
   /**
    * A read-only subset of `Options`.
-   * @default undefined
    */
   summary: Pick<Options, "id" | "size">;
 
   /**
    * Everything in `Options` except `disabled`.
-   * @default undefined
    */
   editable: Omit<Options, "disabled">;
 
   /**
    * Derived from the factory's return type rather than restated.
-   * @default undefined
    */
   defaults: ReturnType<Factory>;
 
   /**
    * The resolved value of an async source.
-   * @default undefined
    */
   resolved: Awaited<Promise<Options>>;
 };


### PR DESCRIPTION
Also fixes argument-less $bindable() so it comes out optional instead
of required, since that's how it behaves at runtime.