### PR TITLE
test(e2e): cli-flags project for check, strict, stdout, custom-elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [24]
         os: [ubuntu-latest, windows-latest, macos-15]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ npx sveld --json --strict
 
 ## Requirements
 
-- Node 22+. CI runs Node 24 on Linux, Windows, and macOS; earlier LTS versions are not verified. `sveld.config.ts` relies on Node's built-in type stripping to load, which is unflagged from Node 22.18 / 23.6 — on older Node 22 patch versions, use a `.js`/`.mjs` config instead.
+- Node 24+ (declared as `engines.node` in `package.json`; npm warns rather than blocking on an older Node). `sveld.config.ts` relies on Node's built-in type stripping to load, which is unflagged from Node 22.18 / 23.6 and so is always available at this floor. CI runs on Bun (see `.bun-version`) and does not pin a separate Node version.
 - `sveld` is ESM-only. `require("sveld")` does not work — use `import` or dynamic `import()`.
 - `sveld` bundles its own template parser to parse `.svelte` files, kept in parity with `svelte/compiler` (see [Approach](#approach)). Parsing does not depend on the Svelte version installed in your project, so Svelte 3 and Svelte 4 codebases parse the same way Svelte 5 codebases do — there is no compiler version to match up.
 - [`resolveTypes`](#opt-in-semantic-resolution-resolvetypes) and [`checkExamples`](#compile-checked-example-blocks-checkexamples) are optional and need `typescript` 7 or later (which provides `typescript/unstable/async`) plus a `tsconfig.json`. Everything else, including `.d.ts` generation, is AST-only and never loads TypeScript. If either is enabled and TypeScript can't be started (missing, too old, or no `tsconfig.json`), the run fails loudly: `sveld()` throws and the CLI exits `2` naming the requirement, rather than silently skipping the check.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "engines": {
+    "node": ">=24"
+  },
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/tests/e2e/cli-flags/.gitignore
+++ b/tests/e2e/cli-flags/.gitignore
@@ -1,0 +1,2 @@
+/lib
+node_modules

--- a/tests/e2e/cli-flags/COMPONENT_API.json
+++ b/tests/e2e/cli-flags/COMPONENT_API.json
@@ -1,0 +1,193 @@
+{
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.36.11",
+    "svelteVersion": "5.56.10"
+  },
+  "total": 2,
+  "components": [
+    {
+      "moduleName": "Badge",
+      "filePath": "component/Badge.svelte",
+      "source": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 0
+        }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
+      "props": [
+        {
+          "name": "color",
+          "kind": "let",
+          "deprecated": "Use `Tag` instead.",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"gray\"",
+          "defaultValue": {
+            "raw": "\"gray\"",
+            "kind": "literal",
+            "value": "gray"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 28
+            }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [
+        {
+          "name": null,
+          "default": true,
+          "slot_props": "Record<string, never>",
+          "source": {
+            "start": {
+              "line": 6,
+              "column": 28
+            },
+            "end": {
+              "line": 6,
+              "column": 36
+            }
+          }
+        }
+      ],
+      "events": [],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    },
+    {
+      "moduleName": "Button",
+      "filePath": "component/Button.svelte",
+      "source": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
+      "props": [
+        {
+          "name": "label",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"Click\"",
+          "defaultValue": {
+            "raw": "\"Click\"",
+            "kind": "literal",
+            "value": "Click"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 2,
+              "column": 29
+            }
+          }
+        },
+        {
+          "name": "value",
+          "kind": "let",
+          "typeSource": "unknown",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 19
+            }
+          }
+        },
+        {
+          "name": "variant",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"solid\"",
+          "defaultValue": {
+            "raw": "\"solid\"",
+            "kind": "literal",
+            "value": "solid"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 4,
+              "column": 2
+            },
+            "end": {
+              "line": 4,
+              "column": 31
+            }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button",
+          "source": {
+            "start": {
+              "line": 7,
+              "column": 34
+            },
+            "end": {
+              "line": 7,
+              "column": 42
+            }
+          }
+        }
+      ],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    }
+  ]
+}

