### PR TITLE
fix(fuzz): exit non-zero on findings and upload repros

### DIFF
--- a/.github/workflows/svelte-canary.yml
+++ b/.github/workflows/svelte-canary.yml
@@ -43,7 +43,15 @@ jobs:
         run: bun run test
 
       - name: Differential fuzz
-        run: bun run fuzz --iterations 300
+        run: bun run fuzz --iterations 300 --findings-dir fuzz-findings
+
+      - name: Upload fuzz findings
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-findings
+          path: fuzz-findings
+          if-no-files-found: ignore
 
       - name: Open or update issue on failure
         if: failure()

--- a/scripts/fuzz-parser.ts
+++ b/scripts/fuzz-parser.ts
@@ -18,13 +18,16 @@
  *   bun run fuzz
  *   bun run fuzz --iterations 500
  *   bun run fuzz --seed 12345
+ *   bun run fuzz --findings-dir /path/to/dir
+ *
+ * Exits non-zero when any finding is produced.
  */
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Glob } from "bun";
 
 const FIXTURES_DIR = path.join(import.meta.dir, "..", "tests", "fixtures");
-const FINDINGS_DIR = path.join(import.meta.dir, "..", ".context", "fuzz-findings");
+const DEFAULT_FINDINGS_DIR = path.join(import.meta.dir, "..", ".context", "fuzz-findings");
 const TRIAL_SCRIPT = path.join(import.meta.dir, "fuzz-trial.ts");
 const DEFAULT_ITERATIONS = 150;
 const SLOW_MS = 1000;
@@ -35,13 +38,15 @@ const MINIMIZE_TEST_CAP = 60;
 interface FuzzArgs {
   iterations: number;
   seed: number;
+  findingsDir: string;
 }
 
 function parseArgs(argv: string[]): FuzzArgs {
-  const args: FuzzArgs = { iterations: DEFAULT_ITERATIONS, seed: Date.now() };
+  const args: FuzzArgs = { iterations: DEFAULT_ITERATIONS, seed: Date.now(), findingsDir: DEFAULT_FINDINGS_DIR };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--iterations") args.iterations = Number(argv[++i]);
     else if (argv[i] === "--seed") args.seed = Number(argv[++i]);
+    else if (argv[i] === "--findings-dir") args.findingsDir = path.resolve(argv[++i]);
   }
   return args;
 }
@@ -468,7 +473,8 @@ async function main() {
   );
 
   if (findings.size > 0) {
-    mkdirSync(FINDINGS_DIR, { recursive: true });
+    mkdirSync(args.findingsDir, { recursive: true });
+    const findingPaths: string[] = [];
     for (const finding of findings.values()) {
       // biome-ignore lint/performance/noAwaitInLoops: sequential so minimizing doesn't multiply load
       const minimized = await minimizeFinding(finding);
@@ -476,13 +482,20 @@ async function main() {
         .replace(/[^a-zA-Z0-9]+/g, "-")
         .toLowerCase()
         .slice(0, 60);
-      const filePath = path.join(FINDINGS_DIR, `${slug}.svelte`);
+      const filePath = path.join(args.findingsDir, `${slug}.svelte`);
       writeFileSync(filePath, minimized);
+      findingPaths.push(filePath);
       console.log(`\n=== finding: ${finding.signature} ===`);
       console.log(`mutation: ${finding.tag}`);
       console.log(`message: ${finding.result.error?.message}`);
       console.log(`minimized source written to: ${path.relative(process.cwd(), filePath)}`);
     }
+
+    console.log(`\n${findings.size} finding(s):`);
+    for (const filePath of findingPaths) {
+      console.log(`  ${path.relative(process.cwd(), filePath)}`);
+    }
+    process.exitCode = 1;
   }
 }
 

