### PR TITLE
fix(types): quote non-identifier keys in generated .d.ts

### DIFF
--- a/src/writer/MarkdownWriterBase.ts
+++ b/src/writer/MarkdownWriterBase.ts
@@ -1,4 +1,25 @@
-import { BACKTICK_REGEX, WHITESPACE_REGEX } from "./markdown-format-utils";
+import { BACKTICK_REGEX } from "./markdown-format-utils";
+
+const NON_SLUG_CHAR_REGEX = /[^\w\- ]+/g;
+const SLUG_SPACE_REGEX = /\s+/g;
+
+/**
+ * Mirrors GitHub's heading slugger: lowercase, strip backticks, drop any
+ * character that isn't a letter/number/space/hyphen/underscore, then turn
+ * spaces into hyphens. Duplicate anchors get `-1`, `-2`, ... suffixes,
+ * tracked via `seen`.
+ */
+function slugifyHeading(raw: string, seen: Map<string, number>): string {
+  const slug = raw
+    .toLowerCase()
+    .replace(BACKTICK_REGEX, "")
+    .replace(NON_SLUG_CHAR_REGEX, "")
+    .replace(SLUG_SPACE_REGEX, "-");
+
+  const count = seen.get(slug) ?? 0;
+  seen.set(slug, count + 1);
+  return count === 0 ? slug : `${slug}-${count}`;
+}
 
 export type AppendType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "quote" | "p" | "divider" | "raw";
 
