### PR TITLE
fix(api): make sveld() respect format for its diagnostics summary

### DIFF
--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -1,6 +1,6 @@
 import type { ComponentParseError } from "./bundle";
 import { type CheckResult, resolveCheckSnapshotFile, runCheck } from "./check";
-import { formatDiagnosticsSummary, type SveldDiagnostic } from "./diagnostics";
+import { formatDiagnosticsSummary, formatDiagnosticsSummaryJson, type SveldDiagnostic } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import { loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
 import { setQuiet } from "./logger";
@@ -77,7 +77,11 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   const shouldReport = merged.reportDiagnostics || merged.strict;
 
   if (shouldReport && diagnostics.length > 0) {
-    console.error(formatDiagnosticsSummary(diagnostics));
+    if (merged.format === "json") {
+      process.stderr.write(formatDiagnosticsSummaryJson(diagnostics));
+    } else {
+      console.error(formatDiagnosticsSummary(diagnostics));
+    }
   }
 
   // Lowest applicable code wins (3 beats 4), matching the CLI's exit-code contract.

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -224,12 +224,14 @@ describe("sveld() strict mode", () => {
   let relativeDir: string;
   let previousExitCode: typeof process.exitCode;
   let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
     previousExitCode = process.exitCode;
     process.exitCode = undefined;
     errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.spyOn(console, "log").mockImplementation(() => {});
+    stderrSpy = jest.spyOn(process.stderr, "write").mockImplementation(() => true);
     absoluteDir = mkdtempSync(join(process.cwd(), "sveld-diagnostics-"));
     relativeDir = basename(absoluteDir);
     // Component with an @event tag that has no dispatch or callback prop.
@@ -279,5 +281,15 @@ describe("sveld() strict mode", () => {
     expect(exitCode).toBe(4);
     expect(process.exitCode).toBe(exitCodeBefore);
     expect(summaryCalls(errorSpy).length).toBeGreaterThan(0);
+  });
+
+  test("format: 'json' prints the diagnostics summary as JSON to stderr instead of text", async () => {
+    await sveld({ entry: relativeDir, glob: true, types: false, reportDiagnostics: true, format: "json" });
+
+    expect(summaryCalls(errorSpy)).toHaveLength(0);
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(stderrSpy.mock.calls[0][0] as string);
+    expect(printed.kind).toBe("diagnostics");
+    expect(printed.diagnostics).toContainEqual(expect.objectContaining({ kind: "event-no-source", name: "phantom" }));
   });
 });


### PR DESCRIPTION
cli() already branched between text and JSON when printing the
diagnostics summary, but sveld() always used the plain-text formatter
regardless of the format option, so JSON callers still got a text
blob on console.error.