--- a/scripts/fuzz-trial.ts
+++ b/scripts/fuzz-trial.ts
@@ -21,6 +21,11 @@ async function readStdin(): Promise<string> {
 
 const source = await readStdin();
 
+/** Test-only escape hatch so a smoke test can force a finding without a real crash. */
+if (process.env.SVELD_FUZZ_FORCE_CRASH === "1") {
+  process.exit(1);
+}
+
 let svelteAccepts = true;
 try {
   svelteParse(source, { modern: true });

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { version as sveldVersion } from "../package.json";
 import type { ParsedComponent, ParsedComponentTypeScriptMetadata } from "./ComponentParser";
@@ -147,7 +147,13 @@ export class ParseCache {
     entry.generatedText = { format, text };
   }
 
-  /** Persists this run's cache entries back to disk. */
+  /**
+   * Persists this run's cache entries back to disk. Writes to a pid-suffixed
+   * temp file and renames it over the target so concurrent sveld processes
+   * sharing a cache dir can't interleave writes into a truncated file; a
+   * failed rename (e.g. read-only cache dir) falls back to a direct write so
+   * generation never fails just because the cache couldn't be saved.
+   */
   save(): void {
     mkdirSync(dirname(this.cacheFilePath), { recursive: true });
     const file: ParseCacheFile = {
@@ -155,6 +161,17 @@ export class ParseCache {
       toolchainVersion: currentToolchainVersion(),
       entries: Object.fromEntries(this.next),
     };
-    writeFileSync(this.cacheFilePath, JSON.stringify(file));
+    const contents = JSON.stringify(file);
+    const tmpPath = `${this.cacheFilePath}.${process.pid}.tmp`;
+    try {
+      writeFileSync(tmpPath, contents);
+      renameSync(tmpPath, this.cacheFilePath);
+    } catch {
+      try {
+        writeFileSync(this.cacheFilePath, contents);
+      } catch {
+        // Cache dir is unwritable (e.g. read-only): skip persisting rather than fail generation.
+      }
+    }
   }
 }

--- a/tests/fuzz-parser.test.ts
+++ b/tests/fuzz-parser.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * `SVELD_FUZZ_FORCE_CRASH` makes `fuzz-trial.ts` exit non-zero unconditionally
+ * (see scripts/fuzz-trial.ts), so this doesn't depend on any real parser bug
+ * to exercise `fuzz-parser.ts`'s findings-to-exit-code path. A fixed `--seed`
+ * keeps which mutation lands deterministic.
+ */
+test("exits non-zero and writes a finding when a trial reports a finding", async () => {
+  const findingsDir = mkdtempSync(join(tmpdir(), "sveld-fuzz-smoke-"));
+
+  try {
+    const proc = Bun.spawn({
+      cmd: ["bun", "scripts/fuzz-parser.ts", "--iterations", "5", "--seed", "1", "--findings-dir", findingsDir],
+      cwd: join(import.meta.dir, ".."),
+      env: { ...process.env, SVELD_FUZZ_FORCE_CRASH: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await proc.exited;
+
+    expect(exitCode).not.toBe(0);
+    expect(readdirSync(findingsDir).length).toBeGreaterThan(0);
+  } finally {
+    rmSync(findingsDir, { recursive: true, force: true });
+  }
+}, 10_000);

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
@@ -247,5 +247,41 @@ describe("cache default", () => {
     await generateBundle(dir, true, { cache: false });
 
     expect(existsSync(join(dir, DEFAULT_CACHE_FILE))).toBe(false);
+  });
+});
+
+describe("ParseCache.save() atomicity", () => {
+  let dir: string;
+  let cacheFile: string;
+  let parseSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sveld-parse-cache-atomic-"));
+    cacheFile = join(dir, ".cache", "parse-cache.json");
+    writeFileSync(join(dir, "Standalone.svelte"), STANDALONE);
+    parseSpy = jest.spyOn(ComponentParser.prototype, "parseSvelteComponent");
+  });
+
+  afterEach(() => {
+    parseSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("leaves no .tmp file behind and the cache loads on the next run", async () => {
+    await generateBundle(dir, true, { cache: cacheFile });
+
+    const entries = readdirSync(join(dir, ".cache"));
+    expect(entries.some((entry) => entry.endsWith(".tmp"))).toBe(false);
+
+    parseSpy.mockClear();
+    await generateBundle(dir, true, { cache: cacheFile });
+
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  test("a rename failure (target occupied by a directory) falls back without failing generation", async () => {
+    mkdirSync(cacheFile, { recursive: true });
+
+    await expect(generateBundle(dir, true, { cache: cacheFile })).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
Covers two independent gaps found in a repo audit: the canary's fuzz
step could find real parser bugs and still report green with nothing
to show for it, and the parse cache could get corrupted by two
concurrent sveld processes writing to it at once.