### PR TITLE
feat(events): read createEventDispatcher type arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2316,6 +2316,13 @@ export default class Component extends SvelteComponentTyped<
 > {}
 ```
 
+#### Detail inference without `@event`
+
+Without an `@event` tag or a typed dispatcher, `sveld` infers a dispatched event's detail type from the `dispatch()` call site itself:
+
+- A scalar literal argument narrows to its literal type: `dispatch("count", 5)` types the detail as `5`, not `number`. Use `@event` or a typed dispatcher (below) to widen it.
+- An object or array literal argument infers a structural type per field/element: `dispatch("save", { id })` types the detail as `{ id: string }` (resolving the `id` variable's own type), and `dispatch("items", [1, 2])` types it as `number[]`. Fields or elements sveld can't resolve fall back to `any` individually, not for the whole detail.
+
 #### Typed dispatchers
 
 `createEventDispatcher<T>()`'s generic argument (`lang="ts"`, or the JSDoc `/** @type {import('svelte').EventDispatcher<T>} */` cast form) works like an `@event` block for every member of `T`, including ones never actually dispatched in the file:

--- a/README.md
+++ b/README.md
@@ -2316,6 +2316,20 @@ export default class Component extends SvelteComponentTyped<
 > {}
 ```
 
+#### Typed dispatchers
+
+`createEventDispatcher<T>()`'s generic argument (`lang="ts"`, or the JSDoc `/** @type {import('svelte').EventDispatcher<T>} */` cast form) works like an `@event` block for every member of `T`, including ones never actually dispatched in the file:
+
+```svelte
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher<{ save: { id: string }; cancel: null }>();
+</script>
+```
+
+`T` may also be a reference to a local `type`/`interface`. An `@event` tag for the same name still overrides the generic's detail type.
+
 #### Using `@property` for complex event details
 
 For events with complex object payloads, use `@property` to document individual fields. The main comment becomes the event description. See the [`@property`](#property) reference for the tag's valid contexts.

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -40,6 +40,7 @@ import {
   buildRunesPropTypeMetadata,
   normalizeRunesCallbackProps,
   parseRunesPropsDeclaration,
+  registerTypedDispatcherEvents,
 } from "./parser/runes-props";
 import {
   createScopeWalkState,
@@ -1108,6 +1109,8 @@ export default class ComponentParser {
     }
 
     let dispatcher_name: undefined | string;
+    let dispatcherDeclaratorNode: unknown;
+    let dispatcherTypeArgument: ModernRunesTypeNode | undefined;
     const hostLocalNames = new Set<string>();
     const hostDispatchedEventNames = new Set<string>();
     // Source ranges are resolved lazily below: only calls to the dispatcher
@@ -1157,7 +1160,11 @@ export default class ComponentParser {
               "name" in parent.id
             ) {
               dispatcher_name = (parent.id as Identifier).name;
+              dispatcherDeclaratorNode = parent;
             }
+            dispatcherTypeArgument = (
+              callExpr as unknown as { typeArguments?: { params?: ModernRunesTypeNode[] } }
+            ).typeArguments?.params?.[0];
           }
 
           if (calleeName === "$host") {
@@ -1641,6 +1648,14 @@ export default class ComponentParser {
     });
 
     if (dispatcher_name !== undefined) {
+      registerTypedDispatcherEvents(
+        this,
+        this.ctx,
+        dispatcherTypeArgument,
+        dispatcher_name,
+        sourceRangeFromNode(this.ctx, dispatcherDeclaratorNode),
+      );
+
       for (const callee of callees) {
         if (callee.name === dispatcher_name) {
           const firstArg = callee.arguments[0];

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -29,7 +29,12 @@ import { createParserContext, type ParserContext } from "./parser/context";
 import { parseSetContextCall } from "./parser/contexts";
 import { recordDiagnostic } from "./parser/diagnostics";
 import { isComponentLikeType, isElementLikeType } from "./parser/element-kind";
-import { addDispatchedEvent, literalDetailToTypeText, parseHostDispatchEventCall } from "./parser/events";
+import {
+  addDispatchedEvent,
+  deriveLiteralDetailType,
+  literalDetailToTypeText,
+  parseHostDispatchEventCall,
+} from "./parser/events";
 import { parseGenericsAttribute } from "./parser/generics";
 import { parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
 import { resolvePropTypeAndDocs } from "./parser/prop-shared";
@@ -1162,9 +1167,8 @@ export default class ComponentParser {
               dispatcher_name = (parent.id as Identifier).name;
               dispatcherDeclaratorNode = parent;
             }
-            dispatcherTypeArgument = (
-              callExpr as unknown as { typeArguments?: { params?: ModernRunesTypeNode[] } }
-            ).typeArguments?.params?.[0];
+            dispatcherTypeArgument = (callExpr as unknown as { typeArguments?: { params?: ModernRunesTypeNode[] } })
+              .typeArguments?.params?.[0];
           }
 
           if (calleeName === "$host") {
@@ -1662,15 +1666,19 @@ export default class ComponentParser {
           const event_name =
             firstArg && typeof firstArg === "object" && "value" in firstArg ? (firstArg as Literal).value : undefined;
           const event_argument = callee.arguments[1];
+          const structuralDetail = deriveLiteralDetailType(this, event_argument);
           const event_detail =
-            event_argument && typeof event_argument === "object" && "value" in event_argument
+            structuralDetail === undefined &&
+            event_argument &&
+            typeof event_argument === "object" &&
+            "value" in event_argument
               ? (event_argument as Literal).value
               : undefined;
 
           if (event_name != null) {
             addDispatchedEvent(this.ctx, {
               name: String(event_name),
-              detail: event_detail == null ? "" : literalDetailToTypeText(event_detail),
+              detail: structuralDetail ?? (event_detail == null ? "" : literalDetailToTypeText(event_detail)),
               has_argument: Boolean(event_argument),
               source: sourceRangeFromNode(this.ctx, callee.node),
             });

--- a/src/parser/events.ts
+++ b/src/parser/events.ts
@@ -1,9 +1,59 @@
-import type { CallExpression } from "estree";
+import type { ArrayExpression, CallExpression, ObjectExpression, Property } from "estree";
 import { isIdentifier, isLiteral, isNewExpressionNamed, isObjectExpression } from "../ast-guards";
+import type ComponentParser from "../ComponentParser";
 import type { DispatchedEvent } from "../ComponentParser";
 import type { ParserContext } from "./context";
 import { sourceRangeFromNode } from "./source-position";
 import { assignValueOrUndefined } from "./utils";
+
+/**
+ * Structurally infers a dispatched event's detail type from an object or array literal `dispatch()`
+ * argument (`{ id: string }`, `number[]`), resolving identifier property values through the
+ * existing variable-type lookup and falling back to `any` per property/element rather than for the
+ * whole detail. Returns `undefined` for anything else so callers keep their own scalar-literal
+ * narrowing (`dispatch("count", 5)` still types as `5`).
+ */
+export function deriveLiteralDetailType(parser: ComponentParser, node: unknown): string | undefined {
+  if (!node || typeof node !== "object" || !("type" in node)) return undefined;
+  if (isObjectExpression(node)) return buildObjectLiteralDetailType(parser, node);
+  if (node.type === "ArrayExpression") return buildArrayLiteralDetailType(parser, node as ArrayExpression);
+  return undefined;
+}
+
+function inferLiteralMemberType(parser: ComponentParser, node: unknown): string {
+  if (!node || typeof node !== "object" || !("type" in node)) return "any";
+  if (isIdentifier(node)) return parser.findVariableTypeAndDescription(node.name)?.type ?? "any";
+
+  if (isLiteral(node)) {
+    const value = node.value;
+    return value === null ? "null" : typeof value;
+  }
+
+  if (isObjectExpression(node)) return buildObjectLiteralDetailType(parser, node);
+  if (node.type === "ArrayExpression") return buildArrayLiteralDetailType(parser, node as ArrayExpression);
+
+  return "any";
+}
+
+function buildObjectLiteralDetailType(parser: ComponentParser, node: ObjectExpression): string {
+  const properties: Array<{ name: string; type: string }> = [];
+  for (const property of node.properties) {
+    if (property.type !== "Property" || property.computed) continue;
+    const name = parser.getPropertyName(property.key as Property["key"]);
+    if (!name) continue;
+    properties.push({ name, type: inferLiteralMemberType(parser, property.value) });
+  }
+  return buildEventDetailFromProperties(properties);
+}
+
+function buildArrayLiteralDetailType(parser: ComponentParser, node: ArrayExpression): string {
+  const elementTypes = new Set(
+    node.elements.filter((element) => element != null).map((element) => inferLiteralMemberType(parser, element)),
+  );
+  if (elementTypes.size === 0) return "any[]";
+  if (elementTypes.size === 1) return `${[...elementTypes][0]}[]`;
+  return `(${[...elementTypes].join(" | ")})[]`;
+}
 
 export function literalDetailToTypeText(value: unknown): string {
   return typeof value === "string" ? JSON.stringify(value) : String(value);

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -7,9 +7,11 @@ import type {
   ModernScriptNode,
   RunesPropsDeclarationMetadata,
   RunesPropTypeMetadata,
+  SourceRange,
   TypeImportBinding,
 } from "../ComponentParser";
 import type { ParserContext } from "./context";
+import { addDispatchedEvent } from "./events";
 import { collectGenericsAttributeTypeDependencies } from "./generics";
 import { processLeadingCommentsJSDoc, processNodeJSDoc } from "./jsdoc";
 import { resolvePropTypeAndDocs } from "./prop-shared";
@@ -60,7 +62,7 @@ function substituteTypeParameters(type: string, substitutions: Map<string, strin
 }
 
 /** Flatten a runes `$props()` type node into prop name -> metadata, following local aliases and intersections. */
-function buildRunesPropTypeMetadataMap(
+export function buildRunesPropTypeMetadataMap(
   parser: ComponentParser,
   ctx: ParserContext,
   typeNode: ModernRunesTypeNode | undefined,
@@ -508,6 +510,116 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
         source: sourceRangeFromNode(ctx, property),
       });
     }
+  }
+}
+
+/** Balance-scans for `EventDispatcher<...>` and returns the generic argument's raw text (unparsed). */
+function extractEventDispatcherGenericText(typeText: string): string | undefined {
+  const marker = "EventDispatcher";
+  const markerIndex = typeText.indexOf(marker);
+  if (markerIndex === -1) return undefined;
+
+  let index = markerIndex + marker.length;
+  while (typeText[index] === " ") index++;
+  if (typeText[index] !== "<") return undefined;
+
+  let depth = 0;
+  const start = index;
+  for (; index < typeText.length; index++) {
+    if (typeText[index] === "<") depth++;
+    else if (typeText[index] === ">") {
+      depth--;
+      if (depth === 0) return typeText.slice(start + 1, index);
+    }
+  }
+  return undefined;
+}
+
+/** Splits a `{ a: X; b: Y }` type-literal body on top-level `;`/`,`, ignoring separators nested inside brackets. */
+function splitTypeLiteralMembers(body: string): string[] {
+  const members: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i];
+    if (char === "{" || char === "(" || char === "[" || char === "<") depth++;
+    else if (char === "}" || char === ")" || char === "]" || char === ">") depth = Math.max(depth - 1, 0);
+    else if (depth === 0 && (char === ";" || char === ",")) {
+      members.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  members.push(body.slice(start));
+
+  return members.map((member) => member.trim()).filter((member) => member.length > 0);
+}
+
+const QUOTED_MEMBER_NAME_REGEX = /^["']|["']$/g;
+const OPTIONAL_MEMBER_NAME_SUFFIX_REGEX = /\?$/;
+const LEADING_BRACE_REGEX = /^\{/;
+const TRAILING_BRACE_REGEX = /\}$/;
+
+/** Splits a `name: Type` (or `name?: Type`) member on its top-level `:`. */
+function splitMemberNameAndType(member: string): { name: string; type: string } | undefined {
+  let depth = 0;
+  for (let i = 0; i < member.length; i++) {
+    const char = member[i];
+    if (char === "{" || char === "(" || char === "[" || char === "<") depth++;
+    else if (char === "}" || char === ")" || char === "]" || char === ">") depth = Math.max(depth - 1, 0);
+    else if (depth === 0 && char === ":") {
+      const name = member
+        .slice(0, i)
+        .trim()
+        .replace(OPTIONAL_MEMBER_NAME_SUFFIX_REGEX, "")
+        .replace(QUOTED_MEMBER_NAME_REGEX, "");
+      const type = member.slice(i + 1).trim();
+      if (!name || !type) return undefined;
+      return { name, type };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Reads `createEventDispatcher<{...}>()`'s type argument (a `TSTypeLiteral`, or a reference to a
+ * local `type`/`interface`) and registers each member as a dispatched event, so events declared in
+ * the generic but never actually dispatched in the file still show up. Falls back to the JSDoc
+ * `/** @type {import('svelte').EventDispatcher<{...}>} *\/` cast form when there's no TS generic.
+ * An `@event` JSDoc tag for the same name still wins (`addDispatchedEvent` keeps its `detail`).
+ */
+export function registerTypedDispatcherEvents(
+  parser: ComponentParser,
+  ctx: ParserContext,
+  typeArgument: ModernRunesTypeNode | undefined,
+  dispatcherName: string,
+  fallbackSource: SourceRange | undefined,
+) {
+  if (typeArgument) {
+    const localTypeDeclarations = new Map(
+      Array.from(ctx.localTypeDeclarationsByName.entries(), ([name, declaration]) => [name, declaration.node]),
+    );
+    const members = buildRunesPropTypeMetadataMap(parser, ctx, typeArgument, localTypeDeclarations);
+    for (const [name, member] of members) {
+      addDispatchedEvent(ctx, { name, detail: member.type, has_argument: true, source: member.source });
+    }
+    return;
+  }
+
+  const jsdocType = parser.resolveLocalVarJSDoc(dispatcherName)?.type;
+  const genericText = jsdocType ? extractEventDispatcherGenericText(jsdocType) : undefined;
+  if (!genericText) return;
+
+  const body = genericText.trim().replace(LEADING_BRACE_REGEX, "").replace(TRAILING_BRACE_REGEX, "");
+  for (const rawMember of splitTypeLiteralMembers(body)) {
+    const parsedMember = splitMemberNameAndType(rawMember);
+    if (!parsedMember) continue;
+    addDispatchedEvent(ctx, {
+      name: parsedMember.name,
+      detail: parsedMember.type,
+      has_argument: true,
+      source: fallbackSource,
+    });
   }
 }
 

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/output-class.d.ts
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/output-class.d.ts
@@ -4,6 +4,6 @@ export type DispatchedAndForwardedSameEventNameProps = Record<string, never>;
 
 export default class DispatchedAndForwardedSameEventName extends SvelteComponentTyped<
   DispatchedAndForwardedSameEventNameProps,
-  { click: CustomEvent<any> },
+  { click: CustomEvent<{ x: number }> },
   Record<string, never>
 > {}

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/output-component.d.ts
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/output-component.d.ts
@@ -1,7 +1,7 @@
 import type { Component } from "svelte";
 
 export type DispatchedAndForwardedSameEventNameProps = {
-  onclick?: (event: CustomEvent<any>) => void;
+  onclick?: (event: CustomEvent<{ x: number }>) => void;
 };
 
 export type DispatchedAndForwardedSameEventNameExports = Record<string, never>;

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/output.json
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/output.json
@@ -18,6 +18,7 @@
     {
       "type": "dispatched",
       "name": "click",
+      "detail": "{ x: number; }",
       "source": {
         "start": {
           "line": 6,

--- a/tests/fixtures/dispatched-events-object-detail/input.svelte
+++ b/tests/fixtures/dispatched-events-object-detail/input.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  /** @type {string} */
+  export let id;
+
+  function save() {
+    dispatch("save", { id });
+  }
+
+  function reorder() {
+    dispatch("items", [1, 2]);
+  }
+</script>
+
+<button onclick={save}>Save</button>
+<button onclick={reorder}>Reorder</button>

--- a/tests/fixtures/dispatched-events-object-detail/output-class.d.ts
+++ b/tests/fixtures/dispatched-events-object-detail/output-class.d.ts
@@ -1,0 +1,14 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsObjectDetailProps = {
+  id: string;
+};
+
+export default class DispatchedEventsObjectDetail extends SvelteComponentTyped<
+  DispatchedEventsObjectDetailProps,
+  {
+    items: CustomEvent<number[]>;
+    save: CustomEvent<{ id: string }>;
+  },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-events-object-detail/output-component.d.ts
+++ b/tests/fixtures/dispatched-events-object-detail/output-component.d.ts
@@ -1,0 +1,18 @@
+import type { Component } from "svelte";
+
+export type DispatchedEventsObjectDetailProps = {
+  id: string;
+
+  onitems?: (event: CustomEvent<number[]>) => void;
+
+  onsave?: (event: CustomEvent<{ id: string }>) => void;
+};
+
+export type DispatchedEventsObjectDetailExports = Record<string, never>;
+
+declare const DispatchedEventsObjectDetail: Component<
+  DispatchedEventsObjectDetailProps,
+  DispatchedEventsObjectDetailExports,
+  ""
+>;
+export default DispatchedEventsObjectDetail;

--- a/tests/fixtures/dispatched-events-object-detail/output.json
+++ b/tests/fixtures/dispatched-events-object-detail/output.json
@@ -1,0 +1,75 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "id",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 16
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "items",
+      "detail": "number[]",
+      "source": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "save",
+      "detail": "{ id: string; }",
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 4
+        },
+        "end": {
+          "line": 10,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/input.svelte
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/input.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  /** @type {import('svelte').EventDispatcher<{ save: { id: string }; cancel: null }>} */
+  const dispatch = createEventDispatcher();
+
+  function save(id) {
+    dispatch("save", { id });
+  }
+</script>
+
+<button onclick={() => save("1")}>Save</button>

--- a/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output-class.d.ts
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output-class.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsTypedDispatcherJsdocProps = Record<string, never>;
+
+export default class DispatchedEventsTypedDispatcherJsdoc extends SvelteComponentTyped<
+  DispatchedEventsTypedDispatcherJsdocProps,
+  {
+    cancel: CustomEvent<null>;
+    save: CustomEvent<{ id: string }>;
+  },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output-component.d.ts
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output-component.d.ts
@@ -1,0 +1,16 @@
+import type { Component } from "svelte";
+
+export type DispatchedEventsTypedDispatcherJsdocProps = {
+  oncancel?: (event: CustomEvent<null>) => void;
+
+  onsave?: (event: CustomEvent<{ id: string }>) => void;
+};
+
+export type DispatchedEventsTypedDispatcherJsdocExports = Record<string, never>;
+
+declare const DispatchedEventsTypedDispatcherJsdoc: Component<
+  DispatchedEventsTypedDispatcherJsdocProps,
+  DispatchedEventsTypedDispatcherJsdocExports,
+  ""
+>;
+export default DispatchedEventsTypedDispatcherJsdoc;

--- a/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output.json
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output.json
@@ -1,0 +1,53 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "cancel",
+      "detail": "null",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "save",
+      "detail": "{ id: string }",
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 4
+        },
+        "end": {
+          "line": 8,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/dispatched-events-typed-dispatcher-ts/input.svelte
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-ts/input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher<{ save: { id: string }; cancel: null }>();
+
+  function save(id: string) {
+    dispatch("save", { id });
+  }
+</script>
+
+<button onclick={() => save("1")}>Save</button>

--- a/tests/fixtures/dispatched-events-typed-dispatcher-ts/output-class.d.ts
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-ts/output-class.d.ts
@@ -1,0 +1,12 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type DispatchedEventsTypedDispatcherTsProps = Record<string, never>;
+
+export default class DispatchedEventsTypedDispatcherTs extends SvelteComponentTyped<
+  DispatchedEventsTypedDispatcherTsProps,
+  {
+    cancel: CustomEvent<null>;
+    save: CustomEvent<{ id: string }>;
+  },
+  Record<string, never>
+> {}

--- a/tests/fixtures/dispatched-events-typed-dispatcher-ts/output-component.d.ts
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-ts/output-component.d.ts
@@ -1,0 +1,16 @@
+import type { Component } from "svelte";
+
+export type DispatchedEventsTypedDispatcherTsProps = {
+  oncancel?: (event: CustomEvent<null>) => void;
+
+  onsave?: (event: CustomEvent<{ id: string }>) => void;
+};
+
+export type DispatchedEventsTypedDispatcherTsExports = Record<string, never>;
+
+declare const DispatchedEventsTypedDispatcherTs: Component<
+  DispatchedEventsTypedDispatcherTsProps,
+  DispatchedEventsTypedDispatcherTsExports,
+  ""
+>;
+export default DispatchedEventsTypedDispatcherTs;

--- a/tests/fixtures/dispatched-events-typed-dispatcher-ts/output.json
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-ts/output.json
@@ -1,0 +1,53 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 12,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
+  "props": [],
+  "moduleExports": [],
+  "slots": [],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "cancel",
+      "detail": "null",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 65
+        },
+        "end": {
+          "line": 4,
+          "column": 77
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "save",
+      "detail": "{ id: string }",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 4
+        },
+        "end": {
+          "line": 7,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/dispatched-events/output-class.d.ts
+++ b/tests/fixtures/dispatched-events/output-class.d.ts
@@ -10,7 +10,7 @@ export default class DispatchedEvents extends SvelteComponentTyped<
     destroy: CustomEvent<null>;
     "destroy--component": CustomEvent<null>;
     "destroy:component": CustomEvent<null>;
-    hover: CustomEvent<any>;
+    hover: CustomEvent<{ h1: boolean }>;
   },
   { default: Record<string, never> }
 > {}

--- a/tests/fixtures/dispatched-events/output-component.d.ts
+++ b/tests/fixtures/dispatched-events/output-component.d.ts
@@ -9,7 +9,7 @@ export type DispatchedEventsProps = {
 
   "ondestroy:component"?: (event: CustomEvent<null>) => void;
 
-  onhover?: (event: CustomEvent<any>) => void;
+  onhover?: (event: CustomEvent<{ h1: boolean }>) => void;
 };
 
 export type DispatchedEventsExports = Record<string, never>;

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -79,6 +79,7 @@
     {
       "type": "dispatched",
       "name": "hover",
+      "detail": "{ h1: boolean; }",
       "source": {
         "start": {
           "line": 16,

--- a/tests/fixtures/mixed-event-types/output-class.d.ts
+++ b/tests/fixtures/mixed-event-types/output-class.d.ts
@@ -10,7 +10,7 @@ export default class MixedEventTypes extends SvelteComponentTyped<
     customEvent: CustomEvent<number>;
     /** Input value changed (native forwarded event) */
     input: CustomEvent<string>;
-    submit: CustomEvent<any>;
+    submit: CustomEvent<{ data: string }>;
   },
   Record<string, never>
 > {}

--- a/tests/fixtures/mixed-event-types/output-component.d.ts
+++ b/tests/fixtures/mixed-event-types/output-component.d.ts
@@ -9,7 +9,7 @@ export type MixedEventTypesProps = {
   /** Input value changed (native forwarded event) */
   oninput?: (event: CustomEvent<string>) => void;
 
-  onsubmit?: (event: CustomEvent<any>) => void;
+  onsubmit?: (event: CustomEvent<{ data: string }>) => void;
 };
 
 export type MixedEventTypesExports = Record<string, never>;

--- a/tests/fixtures/mixed-event-types/output.json
+++ b/tests/fixtures/mixed-event-types/output.json
@@ -67,6 +67,7 @@
     {
       "type": "dispatched",
       "name": "submit",
+      "detail": "{ data: string; }",
       "source": {
         "start": {
           "line": 13,


### PR DESCRIPTION
Also infers structural detail types for object/array dispatch()
arguments (previously CustomEvent<any>), since both fixes touch the
same dispatch-detail code path in the events parser.