### PR TITLE
fix(alias): try every mapping and prefer the longest prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ Pass `--stdout` alongside exactly one of `--json`, `--markdown`, or `--custom-el
 
 Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld --version` to print the installed version.
 
+Pass `--glob` with a directory as `--entry` (no barrel file) to document every `.svelte` file under it directly, with no re-export needed: each component's sanitized filename becomes its module name in JSON, Markdown, and the generated `index.d.ts`, in addition to the per-component `.d.ts` every `--glob` run already produces. This is the same set `mergeGlobbedComponents` discovers when `--glob` is combined with a file entry; a directory entry just has no barrel to layer it onto.
+
 ### Exit codes
 
 | Code | Meaning |

--- a/README.md
+++ b/README.md
@@ -3417,6 +3417,8 @@ When only `@param` tags are present without `@returns`, the return type defaults
 
 **Output differs in CI.** Commit `COMPONENT_API.json` and run [`--check`](#ci-api-drift-checks---check) in CI so API drift fails the build instead of silently diverging.
 
+**A path alias (`$lib`, `@components`, ...) isn't picked up.** sveld only reads aliases from `compilerOptions.paths` in the nearest `tsconfig.json` or `jsconfig.json`, found by walking up from the file doing the importing. Vite/SvelteKit alias config (`vite.config.*`, `svelte.config.*`) is not read directly — add the same aliases to `paths` so both tools agree. When a pattern has more than one mapping (`"$lib/*": ["./src/lib/*", "./lib/*"]`), sveld tries them in order and uses the first one that exists on disk, falling back to the first mapping if none do; among multiple matching patterns, the one with the longest non-wildcard prefix wins, regardless of declaration order (matching `tsc`).
+
 ## Contributing
 
 See [contributing guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ Run `npx sveld --help` for the full flag list with descriptions, or `npx sveld -
 | Code | Meaning |
 |------|---------|
 | `0` | Success |
-| `1` | Usage or configuration error (unknown flag, bad flag value, unresolvable entry) |
+| `1` | Usage or configuration error (unknown flag, bad flag value, unresolvable entry, unresolved re-export or path alias) |
 | `2` | Generation failure (a component failed to parse under `--fail-fast`, or an unrecoverable pipeline error) |
 | `3` | Breaking API change detected by `--check` |
 | `4` | Diagnostics present under `--strict` |
@@ -3416,6 +3416,8 @@ When only `@param` tags are present without `@returns`, the return type defaults
 **Generated types don't appear for consumers.** Check that the `types` folder is listed in `exports` and `files` in `package.json`. See [Publishing to NPM](#publishing-to-npm).
 
 **Output differs in CI.** Commit `COMPONENT_API.json` and run [`--check`](#ci-api-drift-checks---check) in CI so API drift fails the build instead of silently diverging.
+
+**`sveld: cannot resolve "..." from ...`.** An `export *` or a named re-export points at a module or path alias that doesn't resolve to a file on disk. Fix the specifier, or check the tsconfig/jsconfig `paths` entry it's supposed to match. This exits `1`; see [Exit codes](#exit-codes).
 
 **A path alias (`$lib`, `@components`, ...) isn't picked up.** sveld only reads aliases from `compilerOptions.paths` in the nearest `tsconfig.json` or `jsconfig.json`, found by walking up from the file doing the importing. Vite/SvelteKit alias config (`vite.config.*`, `svelte.config.*`) is not read directly — add the same aliases to `paths` so both tools agree. When a pattern has more than one mapping (`"$lib/*": ["./src/lib/*", "./lib/*"]`), sveld tries them in order and uses the first one that exists on disk, falling back to the first mapping if none do; among multiple matching patterns, the one with the longest non-wildcard prefix wins, regardless of declaration order (matching `tsc`).
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -374,6 +374,17 @@ export function collectComponents(input: string, glob: boolean, documentExports 
   if (glob) {
     const state = createGlobMergeState(allComponentEntries, resolveComponentFilePath);
     mergeGlobbedComponents(rootDir, exports, allComponentEntries, resolveComponentFilePath, state);
+
+    // A directory entry has no barrel to parse exports from (`exports` is
+    // still `{}` at this point), so without this every globbed component
+    // would be missing from JSON/Markdown output and the generated index
+    // `.d.ts`, even though a per-component `.d.ts` is still produced for
+    // each of them via `allComponentEntries`.
+    if (!isFile) {
+      exports = Object.fromEntries(
+        allComponentEntries.map(([moduleName, entry]) => [moduleName, { ...entry, default: true }]),
+      );
+    }
   }
 
   return { exports, allComponentEntries, rootDir, resolveComponentFilePath };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config
 import { setQuiet } from "./logger";
 import { normalizeSeparators } from "./path";
 import { generateBundle, toGenerateBundleOptions, writeOutput, writeStdout } from "./plugin";
+import { UnresolvedModuleError } from "./resolve-alias";
 
 /** Relative fallback entry used only when entry resolution otherwise fails. */
 const FALLBACK_ENTRY = "src/index.js";
@@ -452,6 +453,11 @@ export async function cli(process: NodeJS.Process) {
       if (!options.dryRun) result.cache?.save();
     }
   } catch (error) {
+    if (error instanceof UnresolvedModuleError) {
+      console.error(`sveld: ${error.message}`);
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
+      return;
+    }
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = EXIT_CODES.GENERATION_FAILURE;
     return;

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -1,10 +1,10 @@
-import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { type Node, parse } from "acorn";
 import { asRelativeSourcePath, type RelativeSourcePath } from "./brands";
 import { resolveModuleFile } from "./parse-entry-exports";
 import { normalizeSeparators, SVELTE_EXT_REGEX } from "./path";
-import { resolvePathAlias, resolvePathAliasAbsolute } from "./resolve-alias";
+import { resolveAliasLookup, resolvePathAlias, UnresolvedModuleError } from "./resolve-alias";
 
 interface NodeImportDeclaration extends Node {
   type: "ImportDeclaration";
@@ -80,7 +80,7 @@ function resolveBarrelExports(
 
   resolving.add(targetFile);
   try {
-    return { dir, exports: parseExports(readFileSync(targetFile, "utf-8"), dir, resolving) };
+    return { dir, exports: parseExports(readFileSync(targetFile, "utf-8"), dir, resolving, targetFile) };
   } catch {
     return { dir, exports: {} };
   } finally {
@@ -105,8 +105,11 @@ function resolveBarrelExports(
  * @param resolving - Absolute paths currently being resolved on this call
  *   stack, used to break `export *` cycles between files that re-export
  *   each other. Callers should not pass this; it is threaded internally.
+ * @param fromFile - The file currently being parsed, used only to name the
+ *   source of an unresolved specifier in a thrown {@link UnresolvedModuleError}.
+ *   Callers should not pass this; it is threaded internally.
  */
-export function parseExports(source: string, dir: string, resolving: Set<string> = new Set()) {
+export function parseExports(source: string, dir: string, resolving: Set<string> = new Set(), fromFile: string = dir) {
   let ast = astCache.get(source);
 
   if (!ast) {
@@ -128,29 +131,28 @@ export function parseExports(source: string, dir: string, resolving: Set<string>
     } else if (node.type === "ExportAllDeclaration") {
       if (!node.source) continue;
 
-      const resolvedSource = resolvePathAliasAbsolute(node.source.value, dir);
-      let file_path = resolve(dir, resolvedSource);
+      const specifier = node.source.value;
+      const file_path = resolveModuleFile(specifier, dir);
 
-      if (!lstatSync(file_path).isFile()) {
-        const files = readdirSync(file_path);
-
-        for (const file of files)
-          if (file.includes("index")) {
-            file_path = join(file_path, file);
-            break;
-          }
+      if (!file_path) {
+        const lookup = resolveAliasLookup(specifier, dir);
+        throw new UnresolvedModuleError(
+          specifier,
+          fromFile,
+          lookup.unresolved ? lookup.searched : "no matching file or index found",
+        );
       }
 
       if (resolving.has(file_path)) continue;
       resolving.add(file_path);
 
       const export_file = readFileSync(file_path, "utf-8");
-      const exports = parseExports(export_file, dirname(file_path), resolving);
+      const exports = parseExports(export_file, dirname(file_path), resolving, file_path);
 
       resolving.delete(file_path);
 
       for (const [key, value] of Object.entries(exports)) {
-        const source = asRelativeSourcePath(normalizeSeparators(`./${join(node.source.value, value.source)}`));
+        const source = asRelativeSourcePath(normalizeSeparators(`./${join(specifier, value.source)}`));
         exports_by_identifier[key] = {
           ...value,
           source,
@@ -158,7 +160,16 @@ export function parseExports(source: string, dir: string, resolving: Set<string>
       }
     } else if (node.type === "ExportNamedDeclaration") {
       const sourceValue = node.source?.value;
-      const isBarrelChain = sourceValue !== undefined && !SVELTE_EXT_REGEX.test(sourceValue);
+      const isSvelteSource = sourceValue !== undefined && SVELTE_EXT_REGEX.test(sourceValue);
+
+      if (isSvelteSource) {
+        const lookup = resolveAliasLookup(sourceValue, dir);
+        if (lookup.unresolved) {
+          throw new UnresolvedModuleError(sourceValue, fromFile, lookup.searched);
+        }
+      }
+
+      const isBarrelChain = sourceValue !== undefined && !isSvelteSource;
       const chain = isBarrelChain ? resolveBarrelExports(sourceValue, dir, resolving) : undefined;
 
       if (chain === null) {

--- a/src/resolve-alias.ts
+++ b/src/resolve-alias.ts
@@ -173,9 +173,7 @@ export function resolveAliasLookup(importPath: string, fromDir: string): AliasLo
   const configDir = dirname(configPath);
   const resolvedBaseUrl = resolve(configDir, baseUrl);
 
-  const patterns = Object.entries(paths).sort(
-    ([a], [b]) => patternPrefixLength(b) - patternPrefixLength(a),
-  );
+  const patterns = Object.entries(paths).sort(([a], [b]) => patternPrefixLength(b) - patternPrefixLength(a));
 
   for (const [pattern, mappings] of patterns) {
     const match = importPath.match(getPatternRegex(pattern));

--- a/src/resolve-alias.ts
+++ b/src/resolve-alias.ts
@@ -11,6 +11,39 @@ const pathPatternRegexCache = new Map<string, RegExp>();
 const COMMENT_PATTERN = /\/\*[\s\S]*?\*\/|\/\/.*/g;
 const REGEX_SPECIAL_CHARS = /[.+?^${}()|[\]\\]/g;
 
+/** Extensions probed when checking whether an alias mapping candidate exists on disk. */
+const ALIAS_CANDIDATE_EXTENSIONS = [".svelte", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".d.ts"];
+
+/**
+ * Thrown when a module specifier (an `export *`/named re-export source, or a
+ * path alias) cannot be resolved to a file on disk.
+ */
+export class UnresolvedModuleError extends Error {
+  readonly specifier: string;
+  readonly fromFile: string;
+  readonly searched: string;
+
+  constructor(specifier: string, fromFile: string, searched: string) {
+    super(`cannot resolve "${specifier}" from ${fromFile || "."} (${searched})`);
+    this.name = "UnresolvedModuleError";
+    this.specifier = specifier;
+    this.fromFile = fromFile;
+    this.searched = searched;
+  }
+}
+
+/** True when `fullPath` (or `fullPath` plus a common module extension) exists on disk. */
+function pathAliasTargetExists(fullPath: string): boolean {
+  if (existsSync(fullPath)) return true;
+  return ALIAS_CANDIDATE_EXTENSIONS.some((ext) => existsSync(fullPath + ext));
+}
+
+/** Length of the literal (non-wildcard) prefix of a tsconfig `paths` pattern, for longest-prefix ordering. */
+function patternPrefixLength(pattern: string): number {
+  const wildcardIndex = pattern.indexOf("*");
+  return wildcardIndex === -1 ? pattern.length : wildcardIndex;
+}
+
 /** Clears cached tsconfig/jsconfig reads (tests and hot reload). */
 export function clearConfigCache() {
   configCache.clear();
@@ -89,6 +122,85 @@ function parseConfig(configPath: string): TSConfig | null {
   }
 }
 
+/** Result of looking up a specifier against tsconfig/jsconfig `paths`. */
+export interface AliasLookup {
+  /** Absolute path when resolved via an alias mapping; `importPath` unchanged otherwise. */
+  resolved: string;
+  /** True when `importPath` is a non-relative specifier that no `paths` entry matched. */
+  unresolved: boolean;
+  /** Human-readable description of what was searched, for error messages. */
+  searched: string;
+}
+
+function getPatternRegex(pattern: string): RegExp {
+  let regex = pathPatternRegexCache.get(pattern);
+  if (!regex) {
+    const escapedPattern = pattern
+      .split("*")
+      .map((part) => part.replace(REGEX_SPECIAL_CHARS, "\\$&"))
+      .join("(.*)");
+
+    regex = new RegExp(`^${escapedPattern}$`);
+    pathPatternRegexCache.set(pattern, regex);
+  }
+  return regex;
+}
+
+/**
+ * Resolve a tsconfig/jsconfig path alias, reporting whether resolution failed.
+ *
+ * Patterns are tried longest non-wildcard-prefix first (mirroring `tsc`), not
+ * JSON key order. Within a matched pattern, every mapping is tried in order
+ * and the first one that exists on disk wins; if none exist, the first
+ * mapping is returned as a best-effort guess.
+ */
+export function resolveAliasLookup(importPath: string, fromDir: string): AliasLookup {
+  if (importPath.startsWith(".") || importPath.startsWith("/")) {
+    return { resolved: importPath, unresolved: false, searched: "" };
+  }
+
+  const configPath = findConfig(fromDir);
+  if (!configPath) {
+    return { resolved: importPath, unresolved: true, searched: "no tsconfig/jsconfig paths found" };
+  }
+
+  const config = parseConfig(configPath);
+  if (!config?.compilerOptions?.paths) {
+    return { resolved: importPath, unresolved: true, searched: "no tsconfig/jsconfig paths found" };
+  }
+
+  const { baseUrl = ".", paths } = config.compilerOptions;
+  const configDir = dirname(configPath);
+  const resolvedBaseUrl = resolve(configDir, baseUrl);
+
+  const patterns = Object.entries(paths).sort(
+    ([a], [b]) => patternPrefixLength(b) - patternPrefixLength(a),
+  );
+
+  for (const [pattern, mappings] of patterns) {
+    const match = importPath.match(getPatternRegex(pattern));
+    if (!match) continue;
+
+    let firstCandidate: string | undefined;
+    for (const mapping of mappings) {
+      let resolvedPath = mapping;
+      for (let i = 1; i < match.length; i++) {
+        resolvedPath = resolvedPath.replace("*", match[i]);
+      }
+
+      const fullPath = resolve(resolvedBaseUrl, resolvedPath);
+      if (firstCandidate === undefined) firstCandidate = fullPath;
+      if (pathAliasTargetExists(fullPath)) {
+        return { resolved: fullPath, unresolved: false, searched: configPath };
+      }
+    }
+
+    return { resolved: firstCandidate ?? importPath, unresolved: false, searched: configPath };
+  }
+
+  return { resolved: importPath, unresolved: true, searched: `tsconfig paths (${configPath})` };
+}
+
 /**
  * Resolve a tsconfig/jsconfig path alias to an absolute filesystem path.
  *
@@ -103,54 +215,7 @@ function parseConfig(configPath: string): TSConfig | null {
  * ```
  */
 export function resolvePathAliasAbsolute(importPath: string, fromDir: string): string {
-  if (importPath.startsWith(".") || importPath.startsWith("/")) {
-    return importPath;
-  }
-
-  const configPath = findConfig(fromDir);
-  if (!configPath) {
-    return importPath;
-  }
-
-  const config = parseConfig(configPath);
-  if (!config?.compilerOptions?.paths) {
-    return importPath;
-  }
-
-  const { baseUrl = ".", paths } = config.compilerOptions;
-  const configDir = dirname(configPath);
-  const resolvedBaseUrl = resolve(configDir, baseUrl);
-
-  for (const [pattern, mappings] of Object.entries(paths)) {
-    let regex = pathPatternRegexCache.get(pattern);
-    if (!regex) {
-      const escapedPattern = pattern
-        .split("*")
-        .map((part) => part.replace(REGEX_SPECIAL_CHARS, "\\$&"))
-        .join("(.*)");
-
-      regex = new RegExp(`^${escapedPattern}$`);
-      pathPatternRegexCache.set(pattern, regex);
-    }
-
-    const match = importPath.match(regex);
-
-    if (match) {
-      const mapping = mappings[0];
-      if (!mapping) continue;
-
-      let resolvedPath = mapping;
-      for (let i = 1; i < match.length; i++) {
-        resolvedPath = resolvedPath.replace("*", match[i]);
-      }
-
-      const fullPath = resolve(resolvedBaseUrl, resolvedPath);
-
-      return fullPath;
-    }
-  }
-
-  return importPath;
+  return resolveAliasLookup(importPath, fromDir).resolved;
 }
 
 /**

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -179,3 +179,25 @@ describe("generateBundle shares one TypeResolver across resolveTypes and checkEx
     expect(createSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("generateBundle with a directory entry (no barrel) and --glob", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-bundle-dir-glob-"));
+    writeFileSync(path.join(dir, "Button.svelte"), BUTTON);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("populates exports for JSON/Markdown, not just per-component .d.ts", async () => {
+    const result = await generateBundle(dir, true);
+
+    expect(Object.keys(result.exports)).toContain("Button");
+    expect(result.exports.Button?.default).toBe(true);
+    expect(result.components.has("Button")).toBe(true);
+    expect(byModuleName(result.allComponentsForTypes, "Button")).toBeDefined();
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -521,6 +521,18 @@ describe("cli() --dry-run", () => {
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("would write"));
   });
 
+  test("an unresolved re-export alias prints one clear line and exits 1, not a raw stack trace", async () => {
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "$components/Button.svelte";\n');
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--dry-run"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('cannot resolve "$components/Button.svelte"'));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("would write"));
+  });
+
   test("--check still reads the snapshot and reports as in a real run", async () => {
     process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json"];
     await cli(process);

--- a/tests/parse-exports.test.ts
+++ b/tests/parse-exports.test.ts
@@ -3,6 +3,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { parseExports } from "../src/parse-exports";
 
+const UNRESOLVED_RELATIVE_PATH_REGEX = /cannot resolve "\.\/sveld-test-does-not-exist"/;
+const UNRESOLVED_ALIAS_REGEX = /cannot resolve "\$components\/Button\.svelte"/;
+
 describe("parseExports", () => {
   test("circular `export *` between two barrel files does not overflow the stack", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "sveld-parse-exports-circular-"));
@@ -259,5 +262,17 @@ describe("parseExports", () => {
       Theme: { source: "./Theme/Theme.svelte", default: true },
       themes: { source: "./Theme/Theme.svelte", default: false },
     });
+  });
+
+  test("`export *` to a missing relative path throws a structured error instead of crashing raw", () => {
+    const source = `export * from "./sveld-test-does-not-exist";`;
+
+    expect(() => parseExports(source, "")).toThrow(UNRESOLVED_RELATIVE_PATH_REGEX);
+  });
+
+  test("named re-export with an unresolved alias throws a structured error", () => {
+    const source = `export { default as Button } from "$components/Button.svelte";`;
+
+    expect(() => parseExports(source, "")).toThrow(UNRESOLVED_ALIAS_REGEX);
   });
 });

--- a/tests/resolve-alias.test.ts
+++ b/tests/resolve-alias.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { clearConfigCache, resolvePathAlias, resolvePathAliasAbsolute } from "../src/resolve-alias";
+import { dirname, join } from "node:path";
+import { clearConfigCache, resolveAliasLookup, resolvePathAlias, resolvePathAliasAbsolute } from "../src/resolve-alias";
 
 const TEST_DIR = join(import.meta.dir, ".tmp-alias-test");
 
@@ -12,7 +12,7 @@ function setupTestDir(structure: Record<string, string | Record<string, unknown>
 
   for (const [path, content] of Object.entries(structure)) {
     const fullPath = join(TEST_DIR, path);
-    const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+    const dir = dirname(fullPath);
 
     if (dir && !existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
@@ -293,7 +293,7 @@ describe("resolvePathAlias", () => {
     expect(result).toBe("./lib/components/Button.svelte");
   });
 
-  test("uses first mapping when multiple are defined", () => {
+  test("uses first mapping when multiple are defined and neither exists on disk", () => {
     setupTestDir({
       "tsconfig.json": {
         compilerOptions: {
@@ -307,5 +307,68 @@ describe("resolvePathAlias", () => {
 
     const result = resolvePathAlias("$lib/components/Button.svelte", TEST_DIR);
     expect(result).toBe("./src/lib/components/Button.svelte");
+  });
+
+  test("falls back to a later mapping whose target exists on disk", () => {
+    setupTestDir({
+      "tsconfig.json": {
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "$lib/*": ["./src/lib/*", "./lib/*"],
+          },
+        },
+      },
+      "lib/Button.svelte": "<div />",
+    });
+
+    const result = resolvePathAlias("$lib/Button.svelte", TEST_DIR);
+    expect(result).toBe("./lib/Button.svelte");
+  });
+
+  test("prefers the longest non-wildcard prefix over declaration order", () => {
+    setupTestDir({
+      "tsconfig.json": {
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "$lib/*": ["./generic/*"],
+            "$lib/components/*": ["./special/*"],
+          },
+        },
+      },
+    });
+
+    const result = resolvePathAlias("$lib/components/Button.svelte", TEST_DIR);
+    expect(result).toBe("./special/Button.svelte");
+  });
+
+  test("reports an unresolved alias when no tsconfig/jsconfig exists", () => {
+    const result = resolveAliasLookup("$lib/Button.svelte", TEST_DIR);
+    expect(result.unresolved).toBe(true);
+    expect(result.resolved).toBe("$lib/Button.svelte");
+    expect(result.searched).toBe("no tsconfig/jsconfig paths found");
+  });
+
+  test("reports an unresolved alias when no paths pattern matches the specifier", () => {
+    setupTestDir({
+      "tsconfig.json": {
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "$lib/*": ["./src/lib/*"],
+          },
+        },
+      },
+    });
+
+    const result = resolveAliasLookup("$missing/Button.svelte", TEST_DIR);
+    expect(result.unresolved).toBe(true);
+    expect(result.resolved).toBe("$missing/Button.svelte");
+  });
+
+  test("does not report a relative specifier as unresolved", () => {
+    const result = resolveAliasLookup("./Button.svelte", TEST_DIR);
+    expect(result.unresolved).toBe(false);
   });
 });


### PR DESCRIPTION
Also throws a clear UnresolvedModuleError (exit 1) instead of a raw
ENOENT crash or a silently dropped component for unresolved export *
and named .svelte re-exports, and populates exports for a directory
--glob entry so JSON/Markdown/index.d.ts include those components
too.