### PR TITLE
feat(plugin): load sveld.config, deep-merge options, fix watch gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,15 @@ export default defineConfig({
 
 Since Vite uses Rollup for production builds, the same plugin works in Rollup configs.
 
+Unlike the CLI and the programmatic `sveld()` API, the plugin ignores `sveld.config.*` by default: pass `config: true` to load it and merge it with the options given here (these take precedence over the same key in the file), or a string to point at a specific config file.
+
+```ts
+sveld({
+  config: true,
+  json: true, // wins over `json` set in sveld.config.*
+});
+```
+
 By default, `sveld` uses the `"svelte"` field from your `package.json` to determine the entry point. You can override this by specifying an explicit `entry` option:
 
 ```js
@@ -657,7 +666,7 @@ See [`playground/`](playground) in this repo for a working example: it parses Sv
 
 ### Config File
 
-Put a `sveld.config.js`, `sveld.config.mjs`, or `sveld.config.ts` at your project root to set defaults for the CLI and the programmatic `sveld()` API.
+Put a `sveld.config.js`, `sveld.config.mjs`, or `sveld.config.ts` at your project root to set defaults for the CLI and the programmatic `sveld()` API. The Vite/Rollup plugin ignores it unless you opt in with the [`config`](#vite) option.
 
 Import `defineConfig` from `sveld` for typed options. Config files must use ESM syntax (`export default`).
 
@@ -688,6 +697,19 @@ export default {
   check: "snapshots/COMPONENT_API.json",
 };
 ```
+
+Merging is one level deep for object-valued options (`typesOptions`, `jsonOptions`, `markdownOptions`, `customElementsOptions`, `additionalWriters`): setting one nested key at the CLI or in `sveld()` doesn't drop sibling keys set in the config file. Arrays and functions (e.g. `markdownOptions.onAppend`) are replaced outright, never merged.
+
+```js
+// sveld.config.js
+export default {
+  typesOptions: { outDir: "dist", preamble: "// license" },
+};
+```
+
+`npx sveld --types-format=component` keeps `outDir` and `preamble` from the file and adds `format: "component"`, rather than replacing `typesOptions` entirely.
+
+An unrecognized option key (top-level, or inside a `*Options` object) is not an error: it prints a `console.warn` naming the key, with a "did you mean" suggestion when a known key is close enough.
 
 A bad config (syntax error, throws at load time, or no default-export object) fails with an error that names the file.
 
@@ -740,7 +762,8 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`customElements`** (boolean, optional): Generate a [Custom Elements Manifest](#custom-elements-manifest) (`custom-elements.json`). Also available as the `--custom-elements` CLI flag.
 - **`customElementsOptions`** (object, optional): Options for Custom Elements Manifest output.
   - **`outFile`** (string, optional, default: `"custom-elements.json"`): Path (relative to the project root) for the generated manifest file.
-- **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when `.svelte` source changes during `vite dev` / `vite build --watch`. Only the changed component and the components that depend on it via [`@extendProps`](#extendprops) / `@extends` are re-parsed, rather than rebuilding every component. Without this option, the plugin only runs during `vite build`.
+- **`config`** (boolean | string, optional, default: `false`): Load `sveld.config.{js,mjs,ts}` and merge it with these options; these options win when a key is set in both. `true` resolves the config from the Vite project root (or `process.cwd()` outside Vite); a string is an explicit path to the config file. See [Config File](#config-file).
+- **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when relevant source changes during `vite dev` / `vite build --watch`. A reparse is triggered by: editing a component; editing the entry barrel itself, which adds/removes the corresponding component; or editing a non-`.svelte` file a component depends on via [`@extendProps`](#extendprops) / `@extends` or a typedef `import("./x")` reference. Only the affected components are re-parsed, rather than rebuilding every component. Overlapping regenerations are queued, never run concurrently. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
 - **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. Also available as `--resolve-types` (`--resolveTypes` remains as a deprecated alias). See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
 - **`cache`** (boolean | string, optional, default: `true`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. On by default, writing to `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path; pass `false` to disable. Also available as `--cache` / `--cache=<path>` / `--cache=false`. See [Persistent parse cache](#persistent-parse-cache-cache).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,8 @@ import {
 } from "./check";
 import { formatDiagnosticsSummary, formatDiagnosticsSummaryJson } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
+import { closestMatch } from "./levenshtein";
+import { loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
 import { setQuiet } from "./logger";
 import { normalizeSeparators } from "./path";
 import { generateBundle, toGenerateBundleOptions, writeOutput, writeStdout } from "./plugin";
@@ -138,51 +139,10 @@ const SPACE_SEPARATED_VALUE_FLAGS = new Set(["entry", "cache", "check", "types-f
 /** Of those, the flags that error (rather than falling back to a bare default) when no value is given. */
 const REQUIRES_VALUE_FLAGS = new Set(["entry", "types-format"]);
 
-/** Largest edit distance for which a typo suggestion is still offered. */
-const MAX_SUGGESTION_DISTANCE = 3;
-
-/** Classic Levenshtein edit distance between two strings. */
-function levenshteinDistance(a: string, b: string): number {
-  const rows = a.length + 1;
-  const columns = b.length + 1;
-  const distances: number[][] = Array.from({ length: rows }, () => new Array<number>(columns).fill(0));
-
-  for (let i = 0; i < rows; i++) distances[i][0] = i;
-  for (let j = 0; j < columns; j++) distances[0][j] = j;
-
-  for (let i = 1; i < rows; i++) {
-    for (let j = 1; j < columns; j++) {
-      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
-      distances[i][j] = Math.min(
-        distances[i - 1][j] + 1,
-        distances[i][j - 1] + 1,
-        distances[i - 1][j - 1] + substitutionCost,
-      );
-    }
-  }
-
-  return distances[rows - 1][columns - 1];
-}
-
 /** Closest known flag (canonical spelling) to an unrecognized raw flag name, or undefined if none is close enough. */
 function suggestFlag(rawFlag: string): string | undefined {
-  let closest: string | undefined;
-  let closestDistance = Number.POSITIVE_INFINITY;
-
-  for (const candidate of FLAG_SUGGESTION_CANDIDATES) {
-    const distance = levenshteinDistance(rawFlag, candidate);
-
-    if (distance < closestDistance) {
-      closest = candidate;
-      closestDistance = distance;
-    }
-  }
-
-  if (closest === undefined || closestDistance > MAX_SUGGESTION_DISTANCE) {
-    return undefined;
-  }
-
-  return FLAG_ALIASES[closest] ?? closest;
+  const closest = closestMatch(rawFlag, FLAG_SUGGESTION_CANDIDATES);
+  return closest === undefined ? undefined : (FLAG_ALIASES[closest] ?? closest);
 }
 
 /**
@@ -367,14 +327,7 @@ export async function cli(process: NodeJS.Process) {
   const cliOptions = parsed.options;
   const fileConfig = await loadConfig();
   const options = mergeConfig<CliOptions>(fileConfig, cliOptions);
-
-  /**
-   * `mergeConfig` shallow-merges: `--types-format` alone would otherwise
-   * replace a config file's whole `typesOptions` object instead of adding to it.
-   */
-  if (fileConfig.typesOptions || cliOptions.typesOptions) {
-    options.typesOptions = { ...fileConfig.typesOptions, ...cliOptions.typesOptions };
-  }
+  validateOptions(options);
 
   if (options.stdout) {
     if (options.stdout !== true && options.stdout !== "json" && options.stdout !== "ndjson") {

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -1,14 +1,20 @@
 import { dirname, resolve } from "node:path";
 import type { ComponentDocApi, ComponentDocs, ResolveComponentFilePath } from "./bundle";
-import { SVELTE_EXT_REGEX } from "./path";
 
 /** Strips matching surrounding single/double quotes from an import specifier. */
 const SURROUNDING_QUOTES_REGEX = /^(['"])(.*)\1$/;
 
+/** Matches a relative or absolute path specifier, as opposed to a bare package import. */
+const LOCAL_SPECIFIER_REGEX = /^[./]/;
+
+/** Matches a JSDoc/TS `import("./x")` type reference; captures the specifier. */
+const TYPE_IMPORT_REGEX = /import\(\s*(['"])((?:(?!\1).)+)\1\s*\)/g;
+
 /**
  * Resolves a component's `@extendProps` / `@extends` target to an absolute path,
- * or `null` when it doesn't point at a local `.svelte` file (e.g. it references
- * an external package interface like `carbon-components-svelte`).
+ * or `null` when it isn't a local path (e.g. it references an external
+ * package interface like `carbon-components-svelte`). The target need not be
+ * `.svelte`: `@extendProps {./types.ts}` names a `.ts` interface.
  */
 function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): string | null {
   const raw = api.extends?.import;
@@ -16,15 +22,50 @@ function resolveExtendsDependency(api: ComponentDocApi, componentPath: string): 
   // `extends.import` is stored verbatim from the JSDoc tag, including any
   // surrounding quotes (e.g. `"./Button.svelte"`).
   const target = raw.replace(SURROUNDING_QUOTES_REGEX, "$2");
-  if (!SVELTE_EXT_REGEX.test(target)) return null;
+  if (!LOCAL_SPECIFIER_REGEX.test(target)) return null;
   return resolve(dirname(componentPath), target);
+}
+
+/** Extracts every local `import("./x")` type-reference target from a type text, resolved to an absolute path. */
+function resolveTypeImportDependencies(typeText: string, componentPath: string): string[] {
+  const targets: string[] = [];
+  for (const match of typeText.matchAll(TYPE_IMPORT_REGEX)) {
+    const specifier = match[2];
+    if (!LOCAL_SPECIFIER_REGEX.test(specifier)) continue;
+    targets.push(resolve(dirname(componentPath), specifier));
+  }
+  return targets;
+}
+
+/**
+ * Resolves every local file a component depends on for its documented shape:
+ * its `@extendProps` / `@extends` target, plus any `import("./x")` type
+ * reference inside its own `@typedef`s or prop types. Changing any of these
+ * files must re-parse the component even though they're never `.svelte`
+ * themselves and so are never components in their own right.
+ */
+function resolveDependencies(api: ComponentDocApi, componentPath: string): string[] {
+  const dependencies: string[] = [];
+
+  const extendsDependency = resolveExtendsDependency(api, componentPath);
+  if (extendsDependency !== null) dependencies.push(extendsDependency);
+
+  for (const typedef of api.typedefs ?? []) {
+    dependencies.push(...resolveTypeImportDependencies(typedef.type, componentPath));
+  }
+  for (const prop of api.props) {
+    if (prop.type) dependencies.push(...resolveTypeImportDependencies(prop.type, componentPath));
+  }
+
+  return dependencies;
 }
 
 /**
  * Builds a reverse-dependency map: `dependencyPath -> set of dependent paths`.
  *
  * A component is a dependent of `X` when it extends `X` via `@extendProps` /
- * `@extends`. When `X` changes, every dependent must be re-parsed.
+ * `@extends`, or references it via a `import("./x")` type. When `X` changes,
+ * every dependent must be re-parsed.
  */
 export function buildReverseDeps(
   components: ComponentDocs,
@@ -34,15 +75,15 @@ export function buildReverseDeps(
 
   for (const api of components.values()) {
     const componentPath = resolveComponentFilePath(api.filePath);
-    const dependency = resolveExtendsDependency(api, componentPath);
-    if (dependency === null) continue;
 
-    let dependents = reverse.get(dependency);
-    if (dependents === undefined) {
-      dependents = new Set();
-      reverse.set(dependency, dependents);
+    for (const dependency of resolveDependencies(api, componentPath)) {
+      let dependents = reverse.get(dependency);
+      if (dependents === undefined) {
+        dependents = new Set();
+        reverse.set(dependency, dependents);
+      }
+      dependents.add(componentPath);
     }
-    dependents.add(componentPath);
   }
 
   return reverse;

--- a/src/levenshtein.ts
+++ b/src/levenshtein.ts
@@ -1,0 +1,46 @@
+/** Largest edit distance for which a typo suggestion is still offered. */
+export const MAX_SUGGESTION_DISTANCE = 3;
+
+/** Classic Levenshtein edit distance between two strings. */
+export function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const columns = b.length + 1;
+  const distances: number[][] = Array.from({ length: rows }, () => new Array<number>(columns).fill(0));
+
+  for (let i = 0; i < rows; i++) distances[i][0] = i;
+  for (let j = 0; j < columns; j++) distances[0][j] = j;
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < columns; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      distances[i][j] = Math.min(
+        distances[i - 1][j] + 1,
+        distances[i][j - 1] + 1,
+        distances[i - 1][j - 1] + substitutionCost,
+      );
+    }
+  }
+
+  return distances[rows - 1][columns - 1];
+}
+
+/** Closest candidate string to `input` by Levenshtein distance, or `undefined` if none is close enough. */
+export function closestMatch(input: string, candidates: Iterable<string>): string | undefined {
+  let closest: string | undefined;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    const distance = levenshteinDistance(input, candidate);
+
+    if (distance < closestDistance) {
+      closest = candidate;
+      closestDistance = distance;
+    }
+  }
+
+  if (closest === undefined || closestDistance > MAX_SUGGESTION_DISTANCE) {
+    return undefined;
+  }
+
+  return closest;
+}

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { isObject } from "./ast-guards";
+import { closestMatch } from "./levenshtein";
 import type { PluginSveldOptions } from "./plugin";
 
 /**
@@ -132,9 +133,100 @@ export async function loadConfig(cwd: string = process.cwd()): Promise<SveldConf
   return loadConfigFrom(configPath);
 }
 
-/** Shallow-merge option sources. Later sources override earlier ones. */
+/**
+ * Merge option sources. Later sources override earlier ones. Keys whose
+ * value is a plain object (e.g. `typesOptions`, `jsonOptions`,
+ * `markdownOptions`, `customElementsOptions`, `additionalWriters`) are
+ * merged one level deep instead of replaced outright, so setting one nested
+ * key from a later source doesn't drop sibling keys set by an earlier one.
+ * Arrays and functions always replace; they are never merged.
+ */
 export function mergeConfig<T extends PluginSveldOptions = PluginSveldOptions>(
   ...sources: Array<Partial<T> | undefined>
 ): Partial<T> {
-  return Object.assign({}, ...sources.filter(Boolean));
+  const merged: Record<string, unknown> = {};
+
+  for (const source of sources) {
+    if (!source) continue;
+
+    for (const [key, value] of Object.entries(source)) {
+      const existing = merged[key];
+      merged[key] =
+        isObject(existing) && !Array.isArray(existing) && isObject(value) && !Array.isArray(value)
+          ? { ...existing, ...value }
+          : value;
+    }
+  }
+
+  return merged as Partial<T>;
+}
+
+/** Top-level keys accepted anywhere in `PluginSveldOptions` / `SveldRuntimeOptions`. */
+const KNOWN_TOP_LEVEL_KEYS = [
+  "entry",
+  "glob",
+  "quiet",
+  "documentExports",
+  "types",
+  "typesOptions",
+  "json",
+  "jsonOptions",
+  "markdown",
+  "markdownOptions",
+  "customElements",
+  "customElementsOptions",
+  "additionalWriters",
+  "failFast",
+  "watch",
+  "config",
+  "resolveTypes",
+  "cache",
+  "checkExamples",
+  "reportDiagnostics",
+  "strict",
+  "check",
+  "stdout",
+  "format",
+  "dryRun",
+];
+
+/** Known keys inside each `*Options` object, keyed by the top-level option name. `additionalWriters` is userland-defined and not validated here. */
+const KNOWN_NESTED_KEYS: Record<string, string[]> = {
+  typesOptions: ["outDir", "preamble", "format", "exports", "dryRun", "cache", "resolvedPathByFilePath"],
+  jsonOptions: ["input", "outFile", "outDir", "entryExports", "dryRun"],
+  markdownOptions: ["write", "outFile", "entryExports", "onAppend", "dryRun"],
+  customElementsOptions: ["outFile", "dryRun"],
+};
+
+/** Prints a "did you mean" suggestion for an unrecognized option key. `prefix` namespaces nested keys, e.g. `"typesOptions"` for `typesOptions.printWidth`. */
+function warnUnknownKey(prefix: string | null, key: string, candidates: string[]): void {
+  const path = prefix === null ? key : `${prefix}.${key}`;
+  const suggestion = closestMatch(key, candidates);
+  const suggestionPath =
+    suggestion === undefined ? undefined : prefix === null ? suggestion : `${prefix}.${suggestion}`;
+  console.warn(`sveld: unknown option "${path}".${suggestionPath ? ` Did you mean "${suggestionPath}"?` : ""}`);
+}
+
+/**
+ * Warns (via `console.warn`) about unknown top-level option keys and unknown
+ * keys inside each `*Options` object. Never throws: an unrecognized option
+ * is surfaced as a hint, not a fatal error.
+ */
+export function validateOptions(options: Partial<PluginSveldOptions>): void {
+  for (const key of Object.keys(options)) {
+    if (!KNOWN_TOP_LEVEL_KEYS.includes(key)) {
+      warnUnknownKey(null, key, KNOWN_TOP_LEVEL_KEYS);
+    }
+  }
+
+  for (const [optionsKey, knownKeys] of Object.entries(KNOWN_NESTED_KEYS)) {
+    const nested = (options as Record<string, unknown>)[optionsKey];
+    if (!isObject(nested)) continue;
+
+    for (const key of Object.keys(nested)) {
+      if (!knownKeys.includes(key)) {
+        warnUnknownKey(optionsKey, key, knownKeys);
+      }
+    }
+  }
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -4,6 +4,13 @@ import type { NormalizedPath } from "./brands";
 /** Matches a trailing `.svelte` extension. Shared so every module tests/strips it the same way. */
 export const SVELTE_EXT_REGEX = /\.svelte$/;
 
+/**
+ * Extensions the watch mode plugin hooks react to: components themselves,
+ * the entry barrel (which may be `.js`/`.ts`), and `@extendProps`/`@extends`/
+ * typedef `import(...)` dependency targets, which are never `.svelte`.
+ */
+export const WATCH_RELEVANT_EXT_REGEX = /\.(?:svelte|[mc]?ts|[mc]?js)$/;
+
 export function normalizeSeparators(filePath: string): NormalizedPath {
   return (sep === "/" ? filePath : filePath.split(sep).join("/")) as NormalizedPath;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { dirname } from "node:path";
+import { dirname, isAbsolute, resolve } from "node:path";
 import {
   type ComponentDocs,
   type GenerateBundleOptions,
@@ -7,8 +7,9 @@ import {
   toGenerateBundleOptions,
 } from "./bundle";
 import { getSvelteEntry } from "./get-svelte-entry";
+import { loadConfig, loadConfigFrom, mergeConfig, validateOptions } from "./load-config";
 import { setQuiet } from "./logger";
-import { SVELTE_EXT_REGEX } from "./path";
+import { WATCH_RELEVANT_EXT_REGEX } from "./path";
 import { createSveldBundle, type SveldBundle } from "./watch";
 // Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements" writers.
 import "./writer/built-in-writers";
@@ -27,6 +28,14 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
    * If not provided, sveld will use the "svelte" field from package.json.
    */
   entry?: string;
+  /**
+   * Load `sveld.config.{js,mjs,ts}` and merge it with these options; these
+   * options win when a key is set in both. `true` resolves the config from
+   * the Vite project root (or `process.cwd()` if the plugin isn't running
+   * under Vite); a string is an explicit path to the config file itself.
+   * @default false
+   */
+  config?: boolean | string;
   glob?: boolean;
   /** Suppress writer progress logs (`created "..."` / `unchanged "..."`). */
   quiet?: boolean;
@@ -54,9 +63,11 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
    */
   failFast?: boolean;
   /**
-   * Regenerate output incrementally when `.svelte` source changes during
-   * `vite dev` / `vite build --watch`. Only the changed component and the
-   * components that depend on it via `@extendProps` / `@extends` are re-parsed.
+   * Regenerate output incrementally when relevant source changes during
+   * `vite dev` / `vite build --watch`: a component, the entry barrel itself
+   * (adding/removing an export), or a non-`.svelte` file a component depends
+   * on via `@extendProps` / `@extends` or a typedef `import("./x")`
+   * reference. Only the affected components are re-parsed.
    * @default false
    */
   watch?: boolean;
@@ -72,10 +83,17 @@ interface RollupPluginContext {
   error(message: string): never;
 }
 
+/** Subset of Vite's resolved config, used only to locate the project root for `config` loading. */
+interface ResolvedViteConfig {
+  root: string;
+}
+
 interface SveldPlugin {
   name: string;
   apply?: "build" | "serve";
   enforce?: "pre" | "post";
+  /** Vite-only hook: captures the project root before `buildStart` runs. */
+  configResolved?(config: ResolvedViteConfig): void;
   buildStart(): void | Promise<void>;
   generateBundle(this: RollupPluginContext): Promise<void>;
   writeBundle(this: RollupPluginContext): Promise<void>;
@@ -92,30 +110,53 @@ const UNRESOLVED_ENTRY_MESSAGE =
 /** Debounce window (ms) for coalescing rapid file changes into one regeneration. */
 const WATCH_DEBOUNCE_MS = 50;
 
+/**
+ * Wraps an async `run` function so repeated calls execute strictly one after
+ * another: a call that arrives while a previous one is still in flight
+ * queues behind it instead of overlapping. Used to serialize watch-mode
+ * flushes, which mutate a shared `SveldBundle`'s internal state and would
+ * race if two ran concurrently.
+ */
+export function createSerialQueue(run: () => Promise<void>): () => void {
+  let pending: Promise<void> = Promise.resolve();
+  return () => {
+    pending = pending.then(run, run);
+  };
+}
+
 export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
   const watch = opts?.watch === true;
   let result: GenerateBundleResult;
   let input: string | null;
+  // Reassigned once in `buildStart` when `config` loading is enabled; every
+  // hook below reads options through this rather than `opts` directly so a
+  // loaded config file is visible everywhere.
+  let mergedOpts: PluginSveldOptions = opts ?? {};
+  let root: string | undefined;
 
   // Watch-mode state: a long-lived bundle that supports scoped re-parsing.
   let bundle: SveldBundle | null = null;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const pending = new Set<string>();
 
-  const flush = async () => {
+  const runFlush = async () => {
     if (bundle == null || input == null || pending.size === 0) return;
     const changed = Array.from(pending);
     pending.clear();
     try {
       const { result: next } = await bundle.update(changed);
-      await writeOutput(next, opts || {}, input);
+      await writeOutput(next, mergedOpts, input);
     } catch (error) {
       console.error("sveld: failed to regenerate types in watch mode:", error);
     }
   };
 
+  // Queues flushes onto one another so a slow `bundle.update()` can't
+  // overlap with the next debounced flush and race on the bundle's shared state.
+  const flush = createSerialQueue(runFlush);
+
   const scheduleUpdate = (id: string) => {
-    if (!watch || bundle == null || !SVELTE_EXT_REGEX.test(id)) return;
+    if (!watch || bundle == null || !WATCH_RELEVANT_EXT_REGEX.test(id)) return;
     pending.add(id);
     clearTimeout(timer);
     timer = setTimeout(flush, WATCH_DEBOUNCE_MS);
@@ -127,15 +168,27 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
     // `apply` unset. Otherwise keep the original build-only behavior.
     apply: watch ? undefined : "build",
     enforce: "post",
+    configResolved(config) {
+      root = config.root;
+    },
     async buildStart() {
-      setQuiet(opts?.quiet === true);
-      input = getSvelteEntry(opts?.entry);
+      if (opts?.config) {
+        const cwd = root ?? process.cwd();
+        const fileConfig =
+          typeof opts.config === "string"
+            ? await loadConfigFrom(isAbsolute(opts.config) ? opts.config : resolve(cwd, opts.config))
+            : await loadConfig(cwd);
+        mergedOpts = mergeConfig<PluginSveldOptions>(fileConfig, opts);
+      }
+      validateOptions(mergedOpts);
+      setQuiet(mergedOpts.quiet === true);
+      input = getSvelteEntry(mergedOpts.entry);
       if (watch && input != null) {
         // Produce the initial output and prime the incremental bundle. This
         // covers both `vite dev` (where generateBundle/writeBundle never fire)
         // and `vite build --watch`.
-        bundle = await createSveldBundle(input, opts?.glob === true, opts?.documentExports === true);
-        await writeOutput(bundle.result, opts || {}, input);
+        bundle = await createSveldBundle(input, mergedOpts.glob === true, mergedOpts.documentExports === true);
+        await writeOutput(bundle.result, mergedOpts, input);
       }
     },
     async generateBundle() {
@@ -144,14 +197,14 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
       if (input == null) {
         this.error(UNRESOLVED_ENTRY_MESSAGE);
       }
-      result = await generateBundle(input, opts?.glob === true, toGenerateBundleOptions(opts));
+      result = await generateBundle(input, mergedOpts.glob === true, toGenerateBundleOptions(mergedOpts));
     },
     async writeBundle() {
       if (watch) return;
       if (input == null) {
         this.error(UNRESOLVED_ENTRY_MESSAGE);
       }
-      await writeOutput(result, opts || {}, input);
+      await writeOutput(result, mergedOpts, input);
       // Persists any generated `.d.ts` text writeOutput just cached, on top
       // of the parse-only save generateBundle() already did.
       result.cache?.save();

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -2,7 +2,7 @@ import type { ComponentParseError } from "./bundle";
 import { type CheckResult, resolveCheckSnapshotFile, runCheck } from "./check";
 import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { loadConfig, mergeConfig, type SveldRuntimeOptions } from "./load-config";
+import { loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
 import { setQuiet } from "./logger";
 import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
@@ -56,6 +56,7 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
     );
   }
   const merged = mergeConfig<SveldRuntimeOptions>(fileConfig, runtimeOpts, { entry: input });
+  validateOptions(merged);
   setQuiet(merged.quiet === true);
   const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -26,9 +26,10 @@ interface SveldBundleUpdate {
   /** The full, updated bundle result (all components, with the affected ones re-parsed). */
   result: GenerateBundleResult;
   /**
-   * Absolute paths of the components that were re-parsed: the changed files
-   * plus their transitive `@extendProps` / `@extends` dependents. Other
-   * components are reused from the previous parse.
+   * Absolute paths of the components that were re-parsed: the changed files,
+   * newly barrel-exported components, plus their transitive dependents via
+   * `@extendProps` / `@extends` or a typedef `import("./x")` reference.
+   * Other components are reused from the previous parse.
    */
   reparsed: string[];
 }
@@ -56,21 +57,28 @@ export interface SveldBundle {
  * @param documentExports - Record consts, functions, and types from the entry barrel
  */
 export async function createSveldBundle(input: string, glob: boolean, documentExports = false): Promise<SveldBundle> {
-  // Export map is stable per edit; re-glob `allComponentEntries` in `update()` when files are added.
-  const { exports, allComponentEntries, rootDir, resolveComponentFilePath } = collectComponents(
-    input,
-    glob,
-    documentExports,
-  );
+  const inputIsFile = lstatSync(input).isFile();
+  // Watched so editing the barrel (adding/removing/renaming an export) is
+  // picked up without restarting the dev server; `null` for a directory
+  // entry, which has no barrel to watch.
+  const resolvedInput = inputIsFile ? resolve(input) : null;
 
-  const entryExports: EntryExports =
-    documentExports && lstatSync(input).isFile() ? await parseEntryExports(resolve(input)) : [];
+  // Export map and `allComponentEntries` are re-collected in `update()` when
+  // the entry barrel itself changes; otherwise stable across edits (glob
+  // mode still re-globs `allComponentEntries` on every update, see below).
+  const initial = collectComponents(input, glob, documentExports);
+  const rootDir = initial.rootDir;
+  let exports = initial.exports;
+  let allComponentEntries = initial.allComponentEntries;
+  let resolveComponentFilePath = initial.resolveComponentFilePath;
 
-  const exportEntries = Object.entries(exports);
+  let entryExports: EntryExports = documentExports && inputIsFile ? await parseEntryExports(resolve(input)) : [];
+
+  let exportEntries = Object.entries(exports);
 
   // Dedupes re-glob adds in `update()` by resolved path, including when two
-  // components share a basename.
-  const globMergeState = createGlobMergeState(allComponentEntries, resolveComponentFilePath);
+  // components share a basename. Rebuilt whenever the entry barrel changes.
+  let globMergeState = createGlobMergeState(allComponentEntries, resolveComponentFilePath);
 
   const components: ComponentDocs = new Map();
   const allComponentsForTypes: ComponentDocs = new Map();
@@ -152,10 +160,42 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
   };
 
   const update = async (changedFilePaths: string[]): Promise<SveldBundleUpdate> => {
-    const changed = changedFilePaths.filter((path) => SVELTE_EXT_REGEX.test(path)).map((path) => resolve(path));
+    const resolvedChanged = changedFilePaths.map((path) => resolve(path));
 
-    if (changed.length === 0) {
+    if (resolvedChanged.length === 0) {
       return { result: buildResult(), reparsed: [] };
+    }
+
+    const entryChanged = resolvedInput !== null && resolvedChanged.includes(resolvedInput);
+    const addedComponentPaths: string[] = [];
+
+    if (entryChanged) {
+      // Re-run export collection on the entry barrel: a name that disappears
+      // is dropped from `components` outright (its file may still surface via
+      // `--glob`); a name that appears is treated as changed so the normal
+      // reparse path below parses it for the first time.
+      const recollected = collectComponents(input, glob, documentExports);
+      const oldNames = new Set(Object.keys(exports));
+      const newNames = new Set(Object.keys(recollected.exports));
+
+      for (const name of oldNames) {
+        if (!newNames.has(name)) components.delete(name);
+      }
+      for (const name of newNames) {
+        if (!oldNames.has(name)) {
+          addedComponentPaths.push(recollected.resolveComponentFilePath(recollected.exports[name].source));
+        }
+      }
+
+      exports = recollected.exports;
+      allComponentEntries = recollected.allComponentEntries;
+      resolveComponentFilePath = recollected.resolveComponentFilePath;
+      exportEntries = Object.entries(exports);
+      globMergeState = createGlobMergeState(allComponentEntries, resolveComponentFilePath);
+
+      if (documentExports && inputIsFile) {
+        entryExports = await parseEntryExports(resolve(input));
+      }
     }
 
     // Pick up components created since the last parse.
@@ -163,7 +203,16 @@ export async function createSveldBundle(input: string, glob: boolean, documentEx
       mergeGlobbedComponents(rootDir, exports, allComponentEntries, resolveComponentFilePath, globMergeState);
     }
 
-    const affected = expandAffected(changed, reverseDeps);
+    // Non-`.svelte` changes only matter when they're a known dependency
+    // target (an `@extendProps`/`@extends` file or a typedef `import(...)`
+    // target); anything else (README, CSS, ...) is ignored here.
+    const relevantChanged = resolvedChanged.filter((path) => SVELTE_EXT_REGEX.test(path) || reverseDeps.has(path));
+
+    if (relevantChanged.length === 0 && addedComponentPaths.length === 0) {
+      return { result: buildResult(), reparsed: [] };
+    }
+
+    const affected = expandAffected([...relevantChanged, ...addedComponentPaths], reverseDeps);
 
     // Clear diagnostics for files about to be re-parsed.
     for (const [filePath, error] of parseErrors) {

--- a/tests/e2e/svelte5-vite/vite.config.js
+++ b/tests/e2e/svelte5-vite/vite.config.js
@@ -8,7 +8,6 @@ export default defineConfig({
     sveld({
       types: true,
       typesOptions: {
-        printWidth: 80,
         format: "component",
       },
       json: true,

--- a/tests/load-config.test.ts
+++ b/tests/load-config.test.ts
@@ -8,6 +8,7 @@ import {
   mergeConfig,
   resolveConfigPath,
   type SveldRuntimeOptions,
+  validateOptions,
 } from "../src/load-config";
 import type { PluginSveldOptions } from "../src/plugin";
 
@@ -154,5 +155,87 @@ describe("mergeConfig", () => {
       check: "snapshots/api.json",
       reportDiagnostics: true,
     });
+  });
+
+  test("deep-merges typesOptions instead of replacing it outright", () => {
+    const fileConfig: Partial<PluginSveldOptions> = { typesOptions: { outDir: "dist", preamble: "// license" } };
+    expect(mergeConfig(fileConfig, { typesOptions: { format: "component" } })).toEqual({
+      typesOptions: { outDir: "dist", preamble: "// license", format: "component" },
+    });
+  });
+
+  test("a later source's key inside typesOptions overrides the earlier one", () => {
+    const fileConfig: Partial<PluginSveldOptions> = { typesOptions: { format: "class" } };
+    expect(mergeConfig(fileConfig, { typesOptions: { format: "component" } })).toEqual({
+      typesOptions: { format: "component" },
+    });
+  });
+
+  test("deep-merges jsonOptions, markdownOptions, and customElementsOptions", () => {
+    const fileConfig: Partial<PluginSveldOptions> = {
+      jsonOptions: { outFile: "api.json" },
+      markdownOptions: { outFile: "index.md" },
+      customElementsOptions: { outFile: "ce.json" },
+    };
+    expect(
+      mergeConfig(fileConfig, {
+        jsonOptions: { outDir: "docs" },
+        markdownOptions: { write: false },
+        customElementsOptions: { dryRun: true },
+      }),
+    ).toEqual({
+      jsonOptions: { outFile: "api.json", outDir: "docs" },
+      markdownOptions: { outFile: "index.md", write: false },
+      customElementsOptions: { outFile: "ce.json", dryRun: true },
+    });
+  });
+
+  test("deep-merges additionalWriters at the writer-name level", () => {
+    const fileConfig: Partial<PluginSveldOptions> = { additionalWriters: { llms: { outFile: "llms.txt" } } };
+    expect(mergeConfig(fileConfig, { additionalWriters: { other: { outFile: "other.txt" } } })).toEqual({
+      additionalWriters: { llms: { outFile: "llms.txt" }, other: { outFile: "other.txt" } },
+    });
+  });
+
+  test("replaces arrays and functions instead of merging them", () => {
+    const onAppend = () => {};
+    const fileConfig: Partial<PluginSveldOptions> = { markdownOptions: { onAppend } };
+    const overriddenOnAppend = () => {};
+    expect(mergeConfig(fileConfig, { markdownOptions: { onAppend: overriddenOnAppend } })).toEqual({
+      markdownOptions: { onAppend: overriddenOnAppend },
+    });
+  });
+});
+
+describe("validateOptions", () => {
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("does not warn for known top-level and nested options", () => {
+    validateOptions({ json: true, typesOptions: { outDir: "dist", format: "component" } });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("warns about an unknown top-level key with a suggestion", () => {
+    validateOptions({ galob: true } as Partial<PluginSveldOptions>);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown option "galob"'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Did you mean "glob"?'));
+  });
+
+  test("warns about an unknown key inside typesOptions with a suggestion", () => {
+    validateOptions({ typesOptions: { printWidth: 80 } } as unknown as Partial<PluginSveldOptions>);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown option "typesOptions.printWidth"'));
+  });
+
+  test("does not validate inside additionalWriters (userland-defined shape)", () => {
+    validateOptions({ additionalWriters: { llms: { anything: true } } });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -1,11 +1,19 @@
 // biome-ignore lint/performance/noNamespaceImport: needed for jest.spyOn
 import * as fs from "node:fs";
+import { tmpdir } from "node:os";
 // biome-ignore lint/performance/noNamespaceImport: needed for jest.spyOn
 import * as path from "node:path";
 import type { ComponentDocs, GenerateBundleResult } from "../src/plugin";
 import pluginSveld, { generateBundle, writeOutput } from "../src/plugin";
 import { registerWriter } from "../src/writer/registry";
 import { mockComponentDocApi } from "./test-brands";
+
+/** Mock Rollup plugin context: throws (instead of `never`-returning) so `this.error(...)` surfaces as a rejected promise. */
+const errorContext = {
+  error: (message: string) => {
+    throw new Error(message);
+  },
+};
 
 describe("pluginSveld", () => {
   const mockCwd = "/mock/project";
@@ -214,5 +222,57 @@ describe("writeOutput additionalWriters", () => {
     );
 
     expect(received).toBe(components);
+  });
+});
+
+describe("pluginSveld config option", () => {
+  const BUTTON = `<script>\n  export let label = "button";\n</script>\n\n<button>{label}</button>`;
+
+  let dir: string;
+  let previousCwd: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(tmpdir(), "sveld-plugin-config-"));
+    fs.writeFileSync(path.join(dir, "Button.svelte"), BUTTON);
+    previousCwd = process.cwd();
+    process.chdir(dir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function runBuild(plugin: ReturnType<typeof pluginSveld>) {
+    await plugin.buildStart();
+    await plugin.generateBundle.call(errorContext);
+    await plugin.writeBundle.call(errorContext);
+  }
+
+  test("config: false (the default) ignores a config file present in cwd", async () => {
+    fs.writeFileSync(path.join(dir, "sveld.config.mjs"), "export default { json: true };");
+    const plugin = pluginSveld({ entry: ".", glob: true, types: false });
+
+    await runBuild(plugin);
+
+    expect(fs.existsSync(path.join(dir, "COMPONENT_API.json"))).toBe(false);
+  });
+
+  test("config: true loads sveld.config.mjs and applies its options", async () => {
+    fs.writeFileSync(path.join(dir, "sveld.config.mjs"), "export default { json: true };");
+    const plugin = pluginSveld({ entry: ".", glob: true, types: false, config: true });
+
+    await runBuild(plugin);
+
+    expect(fs.existsSync(path.join(dir, "COMPONENT_API.json"))).toBe(true);
+  });
+
+  test("call-site options take precedence over the same key in the config file", async () => {
+    fs.writeFileSync(path.join(dir, "sveld.config.mjs"), "export default { json: true };");
+    const plugin = pluginSveld({ entry: ".", glob: true, types: false, config: true, json: false });
+
+    await runBuild(plugin);
+
+    expect(fs.existsSync(path.join(dir, "COMPONENT_API.json"))).toBe(false);
   });
 });

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ComponentDocApi, ComponentDocs } from "../src/bundle";
-import pluginSveld from "../src/plugin";
+import pluginSveld, { createSerialQueue } from "../src/plugin";
 import { createSveldBundle } from "../src/watch";
 
 /** Look up `allComponentsForTypes` by filePath; moduleName is not unique. */
@@ -156,6 +156,64 @@ describe("watch mode (createSveldBundle)", () => {
     expect(propNames).toContain("danger");
     expect(propNames).not.toContain("primary");
   });
+
+  test("editing a non-.svelte @extendProps target reparses its dependent", async () => {
+    const typesPath = join(dir, "types.ts");
+    writeFileSync(typesPath, "export interface ExternalProps {\n  size: string;\n}\n");
+    writeFileSync(
+      join(dir, "WithExternalProps.svelte"),
+      `<script>
+  /** @extendProps {"./types.ts"} ExternalProps */
+  export let size = "medium";
+</script>
+
+<div>{size}</div>`,
+    );
+
+    const bundle = await createSveldBundle(dir, true);
+
+    writeFileSync(typesPath, "export interface ExternalProps {\n  size: string;\n  color: string;\n}\n");
+    const { reparsed } = await bundle.update([resolve(typesPath)]);
+
+    expect(reparsed).toEqual([resolve(dir, "WithExternalProps.svelte")]);
+  });
+
+  test("editing the entry barrel to add an export re-parses the newly exported component", async () => {
+    const entryPath = join(dir, "index.js");
+    writeFileSync(entryPath, 'export { default as Button } from "./Button.svelte";\n');
+
+    const bundle = await createSveldBundle(entryPath, false);
+    expect(Array.from(bundle.result.components.keys())).toEqual(["Button"]);
+
+    writeFileSync(
+      entryPath,
+      'export { default as Button } from "./Button.svelte";\n' +
+        'export { default as Standalone } from "./Standalone.svelte";\n',
+    );
+
+    const { result, reparsed } = await bundle.update([resolve(entryPath)]);
+
+    expect(Array.from(result.components.keys()).sort()).toEqual(["Button", "Standalone"]);
+    expect(reparsed).toContain(resolve(dir, "Standalone.svelte"));
+  });
+
+  test("editing the entry barrel to remove an export drops it from the exported components", async () => {
+    const entryPath = join(dir, "index.js");
+    writeFileSync(
+      entryPath,
+      'export { default as Button } from "./Button.svelte";\n' +
+        'export { default as Standalone } from "./Standalone.svelte";\n',
+    );
+
+    const bundle = await createSveldBundle(entryPath, false);
+    expect(Array.from(bundle.result.components.keys()).sort()).toEqual(["Button", "Standalone"]);
+
+    writeFileSync(entryPath, 'export { default as Button } from "./Button.svelte";\n');
+
+    const { result } = await bundle.update([resolve(entryPath)]);
+
+    expect(Array.from(result.components.keys())).toEqual(["Button"]);
+  });
 });
 
 describe("pluginSveld watch option", () => {
@@ -172,5 +230,53 @@ describe("pluginSveld watch option", () => {
     const plugin = pluginSveld({ watch: true });
     // Should not throw when no bundle exists yet (e.g. invalid entry).
     expect(() => plugin.handleHotUpdate?.({ file: "/tmp/Anything.svelte" })).not.toThrow();
+  });
+});
+
+describe("createSerialQueue", () => {
+  test("queues a call that arrives while the previous one is still in flight, instead of overlapping it", async () => {
+    const order: string[] = [];
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const run = async () => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      order.push("start");
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      order.push("end");
+      concurrent--;
+    };
+
+    const trigger = createSerialQueue(run);
+    trigger();
+    trigger(); // Fires while the first `run()` is still awaiting its timeout.
+
+    // Wait for both queued runs to settle.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(maxConcurrent).toBe(1);
+    expect(order).toEqual(["start", "end", "start", "end"]);
+  });
+
+  test("a rejected run does not break the queue for the next call", async () => {
+    const order: string[] = [];
+    const run = jest
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(async () => {
+        order.push("first");
+        throw new Error("boom");
+      })
+      .mockImplementationOnce(async () => {
+        order.push("second");
+      });
+
+    const trigger = createSerialQueue(run);
+    trigger();
+    trigger();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(order).toEqual(["first", "second"]);
   });
 });


### PR DESCRIPTION
The Vite/Rollup plugin was the only entry point that ignored
sveld.config, and the CLI's typesOptions merge patch didn't cover
the other *Options objects. Watch mode also missed entry barrel
edits and non-.svelte dependency files.