### PR TITLE
feat(writer): first-party llms.txt and llms-full.txt writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,12 @@ export default class Button extends SvelteComponentTyped<
 - [JSON Output](#json-output)
 - [Custom Elements Manifest](#custom-elements-manifest)
   - [Consuming the manifest](#consuming-the-manifest)
+- [llms.txt Output](#llmstxt-output)
 - [Custom Writers](#custom-writers)
   - [The `OutputWriter` contract](#the-outputwriter-contract)
   - [Registering a writer](#registering-a-writer)
   - [Running it via the plugin](#running-it-via-the-plugin)
-  - [Worked example: a minimal `llms.txt` writer](#worked-example-a-minimal-llmstxt-writer)
+  - [Worked example: a `components.txt` name-list writer](#worked-example-a-componentstxt-name-list-writer)
 - [API Reference](#api-reference)
   - [reactive](#reactive)
   - [binding](#binding)
@@ -494,7 +495,7 @@ npx sveld --json --markdown
 
 If no entry point can be resolved (no `package.json#svelte` field and no `--entry`), the CLI exits `1` and prints the reason to `stderr`. If `src/index.js` happens to exist relative to your working directory, sveld falls back to it and prints a one-line note asking you to set `package.json#svelte` (or `--entry`) instead of relying on the fallback.
 
-Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--custom-elements`, `--fail-fast`, `--dry-run`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`, `--stdout`, `--format`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. `--entry`, `--cache`, `--check`, and `--types-format` take their value either as `--flag=value` or as a separate `--flag value` argument (`sveld --entry src/index.js` and `sveld --entry=src/index.js` are equivalent); if the next argument starts with `--` it's not consumed as a value, so `--cache` and `--check` fall back to their default location and `--entry` and `--types-format` report a usage error naming the flag. Boolean flags (`--json`, `--glob`, `--strict`, and the like) never consume a following argument. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; when a close match exists it appends a suggestion, e.g. `Unknown flag: --markdwon Did you mean --markdown?`. sveld takes no positional arguments, so any non-flag argument errors the same way.
+Flags are kebab-case: `--entry`, `--glob`, `--types`, `--json`, `--markdown`, `--custom-elements`, `--llms`, `--fail-fast`, `--dry-run`, `--cache`, `--resolve-types`, `--check-examples`, `--report-diagnostics`, `--strict`, `--check`, `--types-format`, `--quiet`, `--stdout`, `--format`. The camelCase spellings `--resolveTypes` and `--checkExamples` still work as deprecated aliases for compatibility with existing scripts. `--entry`, `--cache`, `--check`, and `--types-format` take their value either as `--flag=value` or as a separate `--flag value` argument (`sveld --entry src/index.js` and `sveld --entry=src/index.js` are equivalent); if the next argument starts with `--` it's not consumed as a value, so `--cache` and `--check` fall back to their default location and `--entry` and `--types-format` report a usage error naming the flag. Boolean flags (`--json`, `--glob`, `--strict`, and the like) never consume a following argument. An unrecognized flag (e.g. `--markdwon`) prints `Unknown flag: --markdwon` to `stderr`, exits `1`, and skips generation; when a close match exists it appends a suggestion, e.g. `Unknown flag: --markdwon Did you mean --markdown?`. sveld takes no positional arguments, so any non-flag argument errors the same way.
 
 Writer progress lines (`created "..."` / `unchanged "..."`) print to `stderr`, keeping `stdout` reserved for machine-readable data. Pass `--quiet` (or `quiet: true` in `sveld.config.*`) to suppress them; it does not suppress error messages, the diagnostics summary (`--report-diagnostics` / `--strict`), or the `--check` report.
 
@@ -762,6 +763,12 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`customElements`** (boolean, optional): Generate a [Custom Elements Manifest](#custom-elements-manifest) (`custom-elements.json`). Also available as the `--custom-elements` CLI flag.
 - **`customElementsOptions`** (object, optional): Options for Custom Elements Manifest output.
   - **`outFile`** (string, optional, default: `"custom-elements.json"`): Path (relative to the project root) for the generated manifest file.
+- **`llms`** (boolean, optional): Generate an [`llms.txt` / `llms-full.txt`](#llmstxt-output) pair. Also available as the `--llms` CLI flag.
+- **`llmsOptions`** (object, optional): Options for `llms.txt` / `llms-full.txt` output.
+  - **`outDir`** (string, optional): Directory (relative to the project root) both files are written into. Defaults to the project root.
+  - **`linkBase`** (string, optional, default: `""`): Prefixed to each component's link in `llms.txt`.
+  - **`title`** (string, optional, default: the `"name"` field from `package.json`): The `# <title>` heading both files start with.
+  - **`summary`** (string, optional, default: the `"description"` field from `package.json`): The `> <summary>` blockquote under the title.
 - **`config`** (boolean | string, optional, default: `false`): Load `sveld.config.{js,mjs,ts}` and merge it with these options; these options win when a key is set in both. `true` resolves the config from the Vite project root (or `process.cwd()` outside Vite); a string is an explicit path to the config file. See [Config File](#config-file).
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when relevant source changes during `vite dev` / `vite build --watch`. A reparse is triggered by: editing a component; editing the entry barrel itself, which adds/removes the corresponding component; or editing a non-`.svelte` file a component depends on via [`@extendProps`](#extendprops) / `@extends` or a typedef `import("./x")` reference. Only the affected components are re-parsed, rather than rebuilding every component. Overlapping regenerations are queued, never run concurrently. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
@@ -1038,6 +1045,25 @@ With that in place:
 - [Storybook](https://storybook.js.org/docs/api/doc-blocks/doc-block-argtypes#extracting-argtypes) for web components reads the manifest to auto-generate `argTypes` (controls, docs tables) for `customElement`-compiled components, once you point it at the file (e.g. `setCustomElementsManifest` from `@storybook/web-components`, or `customElements: "custom-elements.json"` in `.storybook/main.js`).
 - Any other tool built against the [Custom Elements Manifest spec](https://github.com/webcomponents/custom-elements-manifest) (API viewers, doc generators, linters) can read the file directly without sveld-specific integration.
 
+## llms.txt Output
+
+Set `llms: true` to emit an [`llms.txt`](https://llmstxt.org) / `llms-full.txt` pair: `llms.txt` is an index of every exported component (one link plus a one-line summary each), and `llms-full.txt` is the flattened full reference (every component's Props, Bindings, Events, Slots/Snippets, Typedefs, and Module exports, as terse Markdown tables).
+
+```diff
+sveld({
++  llms: true,
+})
+```
+
+- **`llms`** (boolean, optional): Generate `llms.txt` and `llms-full.txt`. Also available as the `--llms` CLI flag.
+- **`llmsOptions`** (object, optional):
+  - **`outDir`** (string, optional): Directory (relative to the project root) both files are written into. Defaults to the project root.
+  - **`linkBase`** (string, optional, default: `""`): Prefixed to each component's link in `llms.txt`, e.g. `[Button](<linkBase>/Button)`. Set this to your published docs site's base path.
+  - **`title`** (string, optional, default: the `"name"` field from `package.json`): The `# <title>` heading both files start with.
+  - **`summary`** (string, optional, default: the `"description"` field from `package.json`): The `> <summary>` blockquote under the title. Omitted when neither is set.
+
+Each component's one-line summary in `llms.txt` is the first sentence of its [`@component` comment](#component-comments), falling back to `"Component"`. Set `documentExports: true` to also list entry-barrel exports (consts, functions, types) in `llms.txt` under an `## Exports` heading.
+
 ## Custom Writers
 
 `json`, `markdown`, `types`, and `custom-elements` are all built on the same
@@ -1118,36 +1144,28 @@ alongside whichever built-in outputs (`types` / `json` / `markdown` /
 programmatic Node API and from `sveld.config.ts` (`additionalWriters` lives on
 the options shared by all three entry points).
 
-### Worked example: a minimal `llms.txt` writer
+### Worked example: a `components.txt` name-list writer
 
-A plain-text, one-file-per-library summary — the kind of thing
-[llms.txt](https://llmstxt.org)-aware tools look for — is a good demo because
-it needs nothing beyond `ComponentApiDocument`.
+Looking for an `llms.txt` writer specifically? Sveld ships one — see [llms.txt Output](#llmstxt-output). This example is a much smaller custom writer, just to show the pattern: a plain-text list of exported component names, needing nothing beyond `ComponentApiDocument`.
 
 ```ts
-// writers/llms-writer.ts
+// writers/components-txt-writer.ts
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildComponentApiDocument, registerWriter } from "sveld";
 
-interface LlmsWriterOptions {
+interface ComponentsTxtWriterOptions {
   outFile?: string;
 }
 
-registerWriter<LlmsWriterOptions>({
-  name: "llms-demo",
+registerWriter<ComponentsTxtWriterOptions>({
+  name: "components-txt",
   componentSet: "exported",
   write(components, options = {}) {
     const document = buildComponentApiDocument(components);
+    const rendered = document.components.map((component) => component.moduleName).join("\n");
 
-    const sections = document.components.map((component) => {
-      const props = component.props.map((prop) => `${prop.name}: ${prop.type ?? "unknown"}`).join(", ");
-      return `## ${component.moduleName}\n\nProps: ${props || "none"}`;
-    });
-
-    const rendered = ["# My Library", "", "> Auto-generated component reference.", "", ...sections].join("\n\n");
-
-    writeFileSync(join(process.cwd(), options.outFile ?? "llms.txt"), rendered);
+    writeFileSync(join(process.cwd(), options.outFile ?? "components.txt"), rendered);
   },
 });
 ```
@@ -1155,21 +1173,21 @@ registerWriter<LlmsWriterOptions>({
 ```ts
 // vite.config.ts
 import sveld from "sveld";
-import "./writers/llms-writer";
+import "./writers/components-txt-writer";
 
 export default {
   plugins: [
     sveld({
       additionalWriters: {
-        "llms-demo": { outFile: "llms.txt" },
+        "components-txt": { outFile: "components.txt" },
       },
     }),
   ],
 };
 ```
 
-Running a build now produces an `llms.txt` alongside the usual output, with
-one section per exported component.
+Running a build now produces a `components.txt` alongside the usual output,
+listing one exported component name per line.
 
 ## API Reference
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,7 @@ Options:
   --json                Generate component documentation in JSON format
   --markdown            Generate component documentation in Markdown format
   --custom-elements     Generate a Custom Elements Manifest (custom-elements.json)
+  --llms                Generate an llms.txt / llms-full.txt pair (https://llmstxt.org)
   --fail-fast           Abort the run when a single component fails to parse
   --dry-run             Resolve, parse, and print "would write" lines for each output file instead of writing anything (including the parse cache)
   --quiet               Suppress progress logs (errors, the diagnostics summary, and the --check report are unaffected)
@@ -101,6 +102,7 @@ const KNOWN_FLAGS = [
   "quiet",
   "stdout",
   "custom-elements",
+  "llms",
   "strict",
   "report-diagnostics",
   "resolve-types",
@@ -125,6 +127,7 @@ const BOOLEAN_FLAGS = new Set([
   "markdown",
   "quiet",
   "custom-elements",
+  "llms",
   "strict",
   "report-diagnostics",
   "resolve-types",
@@ -203,6 +206,8 @@ function parseCliFlagValue(flag: string, value: string | boolean, arg: string, r
       return { kind: "option", option: { stdout: value as "json" | "ndjson" } };
     case "custom-elements":
       return { kind: "option", option: { customElements: value === true || value === "true" } };
+    case "llms":
+      return { kind: "option", option: { llms: value === true || value === "true" } };
     case "strict":
       return { kind: "option", option: { strict: value === true || value === "true" } };
     case "report-diagnostics":

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -175,6 +175,8 @@ const KNOWN_TOP_LEVEL_KEYS = [
   "markdownOptions",
   "customElements",
   "customElementsOptions",
+  "llms",
+  "llmsOptions",
   "additionalWriters",
   "failFast",
   "watch",
@@ -196,6 +198,7 @@ const KNOWN_NESTED_KEYS: Record<string, string[]> = {
   jsonOptions: ["input", "outFile", "outDir", "entryExports", "dryRun"],
   markdownOptions: ["write", "outFile", "entryExports", "onAppend", "dryRun"],
   customElementsOptions: ["outFile", "dryRun"],
+  llmsOptions: ["outDir", "linkBase", "title", "summary", "entryExports", "dryRun"],
 };
 
 /** Prints a "did you mean" suggestion for an unrecognized option key. `prefix` namespaces nested keys, e.g. `"typesOptions"` for `typesOptions.printWidth`. */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -16,6 +16,7 @@ import "./writer/built-in-writers";
 import { getWriter } from "./writer/registry";
 import { renderCustomElementsManifest, type WriteCustomElementsOptions } from "./writer/writer-custom-elements";
 import { renderJsonDocument, renderJsonLines, type WriteJsonOptions } from "./writer/writer-json";
+import type { WriteLlmsOptions } from "./writer/writer-llms";
 import { renderMarkdownDocument, type WriteMarkdownOptions } from "./writer/writer-markdown";
 import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 
@@ -50,6 +51,9 @@ export interface PluginSveldOptions extends Pick<GenerateBundleOptions, "resolve
   /** Generate a Custom Elements Manifest (`custom-elements.json`, schemaVersion "1.0.0"). */
   customElements?: boolean;
   customElementsOptions?: Partial<Omit<WriteCustomElementsOptions, "inputDir">>;
+  /** Generate a first-party `llms.txt` / `llms-full.txt` pair (per https://llmstxt.org). */
+  llms?: boolean;
+  llmsOptions?: Partial<WriteLlmsOptions>;
   /**
    * Run additional, userland-registered writers (via `registerWriter` from
    * "sveld") beyond the built-in `json`/`markdown`/`types` outputs. Keyed by
@@ -220,7 +224,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
 
 /** Looks up a built-in writer by name; throws if `built-in-writers` never registered it. */
 function runBuiltInWriter(
-  name: "types" | "json" | "markdown" | "custom-elements",
+  name: "types" | "json" | "markdown" | "custom-elements" | "llms",
   components: ComponentDocs,
   options: unknown,
 ) {
@@ -317,6 +321,18 @@ export async function writeOutput(
       inputDir,
       dryRun,
     } satisfies WriteCustomElementsOptions);
+  }
+
+  if (opts?.llms) {
+    /**
+     * Use components (exported only) for llms.txt/llms-full.txt, matching
+     * the JSON/Markdown outputs' public-API-surface convention.
+     */
+    await runBuiltInWriter("llms", result.components, {
+      ...opts?.llmsOptions,
+      entryExports: result.entryExports,
+      dryRun,
+    } satisfies WriteLlmsOptions);
   }
 
   const additionalWrites = Object.entries(opts?.additionalWriters ?? {}).map(([name, writerOptions]) => {

--- a/src/read-project-package-meta.ts
+++ b/src/read-project-package-meta.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parsePackageJson } from "./validate";
+
+/** `name`/`description` from the consuming project's `package.json`, or `{}` if it can't be read. */
+export function readProjectPackageMeta(): Pick<ReturnType<typeof parsePackageJson>, "name" | "description"> {
+  try {
+    const { name, description } = parsePackageJson(
+      JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8")),
+    );
+    return { name, description };
+  } catch {
+    return {};
+  }
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -2,6 +2,8 @@ import { isObject } from "./ast-guards";
 
 export interface ParsedPackageJson {
   svelte?: string;
+  name?: string;
+  description?: string;
 }
 
 export function parsePackageJson(value: unknown): ParsedPackageJson {
@@ -9,8 +11,11 @@ export function parsePackageJson(value: unknown): ParsedPackageJson {
     return {};
   }
 
-  const svelte = value.svelte;
-  return typeof svelte === "string" ? { svelte } : {};
+  const result: ParsedPackageJson = {};
+  if (typeof value.svelte === "string") result.svelte = value.svelte;
+  if (typeof value.name === "string") result.name = value.name;
+  if (typeof value.description === "string") result.description = value.description;
+  return result;
 }
 
 export interface ParsedTsConfig {

--- a/src/writer/built-in-writers.ts
+++ b/src/writer/built-in-writers.ts
@@ -1,6 +1,7 @@
 import { registerWriter } from "./registry";
 import writeCustomElements from "./writer-custom-elements";
 import writeJson from "./writer-json";
+import writeLlms from "./writer-llms";
 import writeMarkdown from "./writer-markdown";
 import writeTsDefinitions from "./writer-ts-definitions";
 
@@ -8,3 +9,4 @@ registerWriter({ name: "json", componentSet: "exported", write: writeJson });
 registerWriter({ name: "markdown", componentSet: "exported", write: writeMarkdown });
 registerWriter({ name: "types", componentSet: "all", write: writeTsDefinitions });
 registerWriter({ name: "custom-elements", componentSet: "exported", write: writeCustomElements });
+registerWriter({ name: "llms", componentSet: "exported", write: writeLlms });

--- a/src/writer/writer-llms.ts
+++ b/src/writer/writer-llms.ts
@@ -1,0 +1,229 @@
+import path from "node:path";
+import type { ComponentProp, ComponentSlot, SerializedComponentEvent } from "../ComponentParser";
+import { info } from "../logger";
+import type { EntryExports } from "../parse-entry-exports";
+import { normalizeSeparators } from "../path";
+import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { readProjectPackageMeta } from "../read-project-package-meta";
+import { buildComponentApiDocument } from "./document-model";
+import { MarkdownWriterBaseImpl } from "./MarkdownWriterBase";
+import {
+  EVENT_TABLE_HEADER,
+  formatEventDetail,
+  formatNameWithDeprecation,
+  formatPropDescription,
+  formatPropType,
+  formatPropValue,
+  formatSlotDescription,
+  formatSlotFallback,
+  formatSlotProps,
+  MD_TYPE_UNDEFINED,
+  SLOT_TABLE_HEADER,
+} from "./markdown-format-utils";
+import Writer from "./Writer";
+import { getTypeDefs } from "./writer-ts-definitions-core";
+
+export interface WriteLlmsOptions {
+  outDir?: string;
+  /** Prefixed to each component's link path, e.g. `[Name](<linkBase>/Name)`. @default "" */
+  linkBase?: string;
+  /** @default the "name" field from the project's package.json */
+  title?: string;
+  /** @default the "description" field from the project's package.json */
+  summary?: string;
+  /** @internal Entry-barrel exports when `documentExports` is on. Always computed from the parsed bundle and injected by the caller. */
+  entryExports?: EntryExports;
+  /** @internal Report the resolved paths instead of writing. Always set by the caller from `sveld --dry-run`. */
+  dryRun?: boolean;
+}
+
+/** Terse 5-column table shared by every `ComponentProp[]`-shaped section (Props, Bindings, Module exports). */
+const LLMS_PROP_TABLE_HEADER = "| Name | Type | Default | Required | Description |\n| :- | :- | :- | :- | :- |\n";
+
+const SENTENCE_END_REGEX = /[.!?](?:\s|$)/;
+const BLANK_LINE_REGEX = /\r?\n[ \t]*\r?\n/;
+const WHITESPACE_RUN_REGEX = /\s+/g;
+
+/** First sentence of the first paragraph of `text`, or `fallback` when `text` is empty. */
+function firstSentence(text: string | undefined, fallback: string): string {
+  if (!text) return fallback;
+
+  const firstParagraph = text.trim().split(BLANK_LINE_REGEX)[0]?.replace(WHITESPACE_RUN_REGEX, " ").trim();
+  if (!firstParagraph) return fallback;
+
+  const match = SENTENCE_END_REGEX.exec(firstParagraph);
+  return match ? firstParagraph.slice(0, match.index + 1) : firstParagraph;
+}
+
+function renderPropsTableSection(document: MarkdownWriterBaseImpl, heading: string, props: ComponentProp[]) {
+  if (props.length === 0) return;
+
+  document.append("h3", heading);
+  document.append("raw", LLMS_PROP_TABLE_HEADER);
+  for (const prop of props) {
+    document.append(
+      "raw",
+      `| ${formatNameWithDeprecation(prop.name, prop.deprecated)} | ${formatPropType(prop.type)} | ${formatPropValue(
+        prop.value,
+      )} | ${prop.isRequired ? "Yes" : "No"} | ${formatPropDescription(prop.description)} |\n`,
+    );
+  }
+  document.append("raw", "\n");
+}
+
+function renderEventsSection(document: MarkdownWriterBaseImpl, events: SerializedComponentEvent[]) {
+  if (events.length === 0) return;
+
+  document.append("h3", "Events");
+  document.append("raw", EVENT_TABLE_HEADER);
+  for (const event of events) {
+    document.append(
+      "raw",
+      `| ${formatNameWithDeprecation(event.name, event.deprecated)} | ${event.type} | ${
+        event.type === "dispatched" ? formatEventDetail(event.detail) : MD_TYPE_UNDEFINED
+      } | ${formatPropDescription(event.description)} |\n`,
+    );
+  }
+  document.append("raw", "\n");
+}
+
+function renderSlotsSection(document: MarkdownWriterBaseImpl, heading: string, slots: ComponentSlot[]) {
+  if (slots.length === 0) return;
+
+  document.append("h3", heading);
+  document.append("raw", SLOT_TABLE_HEADER);
+  for (const slot of slots) {
+    document.append(
+      "raw",
+      `| ${formatNameWithDeprecation(slot.default ? MD_TYPE_UNDEFINED : (slot.name ?? MD_TYPE_UNDEFINED), slot.deprecated)} | ${
+        slot.default ? "Yes" : "No"
+      } | ${formatSlotProps(slot.slot_props)} | ${formatSlotFallback(slot.fallback)} | ${formatSlotDescription(
+        slot.description,
+        slot.tags,
+      )} |\n`,
+    );
+  }
+  document.append("raw", "\n");
+}
+
+function renderTypedefsSection(document: MarkdownWriterBaseImpl, component: ComponentDocApi) {
+  if (component.typedefs.length === 0) return;
+
+  document.append("h3", "Typedefs");
+  document.append("raw", `\`\`\`ts\n${getTypeDefs({ typedefs: component.typedefs })}\n\`\`\`\n\n`);
+}
+
+function renderComponentFull(document: MarkdownWriterBaseImpl, component: ComponentDocApi) {
+  document.append("h2", component.moduleName);
+
+  if (component.generics) {
+    document.append("p", `Type parameters: ${formatPropType(`<${component.generics[1]}>`)}`);
+  }
+
+  if (component.componentComment?.trim()) {
+    document.append("p", component.componentComment.trim());
+  }
+
+  renderPropsTableSection(document, "Props", component.props);
+  renderPropsTableSection(
+    document,
+    "Bindings",
+    component.props.filter((prop) => prop.reactive),
+  );
+  renderEventsSection(document, component.events);
+  renderSlotsSection(document, component.syntaxMode === "runes" ? "Snippets" : "Slots", component.slots);
+  renderTypedefsSection(document, component);
+  renderPropsTableSection(document, "Module exports", component.moduleExports);
+}
+
+function renderLlmsTxt(
+  components: ComponentDocApi[],
+  title: string,
+  summary: string | undefined,
+  options: WriteLlmsOptions,
+): string {
+  const document = new MarkdownWriterBaseImpl();
+  const linkBase = options.linkBase ?? "";
+
+  document.append("h1", title);
+  if (summary) document.append("quote", summary);
+
+  document.append("h2", "Components");
+  for (const component of components) {
+    document.append(
+      "raw",
+      `- [${component.moduleName}](${linkBase}/${component.moduleName}): ${firstSentence(component.componentComment, "Component")}\n`,
+    );
+  }
+  document.append("raw", "\n");
+
+  if (options.entryExports && options.entryExports.length > 0) {
+    document.append("h2", "Exports");
+    for (const entry of options.entryExports) {
+      document.append("raw", `- \`${entry.name}\`: ${firstSentence(entry.description, entry.kind)}\n`);
+    }
+    document.append("raw", "\n");
+  }
+
+  return document.end();
+}
+
+function renderLlmsFullTxt(components: ComponentDocApi[], title: string, summary: string | undefined): string {
+  const document = new MarkdownWriterBaseImpl();
+
+  document.append("h1", title);
+  if (summary) document.append("quote", summary);
+
+  for (const component of components) {
+    renderComponentFull(document, component);
+  }
+
+  return document.end();
+}
+
+/**
+ * Renders both `llms.txt` (an index of links, per https://llmstxt.org) and
+ * `llms-full.txt` (the flattened full reference) without touching disk. Used
+ * by both `writeLlms` and tests so the two channels can't drift.
+ */
+export function renderLlmsDocuments(
+  components: ComponentDocs,
+  options: WriteLlmsOptions,
+): { llmsTxt: string; llmsFullTxt: string } {
+  const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
+  const packageMeta = readProjectPackageMeta();
+  const title = options.title ?? packageMeta.name ?? "Components";
+  const summary = options.summary ?? packageMeta.description;
+
+  return {
+    llmsTxt: renderLlmsTxt(document.components, title, summary, options),
+    llmsFullTxt: renderLlmsFullTxt(document.components, title, summary),
+  };
+}
+
+/**
+ * Writes a first-party `llms.txt` / `llms-full.txt` pair (per
+ * https://llmstxt.org) alongside the usual output.
+ *
+ * @example
+ * ```ts
+ * await writeLlms(components, { outDir: ".", linkBase: "/docs" });
+ * ```
+ */
+export default async function writeLlms(components: ComponentDocs, options: WriteLlmsOptions) {
+  const { llmsTxt, llmsFullTxt } = renderLlmsDocuments(components, options);
+  const writer = new Writer({ dryRun: options.dryRun });
+
+  const llmsRelPath = normalizeSeparators(path.join(options.outDir ?? "", "llms.txt"));
+  const llmsFullRelPath = normalizeSeparators(path.join(options.outDir ?? "", "llms-full.txt"));
+
+  const [llmsWritten, llmsFullWritten] = await Promise.all([
+    writer.write(path.join(process.cwd(), llmsRelPath), llmsTxt),
+    writer.write(path.join(process.cwd(), llmsFullRelPath), llmsFullTxt),
+  ]);
+
+  if (!options.dryRun) {
+    info(`${llmsWritten ? "created" : "unchanged"} "${llmsRelPath}".`);
+    info(`${llmsFullWritten ? "created" : "unchanged"} "${llmsFullRelPath}".`);
+  }
+}

--- a/tests/WriterLlms.test.ts
+++ b/tests/WriterLlms.test.ts
@@ -1,0 +1,294 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ComponentProp, ComponentSlot, SerializedComponentEvent, TypeDef } from "../src/ComponentParser";
+import { setQuiet } from "../src/logger";
+import { normalizeSeparators } from "../src/path";
+import type { ComponentDocs } from "../src/plugin";
+import writeLlms, { renderLlmsDocuments } from "../src/writer/writer-llms";
+import { mockComponentDocApi } from "./test-brands";
+
+function mockProp(name: string, overrides?: Partial<ComponentProp>): ComponentProp {
+  return {
+    name,
+    kind: "let",
+    constant: false,
+    isFunction: false,
+    isFunctionDeclaration: false,
+    isRequired: true,
+    reactive: false,
+    ...overrides,
+  };
+}
+
+function mockEvent(name: string, overrides?: Partial<SerializedComponentEvent>): SerializedComponentEvent {
+  return {
+    type: "dispatched",
+    name,
+    ...overrides,
+  } as SerializedComponentEvent;
+}
+
+function mockSlot(overrides?: Partial<ComponentSlot>): ComponentSlot {
+  return {
+    default: true,
+    ...overrides,
+  };
+}
+
+// A Svelte 5 runes component with a generic type parameter.
+const dataTable = mockComponentDocApi("DataTable", "DataTable.svelte", {
+  syntaxMode: "runes",
+  componentComment: "A table for displaying rows of data.\n\nSupports sorting and row selection.",
+  generics: ["Row", "Row extends DataTableRow"],
+  props: [
+    mockProp("rows", { type: "Row[]", isRequired: true, description: "The rows to display." }),
+    mockProp("selected", {
+      type: "Row | null",
+      value: "null",
+      isRequired: false,
+      reactive: true,
+      bindable: true,
+      description: "The currently selected row.",
+    }),
+  ],
+  slots: [mockSlot({ default: false, name: "row", slot_props: "{ row: Row }", description: "Custom row rendering." })],
+});
+
+// A legacy (Svelte 4-style) component with dispatched/forwarded events and slots.
+const modal = mockComponentDocApi("Modal", "Modal.svelte", {
+  syntaxMode: "legacy",
+  componentComment: "A modal dialog.",
+  props: [
+    mockProp("open", {
+      type: "boolean",
+      value: "false",
+      isRequired: false,
+      reactive: true,
+      binding: "writable",
+      description: "Whether the modal is open.",
+    }),
+    mockProp("size", { type: '"sm" | "md" | "lg"', value: '"md"', isRequired: false, description: "Modal size." }),
+  ],
+  slots: [
+    mockSlot({ default: true, description: "Modal body content." }),
+    mockSlot({ default: false, name: "footer", description: "Modal footer content." }),
+  ],
+  events: [
+    mockEvent("close", { detail: "null", description: "Fired when the modal closes." }),
+    mockEvent("submit", {
+      type: "forwarded",
+      element: { type: "Element", name: "form" },
+      description: "Forwarded native submit event.",
+    } as unknown as Partial<SerializedComponentEvent>),
+  ],
+});
+
+// A component with a typedef and a module-level export.
+const select = mockComponentDocApi("Select", "Select.svelte", {
+  syntaxMode: "legacy",
+  props: [mockProp("value", { type: "SelectOption", isRequired: false, description: "The selected option." })],
+  typedefs: [
+    {
+      name: "SelectOption",
+      type: "{ label: string; value: string }",
+      ts: "interface SelectOption {\n  label: string;\n  value: string;\n}",
+      description: "An option in the select.",
+    } satisfies TypeDef,
+  ],
+  moduleExports: [
+    mockProp("DEFAULT_OPTION", {
+      kind: "const",
+      constant: true,
+      type: "SelectOption",
+      value: '{ label: "None", value: "" }',
+      isRequired: false,
+      description: "The default option.",
+    }),
+  ],
+});
+
+const components: ComponentDocs = new Map([
+  ["DataTable", dataTable],
+  ["Modal", modal],
+  ["Select", select],
+]);
+
+describe("renderLlmsDocuments", () => {
+  test("llms.txt lists every component with a link and a one-line summary", () => {
+    const { llmsTxt } = renderLlmsDocuments(components, { title: "my-library", summary: "A component library." });
+
+    expect(llmsTxt).toMatchSnapshot();
+    expect(llmsTxt).toStartWith("# my-library\n\n> A component library.\n\n## Components\n\n");
+    expect(llmsTxt).toContain("- [DataTable](/DataTable): A table for displaying rows of data.\n");
+    expect(llmsTxt).toContain("- [Modal](/Modal): A modal dialog.\n");
+    expect(llmsTxt).toContain("- [Select](/Select): Component\n");
+  });
+
+  test("llms.txt respects a custom linkBase", () => {
+    const { llmsTxt } = renderLlmsDocuments(components, { title: "my-library", linkBase: "/docs/components" });
+
+    expect(llmsTxt).toContain("- [DataTable](/docs/components/DataTable): ");
+  });
+
+  test("llms.txt adds an Exports section when entryExports is set", () => {
+    const { llmsTxt } = renderLlmsDocuments(components, {
+      title: "my-library",
+      summary: "A component library.",
+      entryExports: [
+        {
+          name: "VERSION",
+          kind: "const",
+          value: '"1.0.0"',
+          description: "The current package version.",
+          isTypeOnly: false,
+        },
+        { name: "Theme", kind: "type", type: '"light" | "dark"', isTypeOnly: true },
+      ],
+    });
+
+    expect(llmsTxt).toMatchSnapshot();
+    expect(llmsTxt).toContain("## Exports\n\n- `VERSION`: The current package version.\n- `Theme`: type\n");
+  });
+
+  test("llms.txt omits the Exports section when entryExports is empty", () => {
+    const { llmsTxt } = renderLlmsDocuments(components, { title: "my-library" });
+
+    expect(llmsTxt).not.toContain("## Exports");
+  });
+
+  test("llms-full.txt renders per-component Props/Bindings/Events/Slots/Typedefs/Module exports", () => {
+    const { llmsFullTxt } = renderLlmsDocuments(components, { title: "my-library", summary: "A component library." });
+
+    expect(llmsFullTxt).toMatchSnapshot();
+
+    // DataTable: runes + generics + a bindable prop + a snippet.
+    expect(llmsFullTxt).toContain("## DataTable");
+    expect(llmsFullTxt).toContain("Type parameters:");
+    expect(llmsFullTxt).toContain("A table for displaying rows of data.\n\nSupports sorting and row selection.");
+    expect(llmsFullTxt).toContain("| Name | Type | Default | Required | Description |");
+    expect(llmsFullTxt).toContain("### Bindings");
+    expect(llmsFullTxt).toContain("### Snippets");
+
+    // Modal: legacy + events + slots.
+    expect(llmsFullTxt).toContain("## Modal");
+    expect(llmsFullTxt).toContain("### Events");
+    expect(llmsFullTxt).toContain("### Slots");
+
+    // Select: typedefs + module exports.
+    expect(llmsFullTxt).toContain("## Select");
+    expect(llmsFullTxt).toContain("### Typedefs");
+    expect(llmsFullTxt).toContain("```ts\n/**\n * An option in the select.\n */\nexport interface SelectOption {");
+    expect(llmsFullTxt).toContain("### Module exports");
+    expect(llmsFullTxt).toContain("DEFAULT_OPTION");
+  });
+
+  test("omits empty sections entirely", () => {
+    const { llmsFullTxt } = renderLlmsDocuments(new Map([["Select", select]]), { title: "my-library" });
+
+    expect(llmsFullTxt).not.toContain("### Bindings");
+    expect(llmsFullTxt).not.toContain("### Events");
+    expect(llmsFullTxt).not.toContain("### Slots");
+    expect(llmsFullTxt).not.toContain("### Snippets");
+  });
+
+  test("uses Snippets for runes components and Slots for legacy components", () => {
+    const { llmsFullTxt: dataTableOnly } = renderLlmsDocuments(new Map([["DataTable", dataTable]]), {
+      title: "my-library",
+    });
+    expect(dataTableOnly).toContain("### Snippets");
+    expect(dataTableOnly).not.toContain("### Slots");
+
+    const { llmsFullTxt: modalOnly } = renderLlmsDocuments(new Map([["Modal", modal]]), { title: "my-library" });
+    expect(modalOnly).toContain("### Slots");
+    expect(modalOnly).not.toContain("### Snippets");
+  });
+});
+
+describe("writeLlms", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setQuiet(false);
+    jest.restoreAllMocks();
+  });
+
+  test("writes llms.txt and llms-full.txt to outDir, matching renderLlmsDocuments", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "sveld-llms-"));
+    const previousCwd = process.cwd();
+    process.chdir(tempDir);
+
+    try {
+      const options = { outDir: "docs", title: "my-library", summary: "A component library." };
+      await writeLlms(components, options);
+
+      const { llmsTxt, llmsFullTxt } = renderLlmsDocuments(components, options);
+      expect(readFileSync(join(tempDir, "docs", "llms.txt"), "utf-8")).toBe(llmsTxt);
+      expect(readFileSync(join(tempDir, "docs", "llms-full.txt"), "utf-8")).toBe(llmsFullTxt);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "docs/llms.txt".'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "docs/llms-full.txt".'));
+
+      errorSpy.mockClear();
+      await writeLlms(components, options);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('unchanged "docs/llms.txt".'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('unchanged "docs/llms-full.txt".'));
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run reports the resolved paths and writes nothing to disk", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "sveld-llms-dry-run-"));
+    const previousCwd = process.cwd();
+    process.chdir(tempDir);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await writeLlms(components, { dryRun: true });
+
+      const cwd = process.cwd();
+      expect(existsSync(join(tempDir, "llms.txt"))).toBe(false);
+      expect(existsSync(join(tempDir, "llms-full.txt"))).toBe(false);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`would write "${normalizeSeparators(join(cwd, "llms.txt"))}"`),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`would write "${normalizeSeparators(join(cwd, "llms-full.txt"))}"`),
+      );
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("defaults title/summary from the project's package.json when unset", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "sveld-llms-pkg-"));
+    const previousCwd = process.cwd();
+    process.chdir(tempDir);
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        name: "carbon-components-svelte",
+        description: "Svelte components for IBM's Carbon Design System.",
+      }),
+    );
+
+    try {
+      await writeLlms(components, {});
+
+      const llmsTxt = readFileSync(join(tempDir, "llms.txt"), "utf-8");
+      expect(llmsTxt).toStartWith(
+        "# carbon-components-svelte\n\n> Svelte components for IBM's Carbon Design System.\n\n",
+      );
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/__snapshots__/WriterLlms.test.ts.snap
+++ b/tests/__snapshots__/WriterLlms.test.ts.snap
@@ -1,0 +1,126 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`renderLlmsDocuments llms.txt lists every component with a link and a one-line summary 1`] = `
+"# my-library
+
+> A component library.
+
+## Components
+
+- [DataTable](/DataTable): A table for displaying rows of data.
+- [Modal](/Modal): A modal dialog.
+- [Select](/Select): Component
+
+"
+`;
+
+exports[`renderLlmsDocuments llms.txt adds an Exports section when entryExports is set 1`] = `
+"# my-library
+
+> A component library.
+
+## Components
+
+- [DataTable](/DataTable): A table for displaying rows of data.
+- [Modal](/Modal): A modal dialog.
+- [Select](/Select): Component
+
+## Exports
+
+- \`VERSION\`: The current package version.
+- \`Theme\`: type
+
+"
+`;
+
+exports[`renderLlmsDocuments llms-full.txt renders per-component Props/Bindings/Events/Slots/Typedefs/Module exports 1`] = `
+"# my-library
+
+> A component library.
+
+## DataTable
+
+Type parameters: <code><Row extends DataTableRow></code>
+
+A table for displaying rows of data.
+
+Supports sorting and row selection.
+
+### Props
+
+| Name | Type | Default | Required | Description |
+| :- | :- | :- | :- | :- |
+| rows | <code>Row[]</code> | -- | Yes | The rows to display. |
+| selected | <code>Row &#124; null</code> | <code>null</code> | No | The currently selected row. |
+
+### Bindings
+
+| Name | Type | Default | Required | Description |
+| :- | :- | :- | :- | :- |
+| selected | <code>Row &#124; null</code> | <code>null</code> | No | The currently selected row. |
+
+### Snippets
+
+| Slot name | Default | Props | Fallback | Description |
+| :- | :- | :- | :- | :- |
+| row | No | <code>{ row: Row } </code> | -- | Custom row rendering. |
+
+## Modal
+
+A modal dialog.
+
+### Props
+
+| Name | Type | Default | Required | Description |
+| :- | :- | :- | :- | :- |
+| open | <code>boolean</code> | <code>false</code> | No | Whether the modal is open. |
+| size | <code>"sm" &#124; "md" &#124; "lg"</code> | <code>"md"</code> | No | Modal size. |
+
+### Bindings
+
+| Name | Type | Default | Required | Description |
+| :- | :- | :- | :- | :- |
+| open | <code>boolean</code> | <code>false</code> | No | Whether the modal is open. |
+
+### Events
+
+| Event name | Type | Detail | Description |
+| :- | :- | :- | :- |
+| close | dispatched | <code>null</code> | Fired when the modal closes. |
+| submit | forwarded | -- | Forwarded native submit event. |
+
+### Slots
+
+| Slot name | Default | Props | Fallback | Description |
+| :- | :- | :- | :- | :- |
+| -- | Yes | -- | -- | Modal body content. |
+| footer | No | -- | -- | Modal footer content. |
+
+## Select
+
+### Props
+
+| Name | Type | Default | Required | Description |
+| :- | :- | :- | :- | :- |
+| value | <code>SelectOption</code> | -- | No | The selected option. |
+
+### Typedefs
+
+\`\`\`ts
+/**
+ * An option in the select.
+ */
+export interface SelectOption {
+  label: string;
+  value: string;
+}
+\`\`\`
+
+### Module exports
+
+| Name | Type | Default | Required | Description |
+| :- | :- | :- | :- | :- |
+| DEFAULT_OPTION | <code>SelectOption</code> | <code>{ label: "None", value: "" }</code> | No | The default option. |
+
+"
+`;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -95,6 +95,14 @@ describe("parseCliOptions", () => {
     expect(alias).toEqual(canonical);
   });
 
+  test("--llms enables llms", () => {
+    expect(parseCliOptions(["--llms"])).toEqual({ kind: "options", options: { llms: true } });
+  });
+
+  test("--llms=false disables llms", () => {
+    expect(parseCliOptions(["--llms=false"])).toEqual({ kind: "options", options: { llms: false } });
+  });
+
   test("--report-diagnostics enables reportDiagnostics", () => {
     expect(parseCliOptions(["--report-diagnostics"])).toEqual({
       kind: "options",
@@ -468,7 +476,16 @@ describe("cli() --dry-run", () => {
   });
 
   test("writes nothing to disk, including the parse cache", async () => {
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--dry-run"];
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--json",
+      "--markdown",
+      "--custom-elements",
+      "--llms",
+      "--dry-run",
+    ];
 
     await cli(process);
 
@@ -476,11 +493,22 @@ describe("cli() --dry-run", () => {
     expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(false);
     expect(existsSync(join(dir, "COMPONENT_INDEX.md"))).toBe(false);
     expect(existsSync(join(dir, "custom-elements.json"))).toBe(false);
+    expect(existsSync(join(dir, "llms.txt"))).toBe(false);
+    expect(existsSync(join(dir, "llms-full.txt"))).toBe(false);
     expect(existsSync(join(dir, "src", "node_modules", ".cache"))).toBe(false);
   });
 
   test("prints one would-write line per output file, matching a real run's paths", async () => {
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--dry-run"];
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--json",
+      "--markdown",
+      "--custom-elements",
+      "--llms",
+      "--dry-run",
+    ];
 
     await cli(process);
 
@@ -491,10 +519,12 @@ describe("cli() --dry-run", () => {
     expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "COMPONENT_API.json"))}"`);
     expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "COMPONENT_INDEX.md"))}"`);
     expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "custom-elements.json"))}"`);
+    expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "llms.txt"))}"`);
+    expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "llms-full.txt"))}"`);
 
     // Now run for real and confirm the exact same paths land on disk.
     logSpy.mockClear();
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements"];
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--llms"];
     await cli(process);
 
     expect(existsSync(join(dir, "types", "Button.svelte.d.ts"))).toBe(true);
