### PR TITLE
fix(resolve-types): fail loudly when TS 7/tsconfig missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Without `resolveTypes`, JSON lists no props. With it, each field shows up with `
 }
 ```
 
-**Performance.** Off by default. This is the only path that loads TypeScript. It needs `typescript` and a `tsconfig.json`, runs slower than the AST-only pipeline, and gets slower as your types grow. Use it only when you need expanded JSON. `.d.ts` output is unchanged.
+**Performance.** Off by default. This is one of the two paths that load TypeScript. It needs `typescript` 7+ and a `tsconfig.json` (see [Requirements](#requirements)); if either is missing, `resolveTypes` fails the run instead of silently producing empty props. It also runs slower than the AST-only pipeline and gets slower as your types grow. Use it only when you need expanded JSON. `.d.ts` output is unchanged.
 
 ### Persistent parse cache (`cache`)
 
@@ -343,7 +343,7 @@ Plain TS/JS only. Examples fenced as `svelte` or `html`, or bare markup like `<B
 
 The check is narrow on purpose. It catches renamed or removed symbols and wrong argument counts. It is not full type checking and never pulls in types sveld cannot see.
 
-Needs `typescript` and a `tsconfig.json`, same as `resolveTypes`. Use `--strict` (or the `strict` option) to fail CI when an example breaks.
+Needs `typescript` 7+ and a `tsconfig.json`, same as `resolveTypes` (see [Requirements](#requirements)); missing either fails the run rather than silently skipping every example. Use `--strict` (or the `strict` option) to fail CI when an example breaks.
 
 ### Type inference diagnostics
 
@@ -406,6 +406,7 @@ npx sveld --json --strict
 - Node 22+. CI tests against Node 22 on Linux, Windows, and macOS; earlier LTS versions are not verified.
 - `sveld` is ESM-only. `require("sveld")` does not work — use `import` or dynamic `import()`.
 - `sveld` bundles its own Svelte 5 compiler to parse `.svelte` files. Parsing does not depend on the Svelte version installed in your project, so Svelte 3 and Svelte 4 codebases parse the same way Svelte 5 codebases do — there is no compiler version to match up.
+- [`resolveTypes`](#opt-in-semantic-resolution-resolvetypes) and [`checkExamples`](#compile-checked-example-blocks-checkexamples) are optional and need `typescript` 7 or later (which provides `typescript/unstable/async`) plus a `tsconfig.json`. Everything else, including `.d.ts` generation, is AST-only and never loads TypeScript. If either is enabled and TypeScript can't be started (missing, too old, or no `tsconfig.json`), the run fails loudly: `sveld()` throws and the CLI exits `2` naming the requirement, rather than silently skipping the check.
 
 ## Usage
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -688,7 +688,17 @@ export async function generateBundle(
   if (resolveTypesCandidates.length > 0 || checkExamplesCandidates.length > 0) {
     // Share one TypeResolver when both resolveTypes and checkExamples are enabled.
     const { TypeResolver } = await import("./resolve-types");
-    const resolver = await TypeResolver.create(rootDir);
+    const created = await TypeResolver.create(rootDir);
+    if (!created.ok) {
+      const features = [
+        resolveTypesCandidates.length > 0 ? "resolveTypes" : null,
+        checkExamplesCandidates.length > 0 ? "checkExamples" : null,
+      ]
+        .filter((feature): feature is string => feature !== null)
+        .join(" and ");
+      throw new Error(`sveld: \`${features}\` ${created.message}.`);
+    }
+    const resolver = created.resolver;
 
     try {
       if (resolveTypesCandidates.length > 0) {
@@ -861,11 +871,9 @@ function collectResolveTypesCandidates(components: ComponentDocs): ResolveTypesC
 
 async function resolveImportedPropTypes(
   candidates: ResolveTypesCandidate[],
-  resolver: TypeResolver | null,
+  resolver: TypeResolver,
   resolveComponentFilePath: ResolveComponentFilePath,
 ): Promise<void> {
-  if (!resolver) return;
-
   // Keyed by resolved filePath, not moduleName: two components discovered via
   // `--glob` can share a basename, and moduleName alone isn't unique.
   const resolvedByFilePath = await resolver.expandAll(
@@ -901,11 +909,9 @@ function collectCheckExamplesCandidates(components: ComponentDocs): CheckExample
 
 async function checkComponentExamples(
   candidates: CheckExamplesCandidate[],
-  resolver: TypeResolver | null,
+  resolver: TypeResolver,
   resolveComponentFilePath: ResolveComponentFilePath,
 ): Promise<void> {
-  if (!resolver) return;
-
   // Keyed by resolved filePath, not moduleName: two components discovered via
   // `--glob` can share a basename, and moduleName alone isn't unique.
   const diagnosticsByFilePath = await resolver.checkExamples(

--- a/src/resolve-types.ts
+++ b/src/resolve-types.ts
@@ -1,4 +1,5 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import type { ParsedComponentTypeScriptMetadata, ResolvedComponentProp } from "./ComponentParser";
 import type { ExampleCheckSource } from "./example-check";
@@ -34,6 +35,63 @@ const NON_FILENAME_CHAR_REGEX = /[^A-Za-z0-9_-]/g;
 const NON_IDENTIFIER_CHAR_REGEX = /[^A-Za-z0-9_$]/g;
 const LEADING_DIGIT_REGEX = /^[0-9]/;
 const EXAMPLE_CODE_START_LINE = 2;
+const MIN_SUPPORTED_TS_MAJOR = 7;
+const REQUIREMENT_TEXT = `TypeScript ${MIN_SUPPORTED_TS_MAJOR} or later, which provides \`typescript/unstable/async\``;
+
+/** Outcome of loading the `typescript` package, before any tsconfig lookup. */
+export interface TypeScriptLoadResult {
+  installed: boolean;
+  version?: string;
+  module?: TS;
+}
+
+/** Structured failure reason for {@link TypeResolver.create}. */
+export type TypeResolverFailureReason = "not-installed" | "unsupported-version" | "no-tsconfig";
+
+export interface TypeResolverFailure {
+  ok: false;
+  reason: TypeResolverFailureReason;
+  message: string;
+}
+
+export interface TypeResolverSuccess {
+  ok: true;
+  resolver: TypeResolver;
+}
+
+export type TypeResolverCreateResult = TypeResolverSuccess | TypeResolverFailure;
+
+export interface TypeResolverCreateOptions {
+  /** Test seam: replaces the real `typescript` package lookup/import. */
+  importTs?: (cwd: string) => Promise<TypeScriptLoadResult>;
+}
+
+function isSupportedVersion(version: string | undefined): boolean {
+  if (!version) return false;
+  const major = Number.parseInt(version, 10);
+  return Number.isFinite(major) && major >= MIN_SUPPORTED_TS_MAJOR;
+}
+
+/** Resolves the installed `typescript` version from `cwd`'s module resolution, then imports the async API. */
+async function defaultImportTs(cwd: string): Promise<TypeScriptLoadResult> {
+  let version: string | undefined;
+  try {
+    const require = createRequire(path.join(cwd, "package.json"));
+    const pkgPath = require.resolve("typescript/package.json");
+    version = (JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string }).version;
+  } catch {
+    return { installed: false };
+  }
+
+  if (!isSupportedVersion(version)) return { installed: true, version };
+
+  try {
+    const module = await import("typescript/unstable/async");
+    return { installed: true, version, module };
+  } catch {
+    return { installed: true, version };
+  }
+}
 
 /**
  * Expands opaque imported `$props()` types using the project's TypeScript program.
@@ -55,31 +113,48 @@ export class TypeResolver {
 
   /**
    * Loads `typescript` and the nearest `tsconfig.json`.
-   * Returns `null` when either is missing.
+   *
+   * These features are explicitly opt-in, so a failure to start here is
+   * reported as a structured failure rather than swallowed: the caller
+   * decides whether that's fatal.
    */
-  static async create(cwd: string = process.cwd()): Promise<TypeResolver | null> {
+  static async create(
+    cwd: string = process.cwd(),
+    { importTs = defaultImportTs }: TypeResolverCreateOptions = {},
+  ): Promise<TypeResolverCreateResult> {
+    const loaded = await importTs(cwd);
+
+    if (!loaded.installed) {
+      return {
+        ok: false,
+        reason: "not-installed",
+        message: `requires the \`typescript\` package to be installed (${REQUIREMENT_TEXT}); none was found`,
+      };
+    }
+
+    if (!loaded.module) {
+      return {
+        ok: false,
+        reason: "unsupported-version",
+        message: `requires ${REQUIREMENT_TEXT}; found \`typescript@${loaded.version ?? "unknown"}\` installed, which does not expose that module`,
+      };
+    }
+
     const tsconfigPath = findTsConfig(cwd);
     if (!tsconfigPath) {
-      console.warn("Warning: `resolveTypes` could not locate a tsconfig.json. Skipping semantic resolution.");
-      return null;
+      return {
+        ok: false,
+        reason: "no-tsconfig",
+        message: `could not locate a tsconfig.json starting from "${cwd}"`,
+      };
     }
 
-    let mod: TS;
-    try {
-      mod = await import("typescript/unstable/async");
-    } catch (error) {
-      console.warn(
-        "Warning: `resolveTypes` requires the `typescript` package to be installed. Skipping semantic resolution.",
-        error,
-      );
-      return null;
-    }
-
+    const mod = loaded.module;
     const resolver = new TypeResolver(null, mod.SymbolFlags, mod.TypeFlags, tsconfigPath);
     const api = new mod.API({ cwd, fs: resolver.createFileSystem() });
     // biome-ignore lint/suspicious/noExplicitAny: assign after fs closure is created.
     (resolver as any).api = api;
-    return resolver;
+    return { ok: true, resolver };
   }
 
   /**

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -5,6 +5,8 @@ import { type ComponentDocApi, type ComponentDocs, generateBundle } from "../src
 import ComponentParser from "../src/ComponentParser";
 import { TypeResolver } from "../src/resolve-types";
 
+const RESOLVER_FAILURE_MESSAGE_REGEX = /resolveTypes.*checkExamples.*tsconfig\.json/s;
+
 /** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
 function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
   return Array.from(components.values()).find((component) => component.moduleName === moduleName);
@@ -123,7 +125,9 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     writeFileSync(path.join(dir, "ExampleCheck.svelte"), EXAMPLE_CHECK_COMPONENT);
 
     const fakeResolver = makeFakeResolver();
-    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
+    createSpy = jest
+      .spyOn(TypeResolver, "create")
+      .mockResolvedValue({ ok: true, resolver: fakeResolver as unknown as TypeResolver });
 
     await generateBundle(path.join(dir, "index.ts"), true, {
       resolveTypes: true,
@@ -141,7 +145,9 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     writeFileSync(path.join(dir, "Plain.svelte"), PLAIN_COMPONENT);
 
     const fakeResolver = makeFakeResolver();
-    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(fakeResolver as unknown as TypeResolver);
+    createSpy = jest
+      .spyOn(TypeResolver, "create")
+      .mockResolvedValue({ ok: true, resolver: fakeResolver as unknown as TypeResolver });
 
     await generateBundle(path.join(dir, "index.ts"), true, {
       resolveTypes: true,
@@ -151,25 +157,25 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  test("a null resolver (no tsconfig) leaves both features as graceful no-ops", async () => {
+  test("a failed resolver (no tsconfig) fails the run instead of silently skipping either feature", async () => {
     writeFileSync(path.join(dir, "index.ts"), BARREL);
     writeFileSync(path.join(dir, "PropsImported.svelte"), PROPS_IMPORTED_COMPONENT);
     writeFileSync(path.join(dir, "types.ts"), PROPS_TYPES);
     writeFileSync(path.join(dir, "ExampleCheck.svelte"), EXAMPLE_CHECK_COMPONENT);
 
-    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue(null);
-
-    const result = await generateBundle(path.join(dir, "index.ts"), true, {
-      resolveTypes: true,
-      checkExamples: true,
+    createSpy = jest.spyOn(TypeResolver, "create").mockResolvedValue({
+      ok: false,
+      reason: "no-tsconfig",
+      message: 'could not locate a tsconfig.json starting from "/fake"',
     });
 
+    await expect(
+      generateBundle(path.join(dir, "index.ts"), true, {
+        resolveTypes: true,
+        checkExamples: true,
+      }),
+    ).rejects.toThrow(RESOLVER_FAILURE_MESSAGE_REGEX);
+
     expect(createSpy).toHaveBeenCalledTimes(1);
-
-    const propsImported = result.components.get("PropsImported");
-    expect(propsImported?.props).toEqual([]);
-
-    const exampleCheck = byModuleName(result.allComponentsForTypes, "ExampleCheck");
-    expect(exampleCheck?.diagnostics ?? []).toEqual([]);
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1119,4 +1119,39 @@ describe("cli() exit codes", () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Suggested semver bump: major."));
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("unresolved type"));
   });
+
+  test("sets exitCode 2 and names the requirement when --check-examples finds an incompatible typescript", async () => {
+    // Shadows the real `typescript` package for this project with a fake,
+    // pre-7 install so `TypeResolver.create`'s version check fails without
+    // touching the real dependency the rest of the suite relies on.
+    mkdirSync(join(dir, "node_modules", "typescript"), { recursive: true });
+    writeFileSync(
+      join(dir, "node_modules", "typescript", "package.json"),
+      JSON.stringify({ name: "typescript", version: "5.9.0" }),
+    );
+    writeFileSync(
+      join(dir, "src", "Documented.svelte"),
+      [
+        "<script>",
+        "  /**",
+        "   * @example",
+        "   * ```js",
+        '   * formatValue("ok");',
+        "   * ```",
+        "   */",
+        "  export function formatValue(value) {",
+        "    return value;",
+        "  }",
+        "</script>",
+      ].join("\n"),
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Documented } from "./Documented.svelte";\n');
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json", "--check-examples"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(2);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("TypeScript 7"));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("5.9.0"));
+  });
 });

