### PR TITLE
fix(cli): correct exit-code text for --strict and --check

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,19 +573,20 @@ const { diagnostics } = await sveld({
 });
 ```
 
-`diagnostics` is always populated; printing is opt-in via `reportDiagnostics` or `strict` (see [Type inference diagnostics](#type-inference-diagnostics)).
+`diagnostics` is always populated; printing is opt-in via `reportDiagnostics` or `strict` (see [Type inference diagnostics](#type-inference-diagnostics)). `errors` is always populated too: components that failed to parse, whether or not `failFast` is set.
 
-Pass `check: true` (or `check: "<path>"` for a custom snapshot location) to diff against a committed `COMPONENT_API.json`, the same way `--check` does on the CLI. The result lands on `SveldResult.check`; sveld does not print it or touch `process.exitCode` for you, so inspect and act on it yourself:
+Pass `check: true` (or `check: "<path>"` for a custom snapshot location) to diff against a committed `COMPONENT_API.json`, the same way `--check` does on the CLI. The result lands on `SveldResult.check`. `sveld()` never touches `process.exitCode` itself; it returns a suggested `exitCode` (`0`, `3` for a breaking `check` result, or `4` for `strict` diagnostics — the same mapping the CLI uses, `3` winning over `4`) so you can assign it yourself:
 
 ```js
 import { formatCheckReport } from "sveld";
 
-const { check } = await sveld({ json: true, check: true });
+const { check, exitCode } = await sveld({ json: true, check: true });
 
 if (check) {
   console.log(formatCheckReport(check));
-  if (check.bump === "major") process.exitCode = 1;
 }