--- a/tests/e2e/cli-flags/COMPONENT_INDEX.md
+++ b/tests/e2e/cli-flags/COMPONENT_INDEX.md
@@ -1,0 +1,47 @@
+# Component Index
+
+## Components
+
+- [`Badge`](#badge)
+- [`Button`](#button)
+
+---
+
+## `Badge`
+
+### Props
+
+| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
+| :- | :- | :- | :- | :- | :- | :- | :- |
+| <s>color</s><br />**Deprecated**: Use `Tag` instead. | No | <code>let</code> | No | -- | <code>string</code> | <code>"gray"</code> | -- |
+
+### Slots
+
+| Slot name | Default | Props | Fallback | Description |
+| :- | :- | :- | :- | :- |
+| -- | Yes | <code>Record<string, never> </code> | -- | -- |
+
+### Events
+
+None.
+
+## `Button`
+
+### Props
+
+| Prop name | Required | Kind | Reactive | Binding | Type | Default value | Description |
+| :- | :- | :- | :- | :- | :- | :- | :- |
+| label | No | <code>let</code> | No | -- | <code>string</code> | <code>"Click"</code> | -- |
+| value | Yes | <code>let</code> | No | -- | -- | -- | -- |
+| variant | No | <code>let</code> | No | -- | <code>string</code> | <code>"solid"</code> | -- |
+
+### Slots
+
+None.
+
+### Events
+
+| Event name | Type | Detail | Description |
+| :- | :- | :- | :- |
+| click | forwarded | -- | -- |
+

--- a/tests/e2e/cli-flags/component/Badge.svelte
+++ b/tests/e2e/cli-flags/component/Badge.svelte
@@ -1,0 +1,6 @@
+<script>
+  /** @deprecated Use `Tag` instead. */
+  export let color = "gray";
+</script>
+
+<span class="badge {color}"><slot /></span>

--- a/tests/e2e/cli-flags/component/Button.svelte
+++ b/tests/e2e/cli-flags/component/Button.svelte
@@ -1,0 +1,9 @@
+<script>
+  export let label = "Click";
+  export let value;
+  export let variant = "solid";
+</script>
+
+<button class="variant-{variant}" on:click>
+  {label}: {value}
+</button>

--- a/tests/e2e/cli-flags/component/index.js
+++ b/tests/e2e/cli-flags/component/index.js
@@ -1,0 +1,2 @@
+export { default as Badge } from "./Badge.svelte";
+export { default as Button } from "./Button.svelte";

--- a/tests/e2e/cli-flags/custom-elements.json
+++ b/tests/e2e/cli-flags/custom-elements.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "component/Badge.svelte",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "Badge",
+          "members": [
+            {
+              "kind": "field",
+              "name": "color",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"gray\"",
+              "deprecated": "Use `Tag` instead."
+            }
+          ],
+          "attributes": [
+            {
+              "name": "color",
+              "fieldName": "color",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"gray\""
+            }
+          ],
+          "events": [],
+          "slots": [
+            {
+              "name": ""
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Badge",
+          "declaration": {
+            "name": "Badge",
+            "module": "component/Badge.svelte"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "component/Button.svelte",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "Button",
+          "members": [
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Click\""
+            },
+            {
+              "kind": "field",
+              "name": "value"
+            },
+            {
+              "kind": "field",
+              "name": "variant",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"solid\""
+            }
+          ],
+          "attributes": [
+            {
+              "name": "label",
+              "fieldName": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Click\""
+            },
+            {
+              "name": "variant",
+              "fieldName": "variant",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"solid\""
+            }
+          ],
+          "events": [],
+          "slots": []
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Button",
+          "declaration": {
+            "name": "Button",
+            "module": "component/Button.svelte"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/cli-flags/package.json
+++ b/tests/e2e/cli-flags/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cli-flags",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "svelte": "./component/index.js",
+  "scripts": {
+    "gen": "sveld --json --markdown --custom-elements",
+    "check-minor": "sveld --check=snapshots/minor-change.json --format=json",
+    "check-removed": "sveld --check=snapshots/removed-prop.json",
+    "strict": "sveld --strict",
+    "stdout-ndjson": "sveld --stdout=ndjson --json"
+  },
+  "e2e": {
+    "scripts": [
+      { "script": "gen" },
+      { "script": "check-minor", "expectStdout": "json" },
+      { "script": "check-removed", "expectExitCode": 3 },
+      { "script": "strict", "expectExitCode": 4 },
+      { "script": "stdout-ndjson", "expectStdout": "ndjson", "expectLines": 2 }
+    ]
+  }
+}

--- a/tests/e2e/cli-flags/snapshots/minor-change.json
+++ b/tests/e2e/cli-flags/snapshots/minor-change.json
@@ -1,0 +1,166 @@
+{
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.36.11",
+    "svelteVersion": "5.56.10"
+  },
+  "total": 2,
+  "components": [
+    {
+      "moduleName": "Badge",
+      "filePath": "component/Badge.svelte",
+      "source": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 0
+        }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
+      "props": [
+        {
+          "name": "color",
+          "kind": "let",
+          "deprecated": "Use `Tag` instead.",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"gray\"",
+          "defaultValue": {
+            "raw": "\"gray\"",
+            "kind": "literal",
+            "value": "gray"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 28
+            }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [
+        {
+          "name": null,
+          "default": true,
+          "slot_props": "Record<string, never>",
+          "source": {
+            "start": {
+              "line": 6,
+              "column": 28
+            },
+            "end": {
+              "line": 6,
+              "column": 36
+            }
+          }
+        }
+      ],
+      "events": [],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    },
+    {
+      "moduleName": "Button",
+      "filePath": "component/Button.svelte",
+      "source": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
+      "props": [
+        {
+          "name": "label",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"Click\"",
+          "defaultValue": {
+            "raw": "\"Click\"",
+            "kind": "literal",
+            "value": "Click"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 2,
+              "column": 29
+            }
+          }
+        },
+        {
+          "name": "value",
+          "kind": "let",
+          "typeSource": "unknown",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 19
+            }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button",
+          "source": {
+            "start": {
+              "line": 7,
+              "column": 34
+            },
+            "end": {
+              "line": 7,
+              "column": 42
+            }
+          }
+        }
+      ],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    }
+  ]
+}

--- a/tests/e2e/cli-flags/snapshots/removed-prop.json
+++ b/tests/e2e/cli-flags/snapshots/removed-prop.json
@@ -1,0 +1,220 @@
+{
+  "schemaVersion": 1,
+  "generator": {
+    "name": "sveld",
+    "version": "0.36.11",
+    "svelteVersion": "5.56.10"
+  },
+  "total": 2,
+  "components": [
+    {
+      "moduleName": "Badge",
+      "filePath": "component/Badge.svelte",
+      "source": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 0
+        }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
+      "props": [
+        {
+          "name": "color",
+          "kind": "let",
+          "deprecated": "Use `Tag` instead.",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"gray\"",
+          "defaultValue": {
+            "raw": "\"gray\"",
+            "kind": "literal",
+            "value": "gray"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 28
+            }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [
+        {
+          "name": null,
+          "default": true,
+          "slot_props": "Record<string, never>",
+          "source": {
+            "start": {
+              "line": 6,
+              "column": 28
+            },
+            "end": {
+              "line": 6,
+              "column": 36
+            }
+          }
+        }
+      ],
+      "events": [],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    },
+    {
+      "moduleName": "Button",
+      "filePath": "component/Button.svelte",
+      "source": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        }
+      },
+      "syntaxMode": "legacy",
+      "scriptLanguage": "js",
+      "props": [
+        {
+          "name": "label",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"Click\"",
+          "defaultValue": {
+            "raw": "\"Click\"",
+            "kind": "literal",
+            "value": "Click"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 2,
+              "column": 29
+            }
+          }
+        },
+        {
+          "name": "value",
+          "kind": "let",
+          "typeSource": "unknown",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": true,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 19
+            }
+          }
+        },
+        {
+          "name": "variant",
+          "kind": "let",
+          "type": "string",
+          "typeSource": "default",
+          "value": "\"solid\"",
+          "defaultValue": {
+            "raw": "\"solid\"",
+            "kind": "literal",
+            "value": "solid"
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 4,
+              "column": 2
+            },
+            "end": {
+              "line": 4,
+              "column": 31
+            }
+          }
+        },
+        {
+          "name": "legacyFlag",
+          "kind": "let",
+          "type": "boolean",
+          "typeSource": "default",
+          "value": "false",
+          "defaultValue": {
+            "raw": "false",
+            "kind": "literal",
+            "value": false
+          },
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false,
+          "source": {
+            "start": {
+              "line": 5,
+              "column": 2
+            },
+            "end": {
+              "line": 5,
+              "column": 30
+            }
+          }
+        }
+      ],
+      "moduleExports": [],
+      "slots": [],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button",
+          "source": {
+            "start": {
+              "line": 7,
+              "column": 34
+            },
+            "end": {
+              "line": 7,
+              "column": 42
+            }
+          }
+        }
+      ],
+      "typedefs": [],
+      "generics": null,
+      "contexts": []
+    }
+  ]
+}