--- a/tests/example-check.test.ts
+++ b/tests/example-check.test.ts
@@ -34,9 +34,10 @@ describe("opt-in @example compile checking", () => {
     const parsed = await parseFixture();
     const sources = collectExampleSources(parsed);
 
-    const resolver = await TypeResolver.create(FIXTURE_DIR);
-    expect(resolver).not.toBeNull();
-    if (!resolver) return;
+    const created = await TypeResolver.create(FIXTURE_DIR);
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const resolver = created.resolver;
 
     try {
       const diagnosticsByFilePath = await resolver.checkExamples([

--- a/tests/resolve-types.test.ts
+++ b/tests/resolve-types.test.ts
@@ -52,9 +52,10 @@ describe("opt-in TypeScript semantic resolution", () => {
     const metadata = getParsedComponentTypeScriptMetadata(parsed);
     if (!metadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
 
-    const resolver = await TypeResolver.create(FIXTURE_DIR);
-    expect(resolver).not.toBeNull();
-    if (!resolver) return;
+    const created = await TypeResolver.create(FIXTURE_DIR);
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const resolver = created.resolver;
 
     try {
       const resolved = await resolver.expandAll([
@@ -87,9 +88,10 @@ describe("opt-in TypeScript semantic resolution", () => {
     const metadata = getParsedComponentTypeScriptMetadata(parsed);
     if (!metadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
 
-    const resolver = await TypeResolver.create(UNION_FIXTURE_DIR);
-    expect(resolver).not.toBeNull();
-    if (!resolver) return;
+    const created = await TypeResolver.create(UNION_FIXTURE_DIR);
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const resolver = created.resolver;
 
     try {
       const resolved = await resolver.expandAll([
@@ -121,9 +123,10 @@ describe("opt-in TypeScript semantic resolution", () => {
     expect(metadata.canonicalPropsType).toBe("Props<T>");
     expect(metadata.referencesComponentGenerics).toBe(true);
 
-    const resolver = await TypeResolver.create(GENERIC_FIXTURE_DIR);
-    expect(resolver).not.toBeNull();
-    if (!resolver) return;
+    const created = await TypeResolver.create(GENERIC_FIXTURE_DIR);
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const resolver = created.resolver;
 
     try {
       const resolved = await resolver.expandAll([
@@ -156,9 +159,10 @@ describe("opt-in TypeScript semantic resolution", () => {
     const unionMetadata = getParsedComponentTypeScriptMetadata(unionParsed);
     if (!unionMetadata?.canonicalPropsType) throw new Error("fixture missing canonical props type");
 
-    const resolver = await TypeResolver.create(FIXTURE_DIR);
-    expect(resolver).not.toBeNull();
-    if (!resolver) return;
+    const created = await TypeResolver.create(FIXTURE_DIR);
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const resolver = created.resolver;
 
     try {
       // Simulates two `--glob`-discovered `.svelte` files sharing a basename
@@ -177,4 +181,42 @@ describe("opt-in TypeScript semantic resolution", () => {
     expect(importedParsed.props.map((prop) => prop.name).sort()).toEqual(["disabled", "href", "variant"]);
     expect(unionParsed.props.map((prop) => prop.name).sort()).toEqual(["duration", "kind", "target"]);
   }, 30_000);
+});
+
+describe("TypeResolver.create failure modes", () => {
+  test("reports not-installed when `typescript` cannot be found", async () => {
+    const result = await TypeResolver.create(FIXTURE_DIR, {
+      importTs: async () => ({ installed: false }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("not-installed");
+    expect(result.message).toContain("typescript");
+    expect(result.message).toContain("TypeScript 7");
+  });
+
+  test("reports unsupported-version and names the installed version when below TypeScript 7", async () => {
+    const result = await TypeResolver.create(FIXTURE_DIR, {
+      importTs: async () => ({ installed: true, version: "5.9.0" }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unsupported-version");
+    expect(result.message).toContain("5.9.0");
+    expect(result.message).toContain("TypeScript 7");
+  });
+
+  test("reports no-tsconfig when TypeScript loads but no tsconfig.json is found", async () => {
+    const noTsconfigDir = path.parse(process.cwd()).root;
+    const result = await TypeResolver.create(noTsconfigDir, {
+      importTs: async () => ({ installed: true, version: "7.0.2", module: {} }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no-tsconfig");
+    expect(result.message).toContain("tsconfig.json");
+  });
 });


### PR DESCRIPTION
resolveTypes and checkExamples used to warn and silently no-op when
typescript was missing, older than 7, or had no tsconfig.json, so a
strict CI check could pass having verified nothing. Now TypeResolver
reports a structured failure naming the unmet requirement, and
bundle.ts turns that into a thrown error so the CLI exits 2 and
sveld() throws instead.