+
+process.exitCode = exitCode;
 ```
 
 See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check) for how changes are classified.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,6 +104,7 @@ const KNOWN_FLAGS = [
   "resolve-types",
   "check-examples",
   "fail-fast",
+  "dry-run",
   "entry",
   "cache",
   "check",
@@ -127,6 +128,7 @@ const BOOLEAN_FLAGS = new Set([
   "resolve-types",
   "check-examples",
   "fail-fast",
+  "dry-run",
 ]);
 
 /** Value-taking flags that also accept their value as the next argument. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,9 +59,9 @@ Options:
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
   --report-diagnostics  Print unresolved-type diagnostics to stderr
-  --strict              Exit with code 1 when diagnostics exist (implies --report-diagnostics)
+  --strict              Exit with code 4 when diagnostics exist (implies --report-diagnostics)
   --types-format=<format>  ".d.ts" output format: "class" (default) or "component" (Svelte 5 Component<...>)
-  --check[=<path>]      Diff the parsed API against a committed snapshot; exit 1 on a breaking change (default path: COMPONENT_API.json)
+  --check[=<path>]      Diff the parsed API against a committed snapshot; exit 3 on a breaking change (default path: COMPONENT_API.json)
   --format=<text|json>  Output format for the --check report and the diagnostics summary (default: text)
   --help                Print this help message and exit
   --version             Print the installed sveld version and exit

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,6 @@ export type { SveldDiagnostic, SveldDiagnosticKind } from "./diagnostics";
 export type { SvelteEntryPoint } from "./get-svelte-entry";
 export { defineConfig, type SveldConfig, type SveldRuntimeOptions } from "./load-config";
 export { default } from "./plugin";
-export { sveld, type SveldResult } from "./sveld";
+export { type SveldResult, sveld } from "./sveld";
 export { buildComponentApiDocument, type ComponentApiDocument } from "./writer/document-model";
 export { getWriter, listWriters, type OutputWriter, registerWriter } from "./writer/registry";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export {
 export { cli } from "./cli";
 export type { SveldDiagnostic, SveldDiagnosticKind } from "./diagnostics";
 export type { SvelteEntryPoint } from "./get-svelte-entry";
-export { defineConfig, type SveldConfig } from "./load-config";
+export { defineConfig, type SveldConfig, type SveldRuntimeOptions } from "./load-config";
 export { default } from "./plugin";
-export { sveld } from "./sveld";
+export { sveld, type SveldResult } from "./sveld";
 export { buildComponentApiDocument, type ComponentApiDocument } from "./writer/document-model";
 export { getWriter, listWriters, type OutputWriter, registerWriter } from "./writer/registry";

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -12,12 +12,12 @@ import type { PluginSveldOptions } from "./plugin";
 export interface SveldRuntimeOptions extends PluginSveldOptions {
   /** Print unresolved-type diagnostics to stderr. */
   reportDiagnostics?: boolean;
-  /** Exit code 1 when diagnostics exist. Implies `reportDiagnostics`. */
+  /** Exit code 4 when diagnostics exist. Implies `reportDiagnostics`. */
   strict?: boolean;
   /**
    * Diff the parsed component API against a committed snapshot (default:
    * the `json` writer's `outFile`, or `COMPONENT_API.json`) and assign a
-   * semver bump to each change. Exits `1` on a breaking change. Pass a
+   * semver bump to each change. Exits `3` on a breaking change. Pass a
    * string for a custom snapshot path.
    */
   check?: boolean | string;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,12 +3,13 @@
  *
  * Writers are invoked through the writer registry and don't receive runtime
  * options today, so threading a `quiet` param through every writer signature
- * would be a larger refactor than the CLI's `--quiet` flag warrants. A
- * module-level toggle (set once by `cli()`) is the pragmatic shape instead.
+ * would be a larger refactor than the `quiet` option warrants. A
+ * module-level toggle (set once per run by `cli()`, `sveld()`, or the plugin)
+ * is the pragmatic shape instead.
  */
 let quiet = false;
 
-/** Sets the module-level quiet toggle. Called once by `cli()`. */
+/** Sets the module-level quiet toggle. Called once per run by `cli()`, `sveld()`, or the plugin. */
 export function setQuiet(value: boolean): void {
   quiet = value;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -64,18 +64,27 @@ interface HotUpdateContext {
   file: string;
 }
 
+/** Subset of Rollup's plugin context that `generateBundle`/`writeBundle` rely on to fail the build. */
+interface RollupPluginContext {
+  error(message: string): never;
+}
+
 interface SveldPlugin {
   name: string;
   apply?: "build" | "serve";
   enforce?: "pre" | "post";
   buildStart(): void | Promise<void>;
-  generateBundle(): Promise<void>;
-  writeBundle(): Promise<void>;
+  generateBundle(this: RollupPluginContext): Promise<void>;
+  writeBundle(this: RollupPluginContext): Promise<void>;
   /** Vite dev-server HMR hook (serve mode). */
   handleHotUpdate?(ctx: HotUpdateContext): void;
   /** Rollup/Vite watch hook (build `--watch`). */
   watchChange?(id: string): void;
 }
+
+/** Message emitted (via `this.error`) when the entry point cannot be resolved. Matches `sveld()`'s thrown message. */
+const UNRESOLVED_ENTRY_MESSAGE =
+  'sveld: could not resolve a Svelte entry point. Set package.json#svelte, or pass the "entry" option.';
 
 /** Debounce window (ms) for coalescing rapid file changes into one regeneration. */
 const WATCH_DEBOUNCE_MS = 50;
@@ -128,18 +137,20 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
     async generateBundle() {
       // In watch mode the initial build happens in `buildStart`.
       if (watch) return;
-      if (input != null) {
-        result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
+      if (input == null) {
+        this.error(UNRESOLVED_ENTRY_MESSAGE);
       }
+      result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
     },
     async writeBundle() {
       if (watch) return;
-      if (input != null) {
-        await writeOutput(result, opts || {}, input);
-        // Persists any generated `.d.ts` text writeOutput just cached, on top
-        // of the parse-only save generateBundle() already did.
-        result.cache?.save();
+      if (input == null) {
+        this.error(UNRESOLVED_ENTRY_MESSAGE);
       }
+      await writeOutput(result, opts || {}, input);
+      // Persists any generated `.d.ts` text writeOutput just cached, on top
+      // of the parse-only save generateBundle() already did.
+      result.cache?.save();
     },
     handleHotUpdate(ctx) {
       scheduleUpdate(ctx.file);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   toGenerateBundleOptions,
 } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
+import { setQuiet } from "./logger";
 import { SVELTE_EXT_REGEX } from "./path";
 import { createSveldBundle, type SveldBundle } from "./watch";
 // Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements" writers.
@@ -27,6 +28,8 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
    */
   entry?: string;
   glob?: boolean;
+  /** Suppress writer progress logs (`created "..."` / `unchanged "..."`). */
+  quiet?: boolean;
   /** Record consts, functions, and types from the entry barrel. Off by default. */
   documentExports?: boolean;
   types?: boolean;
@@ -125,6 +128,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
     apply: watch ? undefined : "build",
     enforce: "post",
     async buildStart() {
+      setQuiet(opts?.quiet === true);
       input = getSvelteEntry(opts?.entry);
       if (watch && input != null) {
         // Produce the initial output and prime the incremental bundle. This

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,3 +1,4 @@
+import type { ComponentParseError } from "./bundle";
 import { type CheckResult, resolveCheckSnapshotFile, runCheck } from "./check";
 import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
@@ -9,11 +10,21 @@ type SveldOptions = SveldRuntimeOptions;
 /**
  * Result of a programmatic `sveld` run.
  */
-interface SveldResult {
+export interface SveldResult {
   /** Diagnostics from this run. */
   diagnostics: SveldDiagnostic[];
   /** Populated when `check` is enabled: the API diff against the committed snapshot. */
   check?: CheckResult;
+  /** Parse errors for components that failed to parse (empty unless `failFast` is disabled and a component errors). */
+  errors: ComponentParseError[];
+  /**
+   * Suggested process exit code for this run, using the same mapping as the
+   * CLI (a breaking `check` result wins over `strict` diagnostics): `0` on
+   * success, `3` on a breaking API change, `4` when `strict` diagnostics
+   * exist. `sveld()` never mutates `process.exitCode` itself; assign this
+   * value yourself if you want the process to exit non-zero.
+   */
+  exitCode: 0 | 3 | 4;
 }
 
 /**
@@ -66,9 +77,14 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
     console.error(formatDiagnosticsSummary(diagnostics));
   }
 
-  if (merged.strict && diagnostics.length > 0) {
-    process.exitCode = 1;
+  // Lowest applicable code wins (3 beats 4), matching the CLI's exit-code contract.
+  let exitCode: 0 | 3 | 4 = 0;
+
+  if (checkResult?.bump === "major") {
+    exitCode = 3;
+  } else if (merged.strict && diagnostics.length > 0) {
+    exitCode = 4;
   }
 
-  return { diagnostics, check: checkResult };
+  return { diagnostics, check: checkResult, errors: result.errors, exitCode };
 }

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -3,6 +3,7 @@ import { type CheckResult, resolveCheckSnapshotFile, runCheck } from "./check";
 import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
+import { setQuiet } from "./logger";
 import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
 type SveldOptions = SveldRuntimeOptions;
@@ -55,6 +56,7 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
     );
   }
   const merged = mergeConfig<SveldRuntimeOptions>(fileConfig, runtimeOpts, { entry: input });
+  setQuiet(merged.quiet === true);
   const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));
 
   // Read the committed snapshot before `writeOutput` can overwrite it.

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -164,6 +164,10 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--xyz123garbage"])).toEqual({ kind: "unknown", arg: "--xyz123garbage" });
   });
 
+  test("--dryrun suggests --dry-run", () => {
+    expect(parseCliOptions(["--dryrun"])).toEqual({ kind: "unknown", arg: "--dryrun", suggestion: "dry-run" });
+  });
+
   test("a positional argument surfaces as an unknown result", () => {
     expect(parseCliOptions(["foo"])).toEqual({ kind: "unknown", arg: "foo" });
   });
@@ -172,6 +176,14 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--json", "true"])).toEqual({
       kind: "unknown",
       arg: "true",
+      positionalHint: true,
+    });
+  });
+
+  test("a positional argument after --dry-run hints at the space-separated form", () => {
+    expect(parseCliOptions(["--dry-run", "foo"])).toEqual({
+      kind: "unknown",
+      arg: "foo",
       positionalHint: true,
     });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1155,3 +1155,30 @@ describe("cli() exit codes", () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("5.9.0"));
   });
 });
+
+describe("cli() --help", () => {
+  let previousArgv: string[];
+  let logSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    previousArgv = process.argv;
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = previousArgv;
+    jest.restoreAllMocks();
+  });
+
+  test("documents the real exit codes for --strict and --check, not the stale code 1", async () => {
+    process.argv = ["bun", "cli.js", "--help"];
+
+    await cli(process);
+
+    const help = logSpy.mock.calls.map((call: unknown[]) => call[0]).join("\n");
+    expect(help).toContain("Exit with code 4");
+    expect(help).toContain("exit 3 on a breaking change");
+    expect(help).not.toContain("Exit with code 1 when diagnostics exist");
+    expect(help).not.toContain("exit 1 on a breaking change");
+  });
+});

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -271,11 +271,13 @@ describe("sveld() strict mode", () => {
     expect(summaryCalls(errorSpy).length).toBeGreaterThan(0);
   });
 
-  test("strict: true sets a non-zero exit code when diagnostics exist", async () => {
-    const { diagnostics } = await sveld({ entry: relativeDir, glob: true, types: false, strict: true });
+  test("strict: true returns exitCode 4 without touching process.exitCode", async () => {
+    const exitCodeBefore = process.exitCode;
+    const { diagnostics, exitCode } = await sveld({ entry: relativeDir, glob: true, types: false, strict: true });
 
     expect(diagnostics.length).toBeGreaterThan(0);
-    expect(process.exitCode).toBe(1);
+    expect(exitCode).toBe(4);
+    expect(process.exitCode).toBe(exitCodeBefore);
     expect(summaryCalls(errorSpy).length).toBeGreaterThan(0);
   });
 });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -53,6 +53,38 @@ describe("pluginSveld", () => {
     expect(fs.existsSync).toHaveBeenCalledWith(`${mockCwd}/src/Override.svelte`);
     expect(fs.readFileSync).not.toHaveBeenCalled();
   });
+
+  test("generateBundle hook calls this.error when the entry cannot be resolved", async () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+
+    const plugin = pluginSveld();
+    await plugin.buildStart?.call({});
+
+    const errorSpy = jest.fn((message: string) => {
+      throw new Error(message);
+    });
+
+    await expect(plugin.generateBundle.call({ error: errorSpy })).rejects.toThrow(
+      "sveld: could not resolve a Svelte entry point",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("sveld: could not resolve a Svelte entry point"));
+  });
+
+  test("writeBundle hook calls this.error when the entry cannot be resolved", async () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+
+    const plugin = pluginSveld();
+    await plugin.buildStart?.call({});
+
+    const errorSpy = jest.fn((message: string) => {
+      throw new Error(message);
+    });
+
+    await expect(plugin.writeBundle.call({ error: errorSpy })).rejects.toThrow(
+      "sveld: could not resolve a Svelte entry point",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("sveld: could not resolve a Svelte entry point"));
+  });
 });
 
 describe("generateBundle", () => {

--- a/tests/sveld.test.ts
+++ b/tests/sveld.test.ts
@@ -87,3 +87,87 @@ describe("sveld() check", () => {
     expect(result.check).toBeUndefined();
   });
 });
+
+describe("sveld() exitCode and errors", () => {
+  let absoluteDir: string;
+  let relativeDir: string;
+  let entry: string;
+  let previousExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    absoluteDir = mkdtempSync(join(process.cwd(), "sveld-exitcode-"));
+    relativeDir = basename(absoluteDir);
+    entry = join(relativeDir, "index.js");
+    previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+    rmSync(absoluteDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test("never mutates process.exitCode, even with strict diagnostics", async () => {
+    writeFileSync(
+      join(absoluteDir, "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(absoluteDir, "index.js"), 'export { default as Phantom } from "./Phantom.svelte";\n');
+
+    const result = await sveld({ entry, types: false, strict: true });
+
+    expect(process.exitCode).toBe(0);
+    expect(result.exitCode).toBe(4);
+  });
+
+  test("result.exitCode is 3 when --check finds a breaking change", async () => {
+    writeFileSync(join(absoluteDir, "Button.svelte"), "<script></script>\n<button>Click</button>\n");
+    writeFileSync(join(absoluteDir, "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    const snapshotFile = join(relativeDir, "COMPONENT_API.json");
+    const snapshot = buildComponentApiDocument(
+      new Map([["Button", mockComponentDocApi("Button", "Button.svelte", { props: [] })]]),
+    );
+    writeFileSync(join(absoluteDir, "COMPONENT_API.json"), JSON.stringify(snapshot));
+    writeFileSync(
+      join(absoluteDir, "Button.svelte"),
+      "<script>\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+
+    const result = await sveld({ entry, types: false, check: snapshotFile });
+
+    expect(result.exitCode).toBe(3);
+  });
+
+  test("result.exitCode is 3 (not 4) when a breaking check and strict diagnostics both apply", async () => {
+    writeFileSync(
+      join(absoluteDir, "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(absoluteDir, "index.js"), 'export { default as Phantom } from "./Phantom.svelte";\n');
+    const snapshotFile = join(relativeDir, "COMPONENT_API.json");
+    const snapshot = buildComponentApiDocument(
+      new Map([["Phantom", mockComponentDocApi("Phantom", "Phantom.svelte", { props: [] })]]),
+    );
+    writeFileSync(join(absoluteDir, "COMPONENT_API.json"), JSON.stringify(snapshot));
+
+    const result = await sveld({ entry, types: false, check: snapshotFile, strict: true });
+
+    expect(result.check?.bump).toBe("major");
+    expect(result.exitCode).toBe(3);
+  });
+
+  test("result.errors is populated for a component that fails to parse", async () => {
+    writeFileSync(
+      join(absoluteDir, "Broken.svelte"),
+      "<script>\n  export let label = ;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(absoluteDir, "index.js"), 'export { default as Broken } from "./Broken.svelte";\n');
+
+    const result = await sveld({ entry, types: false });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(expect.objectContaining({ filePath: expect.stringContaining("Broken.svelte") }));
+  });
+});


### PR DESCRIPTION
Also makes sveld() return exitCode/errors instead of touching
process.exitCode, fails the Vite/Rollup build when the entry can't
be resolved, wires quiet through sveld() and the plugin, and
registers --dry-run in the CLI's flag tables so typos get a
suggestion.