### PR TITLE
fix(parser): fall back to name for bare @generics, accumulate tags

### DIFF
--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -1003,105 +1003,141 @@ export default class ComponentParser {
               return;
             }
 
-            let prop_name: string;
-            let kind: "let" | "const" | "function";
-            let isFunctionDeclaration = false;
-            let value: string | undefined;
-            let typeSeed: string | undefined;
-            let explicitType: string | undefined;
-            let initializerIsFunction = false;
-            let defaultValue: ComponentPropDefaultValue | undefined;
-            let inferredTypeForSource: string | undefined;
-            let resolvedJSDoc:
-              | Pick<
-                  ProcessedInitializer,
-                  | "resolvedType"
-                  | "resolvedDescription"
-                  | "resolvedParams"
-                  | "resolvedReturnType"
-                  | "pendingCallDefault"
-                >
-              | undefined;
+            type ModuleExportDeclarator = {
+              prop_name: string;
+              kind: "let" | "const" | "function";
+              isFunctionDeclaration: boolean;
+              value: string | undefined;
+              typeSeed: string | undefined;
+              explicitType: string | undefined;
+              initializerIsFunction: boolean;
+              defaultValue: ComponentPropDefaultValue | undefined;
+              inferredTypeForSource: string | undefined;
+              resolvedJSDoc:
+                | Pick<
+                    ProcessedInitializer,
+                    | "resolvedType"
+                    | "resolvedDescription"
+                    | "resolvedParams"
+                    | "resolvedReturnType"
+                    | "pendingCallDefault"
+                  >
+                | undefined;
+            };
+            const declarators: ModuleExportDeclarator[] = [];
 
             if (node.declaration.type === "FunctionDeclaration") {
               const funcDecl = node.declaration as { id?: { name?: string } };
               if (!funcDecl.id?.name) return;
-              prop_name = funcDecl.id.name;
-              kind = "function";
-              value = undefined;
-              typeSeed = "() => any";
-              initializerIsFunction = true;
-              isFunctionDeclaration = true;
+              declarators.push({
+                prop_name: funcDecl.id.name,
+                kind: "function",
+                isFunctionDeclaration: true,
+                value: undefined,
+                typeSeed: "() => any",
+                explicitType: undefined,
+                initializerIsFunction: true,
+                defaultValue: undefined,
+                inferredTypeForSource: undefined,
+                resolvedJSDoc: undefined,
+              });
             } else if (node.declaration.type === "VariableDeclaration") {
               const varDecl = node.declaration as VariableDeclaration;
-              const firstDeclarator = varDecl.declarations[0];
-              if (!firstDeclarator || typeof firstDeclarator !== "object" || !("id" in firstDeclarator)) {
-                return;
-              }
+              const kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
 
-              const { id, init } = firstDeclarator as VariableDeclarator;
+              for (const declarator of varDecl.declarations) {
+                if (!declarator || typeof declarator !== "object" || !("id" in declarator)) {
+                  continue;
+                }
 
-              if (!id || typeof id !== "object" || !("name" in id)) {
-                return;
-              }
+                const { id, init } = declarator as VariableDeclarator;
 
-              const localPropName = (id as Identifier).name;
-              prop_name = localPropName;
-              kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
-              const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
-              ({ value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult);
-              inferredTypeForSource = typeSeed;
-              resolvedJSDoc = initResult;
-              explicitType = this.getExplicitPropType(localPropName);
-              if (resolvedJSDoc.pendingCallDefault) {
-                this.ctx.pendingCallDefaultCandidates.push({
-                  propName: localPropName,
-                  location: "moduleExports",
-                  ...resolvedJSDoc.pendingCallDefault,
+                if (!id || typeof id !== "object" || !("name" in id)) {
+                  continue;
+                }
+
+                const localPropName = (id as Identifier).name;
+                const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
+                const { value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult;
+                const resolvedJSDoc = initResult;
+                if (resolvedJSDoc.pendingCallDefault) {
+                  this.ctx.pendingCallDefaultCandidates.push({
+                    propName: localPropName,
+                    location: "moduleExports",
+                    ...resolvedJSDoc.pendingCallDefault,
+                  });
+                }
+
+                declarators.push({
+                  prop_name: localPropName,
+                  kind,
+                  isFunctionDeclaration: false,
+                  value,
+                  typeSeed,
+                  explicitType: this.getExplicitPropType(localPropName),
+                  initializerIsFunction,
+                  defaultValue,
+                  inferredTypeForSource: typeSeed,
+                  resolvedJSDoc,
                 });
               }
+
+              if (declarators.length === 0) return;
             } else {
               return;
             }
 
             const jsdocInfo = processNodeJSDoc(this.ctx, this, node);
 
-            const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
-              explicitType,
-              typeSeed,
-              inferredTypeForSource,
-              jsdocType: jsdocInfo?.type,
-              jsdocDescription: jsdocInfo?.description,
-              jsdocParams: jsdocInfo?.params,
-              jsdocReturnType: jsdocInfo?.returnType,
-              resolvedType: resolvedJSDoc?.resolvedType,
-              resolvedDescription: resolvedJSDoc?.resolvedDescription,
-              resolvedParams: resolvedJSDoc?.resolvedParams,
-              resolvedReturnType: resolvedJSDoc?.resolvedReturnType,
-              initializerIsFunction,
-              isFunctionDeclaration,
-              typedefs: this.ctx.typedefs,
-            });
-
-            this.addModuleExport(prop_name, {
-              name: prop_name,
+            for (const {
+              prop_name,
               kind,
-              description,
-              deprecated: jsdocInfo?.deprecated,
-              tags: jsdocInfo?.tags,
-              type,
-              typeSource,
-              value,
-              defaultValue,
-              params,
-              returnType,
-              isFunction,
               isFunctionDeclaration,
-              isRequired: false,
-              constant: kind === "const",
-              reactive: false,
-              source: sourceRangeFromNode(this.ctx, node),
-            });
+              value,
+              typeSeed,
+              explicitType,
+              initializerIsFunction,
+              defaultValue,
+              inferredTypeForSource,
+              resolvedJSDoc,
+            } of declarators) {
+              const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
+                explicitType,
+                typeSeed,
+                inferredTypeForSource,
+                jsdocType: jsdocInfo?.type,
+                jsdocDescription: jsdocInfo?.description,
+                jsdocParams: jsdocInfo?.params,
+                jsdocReturnType: jsdocInfo?.returnType,
+                resolvedType: resolvedJSDoc?.resolvedType,
+                resolvedDescription: resolvedJSDoc?.resolvedDescription,
+                resolvedParams: resolvedJSDoc?.resolvedParams,
+                resolvedReturnType: resolvedJSDoc?.resolvedReturnType,
+                initializerIsFunction,
+                isFunctionDeclaration,
+                typedefs: this.ctx.typedefs,
+              });
+
+              this.addModuleExport(prop_name, {
+                name: prop_name,
+                kind,
+                description,
+                deprecated: jsdocInfo?.deprecated,
+                tags: jsdocInfo?.tags,
+                type,
+                typeSource,
+                value,
+                defaultValue,
+                params,
+                returnType,
+                isFunction,
+                isFunctionDeclaration,
+                isRequired: false,
+                constant: kind === "const",
+                reactive: false,
+                source: sourceRangeFromNode(this.ctx, node),
+              });
+            }
           }
         },
       });