@@ -502,6 +532,8 @@ describe("cli() --dry-run", () => {
     expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(true);
     expect(existsSync(join(dir, "COMPONENT_INDEX.md"))).toBe(true);
     expect(existsSync(join(dir, "custom-elements.json"))).toBe(true);
+    expect(existsSync(join(dir, "llms.txt"))).toBe(true);
+    expect(existsSync(join(dir, "llms-full.txt"))).toBe(true);
   });
 
   test("prints per-component .api.json paths when jsonOptions.outDir is set", async () => {
@@ -595,7 +627,7 @@ describe("cli() --quiet", () => {
   });
 
   test("a plain run prints writer progress lines to stderr", async () => {
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements"];
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--llms"];
 
     await cli(process);
 
@@ -603,10 +635,21 @@ describe("cli() --quiet", () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "COMPONENT_API.json".'));
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "COMPONENT_INDEX.md".'));
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "custom-elements.json".'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "llms.txt".'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "llms-full.txt".'));
   });
 
   test("--quiet suppresses writer progress lines but still writes output files", async () => {
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--quiet"];
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--json",
+      "--markdown",
+      "--custom-elements",
+      "--llms",
+      "--quiet",
+    ];
 
     await cli(process);
 
@@ -615,6 +658,8 @@ describe("cli() --quiet", () => {
     expect(existsSync(join(dir, "COMPONENT_API.json"))).toBe(true);
     expect(existsSync(join(dir, "COMPONENT_INDEX.md"))).toBe(true);
     expect(existsSync(join(dir, "custom-elements.json"))).toBe(true);
+    expect(existsSync(join(dir, "llms.txt"))).toBe(true);
+    expect(existsSync(join(dir, "llms-full.txt"))).toBe(true);
   });
 
   test("quiet: true in the config file suppresses progress lines", async () => {

--- a/tests/writer-registry.test.ts
+++ b/tests/writer-registry.test.ts
@@ -4,11 +4,21 @@ import path from "node:path";
 import { getWriter, listWriters, type OutputWriter, registerWriter } from "../src/index";
 import type { ComponentDocs, GenerateBundleResult } from "../src/plugin";
 import { writeOutput } from "../src/plugin";
+// Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements"/"llms" writers.
+import "../src/writer/built-in-writers";
 import { mockComponentDocApi } from "./test-brands";
 
 interface PlainTextWriterOptions {
   outFile: string;
 }
+
+describe("built-in writers", () => {
+  test("registers json, markdown, types, custom-elements, and llms", () => {
+    const names = listWriters().map((writer) => writer.name);
+    expect(names).toEqual(expect.arrayContaining(["json", "markdown", "types", "custom-elements", "llms"]));
+    expect(getWriter("llms")?.componentSet).toBe("exported");
+  });
+});
 
 describe("custom writer registration (public API)", () => {
   test("registerWriter makes a writer discoverable via getWriter and listWriters", () => {


### PR DESCRIPTION
Adds a built-in "llms" writer alongside json/markdown/custom-elements,
producing an llms.txt index (per llmstxt.org) and a flattened
llms-full.txt reference. Wired through --llms on the CLI, and
llms/llmsOptions on the plugin, config file, and Node API. Title and
summary default from the consuming project's package.json.