### PR TITLE
fix(parser): flag $$restProps spread only onto a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,10 +425,15 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/extend-props-target-missing` | `error` | Point `@extends`/`@extendProps` at a file that exists, and (for a bundled `.svelte` target) name its generated `<Name>Props` interface exactly. |
 | `sveld/extend-props-duplicate` | `warning` | Remove the extra `@extends`/`@extendProps` tag; only the last one is used. |
 | `sveld/extend-props-override` | `warning` | Rename the own prop, or accept that it intentionally overrides the `@extends` target's prop of the same name. |
+| `sveld/jsdoc-unknown-tag` | `warning` | Fix the tag name if it's a typo (e.g. `@depreacted` → `@deprecated`); otherwise no action needed, the tag still passes through unchanged. Only surfaced under `--strict`/`--report-diagnostics`. |
+| `sveld/typedef-duplicate` | `warning` | Rename one of the `@typedef`/`@callback` declarations; only the later one is kept. |
+| `sveld/property-duplicate` | `warning` | Remove the duplicate `@property`; only the later one is kept. |
+| `sveld/generics-conflict` | `warning` | Rename one of the `@generics`/`@template` declarations to a distinct generic name. |
+| `sveld/jsdoc-tag-dropped` | `warning` | Move the tag next to a `@slot`/`@snippet`/`@event`/`@typedef`/`@callback` tag in the same comment block so it has something to attach to. |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped`, `extend-props-target-missing` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped`, `extend-props-target-missing` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override`, `jsdoc-unknown-tag`, `typedef-duplicate`, `property-duplicate`, `generics-conflict`, `jsdoc-tag-dropped` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/README.md
+++ b/README.md
@@ -421,10 +421,11 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/rest-props-unresolved` | `warning` | Spread `$$restProps` onto a plain element (or `svelte:element`) instead of a component, or add an `@restProps` tag to type it manually. |
 | `sveld/context-duplicate-key` | `warning` | Remove the duplicate `setContext` call, or give it a distinct key; only the first call's shape is used. |
 | `sveld/spread-unresolved` | `warning` | Spread a local object literal or a variable with a resolvable type instead; otherwise the spread widens the generated type to `Record<string, any>`. |
+| `sveld/export-unresolved` | `warning` | Export a local declaration directly instead of re-exporting an import or a binding from another file; sveld only resolves exports of a local declaration. |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/README.md
+++ b/README.md
@@ -422,10 +422,13 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/context-duplicate-key` | `warning` | Remove the duplicate `setContext` call, or give it a distinct key; only the first call's shape is used. |
 | `sveld/spread-unresolved` | `warning` | Spread a local object literal or a variable with a resolvable type instead; otherwise the spread widens the generated type to `Record<string, any>`. |
 | `sveld/export-unresolved` | `warning` | Export a local declaration directly instead of re-exporting an import or a binding from another file; sveld only resolves exports of a local declaration. |
