### PR TITLE
fix(exports): follow named re-export chains through nested barrels

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,8 @@ export type { Theme } from "./types";
 
 From that barrel, `sveld` documents `VERSION`, `clamp`, and `Theme`. `Button` still goes through the component path. Type text is copied from source, not resolved with `tsc`, same as the rest of the tool.
 
+Nested barrels are followed too: `export { X } from "./dir"`, where `./dir/index.js` itself re-exports `.svelte` files, resolves `X` to the underlying component without needing `--glob`.
+
 JSON adds `exports` and `totalExports`. Markdown adds an "Exports" section. Each item has `name`, `kind`, type text, optional JSDoc `description`, and `source`.
 
 ## JSON Output

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -1,8 +1,9 @@
 import { lstatSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { type Node, parse } from "acorn";
 import { asRelativeSourcePath, type RelativeSourcePath } from "./brands";
-import { normalizeSeparators } from "./path";
+import { resolveModuleFile } from "./parse-entry-exports";
+import { normalizeSeparators, SVELTE_EXT_REGEX } from "./path";
 import { resolvePathAlias, resolvePathAliasAbsolute } from "./resolve-alias";
 
 interface NodeImportDeclaration extends Node {
@@ -52,6 +53,39 @@ function parseProgram(source: string): ProgramNode {
     ecmaVersion: "latest",
     sourceType: "module",
   }) as ProgramNode;
+}
+
+/**
+ * Follows a re-export specifier that does not point directly at a `.svelte`
+ * file (e.g. `export { X } from "./barrel"`) to the module it resolves to,
+ * and parses that module's own exports.
+ *
+ * Returns `null` when the specifier cannot be resolved to a file at all, so
+ * callers can warn instead of recording a dangling source path. Returns an
+ * empty map (not `null`) when the target participates in an import cycle
+ * (mirroring the silent `export *` cycle guard below) or when it can't be
+ * parsed as plain JS (e.g. a TypeScript-only `documentExports` data module),
+ * so callers fall back to recording the literal specifier instead.
+ */
+function resolveBarrelExports(
+  specifier: string,
+  fromDir: string,
+  resolving: Set<string>,
+): { dir: string; exports: ParsedExports } | null {
+  const targetFile = resolveModuleFile(specifier, fromDir);
+  if (!targetFile) return null;
+
+  const dir = dirname(targetFile);
+  if (resolving.has(targetFile)) return { dir, exports: {} };
+
+  resolving.add(targetFile);
+  try {
+    return { dir, exports: parseExports(readFileSync(targetFile, "utf-8"), dir, resolving) };
+  } catch {
+    return { dir, exports: {} };
+  } finally {
+    resolving.delete(targetFile);
+  }
 }
 
 /**
@@ -123,24 +157,37 @@ export function parseExports(source: string, dir: string, resolving: Set<string>
         };
       }
     } else if (node.type === "ExportNamedDeclaration") {
+      const sourceValue = node.source?.value;
+      const isBarrelChain = sourceValue !== undefined && !SVELTE_EXT_REGEX.test(sourceValue);
+      const chain = isBarrelChain ? resolveBarrelExports(sourceValue, dir, resolving) : undefined;
+
+      if (chain === null) {
+        console.warn(
+          `sveld: could not resolve re-exported module "${sourceValue}" from barrel "${dir || "."}"; skipping.`,
+        );
+      }
+
       for (const specifier of node.specifiers) {
         const exported_name = specifier.exported.name;
         const local_name = specifier.local.name;
         const id = exported_name || local_name;
 
+        if (chain === null) continue;
+
+        const chained = chain?.exports[local_name];
+        const source: RelativeSourcePath = chained
+          ? asRelativeSourcePath(normalizeSeparators(`./${relative(dir, resolve(chain.dir, chained.source))}`))
+          : asRelativeSourcePath(resolvePathAlias(sourceValue ?? "", dir));
+        const isDefault = chained ? chained.default : local_name === "default";
+
         if (id in exports_by_identifier) {
-          if (node.type === "ExportNamedDeclaration") {
-            exports_by_identifier[id].mixed = true;
-          }
+          exports_by_identifier[id].mixed = true;
 
           if (!exports_by_identifier[id].source) {
-            exports_by_identifier[id].source = asRelativeSourcePath(resolvePathAlias(node.source?.value ?? "", dir));
+            exports_by_identifier[id].source = source;
           }
         } else {
-          exports_by_identifier[id] = {
-            source: asRelativeSourcePath(resolvePathAlias(node.source?.value ?? "", dir)),
-            default: local_name === "default",
-          };
+          exports_by_identifier[id] = { source, default: isDefault };
         }
       }
     } else if (node.type === "ImportDeclaration") {

--- a/tests/parse-exports.test.ts
+++ b/tests/parse-exports.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { parseExports } from "../src/parse-exports";
@@ -112,13 +112,144 @@ describe("parseExports", () => {
     });
   });
 
-  test("multiple, non-default exports", () => {
-    const source = `export { Component, Component2 } from "./component";`;
+  test("multiple, non-default exports (target has no matching re-exports, falls back to literal source)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-flat-"));
 
-    expect(parseExports(source, "")).toEqual({
-      Component: { source: "./component", default: false },
-      Component2: { source: "./component", default: false },
-    });
+    try {
+      writeFileSync(path.join(dir, "component.js"), "export const Component = 1;\nexport const Component2 = 2;\n");
+
+      const source = `export { Component, Component2 } from "./component";`;
+
+      expect(parseExports(source, dir)).toEqual({
+        Component: { source: "./component", default: false },
+        Component2: { source: "./component", default: false },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("target that is not parseable as plain JS (e.g. TypeScript syntax) falls back to literal source", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-ts-target-"));
+
+    try {
+      writeFileSync(path.join(dir, "constants.ts"), "export const MAX_RETRIES: number = 5;\n");
+
+      const source = `export { MAX_RETRIES } from "./constants";`;
+
+      expect(parseExports(source, dir)).toEqual({
+        MAX_RETRIES: { source: "./constants", default: false },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("two-level named chain through a directory barrel", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-chain-"));
+
+    try {
+      const catDir = path.join(dir, "cat");
+      mkdirSync(catDir);
+      writeFileSync(path.join(catDir, "index.js"), `export { default as A } from "./A.svelte";\n`);
+
+      const source = `export { A } from "./cat";`;
+
+      expect(parseExports(source, dir)).toEqual({
+        A: { source: "./cat/A.svelte", default: true },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rename through a named chain", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-chain-rename-"));
+
+    try {
+      const catDir = path.join(dir, "cat");
+      mkdirSync(catDir);
+      writeFileSync(path.join(catDir, "index.js"), `export { default as A } from "./A.svelte";\n`);
+
+      const source = `export { A as B } from "./cat";`;
+
+      expect(parseExports(source, dir)).toEqual({
+        B: { source: "./cat/A.svelte", default: true },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("named chain by filename instead of directory", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-chain-filename-"));
+
+    try {
+      const catDir = path.join(dir, "cat");
+      mkdirSync(catDir);
+      writeFileSync(path.join(catDir, "index.js"), `export { default as A } from "./A.svelte";\n`);
+
+      const source = `export { A } from "./cat/index.js";`;
+
+      expect(parseExports(source, dir)).toEqual({
+        A: { source: "./cat/A.svelte", default: true },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("three-level named chain", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-chain-three-"));
+
+    try {
+      const catDir = path.join(dir, "cat");
+      const dogDir = path.join(catDir, "dog");
+      mkdirSync(catDir);
+      mkdirSync(dogDir);
+      writeFileSync(path.join(dogDir, "index.js"), `export { default as A } from "./A.svelte";\n`);
+      writeFileSync(path.join(catDir, "index.js"), `export { A } from "./dog";\n`);
+
+      const source = `export { A } from "./cat";`;
+
+      expect(parseExports(source, dir)).toEqual({
+        A: { source: "./cat/dog/A.svelte", default: true },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("cycle between two named-chain barrels terminates", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-chain-cycle-"));
+
+    try {
+      const catDir = path.join(dir, "cat");
+      const dogDir = path.join(dir, "dog");
+      mkdirSync(catDir);
+      mkdirSync(dogDir);
+      writeFileSync(path.join(catDir, "index.js"), `export { A } from "../dog";\n`);
+      writeFileSync(path.join(dogDir, "index.js"), `export { A } from "../cat";\n`);
+
+      const source = `export { A } from "./cat";`;
+
+      expect(() => parseExports(source, dir)).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unresolvable specifier warns and omits the entry", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const source = `export { A } from "./does-not-exist";`;
+
+      expect(parseExports(source, "")).toEqual({});
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test("mixed default and named export from same source", () => {


### PR DESCRIPTION
Named re-exports like \`export { X } from "./dir"\` only worked when
\`./dir\` pointed straight at a \`.svelte\` file. When it was itself a
barrel (the layout carbon-components-svelte uses), the component got
silently dropped from JSON, Markdown, and \`.d.ts\` unless \`--glob\`
papered over it. This resolves and recurses into those targets the
same way \`export *\` chains already do, and warns instead of dropping
silently when a specifier can't be resolved at all.