--- a/tests/e2e/cli-flags/types/Badge.svelte.d.ts
+++ b/tests/e2e/cli-flags/types/Badge.svelte.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type BadgeProps = {
+  /**
+   * @deprecated Use `Tag` instead.
+   * @default "gray"
+   */
+  color?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class Badge extends SvelteComponentTyped<
+  BadgeProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/e2e/cli-flags/types/Button.svelte.d.ts
+++ b/tests/e2e/cli-flags/types/Button.svelte.d.ts
@@ -1,0 +1,21 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type ButtonProps = {
+  /**
+   * @default "Click"
+   */
+  label?: string;
+
+  value: any;
+
+  /**
+   * @default "solid"
+   */
+  variant?: string;
+};
+
+export default class Button extends SvelteComponentTyped<
+  ButtonProps,
+  { click: WindowEventMap["click"] },
+  Record<string, never>
+> {}

--- a/tests/e2e/cli-flags/types/index.d.ts
+++ b/tests/e2e/cli-flags/types/index.d.ts
@@ -1,0 +1,2 @@
+export { default as Badge } from "./Badge.svelte";
+export { default as Button } from "./Button.svelte";

--- a/tests/test-e2e.ts
+++ b/tests/test-e2e.ts
@@ -7,10 +7,88 @@ await $`bun link`;
 
 let hasError = false;
 
+/** `--only <name>` (or `--only=<name>`) restricts the run to one e2e project by directory name. */
+const onlyIndex = process.argv.indexOf("--only");
+const only =
+  onlyIndex === -1
+    ? process.argv.find((arg) => arg.startsWith("--only="))?.slice("--only=".length)
+    : process.argv[onlyIndex + 1];
+
 const e2eRoot = "tests/e2e";
 const dirs = readdirSync(e2eRoot, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
+  .filter((entry) => only === undefined || entry.name === only)
   .map((entry) => join(e2eRoot, entry.name));
+
+if (only !== undefined && dirs.length === 0) {
+  console.error(`--only "${only}" matched no directory under ${e2eRoot}.`);
+  process.exit(1);
+}
+
+/** One step of a `package.json#e2e.scripts` entry; see `runE2eScripts`. */
+interface E2eScriptStep {
+  script: string;
+  /** Defaults to 0. */
+  expectExitCode?: number;
+  /** Asserts stdout is a single JSON document, or one JSON object per non-empty line. */
+  expectStdout?: "json" | "ndjson";
+  /** With `expectStdout: "ndjson"`, the exact number of JSON lines expected. */
+  expectLines?: number;
+}
+
+/**
+ * Runs a project's `package.json#e2e.scripts` in order, each against its own
+ * expected exit code and (optionally) stdout shape, instead of the single
+ * always-exit-0 script the rest of this file assumes. Opt-in via an `e2e`
+ * field so existing single-script projects are unaffected.
+ */
+async function runE2eScripts(dir: string, steps: E2eScriptStep[]): Promise<boolean> {
+  let ok = true;
+
+  for (const step of steps) {
+    // biome-ignore lint/performance/noAwaitInLoops: steps mutate shared on-disk state (snapshots, cache) and must run in order.
+    const result = await $`cd ${dir} && bun run ${step.script}`.nothrow();
+    const expectedExitCode = step.expectExitCode ?? 0;
+
+    if (result.exitCode !== expectedExitCode) {
+      console.error(`${dir}: "${step.script}" exited ${result.exitCode}, expected ${expectedExitCode}`);
+      ok = false;
+      continue;
+    }
+
+    if (step.expectStdout === "json") {
+      try {
+        JSON.parse(result.stdout.toString());
+      } catch {
+        console.error(`${dir}: "${step.script}" stdout is not valid JSON`);
+        ok = false;
+      }
+    }
+
+    if (step.expectStdout === "ndjson") {
+      const lines = result.stdout
+        .toString()
+        .split("\n")
+        .filter((line) => line.length > 0);
+
+      if (step.expectLines !== undefined && lines.length !== step.expectLines) {
+        console.error(`${dir}: "${step.script}" printed ${lines.length} ndjson lines, expected ${step.expectLines}`);
+        ok = false;
+      }
+
+      for (const line of lines) {
+        try {
+          JSON.parse(line);
+        } catch {
+          console.error(`${dir}: "${step.script}" printed a non-JSON ndjson line: ${line}`);
+          ok = false;
+        }
+      }
+    }
+  }
+
+  return ok;
+}
 
 for (const dir of dirs) {
   const packageJsonPath = `${dir}/package.json`;
@@ -28,6 +106,12 @@ for (const dir of dirs) {
     await $`cd ${dir} && bun install`;
 
     const pkg = await Bun.file(packageJsonPath).json();
+
+    if (pkg.e2e?.scripts) {
+      if (!(await runE2eScripts(dir, pkg.e2e.scripts))) hasError = true;
+      continue;
+    }
+
     const script = pkg.scripts?.sveld ? "sveld" : "build";
     if (!pkg.scripts?.[script]) {
       console.error(`Missing "${script}" script in ${dir}`);


### PR DESCRIPTION
Covers CLI surface no e2e project touched before (--check against a
committed snapshot, --strict, --stdout=ndjson, --custom-elements)
against a real bun-linked install, adds a small per-script exit-code
harness for it, and bumps the declared Node floor to 24, dropping
the CI matrix.node entry that was never wired to setup-node.