+| `sveld/extend-props-target-missing` | `error` | Point `@extends`/`@extendProps` at a file that exists, and (for a bundled `.svelte` target) name its generated `<Name>Props` interface exactly. |
+| `sveld/extend-props-duplicate` | `warning` | Remove the extra `@extends`/`@extendProps` tag; only the last one is used. |
+| `sveld/extend-props-override` | `warning` | Rename the own prop, or accept that it intentionally overrides the `@extends` target's prop of the same name. |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped`, `extend-props-target-missing` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/README.md
+++ b/README.md
@@ -419,10 +419,11 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/example-compile-error` | `error` | Fix the `@example` code block so it type-checks, or remove the broken example. |
 | `sveld/syntax-skipped` | `error` | Rewrite the flagged syntax in a form sveld can model (see the diagnostic's `message` for what was skipped). |
 | `sveld/rest-props-unresolved` | `warning` | Spread `$$restProps` onto a plain element (or `svelte:element`) instead of a component, or add an `@restProps` tag to type it manually. |
+| `sveld/context-duplicate-key` | `warning` | Remove the duplicate `setContext` call, or give it a distinct key; only the first call's shape is used. |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/README.md
+++ b/README.md
@@ -420,10 +420,11 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/syntax-skipped` | `error` | Rewrite the flagged syntax in a form sveld can model (see the diagnostic's `message` for what was skipped). |
 | `sveld/rest-props-unresolved` | `warning` | Spread `$$restProps` onto a plain element (or `svelte:element`) instead of a component, or add an `@restProps` tag to type it manually. |
 | `sveld/context-duplicate-key` | `warning` | Remove the duplicate `setContext` call, or give it a distinct key; only the first call's shape is used. |
+| `sveld/spread-unresolved` | `warning` | Spread a local object literal or a variable with a resolvable type instead; otherwise the spread widens the generated type to `Record<string, any>`. |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/README.md
+++ b/README.md
@@ -418,10 +418,11 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/event-no-source` | `warning` | Dispatch the event (`createEventDispatcher`/`dispatch`), forward it (`on:name`), or add a matching `on<Name>` callback prop; otherwise remove the stale `@event` tag. |
 | `sveld/example-compile-error` | `error` | Fix the `@example` code block so it type-checks, or remove the broken example. |
 | `sveld/syntax-skipped` | `error` | Rewrite the flagged syntax in a form sveld can model (see the diagnostic's `message` for what was skipped). |
+| `sveld/rest-props-unresolved` | `warning` | Spread `$$restProps` onto a plain element (or `svelte:element`) instead of a component, or add an `@restProps` tag to type it manually. |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -282,7 +282,11 @@
         "type": { "type": "string" },
         "name": { "type": "string" },
         "description": { "type": "string" },
-        "ts": { "type": "string" }
+        "ts": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/jsdocTag" }
+        }
       }
     },
     "context": {

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -296,6 +296,10 @@
         "properties": {
           "type": "array",
           "items": { "$ref": "#/$defs/contextProperty" }
+        },
+        "hasUnresolvedSpread": {
+          "type": "boolean",
+          "description": "True when a {...spread} in the context's object literal couldn't be resolved; the generated type intersects with Record<string, any>."
         }
       }
     },

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -511,6 +511,8 @@ export interface TypeDef {
   description?: string;
   /** Full `type` alias declaration text. */
   ts: string;
+  /** Tags in the same block (e.g. `@since`, `@example`, `@see`), in source order. */
+  tags?: JsDocPassthroughTag[];
 }
 
 export type ComponentGenerics = [name: string, type: string] | null;

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -1009,6 +1009,67 @@ export default class ComponentParser {
           }
 
           if (node.type === "ExportNamedDeclaration") {
+            if (node.declaration == null && node.specifiers.length === 0) {
+              return;
+            }
+
+            let moduleExportedName: string | undefined;
+            let isResolvedModuleSpecifierExport = false;
+            if (node.declaration == null && node.specifiers[0]?.type === "ExportSpecifier") {
+              const specifier = node.specifiers[0];
+              const localName =
+                specifier.local && typeof specifier.local === "object" && "name" in specifier.local
+                  ? (specifier.local as Identifier).name
+                  : undefined;
+              const exportedName =
+                specifier.exported && typeof specifier.exported === "object" && "name" in specifier.exported
+                  ? (specifier.exported as Identifier).name
+                  : undefined;
+              if (!localName || !exportedName) return;
+
+              let declaration: VariableDeclaration | undefined;
+              for (const varDecl of Array.from(this.ctx.vars)) {
+                if (
+                  varDecl.declarations.some(
+                    (decl) =>
+                      decl.id &&
+                      typeof decl.id === "object" &&
+                      "type" in decl.id &&
+                      decl.id.type === "Identifier" &&
+                      (decl.id as Identifier).name === localName,
+                  )
+                ) {
+                  declaration = varDecl;
+                  break;
+                }
+              }
+
+              if (!declaration) {
+                const source =
+                  "source" in node && node.source && typeof node.source === "object" && "value" in node.source
+                    ? node.source.value
+                    : undefined;
+                const reason =
+                  typeof source === "string"
+                    ? `it re-exports from "${source}"`
+                    : this.ctx.valueImportBindingsByLocalName.has(localName)
+                      ? "it re-exports an imported binding"
+                      : "no matching local declaration was found";
+                recordDiagnostic(
+                  this.ctx,
+                  "export-unresolved",
+                  exportedName,
+                  `export "${exportedName}" was skipped because ${reason}; sveld only resolves exports of a local declaration.`,
+                  sourceRangeFromNode(this.ctx, node),
+                );
+                return;
+              }
+
+              node.declaration = declaration;
+              moduleExportedName = exportedName;
+              isResolvedModuleSpecifierExport = true;
+            }
+
             if (node.declaration == null) {
               return;
             }
@@ -1060,8 +1121,11 @@ export default class ComponentParser {
             } else if (node.declaration.type === "VariableDeclaration") {
               const varDecl = node.declaration as VariableDeclaration;
               const kind = variableDeclarationKindToComponentPropKind(varDecl.kind);
+              const declaratorsToProcess = isResolvedModuleSpecifierExport
+                ? varDecl.declarations.slice(0, 1)
+                : varDecl.declarations;
 
-              for (const declarator of varDecl.declarations) {
+              for (const declarator of declaratorsToProcess) {
                 if (!declarator || typeof declarator !== "object" || !("id" in declarator)) {
                   continue;
                 }
@@ -1073,6 +1137,7 @@ export default class ComponentParser {
                 }
 
                 const localPropName = (id as Identifier).name;
+                const declaratorPropName = moduleExportedName ?? localPropName;
                 const initResult = init == null ? { isFunction: false } : processInitializer(this, this.ctx, init);
                 const { value, type: typeSeed, isFunction: initializerIsFunction, defaultValue } = initResult;
                 const resolvedJSDoc = initResult;
@@ -1085,7 +1150,7 @@ export default class ComponentParser {
                 }
 
                 declarators.push({
-                  prop_name: localPropName,
+                  prop_name: declaratorPropName,
                   kind,
                   isFunctionDeclaration: false,
                   value,
@@ -1334,6 +1399,27 @@ export default class ComponentParser {
             node.declaration = declaration;
             prop_name = exportedName;
             isResolvedSpecifierExport = true;
+
+            if (!declaration) {
+              const source =
+                "source" in node && node.source && typeof node.source === "object" && "value" in node.source
+                  ? node.source.value
+                  : undefined;
+              const reason =
+                typeof source === "string"
+                  ? `it re-exports from "${source}"`
+                  : this.ctx.valueImportBindingsByLocalName.has(localName)
+                    ? "it re-exports an imported binding"
+                    : "no matching local declaration was found";
+              recordDiagnostic(
+                this.ctx,
+                "export-unresolved",
+                exportedName,
+                `export "${exportedName}" was skipped because ${reason}; sveld only resolves exports of a local declaration.`,
+                sourceRangeFromNode(this.ctx, node),
+              );
+              return;
+            }
           }
 
           if (node.declaration == null) {

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -424,6 +424,8 @@ export type SlotProps = Record<string, SlotPropValue>;
  */
 export type InternalComponentSlot = Omit<ComponentSlot, "slot_props"> & {
   slot_props?: string | SlotProps;
+  /** True when a `{...spread}` in the slot's props object couldn't be resolved; folded into `slot_props` text as `& Record<string, any>` before output. */
+  slot_props_unresolved_spread?: boolean;
 };
 
 /** Event forwarded with `on:eventname` and no handler. */
@@ -577,6 +579,8 @@ export interface ComponentContext {
   description?: string;
   /** Context object properties. */
   properties: ComponentContextProp[];
+  /** True when a `{...spread}` in the context's object literal couldn't be resolved; the generated type intersects with `Record<string, any>`. */
+  hasUnresolvedSpread?: boolean;
 }
 
 /**
@@ -1604,6 +1608,7 @@ export default class ComponentParser {
           const renderInfo = extractRenderTagInfo(this.ctx, renderTag.expression);
           if (renderInfo) {
             let slot_props: SlotProps | undefined;
+            let slot_props_unresolved_spread = false;
             if (renderInfo.arguments.length === 0) {
               slot_props = {};
             } else if (
@@ -1613,11 +1618,13 @@ export default class ComponentParser {
               "type" in renderInfo.arguments[0] &&
               renderInfo.arguments[0].type === "ObjectExpression"
             ) {
-              slot_props = buildSlotPropsFromObjectExpression(
+              const built = buildSlotPropsFromObjectExpression(
                 this.ctx,
                 this,
                 renderInfo.arguments[0] as ObjectExpression,
               );
+              slot_props = built.slot_props;
+              slot_props_unresolved_spread = built.hasUnresolvedSpread;
             } else if (renderInfo.arguments.length === 1) {
               /**
                * Multiple positional arguments (e.g. `{@render row(item, index)}`) are a
@@ -1640,6 +1647,7 @@ export default class ComponentParser {
               addSlot(this.ctx, {
                 slot_name,
                 slot_props,
+                slot_props_unresolved_spread: slot_props_unresolved_spread || undefined,
                 source: sourceRangeFromNode(this.ctx, node),
               });
             }
@@ -1855,14 +1863,16 @@ export default class ComponentParser {
 
     const processedSlots = ComponentParser.mapToArray(this.ctx.slots)
       .map((slot) => {
+        const { slot_props_unresolved_spread, ...publicSlot } = slot;
+
         // JSDoc `@slot`/`@snippet` tags are already TS type text; template parsing yields a SlotProps map.
         if (!slot.slot_props) {
-          return slot as ComponentSlot;
+          return publicSlot as ComponentSlot;
         }
         if (typeof slot.slot_props === "string") {
           return EMPTY_OBJECT_TYPE_REGEX.test(slot.slot_props)
-            ? { ...slot, slot_props: "Record<string, never>" }
-            : (slot as ComponentSlot);
+            ? { ...publicSlot, slot_props: "Record<string, never>" }
+            : (publicSlot as ComponentSlot);
         }
 
         const slot_props = slot.slot_props;
@@ -1877,15 +1887,19 @@ export default class ComponentParser {
           new_props.push(`${key}: ${slot_props[key].value}`);
         }
 
+        const widenSuffix = slot_props_unresolved_spread ? " & Record<string, any>" : "";
+
         // Force multiline when count > 1 (matches interface body formatting).
         const formatted_slot_props =
           new_props.length === 0
-            ? "Record<string, never>"
+            ? slot_props_unresolved_spread
+              ? "Record<string, any>"
+              : "Record<string, never>"
             : new_props.length === 1
-              ? `{ ${new_props[0]} }`
-              : `{\n  ${new_props.join(";\n  ")};\n}`;
+              ? `{ ${new_props[0]} }${widenSuffix}`
+              : `{\n  ${new_props.join(";\n  ")};\n}${widenSuffix}`;
 
-        return { ...slot, slot_props: formatted_slot_props };
+        return { ...publicSlot, slot_props: formatted_slot_props };
       })
       .sort((a, b) => {
         const aName = a.name ?? "";

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -2007,6 +2007,19 @@ export default class ComponentParser {
       );
     }
 
+    /**
+     * `{...$$restProps}` spread only onto components: sveld can't type another
+     * component's rest-prop shape, and no `@restProps` tag supplied one manually.
+     */
+    if (this.ctx.rest_props?.type === "InlineComponent") {
+      recordDiagnostic(
+        this.ctx,
+        "rest-props-unresolved",
+        "$$restProps",
+        `$$restProps is only spread onto component "${this.ctx.rest_props.name}"; sveld cannot infer its rest-prop type. Spread onto a plain element or add an @restProps tag.`,
+      );
+    }
+
     const parsedComponent: ParsedComponent = {
       source: sourceRangeFromOffsets(this.ctx, 0, this.ctx.source?.length),
       syntaxMode: this.ctx.syntaxMode,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,7 +1,7 @@
 import type { Dirent } from "node:fs";
-import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, join, parse, relative, resolve } from "node:path";
+import { dirname, extname, isAbsolute, join, parse, relative, resolve } from "node:path";
 import { asRelativeSourcePath, type NormalizedPath } from "./brands";
 import type { ParsedComponent, PendingCallDefaultCandidate, PendingContextKeyCandidate } from "./ComponentParser";
 import { buildReverseDeps, expandAffected } from "./dependency-graph";
@@ -782,6 +782,8 @@ export async function generateBundle(
     }
   }
 
+  validateExtendsTargets(allComponentsForTypes, resolveComponentFilePath);
+
   // Dedupe diagnostics from export and all-components passes.
   const diagnostics = applyDiagnosticIgnores(
     dedupeDiagnostics(Array.from(allComponentsForTypes.values()).flatMap((component) => component.diagnostics ?? [])),
@@ -984,6 +986,109 @@ async function checkComponentExamples(
           ...(source ? { source } : {}),
         }),
       );
+    }
+    component.diagnostics = diagnostics;
+  }
+}
+
+const RESOLVABLE_EXTENDS_EXTENSIONS = [".ts", ".tsx", ".d.ts", ".svelte"];
+
+/** Strips a matching pair of quote characters from an `@extends`/`@extendProps` import specifier, stored verbatim. */
+function stripQuotes(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (trimmed.length < 2) return undefined;
+  const first = trimmed[0];
+  const last = trimmed[trimmed.length - 1];
+  if ((first === '"' || first === "'" || first === "`") && first === last) {
+    return trimmed.slice(1, -1);
+  }
+  return undefined;
+}
+
+/** Resolves a relative/absolute `@extends` import specifier to a file on disk, trying common extensions. */
+function resolveExtendsTargetPath(fromAbsoluteFilePath: string, specifier: string): string | undefined {
+  const base = resolve(dirname(fromAbsoluteFilePath), specifier);
+  if (existsSync(base) && statSync(base).isFile()) return base;
+  if (extname(specifier) !== "") return undefined;
+
+  for (const ext of RESOLVABLE_EXTENDS_EXTENSIONS) {
+    const candidate = `${base}${ext}`;
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Verifies every component's `@extends`/`@extendProps` target once all
+ * components have parsed: the referenced file must exist, and when it's a
+ * `.svelte` file in the bundle, the named interface must match that file's
+ * generated `<Name>Props`. Also flags an own prop that shares a name with a
+ * same-named prop of a different type on a bundled target, since `Base &
+ * $Props` silently collapses that prop to `never` in the generated type.
+ *
+ * Bare/package specifiers (not starting with `.` or `/`) aren't verifiable
+ * without a module resolver and are left alone.
+ */
+function validateExtendsTargets(components: ComponentDocs, resolveComponentFilePath: ResolveComponentFilePath): void {
+  const componentsByAbsolutePath = new Map(
+    Array.from(components.values()).map((component) => [resolveComponentFilePath(component.filePath), component]),
+  );
+
+  for (const component of components.values()) {
+    const extendsInfo = component.extends;
+    if (!extendsInfo) continue;
+
+    const specifier = stripQuotes(extendsInfo.import);
+    if (specifier === undefined || (!specifier.startsWith(".") && !specifier.startsWith("/"))) continue;
+
+    const fromAbsoluteFilePath = resolveComponentFilePath(component.filePath);
+    const targetPath = resolveExtendsTargetPath(fromAbsoluteFilePath, specifier);
+    const diagnostics = component.diagnostics ?? [];
+
+    if (targetPath === undefined) {
+      diagnostics.push(
+        createDiagnostic({
+          component: component.filePath,
+          kind: "extend-props-target-missing",
+          name: extendsInfo.interface,
+          message: `@extends/@extendProps target "${specifier}" was not found on disk.`,
+        }),
+      );
+      component.diagnostics = diagnostics;
+      continue;
+    }
+
+    // A real file outside the bundle (e.g. a hand-written .ts interface): file
+    // existence is all that's verifiable without a module resolver.
+    const target = componentsByAbsolutePath.get(targetPath);
+    if (!target) continue;
+
+    const expectedInterface = `${target.moduleName}Props`;
+    if (extendsInfo.interface !== expectedInterface) {
+      diagnostics.push(
+        createDiagnostic({
+          component: component.filePath,
+          kind: "extend-props-target-missing",
+          name: extendsInfo.interface,
+          message: `@extends/@extendProps names "${extendsInfo.interface}", but "${specifier}" generates "${expectedInterface}".`,
+        }),
+      );
+      component.diagnostics = diagnostics;
+      continue;
+    }
+
+    for (const ownProp of component.props) {
+      const baseProp = target.props.find((prop) => prop.name === ownProp.name);
+      if (baseProp && baseProp.type !== ownProp.type) {
+        diagnostics.push(
+          createDiagnostic({
+            component: component.filePath,
+            kind: "extend-props-override",
+            name: ownProp.name,
+            message: `Own prop "${ownProp.name}" (${ownProp.type}) overrides "${expectedInterface}"'s "${ownProp.name}" (${baseProp.type}).`,
+          }),
+        );
+      }
     }
     component.diagnostics = diagnostics;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,12 @@ import {
   resolveCheckSnapshotFile,
   runCheck,
 } from "./check";
-import { failingDiagnostics, formatDiagnosticsSummary, formatDiagnosticsSummaryJson } from "./diagnostics";
+import {
+  failingDiagnostics,
+  filterSpeculativeDiagnostics,
+  formatDiagnosticsSummary,
+  formatDiagnosticsSummaryJson,
+} from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
 import {
   formatCheckGitHub,
@@ -449,8 +454,8 @@ export async function cli(process: NodeJS.Process) {
     return;
   }
 
-  const { diagnostics } = result;
   const shouldReport = options.reportDiagnostics || options.strict;
+  const diagnostics = filterSpeculativeDiagnostics(result.diagnostics, shouldReport);
   const stepSummaryParts: string[] = [];
 
   if (shouldReport && diagnostics.length > 0) {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -12,6 +12,7 @@ import { matchesGlob } from "./glob-match";
  * - `rest-props-unresolved`: every `{...$$restProps}` target was a component, so `$RestProps` couldn't be typed.
  * - `context-duplicate-key`: `setContext` called more than once with the same key; only the first call's shape is used.
  * - `spread-unresolved`: a `{...spread}` in a context or slot-props object literal couldn't be resolved; widened to `Record<string, any>`.
+ * - `export-unresolved`: a named export specifier (re-export or renamed import) couldn't be resolved to a local declaration.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
@@ -21,7 +22,8 @@ export type SveldDiagnosticKind =
   | "syntax-skipped"
   | "rest-props-unresolved"
   | "context-duplicate-key"
-  | "spread-unresolved";
+  | "spread-unresolved"
+  | "export-unresolved";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -41,6 +43,7 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "rest-props-unresolved": "sveld/rest-props-unresolved",
   "context-duplicate-key": "sveld/context-duplicate-key",
   "spread-unresolved": "sveld/spread-unresolved",
+  "export-unresolved": "sveld/export-unresolved",
 };
 
 /**
@@ -57,6 +60,7 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "rest-props-unresolved": "warning",
   "context-duplicate-key": "warning",
   "spread-unresolved": "warning",
+  "export-unresolved": "warning",
 };
 
 /**
@@ -156,6 +160,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "rest-props-unresolved": "$$restProps spread only onto components",
   "context-duplicate-key": "Duplicate setContext keys",
   "spread-unresolved": "Unresolved spreads widened to Record<string, any>",
+  "export-unresolved": "Unresolved named export specifiers",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -167,6 +172,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "rest-props-unresolved",
   "context-duplicate-key",
   "spread-unresolved",
+  "export-unresolved",
 ];
 
 /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -16,6 +16,11 @@ import { matchesGlob } from "./glob-match";
  * - `extend-props-target-missing`: an `@extends`/`@extendProps` target file wasn't found, or its named interface doesn't match the bundled component it points at.
  * - `extend-props-duplicate`: a second `@extends`/`@extendProps` tag overwrote the first.
  * - `extend-props-override`: an own prop has the same name as an `@extends` target's prop but a different type.
+ * - `jsdoc-unknown-tag`: a JSDoc tag sveld doesn't recognize (e.g. a typo like `@depreacted`); passed through unchanged, surfaced only under `--strict`/`--report-diagnostics`.
+ * - `typedef-duplicate`: a second `@typedef`/`@callback` reused a name; the later declaration overwrites the earlier one.
+ * - `property-duplicate`: a second `@property` reused a name on the same `@event`/`@typedef`; the later declaration overwrites the earlier one.
+ * - `generics-conflict`: a second `@generics`/`@template` reused a generic name.
+ * - `jsdoc-tag-dropped`: a passthrough JSDoc tag (e.g. `@see`) couldn't attach to a following or preceding structural tag.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
@@ -29,7 +34,12 @@ export type SveldDiagnosticKind =
   | "export-unresolved"
   | "extend-props-target-missing"
   | "extend-props-duplicate"
-  | "extend-props-override";
+  | "extend-props-override"
+  | "jsdoc-unknown-tag"
+  | "typedef-duplicate"
+  | "property-duplicate"
+  | "generics-conflict"
+  | "jsdoc-tag-dropped";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -53,6 +63,11 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "extend-props-target-missing": "sveld/extend-props-target-missing",
   "extend-props-duplicate": "sveld/extend-props-duplicate",
   "extend-props-override": "sveld/extend-props-override",
+  "jsdoc-unknown-tag": "sveld/jsdoc-unknown-tag",
+  "typedef-duplicate": "sveld/typedef-duplicate",
+  "property-duplicate": "sveld/property-duplicate",
+  "generics-conflict": "sveld/generics-conflict",
+  "jsdoc-tag-dropped": "sveld/jsdoc-tag-dropped",
 };
 
 /**
@@ -73,6 +88,11 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "extend-props-target-missing": "error",
   "extend-props-duplicate": "warning",
   "extend-props-override": "warning",
+  "jsdoc-unknown-tag": "warning",
+  "typedef-duplicate": "warning",
+  "property-duplicate": "warning",
+  "generics-conflict": "warning",
+  "jsdoc-tag-dropped": "warning",
 };
 
 /**
@@ -109,6 +129,21 @@ export function createDiagnostic(input: SveldDiagnosticInput): SveldDiagnostic {
     code: DIAGNOSTIC_CODES[input.kind],
     severity: DIAGNOSTIC_SEVERITIES[input.kind],
   };
+}
+
+/**
+ * `jsdoc-unknown-tag` is speculative: a misspelled tag (`@depreacted`) and an
+ * intentional custom tag look identical to the parser, so it's noisier than
+ * the rest of the codes. Surface it only when the caller opted into
+ * diagnostics via `--strict`/`--report-diagnostics`; a plain run stays quiet
+ * about tags sveld already passes through unchanged.
+ */
+export function filterSpeculativeDiagnostics(
+  diagnostics: SveldDiagnostic[],
+  shouldReport: boolean | "errors" | undefined,
+): SveldDiagnostic[] {
+  if (shouldReport) return diagnostics;
+  return diagnostics.filter((diagnostic) => diagnostic.kind !== "jsdoc-unknown-tag");
 }
 
 /**
@@ -176,6 +211,11 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "extend-props-target-missing": "@extends/@extendProps targets that couldn't be verified",
   "extend-props-duplicate": "Duplicate @extends/@extendProps tags",
   "extend-props-override": "Own props overriding an @extends target's prop",
+  "jsdoc-unknown-tag": "Unknown JSDoc tags",
+  "typedef-duplicate": "Duplicate @typedef/@callback names",
+  "property-duplicate": "Duplicate @property names",
+  "generics-conflict": "Duplicate @generics/@template names",
+  "jsdoc-tag-dropped": "Passthrough JSDoc tags that couldn't attach",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -191,6 +231,11 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "extend-props-target-missing",
   "extend-props-duplicate",
   "extend-props-override",
+  "jsdoc-unknown-tag",
+  "typedef-duplicate",
+  "property-duplicate",
+  "generics-conflict",
+  "jsdoc-tag-dropped",
 ];
 
 /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -9,13 +9,15 @@ import { matchesGlob } from "./glob-match";
  * - `event-no-source`: `@event` with no dispatch, forward, or callback prop.
  * - `example-compile-error`: an `@example` block failed to type-check (opt-in, `checkExamples`).
  * - `syntax-skipped`: `$props()`/`{@render}` syntax the parser can't model; omitted from output.
+ * - `rest-props-unresolved`: every `{...$$restProps}` target was a component, so `$RestProps` couldn't be typed.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
   | "context-any-type"
   | "event-no-source"
   | "example-compile-error"
-  | "syntax-skipped";
+  | "syntax-skipped"
+  | "rest-props-unresolved";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -32,6 +34,7 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "event-no-source": "sveld/event-no-source",
   "example-compile-error": "sveld/example-compile-error",
   "syntax-skipped": "sveld/syntax-skipped",
+  "rest-props-unresolved": "sveld/rest-props-unresolved",
 };
 
 /**
@@ -45,6 +48,7 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "event-no-source": "warning",
   "example-compile-error": "error",
   "syntax-skipped": "error",
+  "rest-props-unresolved": "warning",
 };
 
 /**
@@ -141,6 +145,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "event-no-source": "@event tags with no dispatch or callback",
   "example-compile-error": "@example blocks that failed to compile",
   "syntax-skipped": "Component syntax sveld skipped",
+  "rest-props-unresolved": "$$restProps spread only onto components",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -149,6 +154,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "event-no-source",
   "example-compile-error",
   "syntax-skipped",
+  "rest-props-unresolved",
 ];
 
 /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -11,6 +11,7 @@ import { matchesGlob } from "./glob-match";
  * - `syntax-skipped`: `$props()`/`{@render}` syntax the parser can't model; omitted from output.
  * - `rest-props-unresolved`: every `{...$$restProps}` target was a component, so `$RestProps` couldn't be typed.
  * - `context-duplicate-key`: `setContext` called more than once with the same key; only the first call's shape is used.
+ * - `spread-unresolved`: a `{...spread}` in a context or slot-props object literal couldn't be resolved; widened to `Record<string, any>`.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
@@ -19,7 +20,8 @@ export type SveldDiagnosticKind =
   | "example-compile-error"
   | "syntax-skipped"
   | "rest-props-unresolved"
-  | "context-duplicate-key";
+  | "context-duplicate-key"
+  | "spread-unresolved";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -38,6 +40,7 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "syntax-skipped": "sveld/syntax-skipped",
   "rest-props-unresolved": "sveld/rest-props-unresolved",
   "context-duplicate-key": "sveld/context-duplicate-key",
+  "spread-unresolved": "sveld/spread-unresolved",
 };
 
 /**
@@ -53,6 +56,7 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "syntax-skipped": "error",
   "rest-props-unresolved": "warning",
   "context-duplicate-key": "warning",
+  "spread-unresolved": "warning",
 };
 
 /**
@@ -151,6 +155,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "syntax-skipped": "Component syntax sveld skipped",
   "rest-props-unresolved": "$$restProps spread only onto components",
   "context-duplicate-key": "Duplicate setContext keys",
+  "spread-unresolved": "Unresolved spreads widened to Record<string, any>",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -161,6 +166,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "syntax-skipped",
   "rest-props-unresolved",
   "context-duplicate-key",
+  "spread-unresolved",
 ];
 
 /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -13,6 +13,9 @@ import { matchesGlob } from "./glob-match";
  * - `context-duplicate-key`: `setContext` called more than once with the same key; only the first call's shape is used.
  * - `spread-unresolved`: a `{...spread}` in a context or slot-props object literal couldn't be resolved; widened to `Record<string, any>`.
  * - `export-unresolved`: a named export specifier (re-export or renamed import) couldn't be resolved to a local declaration.
+ * - `extend-props-target-missing`: an `@extends`/`@extendProps` target file wasn't found, or its named interface doesn't match the bundled component it points at.
+ * - `extend-props-duplicate`: a second `@extends`/`@extendProps` tag overwrote the first.
+ * - `extend-props-override`: an own prop has the same name as an `@extends` target's prop but a different type.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
@@ -23,7 +26,10 @@ export type SveldDiagnosticKind =
   | "rest-props-unresolved"
   | "context-duplicate-key"
   | "spread-unresolved"
-  | "export-unresolved";
+  | "export-unresolved"
+  | "extend-props-target-missing"
+  | "extend-props-duplicate"
+  | "extend-props-override";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -44,6 +50,9 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "context-duplicate-key": "sveld/context-duplicate-key",
   "spread-unresolved": "sveld/spread-unresolved",
   "export-unresolved": "sveld/export-unresolved",
+  "extend-props-target-missing": "sveld/extend-props-target-missing",
+  "extend-props-duplicate": "sveld/extend-props-duplicate",
+  "extend-props-override": "sveld/extend-props-override",
 };
 
 /**
@@ -61,6 +70,9 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "context-duplicate-key": "warning",
   "spread-unresolved": "warning",
   "export-unresolved": "warning",
+  "extend-props-target-missing": "error",
+  "extend-props-duplicate": "warning",
+  "extend-props-override": "warning",
 };
 
 /**
@@ -161,6 +173,9 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "context-duplicate-key": "Duplicate setContext keys",
   "spread-unresolved": "Unresolved spreads widened to Record<string, any>",
   "export-unresolved": "Unresolved named export specifiers",
+  "extend-props-target-missing": "@extends/@extendProps targets that couldn't be verified",
+  "extend-props-duplicate": "Duplicate @extends/@extendProps tags",
+  "extend-props-override": "Own props overriding an @extends target's prop",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -173,6 +188,9 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "context-duplicate-key",
   "spread-unresolved",
   "export-unresolved",
+  "extend-props-target-missing",
+  "extend-props-duplicate",
+  "extend-props-override",
 ];
 
 /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -10,6 +10,7 @@ import { matchesGlob } from "./glob-match";
  * - `example-compile-error`: an `@example` block failed to type-check (opt-in, `checkExamples`).
  * - `syntax-skipped`: `$props()`/`{@render}` syntax the parser can't model; omitted from output.
  * - `rest-props-unresolved`: every `{...$$restProps}` target was a component, so `$RestProps` couldn't be typed.
+ * - `context-duplicate-key`: `setContext` called more than once with the same key; only the first call's shape is used.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
@@ -17,7 +18,8 @@ export type SveldDiagnosticKind =
   | "event-no-source"
   | "example-compile-error"
   | "syntax-skipped"
-  | "rest-props-unresolved";
+  | "rest-props-unresolved"
+  | "context-duplicate-key";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -35,6 +37,7 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "example-compile-error": "sveld/example-compile-error",
   "syntax-skipped": "sveld/syntax-skipped",
   "rest-props-unresolved": "sveld/rest-props-unresolved",
+  "context-duplicate-key": "sveld/context-duplicate-key",
 };
 
 /**
@@ -49,6 +52,7 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "example-compile-error": "error",
   "syntax-skipped": "error",
   "rest-props-unresolved": "warning",
+  "context-duplicate-key": "warning",
 };
 
 /**
@@ -146,6 +150,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "example-compile-error": "@example blocks that failed to compile",
   "syntax-skipped": "Component syntax sveld skipped",
   "rest-props-unresolved": "$$restProps spread only onto components",
+  "context-duplicate-key": "Duplicate setContext keys",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -155,6 +160,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "example-compile-error",
   "syntax-skipped",
   "rest-props-unresolved",
+  "context-duplicate-key",
 ];
 
 /**

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -258,7 +258,18 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
 
   const contextKey = resolution.key;
   const contextInfo = parseContextValue(ctx, parser, valueArg, contextKey);
-  if (contextInfo && !ctx.contexts.has(contextKey)) {
-    ctx.contexts.set(contextKey, contextInfo);
+  if (!contextInfo) return;
+
+  if (ctx.contexts.has(contextKey)) {
+    recordDiagnostic(
+      ctx,
+      "context-duplicate-key",
+      contextKey,
+      `setContext("${contextKey}", ...) was called more than once; only the first call's shape is used.`,
+      sourceRangeFromNode(ctx, node),
+    );
+    return;
   }
+
+  ctx.contexts.set(contextKey, contextInfo);
 }

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -1,12 +1,136 @@
-import type { ArrowFunctionExpression, CallExpression, Expression, FunctionExpression, NewExpression } from "estree";
+import type {
+  ArrowFunctionExpression,
+  CallExpression,
+  Expression,
+  FunctionExpression,
+  NewExpression,
+  ObjectExpression,
+} from "estree";
 import type { Node } from "estree-walker";
 import { isIdentifier, isLiteral, isObjectExpression, resolveStaticStringLiteral } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type { ComponentContext, ComponentContextProp } from "../ComponentParser";
 import type { ParserContext } from "./context";
 import { recordDiagnostic } from "./diagnostics";
+import { parseObjectTypeLiteralMembers } from "./object-type-literal";
 import { resolveConstInitializer } from "./props";
 import { sourceRangeFromNode } from "./source-position";
+
+/**
+ * Resolves `{...identifier}` inside a `setContext` object literal to a property
+ * list: either the spread-of-a-literal's own properties (recursively, so a chain
+ * of `const` object literals merges all the way down) or, when the identifier
+ * only has a resolvable JSDoc/native object-type annotation, that type's members.
+ * Returns `null` when neither resolves, so the caller can widen to `Record<string, any>`.
+ */
+function resolveSpreadShape(
+  ctx: ParserContext,
+  parser: ComponentParser,
+  argument: unknown,
+  key: string,
+): ComponentContextProp[] | null {
+  if (!isIdentifier(argument)) return null;
+
+  const initializer = resolveConstInitializer(ctx, argument.name);
+  if (isObjectExpression(initializer)) {
+    return parseContextObjectProperties(ctx, parser, initializer, key).properties;
+  }
+
+  const varInfo = parser.findVariableTypeAndDescription(argument.name);
+  if (!varInfo) return null;
+
+  const members = parseObjectTypeLiteralMembers(varInfo.type);
+  if (!members) return null;
+
+  return members.map((member) => ({
+    name: member.name,
+    type: member.type,
+    optional: member.optional,
+  }));
+}
+
+/** Build a context's property list from an object literal, merging or flagging spreads. */
+function parseContextObjectProperties(
+  ctx: ParserContext,
+  parser: ComponentParser,
+  objExpr: ObjectExpression,
+  key: string,
+): { properties: ComponentContextProp[]; hasUnresolvedSpread: boolean } {
+  const properties: ComponentContextProp[] = [];
+  let hasUnresolvedSpread = false;
+
+  for (const prop of objExpr.properties) {
+    if (prop.type === "SpreadElement") {
+      const merged = resolveSpreadShape(ctx, parser, prop.argument, key);
+      if (merged) {
+        properties.push(...merged);
+      } else {
+        hasUnresolvedSpread = true;
+        recordDiagnostic(
+          ctx,
+          "spread-unresolved",
+          key,
+          `Context "${key}" spreads a value sveld can't resolve; its shape is widened to "Record<string, any>".`,
+          sourceRangeFromNode(ctx, prop),
+        );
+      }
+      continue;
+    }
+
+    if (prop.type !== "Property") continue;
+
+    const propName = parser.getPropertyName(prop.key);
+    if (!propName) continue;
+
+    let propType = "any";
+    let propDescription: string | undefined;
+
+    if (isIdentifier(prop.value)) {
+      const varName = prop.value.name;
+      const varInfo = parser.findVariableTypeAndDescription(varName);
+      if (varInfo) {
+        propType = varInfo.type;
+        propDescription = varInfo.description;
+      } else {
+        recordDiagnostic(
+          ctx,
+          "context-any-type",
+          propName,
+          `Context "${key}" property "${propName}" has no type annotation; defaulted to "any".`,
+          sourceRangeFromNode(ctx, prop),
+        );
+      }
+    } else if (
+      prop.value &&
+      typeof prop.value === "object" &&
+      "type" in prop.value &&
+      (prop.value.type === "ArrowFunctionExpression" || prop.value.type === "FunctionExpression")
+    ) {
+      const funcExpr = prop.value as ArrowFunctionExpression | FunctionExpression;
+      const params =
+        funcExpr.params
+          ?.map((p) => {
+            if (isIdentifier(p)) {
+              return `${p.name || "arg"}: any`;
+            }
+            return "arg: any";
+          })
+          .join(", ") || "";
+      propType = `(${params}) => any`;
+    } else if (isLiteral(prop.value)) {
+      propType = prop.value.value == null ? "null" : typeof prop.value.value;
+    }
+
+    properties.push({
+      name: propName,
+      type: propType,
+      description: propDescription,
+      optional: false,
+    });
+  }
+
+  return { properties, hasUnresolvedSpread };
+}
 
 /** Split a `setContext` key on `-`, `_`, `.`, `:`, `/`, or whitespace for PascalCase naming. */
 const CONTEXT_KEY_SPLIT_REGEX = /[-_.:/\s]+/;
@@ -28,70 +152,18 @@ function parseContextValue(
   if (!node || typeof node !== "object" || !("type" in node)) return null;
 
   if (node.type === "ObjectExpression") {
-    const properties: ComponentContextProp[] = [];
     if (!isObjectExpression(node)) {
       return null;
     }
-    const objExpr = node;
 
-    for (const prop of objExpr.properties) {
-      if (prop.type !== "Property") continue;
-
-      const propName = parser.getPropertyName(prop.key);
-      if (!propName) continue;
-
-      let propType = "any";
-      let propDescription: string | undefined;
-
-      if (isIdentifier(prop.value)) {
-        const varName = prop.value.name;
-        const varInfo = parser.findVariableTypeAndDescription(varName);
-        if (varInfo) {
-          propType = varInfo.type;
-          propDescription = varInfo.description;
-        } else {
-          recordDiagnostic(
-            ctx,
-            "context-any-type",
-            propName,
-            `Context "${key}" property "${propName}" has no type annotation; defaulted to "any".`,
-            sourceRangeFromNode(ctx, prop),
-          );
-        }
-      } else if (
-        prop.value &&
-        typeof prop.value === "object" &&
-        "type" in prop.value &&
-        (prop.value.type === "ArrowFunctionExpression" || prop.value.type === "FunctionExpression")
-      ) {
-        const funcExpr = prop.value as ArrowFunctionExpression | FunctionExpression;
-        const params =
-          funcExpr.params
-            ?.map((p) => {
-              if (isIdentifier(p)) {
-                return `${p.name || "arg"}: any`;
-              }
-              return "arg: any";
-            })
-            .join(", ") || "";
-        propType = `(${params}) => any`;
-      } else if (isLiteral(prop.value)) {
-        propType = prop.value.value == null ? "null" : typeof prop.value.value;
-      }
-
-      properties.push({
-        name: propName,
-        type: propType,
-        description: propDescription,
-        optional: false,
-      });
-    }
+    const { properties, hasUnresolvedSpread } = parseContextObjectProperties(ctx, parser, node, key);
 
     return {
       key,
       typeName: generateContextTypeName(key),
       properties,
       description: undefined,
+      ...(hasUnresolvedSpread ? { hasUnresolvedSpread } : {}),
     };
   } else if (isIdentifier(node)) {
     const varName = node.name;

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -60,8 +60,18 @@ function getInlineTagDescription(tagLines: Array<{ content: string }> | undefine
   return tagLines[0].content;
 }
 
-/** `@since` and `@example` are kept out of prose descriptions and exposed as `tags` instead. */
-const IDE_PASSTHROUGH_TAGS = new Set(["since", "example"]);
+/** `@since`, `@example`, and `@see` are kept out of prose descriptions and exposed as `tags` instead. */
+const IDE_PASSTHROUGH_TAGS = new Set(["since", "example", "see"]);
+
+/**
+ * Tags sveld gives meaning to somewhere other than `parseCustomTypes`'s own
+ * switch below: `@bindable` is handled per-prop in {@link getCommentTags},
+ * and `@default`/`@required` are conventional documentation tags sveld
+ * doesn't act on but doesn't consider a typo either. Anything reaching the
+ * `default:` case that isn't in this set or `IDE_PASSTHROUGH_TAGS` is flagged
+ * as `jsdoc-unknown-tag`.
+ */
+const OTHER_KNOWN_JSDOC_TAGS = new Set(["bindable", "default", "required"]);
 
 function deprecatedValueFromBody(body: string): DeprecatedValue {
   const message = body.trim();
@@ -376,10 +386,9 @@ export function parseCustomTypes(
       );
     }
   };
-  const warnAndTrackGenericName = (genericName: string) => {
-    const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
+  const warnAndTrackGenericName = (genericName: string, source: SourceRange | undefined) => {
     if (seenGenericNames.has(genericName)) {
-      console.warn(`Warning: Duplicate generic name "${genericName}"${location}.`);
+      recordDiagnostic(ctx, "generics-conflict", genericName, `Duplicate generic name "${genericName}".`, source);
     } else {
       seenGenericNames.add(genericName);
     }
@@ -404,11 +413,14 @@ export function parseCustomTypes(
     parser.accumulateGeneric(declaredName, constraint);
   };
   /** `ctx.typedefs` holds both `@typedef` and `@callback` declarations, keyed by name; both finalizers share this check. */
-  const warnDuplicateTypedefName = (name: string) => {
+  const warnDuplicateTypedefName = (name: string, source: SourceRange | undefined) => {
     if (ctx.typedefs.has(name)) {
-      const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
-      console.warn(
-        `Warning: Duplicate typedef/callback name "${name}"${location}; the later declaration overwrites the earlier one.`,
+      recordDiagnostic(
+        ctx,
+        "typedef-duplicate",
+        name,
+        `Duplicate typedef/callback name "${name}"; the later declaration overwrites the earlier one.`,
+        source,
       );
     }
   };
@@ -417,15 +429,23 @@ export function parseCustomTypes(
    * second entry - two properties with the same key would otherwise appear
    * in the emitted object type.
    */
-  const pushOrReplaceProperty = <T extends { name: string }>(list: T[], property: T, ownerName: string | undefined) => {
+  const pushOrReplaceProperty = <T extends { name: string }>(
+    list: T[],
+    property: T,
+    ownerName: string | undefined,
+    source: SourceRange | undefined,
+  ) => {
     const existingIndex = list.findIndex((p) => p.name === property.name);
     if (existingIndex === -1) {
       list.push(property);
     } else {
-      const location = ctx.componentFilePath ? ` in ${ctx.componentFilePath}` : "";
       const owner = ownerName ? ` of "${ownerName}"` : "";
-      console.warn(
-        `Warning: Duplicate property "${property.name}"${owner}${location}; the later declaration overwrites the earlier one.`,
+      recordDiagnostic(
+        ctx,
+        "property-duplicate",
+        property.name,
+        `Duplicate property "${property.name}"${owner}; the later declaration overwrites the earlier one.`,
+        source,
       );
       list[existingIndex] = property;
     }
@@ -450,6 +470,8 @@ export function parseCustomTypes(
     let currentTypedefName: string | undefined;
     let currentTypedefType: string | undefined;
     let currentTypedefDescription: string | undefined;
+    let currentTypedefSource: SourceRange | undefined;
+    let currentTypedefTags: JsDocPassthroughTag[] = [];
     const typedefProperties: Array<{
       name: string;
       type: string;
@@ -460,12 +482,23 @@ export function parseCustomTypes(
 
     let currentCallbackName: string | undefined;
     let currentCallbackDescription: string | undefined;
+    let currentCallbackSource: SourceRange | undefined;
+    let currentCallbackTags: JsDocPassthroughTag[] = [];
     const callbackParams: Array<{
       name: string;
       type: string;
       optional?: boolean;
     }> = [];
     let callbackReturnType: string | undefined;
+
+    /**
+     * Where a passthrough tag (`@since`, `@see`, an unknown tag, ...) attaches
+     * once a structural tag (`@slot`/`@snippet`/`@event`/`@typedef`/`@callback`)
+     * has been seen in this block: set every time one starts, so a tag
+     * trailing it attaches to it directly instead of queuing in `pendingTags`
+     * for whatever structural tag happens to come next.
+     */
+    let attachTrailingTag: ((tag: JsDocPassthroughTag) => void) | undefined;
 
     let commentDescriptionUsed = false;
     let isFirstTag = true;
@@ -612,18 +645,21 @@ export function parseCustomTypes(
           typedefTs = `type ${currentTypedefName} = ${typedefType};`;
         }
 
-        warnDuplicateTypedefName(currentTypedefName);
+        warnDuplicateTypedefName(currentTypedefName, currentTypedefSource);
         ctx.typedefs.set(currentTypedefName, {
           type: typedefType,
           name: currentTypedefName,
           description: assignValueOrUndefined(currentTypedefDescription),
           ts: typedefTs,
+          tags: currentTypedefTags.length > 0 ? currentTypedefTags : undefined,
         });
 
         typedefProperties.length = 0;
         currentTypedefName = undefined;
         currentTypedefType = undefined;
         currentTypedefDescription = undefined;
+        currentTypedefSource = undefined;
+        currentTypedefTags = [];
       }
     };
 
@@ -639,18 +675,21 @@ export function parseCustomTypes(
         const callbackType = `(${params}) => ${returnType}`;
         const callbackTs = `type ${currentCallbackName} = ${callbackType};`;
 
-        warnDuplicateTypedefName(currentCallbackName);
+        warnDuplicateTypedefName(currentCallbackName, currentCallbackSource);
         ctx.typedefs.set(currentCallbackName, {
           type: callbackType,
           name: currentCallbackName,
           description: assignValueOrUndefined(currentCallbackDescription),
           ts: callbackTs,
+          tags: currentCallbackTags.length > 0 ? currentCallbackTags : undefined,
         });
 
         callbackParams.length = 0;
         callbackReturnType = undefined;
         currentCallbackName = undefined;
         currentCallbackDescription = undefined;
+        currentCallbackSource = undefined;
+        currentCallbackTags = [];
       }
     };
 
@@ -660,6 +699,16 @@ export function parseCustomTypes(
      */
     const blockHasSlotOrSnippetTag = tags.some((t) => t.tag === "slot" || t.tag === "snippet");
     const blockHasExtendsTag = tags.some((t) => t.tag === "extends" || t.tag === "extendProps");
+    /**
+     * Whether this block declares anything `pendingTags` can attach to. A plain
+     * prop or context comment with just a `@since`/`@example`/`@see` tag has no
+     * such tag, so a leftover passthrough tag there is expected, not dropped -
+     * that comment's own tags are captured separately by `processJSDocComment`.
+     */
+    const blockHasStructuralTag = tags.some(
+      (t) =>
+        t.tag === "slot" || t.tag === "snippet" || t.tag === "event" || t.tag === "typedef" || t.tag === "callback",
+    );
 
     for (const {
       tag,
@@ -730,6 +779,13 @@ export function parseCustomTypes(
           });
           pendingTags.length = 0;
           pendingDeprecated = undefined;
+          {
+            const slotKey = name === undefined || name === "" ? null : name;
+            attachTrailingTag = (trailingTag) => {
+              const slot = ctx.slots.get(slotKey);
+              if (slot) slot.tags = [...(slot.tags ?? []), trailingTag];
+            };
+          }
           break;
         }
         case "event": {
@@ -745,6 +801,11 @@ export function parseCustomTypes(
             commentDescriptionUsed = true;
           }
           currentEventSource = sourceRangeFromCommentTag(ctx, tagSource);
+          if (pendingTags.length > 0) {
+            currentEventTags.push(...pendingTags);
+            pendingTags.length = 0;
+          }
+          attachTrailingTag = (trailingTag) => currentEventTags.push(trailingTag);
           if (isFirstTag) isFirstTag = false;
           break;
         }
@@ -774,9 +835,19 @@ export function parseCustomTypes(
           };
 
           if (currentEventName !== undefined) {
-            pushOrReplaceProperty(eventProperties, propertyData, currentEventName);
+            pushOrReplaceProperty(
+              eventProperties,
+              propertyData,
+              currentEventName,
+              sourceRangeFromCommentTag(ctx, tagSource),
+            );
           } else if (currentTypedefName !== undefined) {
-            pushOrReplaceProperty(typedefProperties, propertyData, currentTypedefName);
+            pushOrReplaceProperty(
+              typedefProperties,
+              propertyData,
+              currentTypedefName,
+              sourceRangeFromCommentTag(ctx, tagSource),
+            );
           }
           break;
         }
@@ -785,12 +856,18 @@ export function parseCustomTypes(
 
           currentTypedefName = normalizeGenericNameSpacing(name);
           currentTypedefType = type;
+          currentTypedefSource = sourceRangeFromCommentTag(ctx, tagSource);
           const inlineTypedefDesc = cleanDescription(getInlineTagDescription(tagSource));
           currentTypedefDescription = inlineTypedefDesc || precedingDescription;
           if (!currentTypedefDescription && isFirstTag && !commentDescriptionUsed && commentDescription) {
             currentTypedefDescription = commentDescription;
             commentDescriptionUsed = true;
           }
+          if (pendingTags.length > 0) {
+            currentTypedefTags.push(...pendingTags);
+            pendingTags.length = 0;
+          }
+          attachTrailingTag = (trailingTag) => currentTypedefTags.push(trailingTag);
           if (isFirstTag) isFirstTag = false;
           break;
         }
@@ -798,12 +875,18 @@ export function parseCustomTypes(
           finalizeCallback();
 
           currentCallbackName = normalizeGenericNameSpacing(name);
+          currentCallbackSource = sourceRangeFromCommentTag(ctx, tagSource);
           const inlineCallbackDesc = cleanDescription(getInlineTagDescription(tagSource));
           currentCallbackDescription = inlineCallbackDesc || precedingDescription;
           if (!currentCallbackDescription && isFirstTag && !commentDescriptionUsed && commentDescription) {
             currentCallbackDescription = commentDescription;
             commentDescriptionUsed = true;
           }
+          if (pendingTags.length > 0) {
+            currentCallbackTags.push(...pendingTags);
+            pendingTags.length = 0;
+          }
+          attachTrailingTag = (trailingTag) => currentCallbackTags.push(trailingTag);
           if (isFirstTag) isFirstTag = false;
           break;
         }
@@ -812,7 +895,7 @@ export function parseCustomTypes(
           // itself, mirroring `@template`'s unconstrained-parameter fallback.
           const constraint = type || name;
           for (const genericName of splitTopLevelCommas(name)) {
-            warnAndTrackGenericName(genericName.trim());
+            warnAndTrackGenericName(genericName.trim(), sourceRangeFromCommentTag(ctx, tagSource));
           }
           usedGenericsTag = true;
           warnMixedGenericsTags();
@@ -835,7 +918,7 @@ export function parseCustomTypes(
             break;
           }
 
-          warnAndTrackGenericName(name);
+          warnAndTrackGenericName(name, sourceRangeFromCommentTag(ctx, tagSource));
           usedTemplateTag = true;
           warnMixedGenericsTags();
           accumulateOrReplaceGeneric(name, constraint);
@@ -872,8 +955,17 @@ export function parseCustomTypes(
               name: tag,
               body: raw,
             };
-            if (currentEventName !== undefined && IDE_PASSTHROUGH_TAGS.has(tag)) {
-              currentEventTags.push(passthroughTag);
+            if (!IDE_PASSTHROUGH_TAGS.has(tag) && !OTHER_KNOWN_JSDOC_TAGS.has(tag)) {
+              recordDiagnostic(
+                ctx,
+                "jsdoc-unknown-tag",
+                tag,
+                `Unknown JSDoc tag "@${tag}"; passed through unchanged. If this is a typo, fix the tag name.`,
+                sourceRangeFromCommentTag(ctx, tagSource),
+              );
+            }
+            if (attachTrailingTag) {
+              attachTrailingTag(passthroughTag);
             } else {
               pendingTags.push(passthroughTag);
             }
@@ -885,5 +977,17 @@ export function parseCustomTypes(
     finalizeEvent();
     finalizeTypedef();
     finalizeCallback();
+
+    if (blockHasStructuralTag && pendingTags.length > 0) {
+      for (const danglingTag of pendingTags) {
+        recordDiagnostic(
+          ctx,
+          "jsdoc-tag-dropped",
+          danglingTag.name,
+          `@${danglingTag.name} could not attach to a @slot/@snippet/@event/@typedef/@callback tag in the same comment block and was dropped.`,
+        );
+      }
+      pendingTags.length = 0;
+    }
   }
 }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -9,7 +9,7 @@ import type {
 import type { JSDocComment } from "./comment-parser";
 import { parseComments } from "./comment-parser";
 import type { ParserContext } from "./context";
-import { recordSveldIgnore } from "./diagnostics";
+import { recordDiagnostic, recordSveldIgnore } from "./diagnostics";
 import { addDispatchedEvent, buildEventDetailFromProperties } from "./events";
 import { splitTopLevelCommas } from "./generics";
 import { addSlot } from "./slots";
@@ -677,6 +677,15 @@ export function parseCustomTypes(
       switch (tag) {
         case "extends":
         case "extendProps":
+          if (ctx.extends !== undefined) {
+            recordDiagnostic(
+              ctx,
+              "extend-props-duplicate",
+              name,
+              `A second @extends/@extendProps tag ("${name}") overwrote the first ("${ctx.extends.interface}"); only one is used.`,
+              sourceRangeFromCommentTag(ctx, tagSource),
+            );
+          }
           ctx.extends = {
             interface: name,
             import: type,

--- a/src/parser/object-type-literal.ts
+++ b/src/parser/object-type-literal.ts
@@ -1,0 +1,84 @@
+/**
+ * Splits a TypeScript object-type body on top-level `;`/`,` member separators,
+ * ignoring separators nested inside `<>`, `()`, `[]`, or `{}`.
+ */
+function splitTopLevelMembers(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === "<" || char === "(" || char === "[" || char === "{") depth++;
+    else if (char === ">" || char === ")" || char === "]" || char === "}") depth = Math.max(depth - 1, 0);
+    else if (depth === 0 && (char === ";" || char === ",")) {
+      parts.push(value.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+}
+
+/** Index of the first top-level `:` (name/type separator), or -1 if none. */
+function findTopLevelColon(value: string): number {
+  let depth = 0;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === "<" || char === "(" || char === "[" || char === "{") depth++;
+    else if (char === ">" || char === ")" || char === "]" || char === "}") depth = Math.max(depth - 1, 0);
+    else if (depth === 0 && char === ":") return i;
+  }
+  return -1;
+}
+
+const OBJECT_TYPE_LITERAL_REGEX = /^\{([\s\S]*)\}$/;
+const MEMBER_NAME_REGEX = /^[A-Za-z_$][\w$]*$/;
+
+export interface ObjectTypeLiteralMember {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+/**
+ * Parses an inline TypeScript object-type literal (e.g. `"{ a: string; b?: number }"`)
+ * into its member list. Returns `null` when `typeText` isn't an object-type literal,
+ * or when a member can't be split into `name: type` (index signatures, mapped types,
+ * computed names) so the caller can fall back to treating the type as unresolved.
+ */
+export function parseObjectTypeLiteralMembers(typeText: string): ObjectTypeLiteralMember[] | null {
+  const trimmed = typeText.trim();
+  const match = OBJECT_TYPE_LITERAL_REGEX.exec(trimmed);
+  if (!match) return null;
+
+  const body = match[1].trim();
+  if (body === "") return [];
+
+  const members: ObjectTypeLiteralMember[] = [];
+
+  for (const rawMember of splitTopLevelMembers(body)) {
+    const member = rawMember.trim();
+    if (!member) continue;
+
+    const colonIndex = findTopLevelColon(member);
+    if (colonIndex === -1) return null;
+
+    let name = member.slice(0, colonIndex).trim();
+    const type = member.slice(colonIndex + 1).trim();
+    if (!type) return null;
+
+    let optional = false;
+    if (name.endsWith("?")) {
+      optional = true;
+      name = name.slice(0, -1).trim();
+    }
+
+    if (!MEMBER_NAME_REGEX.test(name)) return null;
+
+    members.push({ name, type, optional });
+  }
+
+  return members;
+}

--- a/src/parser/rest-props.ts
+++ b/src/parser/rest-props.ts
@@ -35,10 +35,18 @@ function createRestPropsFromParent(parent: unknown): RestProps {
 }
 
 export function maybeSetRestProps(ctx: ParserContext, parent: unknown) {
-  if (ctx.rest_props !== undefined) return;
-
   const restProps = createRestPropsFromParent(parent);
-  if (restProps) {
+  if (!restProps) return;
+
+  if (ctx.rest_props === undefined) {
+    ctx.rest_props = restProps;
+    return;
+  }
+
+  // A plain element target is typeable; a component target is not. Prefer the
+  // first element target seen over an earlier component target, regardless of
+  // template order, so one untypeable spread doesn't shadow a typeable one.
+  if (ctx.rest_props.type === "InlineComponent" && restProps.type === "Element") {
     ctx.rest_props = restProps;
   }
 }

--- a/src/parser/slots.ts
+++ b/src/parser/slots.ts
@@ -93,7 +93,7 @@ export function buildSlotPropsFromObjectExpression(
           ctx,
           "spread-unresolved",
           "slot_props",
-          "Slot props spread a value sveld can't resolve; its shape is widened to \"Record<string, any>\".",
+          'Slot props spread a value sveld can\'t resolve; its shape is widened to "Record<string, any>".',
           sourceRangeFromNode(ctx, property),
         );
       }

--- a/src/parser/slots.ts
+++ b/src/parser/slots.ts
@@ -1,9 +1,13 @@
 import type { CallExpression, Expression, Identifier, Literal, MemberExpression, ObjectExpression } from "estree";
+import { isIdentifier, isObjectExpression } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type { DeprecatedValue, JsDocPassthroughTag, SlotProps, SlotPropValue, SourceRange } from "../ComponentParser";
 import { resolveMemberExpressionType } from "./bindings";
 import type { ParserContext } from "./context";
-import { sourceAtPos } from "./source-position";
+import { recordDiagnostic } from "./diagnostics";
+import { parseObjectTypeLiteralMembers } from "./object-type-literal";
+import { resolveConstInitializer } from "./props";
+import { sourceAtPos, sourceRangeFromNode } from "./source-position";
 import { assignValueOrUndefined } from "./utils";
 
 const DEFAULT_SLOT_NAME = null;
@@ -42,14 +46,60 @@ function inferSlotPropValueFromExpression(
   return slot_prop_value;
 }
 
+/**
+ * Resolves `{...identifier}` inside a `{@render x({...})}` argument to a
+ * property map: the spread-of-a-literal's own properties (recursively), or,
+ * when the identifier only has a resolvable JSDoc/native object-type
+ * annotation, that type's members. Returns `null` when neither resolves, so
+ * the caller can widen the slot's props to `Record<string, any>`.
+ */
+function resolveSlotSpreadShape(ctx: ParserContext, parser: ComponentParser, argument: unknown): SlotProps | null {
+  if (!isIdentifier(argument)) return null;
+
+  const initializer = resolveConstInitializer(ctx, argument.name);
+  if (isObjectExpression(initializer)) {
+    return buildSlotPropsFromObjectExpression(ctx, parser, initializer).slot_props;
+  }
+
+  const varInfo = parser.findVariableTypeAndDescription(argument.name);
+  if (!varInfo) return null;
+
+  const members = parseObjectTypeLiteralMembers(varInfo.type);
+  if (!members) return null;
+
+  const slot_props: SlotProps = {};
+  for (const member of members) {
+    slot_props[member.name] = { value: member.type, replace: false };
+  }
+  return slot_props;
+}
+
 export function buildSlotPropsFromObjectExpression(
   ctx: ParserContext,
   parser: ComponentParser,
   expression: ObjectExpression,
-): SlotProps {
+): { slot_props: SlotProps; hasUnresolvedSpread: boolean } {
   const slot_props: SlotProps = {};
+  let hasUnresolvedSpread = false;
 
   for (const property of expression.properties) {
+    if (property.type === "SpreadElement") {
+      const merged = resolveSlotSpreadShape(ctx, parser, property.argument);
+      if (merged) {
+        Object.assign(slot_props, merged);
+      } else {
+        hasUnresolvedSpread = true;
+        recordDiagnostic(
+          ctx,
+          "spread-unresolved",
+          "slot_props",
+          "Slot props spread a value sveld can't resolve; its shape is widened to \"Record<string, any>\".",
+          sourceRangeFromNode(ctx, property),
+        );
+      }
+      continue;
+    }
+
     if (property.type !== "Property" || property.computed) continue;
 
     const propName = parser.getPropertyName(property.key);
@@ -57,7 +107,7 @@ export function buildSlotPropsFromObjectExpression(
     slot_props[propName] = inferSlotPropValueFromExpression(ctx, parser, property.value);
   }
 
-  return slot_props;
+  return { slot_props, hasUnresolvedSpread };
 }
 
 function resolveRenderTagPropReference(
@@ -171,6 +221,7 @@ export function addSlot(
   {
     slot_name,
     slot_props,
+    slot_props_unresolved_spread,
     slot_fallback,
     slot_description,
     slot_deprecated,
@@ -179,6 +230,7 @@ export function addSlot(
   }: {
     slot_name?: string;
     slot_props?: string | SlotProps;
+    slot_props_unresolved_spread?: boolean;
     slot_fallback?: string;
     slot_description?: string;
     slot_deprecated?: DeprecatedValue;
@@ -200,6 +252,7 @@ export function addSlot(
         default: existing_slot.default ?? default_slot,
         fallback,
         slot_props: existing_slot.slot_props === undefined ? props : existing_slot.slot_props,
+        slot_props_unresolved_spread: existing_slot.slot_props_unresolved_spread || slot_props_unresolved_spread,
         description: existing_slot.description || description,
         deprecated: existing_slot.deprecated ?? slot_deprecated,
         tags: existing_slot.tags || slot_tags,
@@ -212,6 +265,7 @@ export function addSlot(
       default: default_slot,
       fallback,
       slot_props,
+      slot_props_unresolved_spread,
       description,
       deprecated: slot_deprecated,
       tags: slot_tags,

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -2,6 +2,7 @@ import type { ComponentParseError } from "./bundle";
 import { type CheckResult, resolveCheckSnapshotFile, runCheck } from "./check";
 import {
   failingDiagnostics,
+  filterSpeculativeDiagnostics,
   formatDiagnosticsSummary,
   formatDiagnosticsSummaryJson,
   type SveldDiagnostic,
@@ -78,8 +79,8 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
   // the parse-only save generateBundle() already did.
   if (!merged.dryRun) result.cache?.save();
 
-  const { diagnostics } = result;
   const shouldReport = merged.reportDiagnostics || merged.strict;
+  const diagnostics = filterSpeculativeDiagnostics(result.diagnostics, shouldReport);
 
   if (shouldReport && diagnostics.length > 0) {
     if (merged.format === "json") {

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -266,10 +266,14 @@ export function getContextDefs(def: Pick<ComponentDocApi, "contexts" | "generics
        * This complies with Biome linter rules and Svelte 4 compatibility.
        */
       if (context.properties.length === 0) {
-        return `${contextComment}export type ${context.typeName} = Record<string, never>;`;
+        return context.hasUnresolvedSpread
+          ? `${contextComment}export type ${context.typeName} = Record<string, any>;`
+          : `${contextComment}export type ${context.typeName} = Record<string, never>;`;
       }
 
-      return `${contextComment}export type ${context.typeName}${genericSuffix} = {\n  ${props}\n};`;
+      const widenSuffix = context.hasUnresolvedSpread ? " & Record<string, any>" : "";
+
+      return `${contextComment}export type ${context.typeName}${genericSuffix} = {\n  ${props}\n}${widenSuffix};`;
     })
     .join("\n\n");
 }

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -580,7 +580,7 @@ function genPropDef(
     };`
     }
 
-    export type ${props_name}${genericsName} = Omit<$RestProps, keyof ($Props${genericsNameRef} & ${def.extends.interface})> & $Props${genericsNameRef} & ${def.extends.interface};
+    export type ${props_name}${genericsName} = Omit<$RestProps, keyof ($Props${genericsNameRef} & ${def.extends.interface})> & Omit<${def.extends.interface}, keyof $Props${genericsNameRef}> & $Props${genericsNameRef};
   `;
     }
   } else {
@@ -596,13 +596,21 @@ function genPropDef(
     } else if (def.canonicalPropsType) {
       prop_def = `
     ${basePropsDef}
-    export type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `${def.extends.interface} & `}$Props${genericsNameRef};
+    export type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `Omit<${def.extends.interface}, keyof $Props${genericsNameRef}> & `}$Props${genericsNameRef};
+  `;
+    } else if (def.extends === undefined) {
+      prop_def = `
+    export type ${props_name}${genericsName} = {
+      ${props}
+    };
   `;
     } else {
       prop_def = `
-    export type ${props_name}${genericsName} = ${def.extends === undefined ? "" : `${def.extends.interface} & `} {
+    type $Props${genericsName} = {
       ${props}
     };
+
+    export type ${props_name}${genericsName} = Omit<${def.extends.interface}, keyof $Props${genericsNameRef}> & $Props${genericsNameRef};
   `;
     }
   }

--- a/src/writer/writer-ts-definitions-core.ts
+++ b/src/writer/writer-ts-definitions-core.ts
@@ -124,7 +124,14 @@ export function getTypeDefs(def: Pick<ComponentDocApi, "typedefs">) {
   if (def.typedefs.length === 0) return EMPTY_STR;
   return def.typedefs
     .map((typedef) => {
-      const typedefComment = typedef.description ? `${formatMultiLineComment(typedef.description)}\n` : "";
+      const tagLines = expandJsDocTagLines(typedef.tags);
+      let typedefComment: string;
+      if (tagLines.length === 0) {
+        typedefComment = typedef.description ? `${formatMultiLineComment(typedef.description)}\n` : "";
+      } else {
+        const lines = typedef.description ? [...typedef.description.split("\n"), ...tagLines] : tagLines;
+        typedefComment = `/**\n * ${lines.join("\n * ")}\n */\n`;
+      }
       return `${typedefComment}export ${typedef.ts}`;
     })
     .join("\n\n");

--- a/tests/ComponentParser.test.ts
+++ b/tests/ComponentParser.test.ts
@@ -1570,14 +1570,13 @@ describe("ComponentParser", () => {
 
       const result = parser.parseSvelteComponent(source, diagnostics);
       expect(result.generics).toEqual(["Row", "Row extends string = string"]);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Duplicate generic name "Row"'));
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({ kind: "generics-conflict", name: "Row" }));
       expect(warn).toHaveBeenCalledWith(expect.stringContaining("Both @generics and @template tags are used"));
 
       warn.mockRestore();
     });
 
     test("warns when a name repeats across two @generics tags", () => {
-      const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
       const parser = new ComponentParser();
       const source = `
         <script>
@@ -1591,10 +1590,8 @@ describe("ComponentParser", () => {
         </script>
       `;
 
-      parser.parseSvelteComponent(source, diagnostics);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Duplicate generic name "Row"'));
-
-      warn.mockRestore();
+      const result = parser.parseSvelteComponent(source, diagnostics);
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({ kind: "generics-conflict", name: "Row" }));
     });
   });
 

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -201,3 +201,100 @@ describe("generateBundle with a directory entry (no barrel) and --glob", () => {
     expect(byModuleName(result.allComponentsForTypes, "Button")).toBeDefined();
   });
 });
+
+describe("generateBundle validates @extends/@extendProps targets", () => {
+  let dir: string;
+
+  const BASE = `<script>
+  /** @type {string} */
+  export let variant = "a";
+</script>
+`;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-bundle-extends-"));
+    writeFileSync(path.join(dir, "Base.svelte"), BASE);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("flags an @extendProps target that isn't found on disk", async () => {
+    writeFileSync(
+      path.join(dir, "Missing.svelte"),
+      `<script>\n  /** @extendProps {"./NoSuchFile.svelte"} BaseProps */\n</script>\n`,
+    );
+
+    const result = await generateBundle(dir, true);
+    const component = byModuleName(result.allComponentsForTypes, "Missing");
+
+    expect(component?.diagnostics).toContainEqual(
+      expect.objectContaining({ kind: "extend-props-target-missing", name: "BaseProps" }),
+    );
+  });
+
+  test("flags an @extendProps interface name that doesn't match the target's generated Props name", async () => {
+    writeFileSync(
+      path.join(dir, "Mismatch.svelte"),
+      `<script>\n  /** @extendProps {"./Base.svelte"} WrongProps */\n</script>\n`,
+    );
+
+    const result = await generateBundle(dir, true);
+    const component = byModuleName(result.allComponentsForTypes, "Mismatch");
+
+    expect(component?.diagnostics).toContainEqual(
+      expect.objectContaining({ kind: "extend-props-target-missing", name: "WrongProps" }),
+    );
+  });
+
+  test("flags an own prop that collides with a same-named prop of a different type on the target", async () => {
+    writeFileSync(
+      path.join(dir, "Collide.svelte"),
+      `<script>
+  /** @extendProps {"./Base.svelte"} BaseProps */
+
+  /** @type {number} */
+  export let variant = 1;
+</script>
+`,
+    );
+
+    const result = await generateBundle(dir, true);
+    const component = byModuleName(result.allComponentsForTypes, "Collide");
+
+    expect(component?.diagnostics).toContainEqual(
+      expect.objectContaining({ kind: "extend-props-override", name: "variant" }),
+    );
+  });
+
+  test("does not flag a matching target with no colliding prop names", async () => {
+    writeFileSync(
+      path.join(dir, "Clean.svelte"),
+      `<script>
+  /** @extendProps {"./Base.svelte"} BaseProps */
+
+  /** @type {string} */
+  export let label = "ok";
+</script>
+`,
+    );
+
+    const result = await generateBundle(dir, true);
+    const component = byModuleName(result.allComponentsForTypes, "Clean");
+
+    expect(component?.diagnostics?.some((d) => d.kind.startsWith("extend-props-"))).toBeFalsy();
+  });
+
+  test("does not attempt to verify a bare/package import specifier", async () => {
+    writeFileSync(
+      path.join(dir, "External.svelte"),
+      `<script>\n  /** @extendProps {"svelte/elements"} HTMLAttributes */\n</script>\n`,
+    );
+
+    const result = await generateBundle(dir, true);
+    const component = byModuleName(result.allComponentsForTypes, "External");
+
+    expect(component?.diagnostics?.some((d) => d.kind.startsWith("extend-props-"))).toBeFalsy();
+  });
+});

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -336,6 +336,52 @@ describe("ComponentParser diagnostics", () => {
     const defaultSlot = slots.find((s) => s.default);
     expect(defaultSlot?.slot_props).toContain("Record<string, any>");
   });
+
+  test("flags an instance-script export specifier re-exporting an imported binding", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { helper } from "./utils";
+        export { helper };
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const exportDiagnostic = diagnostics?.find((d) => d.kind === "export-unresolved");
+
+    expect(exportDiagnostic).toMatchObject({ kind: "export-unresolved", name: "helper" });
+  });
+
+  test("flags a module-script export specifier from another file", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script module>
+        export { helper } from "./utils";
+      </script>
+      <script>
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const exportDiagnostic = diagnostics?.find((d) => d.kind === "export-unresolved");
+
+    expect(exportDiagnostic).toMatchObject({ kind: "export-unresolved", name: "helper" });
+    expect(exportDiagnostic?.message).toContain('re-exports from "./utils"');
+  });
+
+  test("does not flag a specifier export resolving to a local declaration", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        let className = "test";
+        export { className as class };
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "export-unresolved")).toBe(false);
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -266,6 +266,23 @@ describe("ComponentParser diagnostics", () => {
     expect(rest_props).toMatchObject({ type: "Element", name: "div" });
     expect(diagnostics?.some((d) => d.kind === "rest-props-unresolved")).toBe(false);
   });
+
+  test("flags a second setContext call with the same key, keeping the first's shape", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        setContext("ctx", { a: 1 });
+        setContext("ctx", { b: 2 });
+      </script>
+    `;
+
+    const { diagnostics, contexts } = parser.parseSvelteComponent(source, parseContext);
+    const duplicateDiagnostic = diagnostics?.find((d) => d.kind === "context-duplicate-key");
+
+    expect(duplicateDiagnostic).toMatchObject({ kind: "context-duplicate-key", name: "ctx" });
+    expect(contexts?.find((c) => c.key === "ctx")?.properties?.map((p) => p.name)).toEqual(["a"]);
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -283,6 +283,59 @@ describe("ComponentParser diagnostics", () => {
     expect(duplicateDiagnostic).toMatchObject({ kind: "context-duplicate-key", name: "ctx" });
     expect(contexts?.find((c) => c.key === "ctx")?.properties?.map((p) => p.name)).toEqual(["a"]);
   });
+
+  test("merges a setContext spread of a local object-literal const", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        const base = { a: 1 };
+        setContext("ctx", { ...base, b: 2 });
+      </script>
+    `;
+
+    const { diagnostics, contexts } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "spread-unresolved")).toBe(false);
+    const ctx = contexts?.find((c) => c.key === "ctx");
+    expect(ctx?.properties.map((p) => p.name)).toEqual(["a", "b"]);
+    expect(ctx?.hasUnresolvedSpread).toBeFalsy();
+  });
+
+  test("flags an unresolvable setContext spread and widens the context type", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        import { setContext } from "svelte";
+        setContext("ctx", { ...getRest(), b: 2 });
+      </script>
+    `;
+
+    const { diagnostics, contexts } = parser.parseSvelteComponent(source, parseContext);
+    const spreadDiagnostic = diagnostics?.find((d) => d.kind === "spread-unresolved");
+
+    expect(spreadDiagnostic).toMatchObject({ kind: "spread-unresolved", name: "ctx" });
+    const ctx = contexts?.find((c) => c.key === "ctx");
+    expect(ctx?.hasUnresolvedSpread).toBe(true);
+    expect(ctx?.properties.map((p) => p.name)).toEqual(["b"]);
+  });
+
+  test("flags an unresolvable spread in slot props from {@render} and widens", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        let { children } = $props();
+      </script>
+      {@render children({ ...getRest(), label: "x" })}
+    `;
+
+    const { diagnostics, slots } = parser.parseSvelteComponent(source, parseContext);
+    const spreadDiagnostic = diagnostics?.find((d) => d.kind === "spread-unresolved");
+
+    expect(spreadDiagnostic).toBeDefined();
+    const defaultSlot = slots.find((s) => s.default);
+    expect(defaultSlot?.slot_props).toContain("Record<string, any>");
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -401,6 +401,150 @@ describe("ComponentParser diagnostics", () => {
     expect(duplicateDiagnostic).toMatchObject({ kind: "extend-props-duplicate", name: "LinkProps" });
     expect(extendsInfo?.interface).toBe("LinkProps");
   });
+
+  test("flags a duplicate @typedef name as a diagnostic instead of console.warn", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @typedef {string} Config
+         * @typedef {number} Config
+         */
+        export let value;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const duplicateDiagnostic = diagnostics?.find((d) => d.kind === "typedef-duplicate");
+
+    expect(duplicateDiagnostic).toMatchObject({ kind: "typedef-duplicate", name: "Config" });
+  });
+
+  test("flags a duplicate @property name on a @typedef as a diagnostic", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @typedef {Object} Config
+         * @property {string} id
+         * @property {number} id
+         */
+        export let value;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const duplicateDiagnostic = diagnostics?.find((d) => d.kind === "property-duplicate");
+
+    expect(duplicateDiagnostic).toMatchObject({ kind: "property-duplicate", name: "id" });
+  });
+
+  test("flags a duplicate @template generic name as a diagnostic", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script lang="ts">
+        /**
+         * @template T
+         * @template T
+         */
+        export let value: unknown;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const duplicateDiagnostic = diagnostics?.find((d) => d.kind === "generics-conflict");
+
+    expect(duplicateDiagnostic).toMatchObject({ kind: "generics-conflict", name: "T" });
+  });
+
+  test("a passthrough tag before @typedef attaches to it instead of being dropped", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @since 1.2.0
+         * @typedef {string} Config
+         */
+        export let value;
+      </script>
+    `;
+
+    const { diagnostics, typedefs } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "jsdoc-tag-dropped")).toBe(false);
+    expect(typedefs.find((t) => t.name === "Config")?.tags).toEqual([{ name: "since", body: "1.2.0" }]);
+  });
+
+  test("a passthrough tag after @event attaches to it (also verifies @see is captured for events)", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @event {CustomEvent<null>} change
+         * @see https://example.com/docs
+         */
+        import { createEventDispatcher } from "svelte";
+        const dispatch = createEventDispatcher();
+        dispatch("change");
+      </script>
+    `;
+
+    const { events } = parser.parseSvelteComponent(source, parseContext);
+    const changeEvent = events.find((e) => e.name === "change");
+
+    expect(changeEvent?.tags).toEqual([{ name: "see", body: "https://example.com/docs" }]);
+  });
+
+  test("a passthrough tag on a plain prop comment (no structural tag) is not flagged as dropped", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @since 1.0.0
+         */
+        export let value = "ok";
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "jsdoc-tag-dropped")).toBe(false);
+    expect(diagnostics?.some((d) => d.kind === "jsdoc-unknown-tag")).toBe(false);
+  });
+
+  test("flags a genuinely unknown/misspelled JSDoc tag", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @depreacted use something else
+         * @slot content
+         */
+      </script>
+      <slot />
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const unknownTagDiagnostic = diagnostics?.find((d) => d.kind === "jsdoc-unknown-tag");
+
+    expect(unknownTagDiagnostic).toMatchObject({ kind: "jsdoc-unknown-tag", name: "depreacted" });
+  });
+
+  test("does not flag @bindable/@default/@required as unknown tags", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @bindable readonly
+         */
+        export let value = 1;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "jsdoc-unknown-tag")).toBe(false);
+  });
 });
 
 describe("diagnostics helpers", () => {
@@ -716,5 +860,48 @@ describe("sveld() strict mode", () => {
     });
 
     expect(exitCode).toBe(4);
+  });
+});
+
+describe("sveld() gates jsdoc-unknown-tag on --strict/--report-diagnostics", () => {
+  let absoluteDir: string;
+  let relativeDir: string;
+  let previousExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    absoluteDir = mkdtempSync(join(process.cwd(), "sveld-unknown-tag-"));
+    relativeDir = basename(absoluteDir);
+    writeFileSync(
+      join(absoluteDir, "Typo.svelte"),
+      '<script>\n  /**\n   * @depreacted use something else\n   */\n  export let label = "ok";\n</script>\n',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(absoluteDir, { recursive: true, force: true });
+    process.exitCode = previousExitCode;
+    jest.restoreAllMocks();
+  });
+
+  test("is hidden from the returned diagnostics by default", async () => {
+    const { diagnostics } = await sveld({ entry: relativeDir, glob: true, types: false });
+
+    expect(diagnostics.some((d) => d.kind === "jsdoc-unknown-tag")).toBe(false);
+  });
+
+  test("is included when reportDiagnostics is set", async () => {
+    const { diagnostics } = await sveld({ entry: relativeDir, glob: true, types: false, reportDiagnostics: true });
+
+    expect(diagnostics.some((d) => d.kind === "jsdoc-unknown-tag")).toBe(true);
+  });
+
+  test("is included when strict is set", async () => {
+    const { diagnostics } = await sveld({ entry: relativeDir, glob: true, types: false, strict: true });
+
+    expect(diagnostics.some((d) => d.kind === "jsdoc-unknown-tag")).toBe(true);
   });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -382,6 +382,25 @@ describe("ComponentParser diagnostics", () => {
 
     expect(diagnostics?.some((d) => d.kind === "export-unresolved")).toBe(false);
   });
+
+  test("flags a second @extends/@extendProps tag overwriting the first", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @extendProps {"./Button.svelte"} ButtonProps
+         * @extendProps {"./Link.svelte"} LinkProps
+         */
+        export let label = "";
+      </script>
+    `;
+
+    const { diagnostics, extends: extendsInfo } = parser.parseSvelteComponent(source, parseContext);
+    const duplicateDiagnostic = diagnostics?.find((d) => d.kind === "extend-props-duplicate");
+
+    expect(duplicateDiagnostic).toMatchObject({ kind: "extend-props-duplicate", name: "LinkProps" });
+    expect(extendsInfo?.interface).toBe("LinkProps");
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -236,6 +236,36 @@ describe("ComponentParser diagnostics", () => {
     expect(conflictDiagnostic?.severity).toBe("error");
     expect(conflictDiagnostic?.code).toBe("sveld/syntax-skipped");
   });
+
+  test("flags $$restProps spread only onto a component as rest-props-unresolved", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+      </script>
+      <Button {...$$restProps} />
+    `;
+
+    const { diagnostics, rest_props } = parser.parseSvelteComponent(source, parseContext);
+    const restPropsDiagnostic = diagnostics?.find((d) => d.kind === "rest-props-unresolved");
+
+    expect(restPropsDiagnostic).toMatchObject({ kind: "rest-props-unresolved", name: "$$restProps" });
+    expect(rest_props).toMatchObject({ type: "InlineComponent", name: "Button" });
+  });
+
+  test("prefers a later plain-element $$restProps target over an earlier component target", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+      </script>
+      <Button {...$$restProps} />
+      <div {...$$restProps} />
+    `;
+
+    const { diagnostics, rest_props } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(rest_props).toMatchObject({ type: "Element", name: "div" });
+    expect(diagnostics?.some((d) => d.kind === "rest-props-unresolved")).toBe(false);
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/fixtures/extend-props/output-class.d.ts
+++ b/tests/fixtures/extend-props/output-class.d.ts
@@ -15,7 +15,7 @@ type $Props = {
   [key: `data-${string}`]: unknown;
 };
 
-export type ExtendPropsProps = Omit<$RestProps, keyof ($Props & ButtonProps)> & $Props & ButtonProps;
+export type ExtendPropsProps = Omit<$RestProps, keyof ($Props & ButtonProps)> & Omit<ButtonProps, keyof $Props> & $Props;
 
 export default class ExtendProps extends SvelteComponentTyped<
   ExtendPropsProps,

--- a/tests/fixtures/extend-props/output-component.d.ts
+++ b/tests/fixtures/extend-props/output-component.d.ts
@@ -15,7 +15,7 @@ type $Props = {
   [key: `data-${string}`]: unknown;
 };
 
-export type ExtendPropsProps = Omit<$RestProps, keyof ($Props & ButtonProps)> & $Props & ButtonProps;
+export type ExtendPropsProps = Omit<$RestProps, keyof ($Props & ButtonProps)> & Omit<ButtonProps, keyof $Props> & $Props;
 
 export type ExtendPropsExports = Record<string, never>;
 

--- a/tests/fixtures/instance-reexport/output.json
+++ b/tests/fixtures/instance-reexport/output.json
@@ -75,5 +75,24 @@
   "typedefs": [],
   "generics": null,
   "contexts": [],
-  "diagnostics": []
+  "diagnostics": [
+    {
+      "component": "instance-reexport/input.svelte",
+      "kind": "export-unresolved",
+      "name": "helper",
+      "message": "export \"helper\" was skipped because it re-exports an imported binding; sveld only resolves exports of a local declaration.",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 31
+        }
+      },
+      "code": "sveld/export-unresolved",
+      "severity": "warning"
+    }
+  ]
 }

--- a/tests/fixtures/module-reexport-mixed/output.json
+++ b/tests/fixtures/module-reexport-mixed/output.json
@@ -148,6 +148,24 @@
   "diagnostics": [
     {
       "component": "module-reexport-mixed/input.svelte",
+      "kind": "export-unresolved",
+      "name": "External",
+      "message": "export \"External\" was skipped because it re-exports an imported binding; sveld only resolves exports of a local declaration.",
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 2
+        },
+        "end": {
+          "line": 11,
+          "column": 22
+        }
+      },
+      "code": "sveld/export-unresolved",
+      "severity": "warning"
+    },
+    {
+      "component": "module-reexport-mixed/input.svelte",
       "kind": "prop-unknown-type",
       "name": "name",
       "message": "Prop \"name\" type could not be inferred; falling back to \"any\".",

--- a/tests/fixtures/module-reexport/output.json
+++ b/tests/fixtures/module-reexport/output.json
@@ -93,6 +93,24 @@
   "diagnostics": [
     {
       "component": "module-reexport/input.svelte",
+      "kind": "export-unresolved",
+      "name": "tokTypes",
+      "message": "export \"tokTypes\" was skipped because it re-exports an imported binding; sveld only resolves exports of a local declaration.",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 22
+        }
+      },
+      "code": "sveld/export-unresolved",
+      "severity": "warning"
+    },
+    {
+      "component": "module-reexport/input.svelte",
       "kind": "prop-unknown-type",
       "name": "data",
       "message": "Prop \"data\" type could not be inferred; falling back to \"any\".",

--- a/tests/fixtures/prop-comments/output-class.d.ts
+++ b/tests/fixtures/prop-comments/output-class.d.ts
@@ -3,8 +3,8 @@ import { SvelteComponentTyped } from "svelte";
 export type PropCommentsProps = {
   /**
    * This is a comment.
-   * @see https://github.com/
    * @deprecated this prop will be removed in the next major release.
+   * @see https://github.com/
    * @default true
    */
   prop?: boolean | string;

--- a/tests/fixtures/prop-comments/output-component.d.ts
+++ b/tests/fixtures/prop-comments/output-component.d.ts
@@ -3,8 +3,8 @@ import type { Component } from "svelte";
 export type PropCommentsProps = {
   /**
    * This is a comment.
-   * @see https://github.com/
    * @deprecated this prop will be removed in the next major release.
+   * @see https://github.com/
    * @default true
    */
   prop?: boolean | string;

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -15,8 +15,14 @@
     {
       "name": "prop",
       "kind": "let",
-      "description": "This is a comment.\n@see https://github.com/",
+      "description": "This is a comment.",
       "deprecated": "this prop will be removed in the next major release.",
+      "tags": [
+        {
+          "name": "see",
+          "body": "https://github.com/"
+        }
+      ],
       "type": "boolean | string",
       "typeSource": "jsdoc",
       "value": "true",
@@ -44,7 +50,12 @@
     {
       "name": "prop1",
       "kind": "let",
-      "description": "@see https://github.com/",
+      "tags": [
+        {
+          "name": "see",
+          "body": "https://github.com/"
+        }
+      ],
       "type": "boolean",
       "typeSource": "default",
       "value": "true",

--- a/tests/fixtures/runes-generics/output.json
+++ b/tests/fixtures/runes-generics/output.json
@@ -108,5 +108,24 @@
     "Row extends DataTableRow = DataTableRow"
   ],
   "contexts": [],
-  "diagnostics": []
+  "diagnostics": [
+    {
+      "component": "runes-generics/input.svelte",
+      "kind": "generics-conflict",
+      "name": "Row",
+      "message": "Duplicate generic name \"Row\".",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 5
+        },
+        "end": {
+          "line": 7,
+          "column": 60
+        }
+      },
+      "code": "sveld/generics-conflict",
+      "severity": "warning"
+    }
+  ]
 }

--- a/tests/fixtures/runes-typed-props/output.json
+++ b/tests/fixtures/runes-typed-props/output.json
@@ -42,7 +42,12 @@
     {
       "name": "prop1",
       "kind": "let",
-      "description": "@see https://github.com/",
+      "tags": [
+        {
+          "name": "see",
+          "body": "https://github.com/"
+        }
+      ],
       "type": "boolean",
       "typeSource": "default",
       "value": "true",

--- a/tests/fixtures/slot-extends-template/output-class.d.ts
+++ b/tests/fixtures/slot-extends-template/output-class.d.ts
@@ -1,7 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
 import type { ButtonProps } from "./Button.svelte";
 
-export type SlotExtendsTemplateProps<Icon = any> = ButtonProps & {
+type $Props<Icon = any> = {
   /**
    * @default undefined
    */
@@ -10,6 +10,8 @@ export type SlotExtendsTemplateProps<Icon = any> = ButtonProps & {
   /** Optional badge overlay. */
   badge?: (this: void) => void;
 };
+
+export type SlotExtendsTemplateProps<Icon = any> = Omit<ButtonProps, keyof $Props<Icon>> & $Props<Icon>;
 
 export default class SlotExtendsTemplate<Icon = any> extends SvelteComponentTyped<
   SlotExtendsTemplateProps<Icon>,

--- a/tests/fixtures/slot-extends-template/output-component.d.ts
+++ b/tests/fixtures/slot-extends-template/output-component.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponent, ComponentConstructorOptions, ComponentInternals } from "svelte";
 import type { ButtonProps } from "./Button.svelte";
 
-export type SlotExtendsTemplateProps<Icon = any> = ButtonProps & {
+type $Props<Icon = any> = {
   /**
    * @default undefined
    */
@@ -10,6 +10,8 @@ export type SlotExtendsTemplateProps<Icon = any> = ButtonProps & {
   /** Optional badge overlay. */
   badge?: (this: void) => void;
 };
+
+export type SlotExtendsTemplateProps<Icon = any> = Omit<ButtonProps, keyof $Props<Icon>> & $Props<Icon>;
 
 export type SlotExtendsTemplateExports = Record<string, never>;
 

--- a/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
@@ -41,5 +41,24 @@
   "typedefs": [],
   "generics": null,
   "contexts": [],
-  "diagnostics": []
+  "diagnostics": [
+    {
+      "component": "slot-jsdoc-inheritdoc-before-slot/input.svelte",
+      "kind": "jsdoc-unknown-tag",
+      "name": "inheritdoc",
+      "message": "Unknown JSDoc tag \"@inheritdoc\"; passed through unchanged. If this is a typo, fix the tag name.",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 16
+        }
+      },
+      "code": "sveld/jsdoc-unknown-tag",
+      "severity": "warning"
+    }
+  ]
 }

--- a/tests/fixtures/theme-component/output.json
+++ b/tests/fixtures/theme-component/output.json
@@ -43,7 +43,13 @@
     {
       "name": "tokens",
       "kind": "let",
-      "description": "Customize a theme with your own tokens\n@see https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme",
+      "description": "Customize a theme with your own tokens",
+      "tags": [
+        {
+          "name": "see",
+          "body": "https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme"
+        }
+      ],
       "type": "{ [token: string]: any; }",
       "typeSource": "jsdoc",
       "value": "{}",

--- a/tests/fixtures/typedef-duplicate-name/output.json
+++ b/tests/fixtures/typedef-duplicate-name/output.json
@@ -46,5 +46,24 @@
   ],
   "generics": null,
   "contexts": [],
-  "diagnostics": []
+  "diagnostics": [
+    {
+      "component": "typedef-duplicate-name/input.svelte",
+      "kind": "typedef-duplicate",
+      "name": "Config",
+      "message": "Duplicate typedef/callback name \"Config\"; the later declaration overwrites the earlier one.",
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 5
+        },
+        "end": {
+          "line": 8,
+          "column": 29
+        }
+      },
+      "code": "sveld/typedef-duplicate",
+      "severity": "warning"
+    }
+  ]
 }

--- a/tests/fixtures/typedef-duplicate-property/output.json
+++ b/tests/fixtures/typedef-duplicate-property/output.json
@@ -46,5 +46,24 @@
   ],
   "generics": null,
   "contexts": [],
-  "diagnostics": []
+  "diagnostics": [
+    {
+      "component": "typedef-duplicate-property/input.svelte",
+      "kind": "property-duplicate",
+      "name": "id",
+      "message": "Duplicate property \"id\" of \"Config\"; the later declaration overwrites the earlier one.",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 52
+        }
+      },
+      "code": "sveld/property-duplicate",
+      "severity": "warning"
+    }
+  ]
 }


### PR DESCRIPTION
Turns eight previously-silent parser/writer drops (rest props,
duplicate setContext keys, unresolved spreads, unresolved export
specifiers, @extends/@extendProps collisions, and JSDoc passthrough
tag handling) into typed diagnostics with stable codes, instead of
producing wrong output or nothing at all.