@@ -1241,7 +1277,11 @@ export default class ComponentParser {
             return;
           }
 
-          let prop_name: string;
+          let prop_name: string | undefined;
+          // `export { local as exported }` resolves `prop_name` here and points `node.declaration`
+          // at the local variable's whole declaration; only that one declarator is exported below,
+          // not every declarator sharing the declaration.
+          let isResolvedSpecifierExport = false;
           if (node.declaration == null && node.specifiers[0]?.type === "ExportSpecifier") {
             const specifier = node.specifiers[0];
             const localName =
@@ -1272,6 +1312,7 @@ export default class ComponentParser {
             }
             node.declaration = declaration;
             prop_name = exportedName;
+            isResolvedSpecifierExport = true;
           }
 
           if (node.declaration == null) {
@@ -1282,109 +1323,156 @@ export default class ComponentParser {
             return;
           }
 
-          let kind: "let" | "const" | "function";
-          let isFunctionDeclaration = false;
-          let value: string | undefined;
-          let typeSeed: string | undefined;
-          let explicitType: string | undefined;
-          let initializerIsFunction = false;
-          let isRequired = false;
-          let localName: string | undefined;
-          let defaultValue: ComponentPropDefaultValue | undefined;
-          let inferredTypeForSource: string | undefined;
-          let resolvedJSDoc:
-            | Pick<
-                ProcessedInitializer,
-                "resolvedType" | "resolvedDescription" | "resolvedParams" | "resolvedReturnType" | "pendingCallDefault"
-              >
-            | undefined;
+          type InstancePropDeclarator = {
+            prop_name: string;
+            kind: "let" | "const" | "function";
+            isFunctionDeclaration: boolean;
+            value: string | undefined;
+            typeSeed: string | undefined;
+            explicitType: string | undefined;
+            initializerIsFunction: boolean;
+            isRequired: boolean;
+            localName: string | undefined;
+            defaultValue: ComponentPropDefaultValue | undefined;
+            inferredTypeForSource: string | undefined;
+            resolvedJSDoc:
+              | Pick<
+                  ProcessedInitializer,
+                  | "resolvedType"
+                  | "resolvedDescription"
+                  | "resolvedParams"
+                  | "resolvedReturnType"
+                  | "pendingCallDefault"
+                >
+              | undefined;
+          };
+          const declarators: InstancePropDeclarator[] = [];
 
           if (node.declaration.type === "FunctionDeclaration") {
             const funcDecl = node.declaration as { id?: { name?: string } };
             if (!funcDecl.id?.name) return;
             prop_name ??= funcDecl.id.name;
-            localName = funcDecl.id.name;
-            kind = "function";
-            value = undefined;
-            typeSeed = "() => any";
-            initializerIsFunction = true;
-            isFunctionDeclaration = true;
-            isRequired = false;
+            declarators.push({
+              prop_name,
+              kind: "function",
+              isFunctionDeclaration: true,
+              value: undefined,
+              typeSeed: "() => any",
+              explicitType: undefined,
+              initializerIsFunction: true,
+              isRequired: false,
+              localName: funcDecl.id.name,
+              defaultValue: undefined,
+              inferredTypeForSource: undefined,
+              resolvedJSDoc: undefined,
+            });
           } else if (node.declaration.type === "VariableDeclaration") {
             const varDecl = node.declaration as VariableDeclaration;
-            const firstDeclarator = varDecl.declarations[0];
-            if (!firstDeclarator || typeof firstDeclarator !== "object" || !("id" in firstDeclarator)) {
-              return;
-            }
+            const kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
+            const declaratorsToProcess = isResolvedSpecifierExport
+              ? varDecl.declarations.slice(0, 1)
+              : varDecl.declarations;
 
-            const { id, init } = firstDeclarator as VariableDeclarator;
+            for (const declarator of declaratorsToProcess) {
+              if (!declarator || typeof declarator !== "object" || !("id" in declarator)) {
+                continue;
+              }
 
-            if (id && typeof id === "object" && "name" in id) {
+              const { id, init } = declarator as VariableDeclarator;
+              if (!id || typeof id !== "object" || !("name" in id)) {
+                continue;
+              }
+
               const localPropName = (id as Identifier).name;
-              localName = localPropName;
-              prop_name ??= localPropName;
-              explicitType = this.getExplicitPropType(localPropName);
-            } else {
-              return;
-            }
+              const declaratorPropName = prop_name ?? localPropName;
+              const isRequired = kind === "let" && init == null;
+              const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
+              const { value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult;
+              const resolvedJSDoc = initResult;
+              if (resolvedJSDoc.pendingCallDefault) {
+                this.ctx.pendingCallDefaultCandidates.push({
+                  propName: declaratorPropName,
+                  location: "props",
+                  ...resolvedJSDoc.pendingCallDefault,
+                });
+              }
 
-            kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
-            isRequired = kind === "let" && init == null;
-            const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
-            ({ value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult);
-            inferredTypeForSource = typeSeed;
-            resolvedJSDoc = initResult;
-            if (resolvedJSDoc.pendingCallDefault) {
-              this.ctx.pendingCallDefaultCandidates.push({
-                propName: prop_name,
-                location: "props",
-                ...resolvedJSDoc.pendingCallDefault,
+              declarators.push({
+                prop_name: declaratorPropName,
+                kind,
+                isFunctionDeclaration: false,
+                value,
+                typeSeed,
+                explicitType: this.getExplicitPropType(localPropName),
+                initializerIsFunction,
+                isRequired,
+                localName: localPropName,
+                defaultValue,
+                inferredTypeForSource: typeSeed,
+                resolvedJSDoc,
               });
             }
+
+            if (declarators.length === 0) return;
           } else {
             return;
           }
 
           const jsdocInfo = processNodeJSDoc(this.ctx, this, node);
 
-          const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
-            explicitType,
-            typeSeed,
-            inferredTypeForSource,
-            jsdocType: jsdocInfo?.type,
-            jsdocDescription: jsdocInfo?.description,
-            jsdocParams: jsdocInfo?.params,
-            jsdocReturnType: jsdocInfo?.returnType,
-            resolvedType: resolvedJSDoc?.resolvedType,
-            resolvedDescription: resolvedJSDoc?.resolvedDescription,
-            resolvedParams: resolvedJSDoc?.resolvedParams,
-            resolvedReturnType: resolvedJSDoc?.resolvedReturnType,
-            initializerIsFunction,
-            isFunctionDeclaration,
-            typedefs: this.ctx.typedefs,
-          });
-
-          addProp(this, this.ctx, prop_name, {
-            name: prop_name,
-            ...(localName !== undefined && localName !== prop_name ? { localName } : {}),
+          for (const {
+            prop_name,
             kind,
-            description,
-            binding: jsdocInfo?.binding,
-            deprecated: jsdocInfo?.deprecated,
-            tags: jsdocInfo?.tags,
-            type,
-            typeSource,
-            value,
-            defaultValue,
-            params,
-            returnType,
-            isFunction,
             isFunctionDeclaration,
+            value,
+            typeSeed,
+            explicitType,
+            initializerIsFunction,
             isRequired,
-            constant: kind === "const",
-            reactive: this.ctx.reactive_vars.has(prop_name),
-            source: sourceRangeFromNode(this.ctx, node),
-          });
+            localName,
+            defaultValue,
+            inferredTypeForSource,
+            resolvedJSDoc,
+          } of declarators) {
+            const { type, typeSource, description, params, returnType, isFunction } = resolvePropTypeAndDocs({
+              explicitType,
+              typeSeed,
+              inferredTypeForSource,
+              jsdocType: jsdocInfo?.type,
+              jsdocDescription: jsdocInfo?.description,
+              jsdocParams: jsdocInfo?.params,
+              jsdocReturnType: jsdocInfo?.returnType,
+              resolvedType: resolvedJSDoc?.resolvedType,
+              resolvedDescription: resolvedJSDoc?.resolvedDescription,
+              resolvedParams: resolvedJSDoc?.resolvedParams,
+              resolvedReturnType: resolvedJSDoc?.resolvedReturnType,
+              initializerIsFunction,
+              isFunctionDeclaration,
+              typedefs: this.ctx.typedefs,
+            });
+
+            addProp(this, this.ctx, prop_name, {
+              name: prop_name,
+              ...(localName !== undefined && localName !== prop_name ? { localName } : {}),
+              kind,
+              description,
+              binding: jsdocInfo?.binding,
+              deprecated: jsdocInfo?.deprecated,
+              tags: jsdocInfo?.tags,
+              type,
+              typeSource,
+              value,
+              defaultValue,
+              params,
+              returnType,
+              isFunction,
+              isFunctionDeclaration,
+              isRequired,
+              constant: kind === "const",
+              reactive: this.ctx.reactive_vars.has(prop_name),
+              source: sourceRangeFromNode(this.ctx, node),
+            });
+          }
         }
 
         if (type === "Comment") {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -153,6 +153,23 @@ export interface ProcessComponentOptions {
 }
 
 const HYPHEN_REGEX = /-/g;
+const INVALID_MODULE_NAME_CHAR_REGEX = /[^A-Za-z0-9_$]/g;
+const LEADING_DIGIT_REGEX = /^[0-9]/;
+
+/**
+ * Sanitizes a `moduleName` derived from a file name into a valid identifier:
+ * strips characters `.d.ts` can't emit in a declaration name (e.g. the `.`
+ * in `my.component.svelte`) and prefixes `_` when the result would start
+ * with a digit (e.g. `3d-model.svelte`). Warns when it had to rename.
+ */
+function sanitizeModuleName(rawModuleName: string): string {
+  const stripped = rawModuleName.replace(INVALID_MODULE_NAME_CHAR_REGEX, "");
+  const sanitized = LEADING_DIGIT_REGEX.test(stripped) ? `_${stripped}` : stripped;
+  if (sanitized !== rawModuleName) {
+    console.warn(`Warning: "${rawModuleName}" is not a valid identifier; using "${sanitized}" instead.`);
+  }
+  return sanitized;
+}
 
 /**
  * Discovered component sources for an entry point, before parsing.
@@ -230,7 +247,7 @@ function findSvelteFiles(
 function globComponentSources(rootDir: string): GlobbedComponentSource[] {
   return findSvelteFiles(rootDir)
     .map((file) => {
-      const moduleName = parse(file).name.replace(HYPHEN_REGEX, "");
+      const moduleName = sanitizeModuleName(parse(file).name.replace(HYPHEN_REGEX, ""));
       const source = asRelativeSourcePath(normalizeSeparators(`./${relative(rootDir, file)}`));
       return { moduleName, source };
     })

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -402,15 +402,15 @@ export function parseCustomTypes(
    */
   const pushOrReplaceProperty = <T extends { name: string }>(list: T[], property: T, ownerName: string | undefined) => {
     const existingIndex = list.findIndex((p) => p.name === property.name);
-    if (existingIndex !== -1) {
+    if (existingIndex === -1) {
+      list.push(property);
+    } else {
       const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
       const owner = ownerName ? ` of "${ownerName}"` : "";
       console.warn(
         `Warning: Duplicate property "${property.name}"${owner}${location}; the later declaration overwrites the earlier one.`,
       );
       list[existingIndex] = property;
-    } else {
-      list.push(property);
     }
   };
   for (const { tags, description: commentDescription, lines: blockLines } of parseComments(scanSource)) {

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -386,6 +386,33 @@ export function parseCustomTypes(
     }
     parser.accumulateGeneric(declaredName, constraint);
   };
+  /** `ctx.typedefs` holds both `@typedef` and `@callback` declarations, keyed by name; both finalizers share this check. */
+  const warnDuplicateTypedefName = (name: string) => {
+    if (ctx.typedefs.has(name)) {
+      const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
+      console.warn(
+        `Warning: Duplicate typedef/callback name "${name}"${location}; the later declaration overwrites the earlier one.`,
+      );
+    }
+  };
+  /**
+   * Replaces an earlier `@property` with the same name instead of pushing a
+   * second entry - two properties with the same key would otherwise appear
+   * in the emitted object type.
+   */
+  const pushOrReplaceProperty = <T extends { name: string }>(list: T[], property: T, ownerName: string | undefined) => {
+    const existingIndex = list.findIndex((p) => p.name === property.name);
+    if (existingIndex !== -1) {
+      const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
+      const owner = ownerName ? ` of "${ownerName}"` : "";
+      console.warn(
+        `Warning: Duplicate property "${property.name}"${owner}${location}; the later declaration overwrites the earlier one.`,
+      );
+      list[existingIndex] = property;
+    } else {
+      list.push(property);
+    }
+  };
   for (const { tags, description: commentDescription, lines: blockLines } of parseComments(scanSource)) {
     let currentEventName: string | undefined;
     let currentEventType: string | undefined;
@@ -565,6 +592,7 @@ export function parseCustomTypes(
           typedefTs = `type ${currentTypedefName} = ${typedefType};`;
         }
 
+        warnDuplicateTypedefName(currentTypedefName);
         ctx.typedefs.set(currentTypedefName, {
           type: typedefType,
           name: currentTypedefName,
@@ -591,6 +619,7 @@ export function parseCustomTypes(
         const callbackType = `(${params}) => ${returnType}`;
         const callbackTs = `type ${currentCallbackName} = ${callbackType};`;
 
+        warnDuplicateTypedefName(currentCallbackName);
         ctx.typedefs.set(currentCallbackName, {
           type: callbackType,
           name: currentCallbackName,
@@ -716,9 +745,9 @@ export function parseCustomTypes(
           };
 
           if (currentEventName !== undefined) {
-            eventProperties.push(propertyData);
+            pushOrReplaceProperty(eventProperties, propertyData, currentEventName);
           } else if (currentTypedefName !== undefined) {
-            typedefProperties.push(propertyData);
+            pushOrReplaceProperty(typedefProperties, propertyData, currentTypedefName);
           }
           break;
         }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -345,6 +345,47 @@ export function parseCustomTypes(
   scanSource: string | undefined = ctx.source,
 ) {
   if (!scanSource) return;
+  /** Cross-block bookkeeping for `@generics`/`@template` duplicate/mixed-tag warnings. */
+  let usedGenericsTag = false;
+  let usedTemplateTag = false;
+  let warnedMixedGenericsTags = false;
+  const seenGenericNames = new Set<string>();
+  const warnMixedGenericsTags = () => {
+    if (usedGenericsTag && usedTemplateTag && !warnedMixedGenericsTags) {
+      warnedMixedGenericsTags = true;
+      const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
+      console.warn(
+        `Warning: Both @generics and @template tags are used to declare component generics${location}; their declarations are combined in the order encountered.`,
+      );
+    }
+  };
+  const warnAndTrackGenericName = (genericName: string) => {
+    const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
+    if (seenGenericNames.has(genericName)) {
+      console.warn(`Warning: Duplicate generic name "${genericName}"${location}.`);
+    } else {
+      seenGenericNames.add(genericName);
+    }
+  };
+  /**
+   * Accumulates a `@generics`/`@template` declaration, replacing an earlier
+   * declaration in place when `declaredName` was already declared - so
+   * redeclaring the same generic (e.g. via both tags) updates its constraint
+   * instead of appending a second, invalid duplicate type parameter.
+   */
+  const accumulateOrReplaceGeneric = (declaredName: string, constraint: string) => {
+    if (ctx.generics) {
+      const names = splitTopLevelCommas(ctx.generics[0]).map((n) => n.trim());
+      const existingIndex = names.indexOf(declaredName.trim());
+      if (existingIndex !== -1) {
+        const constraints = splitTopLevelCommas(ctx.generics[1]).map((c) => c.trim());
+        constraints[existingIndex] = constraint;
+        ctx.generics = [ctx.generics[0], constraints.join(", ")];
+        return;
+      }
+    }
+    parser.accumulateGeneric(declaredName, constraint);
+  };
   for (const { tags, description: commentDescription, lines: blockLines } of parseComments(scanSource)) {
     let currentEventName: string | undefined;
     let currentEventType: string | undefined;
@@ -708,10 +749,19 @@ export function parseCustomTypes(
           if (isFirstTag) isFirstTag = false;
           break;
         }
-        case "generics":
-          ctx.generics = [name, type];
+        case "generics": {
+          // A bare `@generics Name` (no `{constraint}`) falls back to the name
+          // itself, mirroring `@template`'s unconstrained-parameter fallback.
+          const constraint = type || name;
+          for (const genericName of splitTopLevelCommas(name)) {
+            warnAndTrackGenericName(genericName.trim());
+          }
+          usedGenericsTag = true;
+          warnMixedGenericsTags();
+          accumulateOrReplaceGeneric(name, constraint);
           if (isFirstTag) isFirstTag = false;
           break;
+        }
         case "template": {
           // Build constraint from standard JSDoc @template syntax:
           //   @template T              → type="", name="T", default=undefined
@@ -727,7 +777,10 @@ export function parseCustomTypes(
             break;
           }
 
-          parser.accumulateGeneric(name, constraint);
+          warnAndTrackGenericName(name);
+          usedTemplateTag = true;
+          warnMixedGenericsTags();
+          accumulateOrReplaceGeneric(name, constraint);
           if (isFirstTag) isFirstTag = false;
           break;
         }

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -1535,6 +1535,69 @@ describe("ComponentParser", () => {
     warn.mockRestore();
   });
 
+  describe("@generics/@template JSDoc tags", () => {
+    test("falls back to the name for a bare @generics tag with no constraint", () => {
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          /**
+           * @generics Item
+           */
+
+          /** @type {Item} */
+          export let value;
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.generics).toEqual(["Item", "Item"]);
+    });
+
+    test("warns when both @generics and @template declare the same name", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          /**
+           * @template {string} Row
+           * @generics {Row extends string = string} Row
+           */
+
+          /** @type {Row} */
+          export let value;
+        </script>
+      `;
+
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.generics).toEqual(["Row", "Row extends string = string"]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Duplicate generic name "Row"'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("Both @generics and @template tags are used"));
+
+      warn.mockRestore();
+    });
+
+    test("warns when a name repeats across two @generics tags", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+      const parser = new ComponentParser();
+      const source = `
+        <script>
+          /**
+           * @generics {Row extends string = string} Row
+           * @generics {Row extends number = number} Row
+           */
+
+          /** @type {Row} */
+          export let value;
+        </script>
+      `;
+
+      parser.parseSvelteComponent(source, diagnostics);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Duplicate generic name "Row"'));
+
+      warn.mockRestore();
+    });
+  });
+
   describe("findVariableTypeAndDescription's JSDoc symbol table", () => {
     test("resolves a JSDoc'd variable whose name is on a different line than its keyword", () => {
       const parser = new ComponentParser();

--- a/tests/fixtures/generics-bare-name/input.svelte
+++ b/tests/fixtures/generics-bare-name/input.svelte
@@ -1,0 +1,10 @@
+<script>
+  /**
+   * @generics Item
+   */
+
+  /** @type {Item} */
+  export let value;
+</script>
+
+<div>{value}</div>

--- a/tests/fixtures/generics-bare-name/output-class.d.ts
+++ b/tests/fixtures/generics-bare-name/output-class.d.ts
@@ -1,0 +1,11 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type GenericsBareNameProps<Item> = {
+  value: Item;
+};
+
+export default class GenericsBareName<Item> extends SvelteComponentTyped<
+  GenericsBareNameProps<Item>,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/generics-bare-name/output-component.d.ts
+++ b/tests/fixtures/generics-bare-name/output-component.d.ts
@@ -1,0 +1,25 @@
+import type { SvelteComponent, ComponentConstructorOptions, ComponentInternals } from "svelte";
+
+export type GenericsBareNameProps<Item> = {
+  value: Item;
+};
+
+export type GenericsBareNameExports = Record<string, never>;
+
+interface GenericsBareNameComponent {
+  new <Item>(
+    options: ComponentConstructorOptions<GenericsBareNameProps<Item>>
+  ): SvelteComponent<GenericsBareNameProps<Item>> & GenericsBareNameExports;
+  <Item>(
+    this: void,
+    internals: ComponentInternals,
+    props: GenericsBareNameProps<Item>
+  ): {
+    $on?(type: string, callback: (e: any) => void): () => void;
+    $set?(props: Partial<GenericsBareNameProps<Item>>): void;
+  } & GenericsBareNameExports;
+  element?: typeof HTMLElement;
+  z_$$bindings?: "";
+}
+declare const GenericsBareName: GenericsBareNameComponent;
+export default GenericsBareName;

--- a/tests/fixtures/generics-bare-name/output.json
+++ b/tests/fixtures/generics-bare-name/output.json
@@ -1,0 +1,47 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "value",
+      "kind": "let",
+      "type": "Item",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 19
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": [
+    "Item",
+    "Item"
+  ],
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/legacy-multi-declarator/input.svelte
+++ b/tests/fixtures/legacy-multi-declarator/input.svelte
@@ -1,0 +1,6 @@
+<script>
+  /** Block description applies to every declarator below. */
+  export let a = 1, b = 2, c;
+</script>
+
+<div>{a}-{b}-{c}</div>

--- a/tests/fixtures/legacy-multi-declarator/input.svelte
+++ b/tests/fixtures/legacy-multi-declarator/input.svelte
@@ -1,6 +1,8 @@
 <script>
   /** Block description applies to every declarator below. */
-  export let a = 1, b = 2, c;
+  export let a = 1,
+    b = 2,
+    c;
 </script>
 
 <div>{a}-{b}-{c}</div>

--- a/tests/fixtures/legacy-multi-declarator/output-class.d.ts
+++ b/tests/fixtures/legacy-multi-declarator/output-class.d.ts
@@ -1,0 +1,26 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type LegacyMultiDeclaratorProps = {
+  /**
+   * Block description applies to every declarator below.
+   * @default 1
+   */
+  a?: number;
+
+  /**
+   * Block description applies to every declarator below.
+   * @default 2
+   */
+  b?: number;
+
+  /**
+   * Block description applies to every declarator below.
+   */
+  c: any;
+};
+
+export default class LegacyMultiDeclarator extends SvelteComponentTyped<
+  LegacyMultiDeclaratorProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/legacy-multi-declarator/output-component.d.ts
+++ b/tests/fixtures/legacy-multi-declarator/output-component.d.ts
@@ -1,0 +1,29 @@
+import type { Component } from "svelte";
+
+export type LegacyMultiDeclaratorProps = {
+  /**
+   * Block description applies to every declarator below.
+   * @default 1
+   */
+  a?: number;
+
+  /**
+   * Block description applies to every declarator below.
+   * @default 2
+   */
+  b?: number;
+
+  /**
+   * Block description applies to every declarator below.
+   */
+  c: any;
+};
+
+export type LegacyMultiDeclaratorExports = Record<string, never>;
+
+declare const LegacyMultiDeclarator: Component<
+  LegacyMultiDeclaratorProps,
+  LegacyMultiDeclaratorExports,
+  ""
+>;
+export default LegacyMultiDeclarator;

--- a/tests/fixtures/legacy-multi-declarator/output.json
+++ b/tests/fixtures/legacy-multi-declarator/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 7,
+      "line": 9,
       "column": 0
     }
   },
@@ -35,8 +35,8 @@
           "column": 2
         },
         "end": {
-          "line": 3,
-          "column": 29
+          "line": 5,
+          "column": 6
         }
       }
     },
@@ -63,8 +63,8 @@
           "column": 2
         },
         "end": {
-          "line": 3,
-          "column": 29
+          "line": 5,
+          "column": 6
         }
       }
     },
@@ -84,8 +84,8 @@
           "column": 2
         },
         "end": {
-          "line": 3,
-          "column": 29
+          "line": 5,
+          "column": 6
         }
       }
     }
@@ -108,8 +108,8 @@
           "column": 2
         },
         "end": {
-          "line": 3,
-          "column": 29
+          "line": 5,
+          "column": 6
         }
       }
     }

--- a/tests/fixtures/legacy-multi-declarator/output.json
+++ b/tests/fixtures/legacy-multi-declarator/output.json
@@ -1,0 +1,117 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "a",
+      "kind": "let",
+      "description": "Block description applies to every declarator below.",
+      "type": "number",
+      "typeSource": "default",
+      "value": "1",
+      "defaultValue": {
+        "raw": "1",
+        "kind": "literal",
+        "value": 1
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 29
+        }
+      }
+    },
+    {
+      "name": "b",
+      "kind": "let",
+      "description": "Block description applies to every declarator below.",
+      "type": "number",
+      "typeSource": "default",
+      "value": "2",
+      "defaultValue": {
+        "raw": "2",
+        "kind": "literal",
+        "value": 2
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 29
+        }
+      }
+    },
+    {
+      "name": "c",
+      "kind": "let",
+      "description": "Block description applies to every declarator below.",
+      "typeSource": "unknown",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 29
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "legacy-multi-declarator/input.svelte",
+      "kind": "prop-unknown-type",
+      "name": "c",
+      "message": "Prop \"c\" type could not be inferred; falling back to \"any\".",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 29
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/runes-generics/input.svelte
+++ b/tests/fixtures/runes-generics/input.svelte
@@ -3,7 +3,7 @@
    * @typedef {{ id: string | number; [key: string]: any; }} DataTableRow
    * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row>
    * @typedef {{ key: DataTableKey<Row>; value: string; }} DataTableHeader<Row=DataTableRow>
-   * @template {DataTableRow} <Row extends DataTableRow = DataTableRow>
+   * @template {DataTableRow} Row
    * @generics {Row extends DataTableRow = DataTableRow} Row
    */
 

--- a/tests/fixtures/typedef-duplicate-name/input.svelte
+++ b/tests/fixtures/typedef-duplicate-name/input.svelte
@@ -1,0 +1,16 @@
+<script>
+  /**
+   * @typedef {object} Config
+   * @property {string} id - Identifier
+   */
+
+  /**
+   * @typedef {object} Config
+   * @property {number} count - Count
+   */
+
+  /** @type {Config} */
+  export let config;
+</script>
+
+<div>{config.count}</div>

--- a/tests/fixtures/typedef-duplicate-name/output-class.d.ts
+++ b/tests/fixtures/typedef-duplicate-name/output-class.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type Config = {
+  /** Count */
+  count: number;
+};
+
+export type TypedefDuplicateNameProps = {
+  config: Config;
+};
+
+export default class TypedefDuplicateName extends SvelteComponentTyped<
+  TypedefDuplicateNameProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/typedef-duplicate-name/output-component.d.ts
+++ b/tests/fixtures/typedef-duplicate-name/output-component.d.ts
@@ -1,0 +1,19 @@
+import type { Component } from "svelte";
+
+export type Config = {
+  /** Count */
+  count: number;
+};
+
+export type TypedefDuplicateNameProps = {
+  config: Config;
+};
+
+export type TypedefDuplicateNameExports = Record<string, never>;
+
+declare const TypedefDuplicateName: Component<
+  TypedefDuplicateNameProps,
+  TypedefDuplicateNameExports,
+  ""
+>;
+export default TypedefDuplicateName;

--- a/tests/fixtures/typedef-duplicate-name/output.json
+++ b/tests/fixtures/typedef-duplicate-name/output.json
@@ -1,0 +1,50 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 17,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "config",
+      "kind": "let",
+      "type": "Config",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{\n  /** Count */\n  count: number;\n}",
+      "name": "Config",
+      "ts": "type Config = {\n  /** Count */\n  count: number;\n};"
+    }
+  ],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/typedef-duplicate-property/input.svelte
+++ b/tests/fixtures/typedef-duplicate-property/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  /**
+   * @typedef {object} Config
+   * @property {string} id - First declaration
+   * @property {number} id - Second declaration wins
+   */
+
+  /** @type {Config} */
+  export let config;
+</script>
+
+<div>{config.id}</div>

--- a/tests/fixtures/typedef-duplicate-property/output-class.d.ts
+++ b/tests/fixtures/typedef-duplicate-property/output-class.d.ts
@@ -1,0 +1,16 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type Config = {
+  /** Second declaration wins */
+  id: number;
+};
+
+export type TypedefDuplicatePropertyProps = {
+  config: Config;
+};
+
+export default class TypedefDuplicateProperty extends SvelteComponentTyped<
+  TypedefDuplicatePropertyProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/typedef-duplicate-property/output-component.d.ts
+++ b/tests/fixtures/typedef-duplicate-property/output-component.d.ts
@@ -1,0 +1,19 @@
+import type { Component } from "svelte";
+
+export type Config = {
+  /** Second declaration wins */
+  id: number;
+};
+
+export type TypedefDuplicatePropertyProps = {
+  config: Config;
+};
+
+export type TypedefDuplicatePropertyExports = Record<string, never>;
+
+declare const TypedefDuplicateProperty: Component<
+  TypedefDuplicatePropertyProps,
+  TypedefDuplicatePropertyExports,
+  ""
+>;
+export default TypedefDuplicateProperty;

--- a/tests/fixtures/typedef-duplicate-property/output.json
+++ b/tests/fixtures/typedef-duplicate-property/output.json
@@ -1,0 +1,50 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "config",
+      "kind": "let",
+      "type": "Config",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 2
+        },
+        "end": {
+          "line": 9,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{\n  /** Second declaration wins */\n  id: number;\n}",
+      "name": "Config",
+      "ts": "type Config = {\n  /** Second declaration wins */\n  id: number;\n};"
+    }
+  ],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/glob-module-name.test.ts
+++ b/tests/glob-module-name.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { type ComponentDocApi, type ComponentDocs, generateBundle } from "../src/bundle";
+
+/** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
+function byModuleName(components: ComponentDocs, moduleName: string): ComponentDocApi | undefined {
+  return Array.from(components.values()).find((component) => component.moduleName === moduleName);
+}
+
+const BUTTON = `<script>
+  export let label = "button";
+</script>
+
+<button>{label}</button>`;
+
+describe("glob-discovered module names are sanitized to valid identifiers", () => {
+  let dir: string;
+  let warn: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-glob-module-name-"));
+    writeFileSync(path.join(dir, "3d-model.svelte"), BUTTON);
+    writeFileSync(path.join(dir, "my.component.svelte"), BUTTON);
+    writeFileSync(path.join(dir, "entry.js"), "");
+    warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("strips invalid characters and prefixes a leading digit", async () => {
+    const result = await generateBundle(path.join(dir, "entry.js"), true);
+
+    expect(byModuleName(result.allComponentsForTypes, "_3dmodel")).toBeDefined();
+    expect(byModuleName(result.allComponentsForTypes, "mycomponent")).toBeDefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"3dmodel" is not a valid identifier'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"my.component" is not a valid identifier'));
+  });
+});


### PR DESCRIPTION
Fixes five cases where the parser or glob discovery produced invalid or
silently truncated .d.ts output: bare @generics, duplicate
typedef/callback/property names, multi-declarator exports, and
non-identifier glob filenames.