@@ -77,11 +98,12 @@ export class MarkdownWriterBaseImpl implements MarkdownWriterBase {
 
   public end(): string {
     const source = this.sourceParts.join("");
+    const seenAnchors = new Map<string, number>();
     return source.replace(
       "<!-- __TOC__ -->",
       this.toc
         .map(({ indent, raw }) => {
-          return `${" ".repeat(indent)}- [${raw}](#${raw.toLowerCase().replace(BACKTICK_REGEX, "").replace(WHITESPACE_REGEX, "-")})`;
+          return `${" ".repeat(indent)}- [${raw}](#${slugifyHeading(raw, seenAnchors)})`;
         })
         .join("\n"),
     );

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -43,7 +43,7 @@ export function formatNameWithDeprecation(name: string, deprecated: DeprecatedVa
 
 export function formatPropDescription(description: string | undefined) {
   if (description === undefined || description.trim().length === 0) return MD_TYPE_UNDEFINED;
-  return escapeHtml(description).replace(NEWLINE_REGEX, "<br />");
+  return escapeHtml(description).replace(PIPE_REGEX, "&#124;").replace(NEWLINE_REGEX, "<br />");
 }
 
 export function formatSlotProps(props?: string) {

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -106,11 +106,11 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
   document.append("h3", "Props");
   renderSectionIfNotEmpty(document, component.props, () => {
     document.append("raw", PROP_TABLE_HEADER);
-    const sortedProps = [...component.props].sort((a) => {
-      if (a.reactive) return -1;
-      if (a.constant) return 1;
-      return 0;
-    });
+    const rank = (prop: (typeof component.props)[number]) => (prop.reactive ? 0 : prop.constant ? 2 : 1);
+    const sortedProps = component.props
+      .map((prop, index) => ({ prop, index }))
+      .sort((a, b) => rank(a.prop) - rank(b.prop) || a.index - b.index)
+      .map(({ prop }) => prop);
     for (const prop of sortedProps) {
       document.append(
         "raw",

--- a/src/writer/writer-custom-elements.ts
+++ b/src/writer/writer-custom-elements.ts
@@ -56,7 +56,7 @@ export default async function writeCustomElements(components: ComponentDocs, opt
 
   const output_path = path.join(process.cwd(), options.outFile);
   const writer = new Writer({ dryRun: options.dryRun });
-  await writer.write(output_path, raw);
+  const wasWritten = await writer.write(output_path, raw);
 
-  if (!options.dryRun) info(`created "${options.outFile}".`);
+  if (!options.dryRun) info(`${wasWritten ? "created" : "unchanged"} "${options.outFile}".`);
 }

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -121,9 +121,9 @@ async function writeJsonLocal(components: ComponentDocs, options: WriteJsonOptio
   const raw = renderJsonDocument(components, options);
   const output_path = path.join(process.cwd(), options.outFile);
   const writer = new Writer({ dryRun: options.dryRun });
-  await writer.write(output_path, raw);
+  const wasWritten = await writer.write(output_path, raw);
 
-  if (!options.dryRun) info(`created "${options.outFile}".`);
+  if (!options.dryRun) info(`${wasWritten ? "created" : "unchanged"} "${options.outFile}".`);
 }
 
 /**

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -58,8 +58,8 @@ export default async function writeMarkdown(components: ComponentDocs, options: 
 
   if (write) {
     const outFile = join(process.cwd(), options.outFile);
-    await new Writer({ dryRun: options.dryRun }).write(outFile, rendered);
-    if (!options.dryRun) info(`created "${options.outFile}".`);
+    const wasWritten = await new Writer({ dryRun: options.dryRun }).write(outFile, rendered);
+    if (!options.dryRun) info(`${wasWritten ? "created" : "unchanged"} "${options.outFile}".`);
   }
 
   return rendered;

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -13,8 +13,7 @@ const EMPTY_EVENTS = "Record<string, any>";
 /** Avoids banned `{}` type; use `Record<string, never>` for empty objects. */
 const EMPTY_OBJECT = "Record<string, never>";
 
-const CLAMP_KEY_REGEX = /(-|\s+|:)/;
-const QUOTE_REGEX = /("|')/;
+const IDENTIFIER_REGEX = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 const CUSTOM_EVENT_REGEX = /CustomEvent/;
 const COMPONENT_NAME_REGEX = /^[A-Z]/;
 const NEWLINE_REGEX = /\n/;
@@ -275,12 +274,13 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
     .join("\n\n");
 }
 
-function clampKey(key: string) {
-  if (CLAMP_KEY_REGEX.test(key)) {
-    return QUOTE_REGEX.test(key) ? key : `"${key}"`;
-  }
-
-  return key;
+/**
+ * Formats an object/type member key for emission in generated TypeScript:
+ * unquoted when it's a valid identifier, otherwise a JSON-quoted string
+ * literal (e.g. a Svelte 5 destructured prop `"data-foo"` or `"123abc"`).
+ */
+function formatKey(key: string): string {
+  return IDENTIFIER_REGEX.test(key) ? key : JSON.stringify(key);
 }
 
 function addCommentLine(value: string | boolean | undefined, returnValue?: string) {
@@ -385,7 +385,7 @@ function genPropDef(
 
     return `
       ${wrapCommentInJSDoc(prop_comments)}
-      ${prop.name}${prop.isRequired ? "" : "?"}: ${prop_value};`;
+      ${formatKey(prop.name)}${prop.isRequired ? "" : "?"}: ${prop_value};`;
   });
 
   const extra_initial_props = def.canonicalPropsType
@@ -407,7 +407,7 @@ function genPropDef(
     )
     .map((slot) => {
       const slotName = slot.name;
-      const key = clampKey(slotName);
+      const key = formatKey(slotName);
       const slotComment = formatSlotJsDoc(slot.description, slot.tags, slot.deprecated);
       const description = slotComment ? `${slotComment}\n      ` : "";
       /**
@@ -614,10 +614,10 @@ function genSlotDef(def: Pick<ComponentDocApi, "slots">) {
 
   const slotDefs = def.slots
     .map(({ name, slot_props, ...rest }) => {
-      const key = rest.default || name === null ? "default" : clampKey(name ?? "");
+      const key = rest.default || name === null ? "default" : formatKey(name ?? "");
       const slotDefComment = formatSlotJsDoc(rest.description, rest.tags, rest.deprecated);
       const description = slotDefComment ? `${slotDefComment}\n` : "";
-      return `${description}${clampKey(key)}: ${formatTsProps(slot_props)};`;
+      return `${description}${key}: ${formatTsProps(slot_props)};`;
     })
     .join("\n");
 
@@ -769,7 +769,7 @@ function genEventDef(def: Pick<ComponentDocApi, "events">) {
         description = `${eventComment}\n`;
       }
 
-      return `${description}${clampKey(event.name)}: ${computeEventTypeString(event)};\n`;
+      return `${description}${formatKey(event.name)}: ${computeEventTypeString(event)};\n`;
     })
     .join("");
 
@@ -796,7 +796,7 @@ function genEventCallbackProps(def: Pick<ComponentDocApi, "events">, existingPro
       }
 
       return `
-      ${description}${clampKey(propName)}?: (event: ${computeEventTypeString(event)}) => void;`;
+      ${description}${formatKey(propName)}?: (event: ${computeEventTypeString(event)}) => void;`;
     })
     .filter((entry): entry is string => entry !== undefined);
 }
@@ -839,7 +839,7 @@ function genAccessors(def: Pick<ComponentDocApi, "props">) {
 
       return `
     ${wrapCommentInJSDoc(prop_comments)}
-    ${prop.name}: ${functionType};`;
+    ${formatKey(prop.name)}: ${functionType};`;
     })
     .join("\n");
 }
@@ -879,7 +879,7 @@ function genExportsDef(def: Pick<ComponentDocApi, "props" | "moduleName" | "gene
 function genBindingsUnion(def: Pick<ComponentDocApi, "props">): string {
   const bindableNames = def.props
     .filter((prop) => prop.bindable === true || prop.binding === "writable")
-    .map((prop) => `"${prop.name}"`);
+    .map((prop) => JSON.stringify(prop.name));
 
   return bindableNames.length === 0 ? EMPTY_STR : bindableNames.join(" | ");
 }

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -377,4 +377,87 @@ describe("WriterMarkdown", () => {
     expect(output).toContain("- [Button (legacy) v2](#button-legacy-v2-1)");
     expect(output).toContain("- [Button (legacy) v2](#button-legacy-v2-2)");
   });
+
+  test("prop table keeps reactive props first, constants last, declaration order otherwise", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [
+              {
+                name: "constantOne",
+                kind: "let",
+                constant: true,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "regularOne",
+                kind: "let",
+                constant: false,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "reactiveOne",
+                kind: "let",
+                constant: false,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: true,
+              },
+              {
+                name: "regularTwo",
+                kind: "let",
+                constant: false,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "reactiveTwo",
+                kind: "let",
+                constant: false,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: true,
+              },
+              {
+                name: "constantTwo",
+                kind: "let",
+                constant: true,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    const names = ["reactiveOne", "reactiveTwo", "regularOne", "regularTwo", "constantOne", "constantTwo"];
+    const positions = names.map((name) => output.indexOf(`| ${name} |`));
+    expect(positions.every((position) => position !== -1)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
 });

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -328,4 +328,53 @@ describe("WriterMarkdown", () => {
       "| <s>change</s><br />**Deprecated**: Listen for `input` instead. | dispatched | -- | Fires on change. |",
     );
   });
+
+  test("escapes pipes in prop descriptions so they don't break the table", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [
+              {
+                name: "mode",
+                kind: "let",
+                constant: false,
+                description: 'Use "a | b" syntax.',
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toContain('Use "a &#124; b" syntax.');
+  });
+
+  test("TOC anchors match GitHub's heading slugger, including duplicate suffixes", () => {
+    const document = new WriterMarkdown({});
+    document.tableOfContents();
+    document.append("h2", "Button (legacy) v2");
+    document.append("h2", "Button (legacy) v2");
+    document.append("h2", "Button (legacy) v2");
+
+    const output = document.end();
+    expect(output).toContain("- [Button (legacy) v2](#button-legacy-v2)\n");
+    expect(output).toContain("- [Button (legacy) v2](#button-legacy-v2-1)");
+    expect(output).toContain("- [Button (legacy) v2](#button-legacy-v2-2)");
+  });
 });

--- a/tests/fixtures/runes-non-identifier-prop-names/input.svelte
+++ b/tests/fixtures/runes-non-identifier-prop-names/input.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  let { "data-foo": dataFoo, "123abc": numeric, normal } = $props();
+
+  const dispatch = createEventDispatcher();
+
+  function selectItem() {
+    dispatch("item:select");
+  }
+</script>
+
+<div
+  data-foo={dataFoo}
+  data-numeric={numeric}
+  data-normal={normal}
+>
+  <slot name="icon-left" />
+</div>
+
+<button onclick={selectItem}>select</button>

--- a/tests/fixtures/runes-non-identifier-prop-names/output-class.d.ts
+++ b/tests/fixtures/runes-non-identifier-prop-names/output-class.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type RunesNonIdentifierPropNamesProps = {
+  "data-foo": any;
+
+  "123abc": any;
+
+  normal: any;
+
+  "icon-left"?: (this: void) => void;
+};
+
+export default class RunesNonIdentifierPropNames extends SvelteComponentTyped<
+  RunesNonIdentifierPropNamesProps,
+  { "item:select": CustomEvent<null> },
+  { "icon-left": Record<string, never> }
+> {}

--- a/tests/fixtures/runes-non-identifier-prop-names/output-component.d.ts
+++ b/tests/fixtures/runes-non-identifier-prop-names/output-component.d.ts
@@ -1,0 +1,20 @@
+import type { Component } from "svelte";
+
+export type RunesNonIdentifierPropNamesProps = {
+  "data-foo": any;
+
+  "123abc": any;
+
+  normal: any;
+
+  "icon-left"?: (this: void) => void;
+};
+
+export type RunesNonIdentifierPropNamesExports = Record<string, never>;
+
+declare const RunesNonIdentifierPropNames: Component<
+  RunesNonIdentifierPropNamesProps,
+  RunesNonIdentifierPropNamesExports,
+  ""
+>;
+export default RunesNonIdentifierPropNames;

--- a/tests/fixtures/runes-non-identifier-prop-names/output.json
+++ b/tests/fixtures/runes-non-identifier-prop-names/output.json
@@ -1,0 +1,166 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 22,
+      "column": 0
+    }
+  },
+  "syntaxMode": "runes",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "data-foo",
+      "localName": "dataFoo",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      }
+    },
+    {
+      "name": "123abc",
+      "localName": "numeric",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 29
+        },
+        "end": {
+          "line": 4,
+          "column": 46
+        }
+      }
+    },
+    {
+      "name": "normal",
+      "kind": "let",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 48
+        },
+        "end": {
+          "line": 4,
+          "column": 54
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [
+    {
+      "name": "icon-left",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 2
+        },
+        "end": {
+          "line": 18,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "item:select",
+      "detail": "null",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 4
+        },
+        "end": {
+          "line": 9,
+          "column": 27
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "runes-non-identifier-prop-names/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "data-foo",
+      "message": "Prop \"data-foo\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      }
+    },
+    {
+      "component": "runes-non-identifier-prop-names/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "123abc",
+      "message": "Prop \"123abc\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 29
+        },
+        "end": {
+          "line": 4,
+          "column": 46
+        }
+      }
+    },
+    {
+      "component": "runes-non-identifier-prop-names/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "normal",
+      "message": "Prop \"normal\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 48
+        },
+        "end": {
+          "line": 4,
+          "column": 54
+        }
+      }
+    }
+  ]
+}

--- a/tests/writer-custom-elements.test.ts
+++ b/tests/writer-custom-elements.test.ts
@@ -106,6 +106,21 @@ describe("writeCustomElements", () => {
     }
   });
 
+  test("logs unchanged on a second identical write", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "custom-elements.json"));
+    const components: ComponentDocs = new Map([["Alpha", mockComponentDocApi("Alpha", "Alpha.svelte")]]);
+
+    try {
+      await writeCustomElements(components, { inputDir: "src", outFile });
+      errorSpy.mockClear();
+      await writeCustomElements(components, { inputDir: "src", outFile });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`unchanged "${outFile}".`));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("suppresses the progress line when quiet mode is on", async () => {
     setQuiet(true);
     const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-cem-"));

--- a/tests/writer-json.test.ts
+++ b/tests/writer-json.test.ts
@@ -130,6 +130,21 @@ describe("writeJson", () => {
     }
   });
 
+  test("logs unchanged on a second identical write", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_API.json"));
+    const components = new Map([["Alpha", createComponent("Alpha", "Alpha.svelte")]]);
+
+    try {
+      await writeJson(components, { input: "src", inputDir: "src", outFile });
+      errorSpy.mockClear();
+      await writeJson(components, { input: "src", inputDir: "src", outFile });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`unchanged "${outFile}".`));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("suppresses the progress line when quiet mode is on", async () => {
     setQuiet(true);
     const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-json-"));

--- a/tests/writer-markdown.test.ts
+++ b/tests/writer-markdown.test.ts
@@ -31,6 +31,21 @@ describe("writeMarkdown", () => {
     }
   });
 
+  test("logs unchanged on a second identical write", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-"));
+    const outFile = path.relative(process.cwd(), path.join(tempDir, "COMPONENT_INDEX.md"));
+    const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+    try {
+      await writeMarkdown(components, { outFile });
+      errorSpy.mockClear();
+      await writeMarkdown(components, { outFile });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`unchanged "${outFile}".`));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("suppresses the progress line when quiet mode is on", async () => {
     setQuiet(true);
     const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-"));


### PR DESCRIPTION
Covers a few other spots where generated output could come out invalid
or misleading: unescaped pipes and mismatched TOC anchors in the
Markdown writer, a broken prop sort comparator, and writers that
always logged "created" even when nothing changed on disk.