### PR TITLE
feat(markdown): render passthrough tags for props and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -2761,7 +2761,7 @@ label?: string;
 
 **Valid contexts:**
 
-- **Prop / module export** — captured as a structured tag: JSON adds a `tags: [{ "name": "since", "body": "..." }]` array on the prop (kept separate from `description`), and the generated `.d.ts` emits `@since ...` as its own JSDoc line above `@default`. **Not rendered in the Markdown table** — the Markdown props/events renderers only read `description`, not `tags` (only the slots renderer does; see [extra tags before `@slot`](#extra-jsdoc-tags-before-slot)).
+- **Prop / module export** — captured as a structured tag: JSON adds a `tags: [{ "name": "since", "body": "..." }]` array on the prop (kept separate from `description`), the generated `.d.ts` emits `@since ...` as its own JSDoc line above `@default`, and the Markdown table's Description column appends `@since ...` after the description, same as slots.
 - **`@event`** — same structured behavior as props, but only when `@since` is placed **after** the `@event` line in the same comment block (matching the [`@deprecated`](#deprecated) rule for events). Placed before `@event`, it is silently dropped.
 - **`@slot` / `@snippet`** — placed before the `@slot`/`@snippet` line, alongside the description. Fully surfaced in JSON, `.d.ts`, *and* the Markdown table. See [extra tags before `@slot`](#extra-jsdoc-tags-before-slot).
 - **`@typedef`** — **not supported.** A `@since` before `@typedef` produces no output anywhere; it is silently dropped.
@@ -2799,7 +2799,11 @@ Output (JSON, relevant slice):
 { "name": "width", "description": "A width prop.", "tags": [{ "name": "since", "body": "1.2.0" }] }
 ```
 
-The Markdown table for the same prop shows only `A width prop.` in the Description column — `@since` does not appear there.
+Output (Markdown props table Description column):
+
+```
+A width prop.<br />@since 1.2.0
+```
 
 ### `@see`
 
@@ -2883,7 +2887,7 @@ The same literal string appears unchanged in JSON `description` and in the Markd
 
 `@example` shares its underlying mechanism with `@since` (both are in the small set of tags `sveld` treats as structured "IDE passthrough" tags), so the valid contexts are the same:
 
-- **Prop / module export (including functions)** — structured `tags` entry in JSON, its own `@example` block in `.d.ts`. **Not rendered in the Markdown table**, same gap as `@since`.
+- **Prop / module export (including functions)** — structured `tags` entry in JSON, its own `@example` block in `.d.ts`, and appended to the Markdown table's Description column, same as `@since`.
 - **`@event`** — only when placed **after** the `@event` line in the same block, same rule as `@since`.
 - **`@slot` / `@snippet`** — placed before `@slot`/`@snippet`: fully supported in JSON, `.d.ts`, and Markdown. See [extra tags before `@slot`](#extra-jsdoc-tags-before-slot).
 - **`@typedef`** — **not supported**, dropped silently, same as `@since`.
@@ -2921,7 +2925,13 @@ Output (`.d.ts`):
 formatValue: (value: string) => string;
 ```
 
-`@param`/`@returns` are consumed into the function's type signature rather than kept as separate JSDoc lines. The Markdown table shows only `Formats a value.` in the Description column — the `@example` block does not appear there.
+`@param`/`@returns` are consumed into the function's type signature rather than kept as separate JSDoc lines.
+
+Output (Markdown props table Description column, newlines rendered as `<br />`):
+
+````
+Formats a value.<br />@example ```js<br /> formatValue("ok");<br /> ```
+````
 
 ### Context API
 

--- a/README.md
+++ b/README.md
@@ -957,7 +957,7 @@ From that barrel, `sveld` documents `VERSION`, `clamp`, and `Theme`. `Button` st
 
 Nested barrels are followed too: `export { X } from "./dir"`, where `./dir/index.js` itself re-exports `.svelte` files, resolves `X` to the underlying component without needing `--glob`.
 
-JSON adds `exports` and `totalExports`. Markdown adds an "Exports" section. Each item has `name`, `kind`, type text, optional JSDoc `description`, and `source`.
+JSON adds `exports` and `totalExports`. Markdown adds an "Exports" section. Each item has `name`, `kind`, type text, optional JSDoc `description`, `source`, and — same as props — optional `@deprecated` and pass-through `tags`. A deprecated export's name is struck through in the Markdown table, same as a deprecated prop. See [`@deprecated`](#deprecated).
 
 ## JSON Output
 
@@ -995,6 +995,8 @@ interface EntryExport {
   type?: string;
   value?: string;
   description?: string;
+  deprecated?: string | true;
+  tags?: Array<{ name: string; body: string }>;
   source?: string;
   isTypeOnly: boolean;
 }
@@ -2710,7 +2712,7 @@ Any free-text prose after the tags is attached to the event description, not to 
 
 ### `@deprecated`
 
-Add `@deprecated` to a prop, event, slot, or exported accessor. An optional message after the tag can explain why or name a replacement.
+Add `@deprecated` to a prop, event, slot, entry export, or exported accessor. An optional message after the tag can explain why or name a replacement.
 
 ```svelte
 <script>
@@ -2739,7 +2741,7 @@ Add `@deprecated` to a prop, event, slot, or exported accessor. An optional mess
 </script>
 ```
 
-For slots, put `@deprecated` before the `@slot` / `@snippet` line, alongside the description and any other [extra tags](#extra-jsdoc-tags-before-slot). For events, put it after the `@event` line.
+For slots, put `@deprecated` before the `@slot` / `@snippet` line, alongside the description and any other [extra tags](#extra-jsdoc-tags-before-slot). For events, put it after the `@event` line. For entry exports (see [Documenting Entry Exports](#documenting-entry-exports)), put it in the JSDoc directly above the `const`/`function`/`class`/`type`/`interface` declaration, same as a prop.
 
 Generated `.d.ts` files include an `@deprecated` JSDoc line so editors strike the symbol through. JSON adds a `deprecated` field (the message string, or `true` when the tag has no message). Markdown strikes through the name and adds a **Deprecated** badge with the message when present.
 

--- a/README.md
+++ b/README.md
@@ -2911,7 +2911,7 @@ A width prop.<br />@see https://example.com/width-docs
 
 `{@link target}` (optionally `{@link target|display text}`) is an inline JSDoc tag used inside prose, not a block-level tag like the others on this page. `sveld`'s comment parser only treats a *line* as starting a new tag when it begins with `@` — `{@link ...}` always starts with `{`, so it's never intercepted. It is always literal text.
 
-**Valid contexts:** anywhere free-form description text is read — prop and module export descriptions, event descriptions, slot descriptions, typedef descriptions, `@component` HTML comments, and `@example` bodies. In every case `sveld` copies it through unchanged, with no link resolution or target validation, into JSON `description`, `.d.ts` JSDoc, and Markdown.
+**Valid contexts:** anywhere free-form description text is read — prop and module export descriptions, event descriptions, slot descriptions, entry export descriptions, typedef descriptions, `@component` HTML comments, and `@example` bodies. `sveld` never resolves or validates the target. JSON `description` and `.d.ts` JSDoc always keep the tag verbatim. **Markdown is the one exception:** in a prop, event, slot, or entry export's Description table cell, `{@link target|text}` / `{@link target}` is rewritten to a Markdown link, `[text](target)` / `[target](target)`. Typedef descriptions (rendered as a `.d.ts`-style code block) and `@component` comments keep the tag literal in Markdown too, since neither goes through the table-cell renderer.
 
 **Example:**
 
@@ -2937,7 +2937,7 @@ export type ScratchProps = {
 };
 ```
 
-The same literal string appears unchanged in JSON `description` and in the Markdown table's Description column.
+The same literal string appears unchanged in JSON `description`. The Markdown table's Description column instead shows: `The element's width in pixels. See [width docs](https://example.com/width).`
 
 ### `@example`
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ export default class Button extends SvelteComponentTyped<
     - [Extra JSDoc tags before `@slot`](#extra-jsdoc-tags-before-slot)
     - [Svelte 5 Snippet Compatibility](#svelte-5-snippet-compatibility)
   - [@event](#event)
+  - [@ignore / @internal](#ignore--internal)
   - [@deprecated](#deprecated)
   - [@since](#since)
   - [@see](#see)
@@ -2709,6 +2710,61 @@ export default class Component extends SvelteComponentTyped<
 ```
 
 Any free-text prose after the tags is attached to the event description, not to a property doc.
+
+### `@ignore` / `@internal`
+
+`@ignore` and `@internal` are equivalent aliases: either one excludes a prop, event, slot, typedef, module export, entry export, or context from every output — JSON, Markdown, `.d.ts`, and the Custom Elements Manifest. Use them for implementation details that would otherwise leak into the public API docs.
+
+The tag's position mirrors [`@deprecated`](#deprecated): before `@slot`/`@snippet`/`@typedef`/`@callback`, alongside the description, and after the `@event` line.
+
+```svelte
+<script>
+  /** The visible label. */
+  export let label = "";
+
+  /**
+   * Implementation detail; not part of the public API.
+   * @internal
+   */
+  export let debugId = "";
+
+  /**
+   * Fired when the value changes.
+   * @event {{ value: string }} change
+   */
+
+  /**
+   * Fired for internal diagnostics only.
+   * @event {{ reason: string }} debug
+   * @internal
+   */
+
+  /**
+   * @internal
+   * @slot {{}} debug-panel
+   */
+</script>
+```
+
+`debugId`, the `debug` event, and the `debug-panel` slot never appear in `COMPONENT_INDEX.md`, `COMPONENT_API.json`, the generated `.d.ts`, or the Custom Elements Manifest — as if they were never declared. Internally, the parser still records them (with an `internal: true` flag) on the raw parsed component; only `buildComponentApiDocument` — the shared step every writer runs through — filters them out, so a custom writer built on the raw parse result can still see them if it chooses to.
+
+For a context (`setContext(key, value)`), tag the JSDoc on the *value* variable, the same place its type annotation and description already live:
+
+```svelte
+<script>
+  /**
+   * @type {{ token: string }}
+   * @internal
+   */
+  let authContext = { token: "" };
+
+  setContext("auth", authContext);
+</script>
+```
+
+An inline object literal passed directly to `setContext` (no intermediate variable) has no JSDoc position of its own, so `@internal` isn't supported there.
+
+Because an internal member never appears in output, adding `@internal` to a previously-public prop, event, slot, or typedef is a breaking change for `--check` purposes (it disappears from the generated `.d.ts` just like an outright removal). Removing an already-`@internal` member, by contrast, is not breaking — it was never part of the committed public snapshot to begin with.
 
 ### `@deprecated`
 

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -362,6 +362,11 @@
         "type": { "type": "string" },
         "value": { "type": "string" },
         "description": { "type": "string" },
+        "deprecated": { "$ref": "#/$defs/deprecated" },
+        "tags": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/jsdocTag" }
+        },
         "source": { "type": "string" },
         "isTypeOnly": { "type": "boolean" }
       }

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -371,6 +371,8 @@ export interface ComponentProp {
   deprecated?: DeprecatedValue;
   /** `@since` / `@example` tags in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
   /** Source range when available. */
   source?: SourceRange;
 }
@@ -400,6 +402,8 @@ export interface ComponentSlot {
   deprecated?: DeprecatedValue;
   /** Tags between the description and `@slot`/`@snippet` (e.g. `@example`), in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
   /** Source range when available. */
   source?: SourceRange;
 }
@@ -444,6 +448,8 @@ export interface ForwardedEvent {
   detail?: string;
   /** `@since` / `@example` tags in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
   /** Source range when available. */
   source?: SourceRange;
 }
@@ -462,6 +468,8 @@ export interface DispatchedEvent {
   deprecated?: DeprecatedValue;
   /** `@since` / `@example` tags in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
   /** Source range when available. */
   source?: SourceRange;
 }
@@ -495,6 +503,8 @@ export interface SerializedForwardedEvent {
   detail?: string;
   /** `@since` / `@example` tags in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
   /** Source range when available. */
   source?: SourceRange;
 }
@@ -513,6 +523,8 @@ export interface TypeDef {
   ts: string;
   /** Tags in the same block (e.g. `@since`, `@example`, `@see`), in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
 }
 
 export type ComponentGenerics = [name: string, type: string] | null;
@@ -583,6 +595,8 @@ export interface ComponentContext {
   properties: ComponentContextProp[];
   /** True when a `{...spread}` in the context's object literal couldn't be resolved; the generated type intersects with `Record<string, any>`. */
   hasUnresolvedSpread?: boolean;
+  /** True from `@ignore`/`@internal` JSDoc on the `setContext` call; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
 }
 
 /**
@@ -842,12 +856,13 @@ export default class ComponentParser {
    * // { type: "number", description: "The count value" }
    * ```
    */
-  findVariableTypeAndDescription(varName: string): { type: string; description?: string } | null {
+  findVariableTypeAndDescription(varName: string): { type: string; description?: string; internal?: boolean } | null {
     const prop = this.getPropByLocalOrPublic(varName);
     if (prop?.type) {
       return {
         type: prop.type,
         description: prop.description,
+        internal: prop.internal,
       };
     }
 
@@ -863,6 +878,7 @@ export default class ComponentParser {
       return {
         type: explicitType,
         description: cached?.description,
+        internal: cached?.internal,
       };
     }
 
@@ -1207,6 +1223,7 @@ export default class ComponentParser {
                 description,
                 deprecated: jsdocInfo?.deprecated,
                 tags: jsdocInfo?.tags,
+                ...(jsdocInfo?.internal ? { internal: true as const } : {}),
                 type,
                 typeSource,
                 value,
@@ -1572,6 +1589,7 @@ export default class ComponentParser {
               binding: jsdocInfo?.binding,
               deprecated: jsdocInfo?.deprecated,
               tags: jsdocInfo?.tags,
+              ...(jsdocInfo?.internal ? { internal: true as const } : {}),
               type,
               typeSource,
               value,
@@ -1764,6 +1782,7 @@ export default class ComponentParser {
 
                 const event_description = this.ctx.eventDescriptions.get(eventHandlerNode.name);
                 const event_deprecated = existing_event?.deprecated;
+                const event_internal = existing_event?.internal;
 
                 if (!existing_event) {
                   this.ctx.events.set(eventHandlerNode.name, {
@@ -1772,6 +1791,7 @@ export default class ComponentParser {
                     element: element,
                     description: event_description,
                     deprecated: event_deprecated,
+                    ...(event_internal ? { internal: true as const } : {}),
                     source: sourceRangeFromNode(this.ctx, node),
                   });
                 } else if (existing_event.type === "forwarded" && event_description && !existing_event.description) {
@@ -1779,6 +1799,7 @@ export default class ComponentParser {
                     ...existing_event,
                     description: event_description,
                     deprecated: existing_event.deprecated ?? event_deprecated,
+                    ...(existing_event.internal || event_internal ? { internal: true as const } : {}),
                     source: existing_event.source || sourceRangeFromNode(this.ctx, node),
                   });
                 }
@@ -1909,6 +1930,9 @@ export default class ComponentParser {
           tags: event.tags,
           source: event.source,
         };
+        if (event.internal) {
+          forwardedEvent.internal = true;
+        }
         // Keep explicit `@event` detail types, including `null`.
         if (event.detail !== undefined && event.detail !== "undefined") {
           forwardedEvent.detail = event.detail;

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -1,7 +1,8 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { isIdentifier, resolveStaticStringLiteral } from "./ast-guards";
-import { extractJsDocReturnType } from "./parser/jsdoc";
+import type { DeprecatedValue, JsDocPassthroughTag } from "./ComponentParser";
+import { extractJsDocDeprecatedAndTags, extractJsDocReturnType } from "./parser/jsdoc";
 import { getParserStack, loadParserStack } from "./parser-stack";
 import { normalizeSeparators } from "./path";
 import { resolvePathAliasAbsolute } from "./resolve-alias";
@@ -15,6 +16,10 @@ export interface EntryExport {
   /** Initializer text for simple constants. */
   value?: string;
   description?: string;
+  /** From `@deprecated` JSDoc. */
+  deprecated?: DeprecatedValue;
+  /** `@since` / `@example` / `@see` tags in source order. */
+  tags?: JsDocPassthroughTag[];
   /** Declaring module, relative to the entry file. */
   source?: string;
   isTypeOnly: boolean;
@@ -257,6 +262,9 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
   const description = leadingJsDoc(source.text, jsdocStart);
   const rawJsDoc = leadingJsDocBlock(source.text, jsdocStart);
   const jsDocReturnType = rawJsDoc ? extractJsDocReturnType(rawJsDoc) : undefined;
+  const { deprecated, tags } = rawJsDoc
+    ? extractJsDocDeprecatedAndTags(rawJsDoc)
+    : { deprecated: undefined, tags: undefined };
 
   if (declaration.type === "VariableDeclaration") {
     const kind = (declaration.kind as "const" | "let" | "var") ?? "const";
@@ -288,7 +296,19 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         }
       }
 
-      results.push({ name, kind, type, value, returnType, literalValue, description, declFile, isTypeOnly: false });
+      results.push({
+        name,
+        kind,
+        type,
+        value,
+        returnType,
+        literalValue,
+        description,
+        deprecated,
+        tags,
+        declFile,
+        isTypeOnly: false,
+      });
     }
 
     return results;
@@ -308,6 +328,8 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
           jsDocReturnType ??
           inferAstLiteralReturnType(declaration),
         description,
+        deprecated,
+        tags,
         declFile,
         isTypeOnly: false,
       },
@@ -317,7 +339,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
   if (declaration.type === "ClassDeclaration") {
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
-    return [{ name, kind: "class", type: name, description, declFile, isTypeOnly: false }];
+    return [{ name, kind: "class", type: name, description, deprecated, tags, declFile, isTypeOnly: false }];
   }
 
   if (declaration.type === "TSTypeAliasDeclaration") {
@@ -329,6 +351,8 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         kind: "type",
         type: textOf(source, asNode(declaration.typeAnnotation)),
         description,
+        deprecated,
+        tags,
         declFile,
         isTypeOnly: true,
       },
@@ -344,6 +368,8 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         kind: "interface",
         type: textOf(source, asNode(declaration.body)),
         description,
+        deprecated,
+        tags,
         declFile,
         isTypeOnly: true,
       },
@@ -353,7 +379,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
   if (declaration.type === "TSEnumDeclaration") {
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
-    return [{ name, kind: "enum", type: name, description, declFile, isTypeOnly: false }];
+    return [{ name, kind: "enum", type: name, description, deprecated, tags, declFile, isTypeOnly: false }];
   }
 
   return [];

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -20,6 +20,8 @@ export interface EntryExport {
   deprecated?: DeprecatedValue;
   /** `@since` / `@example` / `@see` tags in source order. */
   tags?: JsDocPassthroughTag[];
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
   /** Declaring module, relative to the entry file. */
   source?: string;
   isTypeOnly: boolean;
@@ -262,9 +264,10 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
   const description = leadingJsDoc(source.text, jsdocStart);
   const rawJsDoc = leadingJsDocBlock(source.text, jsdocStart);
   const jsDocReturnType = rawJsDoc ? extractJsDocReturnType(rawJsDoc) : undefined;
-  const { deprecated, tags } = rawJsDoc
+  const { deprecated, tags, internal } = rawJsDoc
     ? extractJsDocDeprecatedAndTags(rawJsDoc)
-    : { deprecated: undefined, tags: undefined };
+    : { deprecated: undefined, tags: undefined, internal: false };
+  const internalField = internal ? ({ internal: true } as const) : {};
 
   if (declaration.type === "VariableDeclaration") {
     const kind = (declaration.kind as "const" | "let" | "var") ?? "const";
@@ -306,6 +309,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         description,
         deprecated,
         tags,
+        ...internalField,
         declFile,
         isTypeOnly: false,
       });
@@ -330,6 +334,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         description,
         deprecated,
         tags,
+        ...internalField,
         declFile,
         isTypeOnly: false,
       },
@@ -339,7 +344,9 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
   if (declaration.type === "ClassDeclaration") {
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
-    return [{ name, kind: "class", type: name, description, deprecated, tags, declFile, isTypeOnly: false }];
+    return [
+      { name, kind: "class", type: name, description, deprecated, tags, ...internalField, declFile, isTypeOnly: false },
+    ];
   }
 
   if (declaration.type === "TSTypeAliasDeclaration") {
@@ -353,6 +360,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         description,
         deprecated,
         tags,
+        ...internalField,
         declFile,
         isTypeOnly: true,
       },
@@ -370,6 +378,7 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
         description,
         deprecated,
         tags,
+        ...internalField,
         declFile,
         isTypeOnly: true,
       },
@@ -379,7 +388,9 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
   if (declaration.type === "TSEnumDeclaration") {
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
-    return [{ name, kind: "enum", type: name, description, deprecated, tags, declFile, isTypeOnly: false }];
+    return [
+      { name, kind: "enum", type: name, description, deprecated, tags, ...internalField, declFile, isTypeOnly: false },
+    ];
   }
 
   return [];

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -106,7 +106,7 @@ export interface ParserContext {
   readonly bindings: Map<string, ComponentPropBindings>;
   readonly contexts: Map<string, ComponentContext>;
   readonly typedefs: Map<string, TypeDef>;
-  variableInfoCache: Map<string, { type: string; description?: string }>;
+  variableInfoCache: Map<string, { type: string; description?: string; internal?: boolean }>;
 
   /** True after the per-component variable/JSDoc symbol table has populated {@link variableInfoCache}. */
   variableInfoCacheBuilt: boolean;

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -181,6 +181,8 @@ function parseContextValue(
             optional: false,
           },
         ],
+        description: undefined,
+        ...(varInfo.internal ? { internal: true } : {}),
       };
     }
 

--- a/src/parser/events.ts
+++ b/src/parser/events.ts
@@ -69,8 +69,9 @@ export function addDispatchedEvent(
     description,
     deprecated,
     tags,
+    internal,
     source,
-  }: Pick<DispatchedEvent, "name" | "description" | "deprecated" | "tags" | "source"> & {
+  }: Pick<DispatchedEvent, "name" | "description" | "deprecated" | "tags" | "internal" | "source"> & {
     detail: string;
     has_argument: boolean;
   },
@@ -95,6 +96,7 @@ export function addDispatchedEvent(
       description: event_description || existing_event.description,
       deprecated: deprecated ?? existing_event.deprecated,
       tags: tags ?? existing_event.tags,
+      ...(internal || existing_event.internal ? { internal: true as const } : {}),
       source: source || existing_event.source,
     });
   } else if (existing_event) {
@@ -105,6 +107,7 @@ export function addDispatchedEvent(
       description: existing_event.description || event_description,
       deprecated: existing_event.deprecated ?? deprecated,
       tags: merged_tags,
+      ...(existing_event.internal || internal ? { internal: true as const } : {}),
       source: source || existing_event.source,
     });
   } else {
@@ -115,6 +118,7 @@ export function addDispatchedEvent(
       description: event_description,
       deprecated,
       tags,
+      ...(internal ? { internal: true as const } : {}),
       source,
     });
   }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -149,21 +149,22 @@ export function extractJsDocReturnType(commentValue: string): string | undefined
 }
 
 /**
- * `@deprecated` and passthrough (`@since`/`@example`/`@see`) tags from raw JSDoc text (with or
- * without `/**` delimiters). Standalone so `parse-entry-exports.ts` can read sibling modules
- * without a component parser context, same as {@link extractJsDocReturnType}.
+ * `@deprecated`, passthrough (`@since`/`@example`/`@see`) tags, and `@ignore`/`@internal` from raw
+ * JSDoc text (with or without `/**` delimiters). Standalone so `parse-entry-exports.ts` can read
+ * sibling modules without a component parser context, same as {@link extractJsDocReturnType}.
  */
 export function extractJsDocDeprecatedAndTags(commentValue: string): {
   deprecated?: DeprecatedValue;
   tags?: JsDocPassthroughTag[];
+  internal: boolean;
 } {
   const comment = parseComments(formatComment(commentValue));
-  const { deprecated, passthrough: passthroughTags } = getCommentTags(comment);
+  const { deprecated, passthrough: passthroughTags, internal } = getCommentTags(comment);
 
   const tags: JsDocPassthroughTag[] | undefined =
     passthroughTags.length > 0 ? passthroughTags.map((tag) => ({ name: tag.tag, body: tag.raw })) : undefined;
 
-  return { deprecated, tags };
+  return { deprecated, tags, internal };
 }
 
 export function getCommentTags(parsed: JSDocComment[]) {
@@ -183,6 +184,8 @@ export function getCommentTags(parsed: JSDocComment[]) {
     "callback",
     "bindable",
     "deprecated",
+    "ignore",
+    "internal",
   ]);
 
   let typeTag: (typeof tags)[number] | undefined;
@@ -190,6 +193,7 @@ export function getCommentTags(parsed: JSDocComment[]) {
   let returnsTag: (typeof tags)[number] | undefined;
   let binding: ComponentPropBinding | undefined;
   let deprecated: DeprecatedValue | undefined;
+  let internal = false;
   const additionalTags: typeof tags = [];
   const passthroughTags: typeof tags = [];
   const ignoreCodes: string[] = [];
@@ -203,6 +207,8 @@ export function getCommentTags(parsed: JSDocComment[]) {
       returnsTag = tag;
     } else if (tag.tag === "deprecated") {
       deprecated ??= deprecatedValueFromParts(tag.name, tag.description);
+    } else if (tag.tag === "ignore" || tag.tag === "internal") {
+      internal = true;
     } else if (tag.tag === "sveld-ignore") {
       ignoreCodes.push(tag.name);
     } else if (IDE_PASSTHROUGH_TAGS.has(tag.tag)) {
@@ -227,6 +233,7 @@ export function getCommentTags(parsed: JSDocComment[]) {
     returns: returnsTag,
     binding,
     deprecated,
+    internal,
     additional: additionalTags,
     passthrough: passthroughTags,
     ignore: ignoreCodes,
@@ -309,6 +316,8 @@ function processJSDocComment(
       tags?: JsDocPassthroughTag[];
       /** `@sveld-ignore <code>` codes from this comment; `""` means "ignore anything for this symbol". */
       sveldIgnore?: string[];
+      /** True when `@ignore` or `@internal` is present; excludes this prop from every output. */
+      internal: boolean;
     }
   | undefined {
   if (!leadingComments) return undefined;
@@ -324,6 +333,7 @@ function processJSDocComment(
     returns: returnsTag,
     binding,
     deprecated,
+    internal,
     additional: additionalTags,
     passthrough: passthroughTags,
     ignore: ignoreCodes,
@@ -381,6 +391,7 @@ function processJSDocComment(
     deprecated,
     tags,
     sveldIgnore: ignoreCodes.length > 0 ? ignoreCodes : undefined,
+    internal,
   };
 }
 
@@ -473,6 +484,7 @@ export function parseCustomTypes(
     let currentEventType: string | undefined;
     let currentEventDescription: string | undefined;
     let currentEventDeprecated: DeprecatedValue | undefined;
+    let currentEventInternal = false;
     let currentEventSource: SourceRange | undefined;
     let currentEventTagLine: number | undefined;
     let currentEventTags: JsDocPassthroughTag[] = [];
@@ -490,6 +502,7 @@ export function parseCustomTypes(
     let currentTypedefDescription: string | undefined;
     let currentTypedefSource: SourceRange | undefined;
     let currentTypedefTags: JsDocPassthroughTag[] = [];
+    let currentTypedefInternal = false;
     const typedefProperties: Array<{
       name: string;
       type: string;
@@ -502,6 +515,7 @@ export function parseCustomTypes(
     let currentCallbackDescription: string | undefined;
     let currentCallbackSource: SourceRange | undefined;
     let currentCallbackTags: JsDocPassthroughTag[] = [];
+    let currentCallbackInternal = false;
     const callbackParams: Array<{
       name: string;
       type: string;
@@ -523,6 +537,8 @@ export function parseCustomTypes(
     const pendingTags: JsDocPassthroughTag[] = [];
     /** `@deprecated` for the next `@slot` / `@snippet` in this block. */
     let pendingDeprecated: DeprecatedValue | undefined;
+    /** `@ignore`/`@internal` for the next `@slot`/`@snippet`/`@typedef`/`@callback` in this block. */
+    let pendingInternal = false;
 
     const lineDescriptions = new Map<number, string>();
     const tagLineNumbers = new Set<number>();
@@ -627,6 +643,7 @@ export function parseCustomTypes(
           description: currentEventDescription,
           deprecated: currentEventDeprecated,
           tags: currentEventTags.length > 0 ? currentEventTags : undefined,
+          internal: currentEventInternal || undefined,
           source: currentEventSource,
         });
         ctx.eventDescriptions.set(currentEventName, currentEventDescription);
@@ -638,6 +655,7 @@ export function parseCustomTypes(
         currentEventType = undefined;
         currentEventDescription = undefined;
         currentEventDeprecated = undefined;
+        currentEventInternal = false;
         currentEventSource = undefined;
         currentEventTagLine = undefined;
         currentEventTags = [];
@@ -670,6 +688,7 @@ export function parseCustomTypes(
           description: assignValueOrUndefined(currentTypedefDescription),
           ts: typedefTs,
           tags: currentTypedefTags.length > 0 ? currentTypedefTags : undefined,
+          ...(currentTypedefInternal ? { internal: true as const } : {}),
         });
 
         typedefProperties.length = 0;
@@ -678,6 +697,7 @@ export function parseCustomTypes(
         currentTypedefDescription = undefined;
         currentTypedefSource = undefined;
         currentTypedefTags = [];
+        currentTypedefInternal = false;
       }
     };
 
@@ -700,6 +720,7 @@ export function parseCustomTypes(
           description: assignValueOrUndefined(currentCallbackDescription),
           ts: callbackTs,
           tags: currentCallbackTags.length > 0 ? currentCallbackTags : undefined,
+          ...(currentCallbackInternal ? { internal: true as const } : {}),
         });
 
         callbackParams.length = 0;
@@ -708,6 +729,7 @@ export function parseCustomTypes(
         currentCallbackDescription = undefined;
         currentCallbackSource = undefined;
         currentCallbackTags = [];
+        currentCallbackInternal = false;
       }
     };
 
@@ -793,10 +815,12 @@ export function parseCustomTypes(
             slot_description: slotDesc || undefined,
             slot_deprecated: pendingDeprecated,
             slot_tags: pendingTags.length > 0 ? [...pendingTags] : undefined,
+            slot_internal: pendingInternal || undefined,
             source: sourceRangeFromCommentTag(ctx, tagSource),
           });
           pendingTags.length = 0;
           pendingDeprecated = undefined;
+          pendingInternal = false;
           {
             const slotKey = name === undefined || name === "" ? null : name;
             attachTrailingTag = (trailingTag) => {
@@ -885,6 +909,8 @@ export function parseCustomTypes(
             currentTypedefTags.push(...pendingTags);
             pendingTags.length = 0;
           }
+          currentTypedefInternal = pendingInternal;
+          pendingInternal = false;
           attachTrailingTag = (trailingTag) => currentTypedefTags.push(trailingTag);
           if (isFirstTag) isFirstTag = false;
           break;
@@ -904,6 +930,8 @@ export function parseCustomTypes(
             currentCallbackTags.push(...pendingTags);
             pendingTags.length = 0;
           }
+          currentCallbackInternal = pendingInternal;
+          pendingInternal = false;
           attachTrailingTag = (trailingTag) => currentCallbackTags.push(trailingTag);
           if (isFirstTag) isFirstTag = false;
           break;
@@ -949,6 +977,15 @@ export function parseCustomTypes(
             pendingDeprecated ??= deprecatedValue;
           } else {
             currentEventDeprecated ??= deprecatedValue;
+          }
+          break;
+        }
+        case "ignore":
+        case "internal": {
+          if (currentEventName === undefined) {
+            pendingInternal = true;
+          } else {
+            currentEventInternal = true;
           }
           break;
         }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -148,6 +148,24 @@ export function extractJsDocReturnType(commentValue: string): string | undefined
   return returnsTag ? aliasType(returnsTag.type) : undefined;
 }
 
+/**
+ * `@deprecated` and passthrough (`@since`/`@example`/`@see`) tags from raw JSDoc text (with or
+ * without `/**` delimiters). Standalone so `parse-entry-exports.ts` can read sibling modules
+ * without a component parser context, same as {@link extractJsDocReturnType}.
+ */
+export function extractJsDocDeprecatedAndTags(commentValue: string): {
+  deprecated?: DeprecatedValue;
+  tags?: JsDocPassthroughTag[];
+} {
+  const comment = parseComments(formatComment(commentValue));
+  const { deprecated, passthrough: passthroughTags } = getCommentTags(comment);
+
+  const tags: JsDocPassthroughTag[] | undefined =
+    passthroughTags.length > 0 ? passthroughTags.map((tag) => ({ name: tag.tag, body: tag.raw })) : undefined;
+
+  return { deprecated, tags };
+}
+
 export function getCommentTags(parsed: JSDocComment[]) {
   const tags = parsed[0]?.tags ?? [];
   const excludedTags = new Set([

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -517,6 +517,7 @@ export function parseRunesPropsDeclaration(parser: ComponentParser, ctx: ParserC
         binding: propertyJSDoc?.binding,
         deprecated: propertyJSDoc?.deprecated,
         tags: propertyJSDoc?.tags,
+        ...(propertyJSDoc?.internal ? { internal: true as const } : {}),
         ...(bindable ? { bindable: true as const } : {}),
         type,
         typeSource,

--- a/src/parser/slots.ts
+++ b/src/parser/slots.ts
@@ -226,6 +226,7 @@ export function addSlot(
     slot_description,
     slot_deprecated,
     slot_tags,
+    slot_internal,
     source,
   }: {
     slot_name?: string;
@@ -235,6 +236,7 @@ export function addSlot(
     slot_description?: string;
     slot_deprecated?: DeprecatedValue;
     slot_tags?: JsDocPassthroughTag[];
+    slot_internal?: boolean;
     source?: SourceRange;
   },
 ) {
@@ -256,6 +258,7 @@ export function addSlot(
         description: existing_slot.description || description,
         deprecated: existing_slot.deprecated ?? slot_deprecated,
         tags: existing_slot.tags || slot_tags,
+        ...(existing_slot.internal || slot_internal ? { internal: true as const } : {}),
         source: source || existing_slot.source,
       });
     }
@@ -269,6 +272,7 @@ export function addSlot(
       description,
       deprecated: slot_deprecated,
       tags: slot_tags,
+      ...(slot_internal ? { internal: true as const } : {}),
       source,
     });
   }

--- a/src/parser/variable-jsdoc.ts
+++ b/src/parser/variable-jsdoc.ts
@@ -177,8 +177,8 @@ function findAttachedComment(comments: ScriptComment[], declStart: number, sourc
 export function buildVariableJsDocTable(
   ctx: ParserContext,
   parser: ComponentParser,
-): Map<string, { type: string; description?: string }> {
-  const table = new Map<string, { type: string; description?: string }>();
+): Map<string, { type: string; description?: string; internal?: boolean }> {
+  const table = new Map<string, { type: string; description?: string; internal?: boolean }>();
   if (!ctx.source) return table;
 
   const scripts = [ctx.parsed?.module, ctx.parsed?.instance] as unknown as Array<
@@ -203,7 +203,7 @@ export function buildVariableJsDocTable(
     if (!comment) continue;
 
     const parsed = parseComments(comment.text);
-    const { type: typeTag, description, ignore: ignoreCodes } = getCommentTags(parsed);
+    const { type: typeTag, description, ignore: ignoreCodes, internal } = getCommentTags(parsed);
     if (ignoreCodes.length > 0) {
       recordSveldIgnore(ctx, "context-any-type", declaration.name, ignoreCodes);
     }
@@ -212,6 +212,7 @@ export function buildVariableJsDocTable(
     table.set(declaration.name, {
       type: parser.aliasType(typeTag.type),
       description: description || typeTag.description,
+      internal: internal || undefined,
     });
   }
 

--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -42,10 +42,33 @@ export interface BuildComponentApiDocumentOptions {
  */
 const documentCache = new WeakMap<ComponentDocs, Map<EntryExports | undefined, ComponentApiDocument>>();
 
+/** Drops `@ignore`/`@internal`-tagged entries. The raw, unfiltered list lives on `ParsedComponent`. */
+function excludeInternal<T extends { internal?: boolean }>(items: T[]): T[] {
+  return items.some((item) => item.internal) ? items.filter((item) => !item.internal) : items;
+}
+
+/**
+ * Strips `@ignore`/`@internal` members from every list a component exposes, so no writer -
+ * Markdown, JSON, `.d.ts`, custom elements, `llms.txt` - has to filter independently. The raw,
+ * unfiltered `ParsedComponent` (props/events/slots/etc. still carrying `internal: true`) remains
+ * available to callers that read the parser output directly, e.g. `sveld --check`.
+ */
+function excludeInternalMembers(component: ComponentDocApi): ComponentDocApi {
+  return {
+    ...component,
+    props: excludeInternal(component.props),
+    moduleExports: excludeInternal(component.moduleExports),
+    slots: excludeInternal(component.slots),
+    events: excludeInternal(component.events),
+    typedefs: excludeInternal(component.typedefs),
+    ...(component.contexts ? { contexts: excludeInternal(component.contexts) } : {}),
+  };
+}
+
 /**
  * Builds the canonical document for a component collection: components
  * sorted alphabetically by `moduleName`, with the Node-only `diagnostics`
- * field stripped.
+ * field stripped and `@ignore`/`@internal` members excluded.
  */
 export function buildComponentApiDocument(
   components: ComponentDocs,
@@ -58,7 +81,7 @@ export function buildComponentApiDocument(
   const sorted = Array.from(components, ([, component]) => {
     // `diagnostics` is for the Node API only; rendered output skips it.
     const { diagnostics: _diagnostics, ...rest } = component;
-    return rest as ComponentDocApi;
+    return excludeInternalMembers(rest as ComponentDocApi);
   }).sort((a, b) => a.moduleName.localeCompare(b.moduleName));
 
   const document: ComponentApiDocument = {
@@ -72,9 +95,10 @@ export function buildComponentApiDocument(
     components: sorted,
   };
 
-  if (options.entryExports && options.entryExports.length > 0) {
-    document.totalExports = options.entryExports.length;
-    document.exports = options.entryExports;
+  const entryExports = options.entryExports ? excludeInternal(options.entryExports) : undefined;
+  if (entryExports && entryExports.length > 0) {
+    document.totalExports = entryExports.length;
+    document.exports = entryExports;
   }
 
   if (!byEntryExports) {

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -56,7 +56,7 @@ export function formatSlotFallback(fallback?: string) {
   return formatPropType(escapeHtml(fallback).replace(NEWLINE_REGEX, "<br />"));
 }
 
-export function formatSlotDescription(description?: string, tags?: Array<{ name: string; body: string }>) {
+export function formatDescriptionWithTags(description?: string, tags?: Array<{ name: string; body: string }>) {
   const segments: string[] = [];
 
   if (description !== undefined && description.trim().length > 0) {

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -18,6 +18,21 @@ const LT_REGEX = /</g;
 const GT_REGEX = />/g;
 const NEWLINE_REGEX = /\n/g;
 
+/** `{@link target}` or `{@link target|display text}`, per the inline JSDoc `@link` tag grammar. */
+const JSDOC_LINK_REGEX = /\{@link\s+([^{}\s|]+)(?:\|([^{}]+))?\}/g;
+
+/**
+ * Rewrites inline `{@link target|text}` / `{@link target}` to Markdown
+ * `[text](target)` / `[target](target)`. Markdown-only: JSON and `.d.ts`
+ * keep the JSDoc tag verbatim.
+ */
+function rewriteJsDocLinks(text: string): string {
+  return text.replace(JSDOC_LINK_REGEX, (_match, target: string, label: string | undefined) => {
+    const linkText = label === undefined ? target : label.trim();
+    return `[${linkText}](${target})`;
+  });
+}
+
 export function formatPropType(type?: string) {
   if (type === undefined) return MD_TYPE_UNDEFINED;
   return `<code>${type.replace(PIPE_REGEX, "&#124;")}</code>`;
@@ -43,7 +58,7 @@ export function formatNameWithDeprecation(name: string, deprecated: DeprecatedVa
 
 export function formatPropDescription(description: string | undefined) {
   if (description === undefined || description.trim().length === 0) return MD_TYPE_UNDEFINED;
-  return escapeHtml(description).replace(PIPE_REGEX, "&#124;").replace(NEWLINE_REGEX, "<br />");
+  return escapeHtml(rewriteJsDocLinks(description)).replace(PIPE_REGEX, "&#124;").replace(NEWLINE_REGEX, "<br />");
 }
 
 export function formatSlotProps(props?: string) {
@@ -60,12 +75,12 @@ export function formatDescriptionWithTags(description?: string, tags?: Array<{ n
   const segments: string[] = [];
 
   if (description !== undefined && description.trim().length > 0) {
-    segments.push(escapeHtml(description));
+    segments.push(escapeHtml(rewriteJsDocLinks(description)));
   }
 
   for (const { name, body } of tags ?? []) {
     const trimmed = body?.trim();
-    segments.push(trimmed ? `@${name} ${escapeHtml(trimmed)}` : `@${name}`);
+    segments.push(trimmed ? `@${name} ${escapeHtml(rewriteJsDocLinks(trimmed))}` : `@${name}`);
   }
 
   if (segments.length === 0) return MD_TYPE_UNDEFINED;

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -56,7 +56,7 @@ function renderExports(document: MarkdownDocument, entryExports: EntryExports) {
     const type = (entry.type ?? entry.value)?.replace(WHITESPACE_REGEX, " ").trim();
     document.append(
       "raw",
-      `| ${entry.name} | ${`<code>${entry.kind}</code>`} | ${formatPropType(type)} | ${formatPropDescription(
+      `| ${formatNameWithDeprecation(entry.name, entry.deprecated)} | ${`<code>${entry.kind}</code>`} | ${formatPropType(type)} | ${formatPropDescription(
         entry.description,
       )} |\n`,
     );

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -5,12 +5,12 @@ import type { AppendType } from "./MarkdownWriterBase";
 import {
   EVENT_TABLE_HEADER,
   EXPORT_TABLE_HEADER,
+  formatDescriptionWithTags,
   formatEventDetail,
   formatNameWithDeprecation,
   formatPropDescription,
   formatPropType,
   formatPropValue,
-  formatSlotDescription,
   formatSlotFallback,
   formatSlotProps,
   MD_TYPE_UNDEFINED,
@@ -116,8 +116,9 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
         "raw",
         `| ${formatNameWithDeprecation(prop.name, prop.deprecated)} | ${prop.isRequired ? "Yes" : "No"} | ${`<code>${prop.kind}</code>`} | ${
           prop.reactive ? "Yes" : "No"
-        } | ${prop.binding ?? "--"} | ${formatPropType(prop.type)} | ${formatPropValue(prop.value)} | ${formatPropDescription(
+        } | ${prop.binding ?? "--"} | ${formatPropType(prop.type)} | ${formatPropValue(prop.value)} | ${formatDescriptionWithTags(
           prop.description,
+          prop.tags,
         )} |\n`,
       );
     }
@@ -131,7 +132,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
         "raw",
         `| ${formatNameWithDeprecation(slot.default ? MD_TYPE_UNDEFINED : (slot.name ?? MD_TYPE_UNDEFINED), slot.deprecated)} | ${slot.default ? "Yes" : "No"} | ${formatSlotProps(
           slot.slot_props,
-        )} | ${formatSlotFallback(slot.fallback)} | ${formatSlotDescription(slot.description, slot.tags)} |\n`,
+        )} | ${formatSlotFallback(slot.fallback)} | ${formatDescriptionWithTags(slot.description, slot.tags)} |\n`,
       );
     }
   });
@@ -144,7 +145,7 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
         "raw",
         `| ${formatNameWithDeprecation(event.name, event.deprecated)} | ${event.type} | ${
           event.type === "dispatched" ? formatEventDetail(event.detail) : MD_TYPE_UNDEFINED
-        } | ${formatPropDescription(event.description)} |\n`,
+        } | ${formatDescriptionWithTags(event.description, event.tags)} |\n`,
       );
     }
   });

--- a/src/writer/writer-custom-elements-core.ts
+++ b/src/writer/writer-custom-elements-core.ts
@@ -6,6 +6,10 @@ import { buildComponentApiDocument } from "./document-model";
  * Minimal local subset of the published Custom Elements Manifest schema
  * (schemaVersion "1.0.0") for the fields sveld can populate. See
  * https://github.com/webcomponents/custom-elements-manifest for the full spec.
+ *
+ * The CEM spec has no field for JSDoc passthrough tags (`@since`, `@example`,
+ * `@see`), so members/events/slots below carry `description` and
+ * `deprecated` only; `tags` is intentionally not read here.
  */
 export interface CemType {
   text: string;

--- a/src/writer/writer-llms.ts
+++ b/src/writer/writer-llms.ts
@@ -9,12 +9,12 @@ import { buildComponentApiDocument } from "./document-model";
 import { MarkdownWriterBaseImpl } from "./MarkdownWriterBase";
 import {
   EVENT_TABLE_HEADER,
+  formatDescriptionWithTags,
   formatEventDetail,
   formatNameWithDeprecation,
   formatPropDescription,
   formatPropType,
   formatPropValue,
-  formatSlotDescription,
   formatSlotFallback,
   formatSlotProps,
   MD_TYPE_UNDEFINED,
@@ -97,7 +97,7 @@ function renderSlotsSection(document: MarkdownWriterBaseImpl, heading: string, s
       "raw",
       `| ${formatNameWithDeprecation(slot.default ? MD_TYPE_UNDEFINED : (slot.name ?? MD_TYPE_UNDEFINED), slot.deprecated)} | ${
         slot.default ? "Yes" : "No"
-      } | ${formatSlotProps(slot.slot_props)} | ${formatSlotFallback(slot.fallback)} | ${formatSlotDescription(
+      } | ${formatSlotProps(slot.slot_props)} | ${formatSlotFallback(slot.fallback)} | ${formatDescriptionWithTags(
         slot.description,
         slot.tags,
       )} |\n`,

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -195,6 +195,51 @@ describe("WriterMarkdown", () => {
     expect(output).toContain("| footer | No | -- | -- | -- |");
   });
 
+  test("props and events tables render pass-through tags like slots do", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [
+              {
+                name: "size",
+                kind: "let",
+                constant: false,
+                description: "Current value.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+                tags: [{ name: "since", body: "1.2.0" }],
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [
+              {
+                type: "dispatched",
+                name: "change",
+                description: "Fires on change.",
+                tags: [{ name: "example", body: "on:change={handleChange}" }],
+              },
+            ],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toContain("| size | No | <code>let</code> | No | -- | -- | -- | Current value.<br />@since 1.2.0 |");
+    expect(output).toContain("| change | dispatched | -- | Fires on change.<br />@example on:change={handleChange} |");
+  });
+
   test("defines the component's type parameters for generic components", () => {
     const output = writeMarkdownCore(
       new Map([

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -240,6 +240,53 @@ describe("WriterMarkdown", () => {
     expect(output).toContain("| change | dispatched | -- | Fires on change.<br />@example on:change={handleChange} |");
   });
 
+  test("rewrites {@link} to a Markdown link in prop and slot descriptions", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [
+              {
+                name: "width",
+                kind: "let",
+                constant: false,
+                description: "The width in pixels. See {@link https://example.com/width|width docs}.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "height",
+                kind: "let",
+                constant: false,
+                description: "See {@link https://example.com/height}.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toContain("See [width docs](https://example.com/width).");
+    expect(output).toContain("See [https://example.com/height](https://example.com/height).");
+  });
+
   test("defines the component's type parameters for generic components", () => {
     const output = writeMarkdownCore(
       new Map([

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -2,7 +2,13 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import Ajv2020 from "ajv/dist/2020";
 import { Glob } from "bun";
-import { asNormalizedPath, buildComponentApiDocument, type ComponentDocs, ComponentParser } from "../src/browser";
+import {
+  asNormalizedPath,
+  buildComponentApiDocument,
+  type ComponentDocs,
+  ComponentParser,
+  writeTsDefinition,
+} from "../src/browser";
 import { parseEntryExports } from "../src/parse-entry-exports";
 
 type JsonObject = Record<string, unknown>;
@@ -244,6 +250,51 @@ describe("component API JSON schema", () => {
         value: 0,
       },
     });
+  });
+
+  test("@ignore/@internal excludes members from the built document and .d.ts, but not from the raw parse", () => {
+    const filePath = path.join(root, "tests", "fixtures", "jsdoc-internal-ignore", "input.svelte");
+    const source = readFileSync(filePath, "utf-8");
+    const parser = new ComponentParser();
+    const parsed = parser.parseSvelteComponent(source, { filePath, moduleName: "JsdocInternalIgnore" });
+    const component = { ...parsed, moduleName: "JsdocInternalIgnore", filePath: asNormalizedPath(filePath) };
+
+    // The raw ParsedComponent keeps every member, flagged `internal: true`.
+    expect(findObjectByProperty(component.props, "name", "debugId")).toMatchObject({ internal: true });
+    expect(findObjectByProperty(component.props, "name", "legacyFlag")).toMatchObject({ internal: true });
+    expect(findObjectByProperty(component.moduleExports, "name", "INTERNAL_CONST")).toMatchObject({
+      internal: true,
+    });
+    expect(findObjectByProperty(component.events, "name", "debug")).toMatchObject({ internal: true });
+    expect(findObjectByProperty(component.slots, "name", "debug-panel")).toMatchObject({ internal: true });
+    expect(findObjectByProperty(component.typedefs, "name", "InternalCount")).toMatchObject({ internal: true });
+
+    const components: ComponentDocs = new Map([["JsdocInternalIgnore", component]]);
+    const document = buildComponentApiDocument(components);
+    const filtered = document.components[0];
+
+    expect(filtered.props.map((p) => p.name)).not.toEqual(expect.arrayContaining(["debugId", "legacyFlag"]));
+    expect(filtered.moduleExports.map((e) => e.name)).not.toContain("INTERNAL_CONST");
+    expect(filtered.events.map((e) => e.name)).not.toContain("debug");
+    expect(filtered.slots.map((s) => s.name)).not.toContain("debug-panel");
+    expect(filtered.typedefs.map((t) => t.name)).not.toContain("InternalCount");
+
+    // Public members survive filtering untouched.
+    expect(filtered.props.map((p) => p.name)).toContain("label");
+    expect(filtered.moduleExports.map((e) => e.name)).toContain("PUBLIC_CONST");
+    expect(filtered.events.map((e) => e.name)).toContain("change");
+    expect(filtered.slots.map((s) => s.name)).toContain("badge");
+    expect(filtered.typedefs.map((t) => t.name)).toContain("PublicLabel");
+
+    const dts = writeTsDefinition(filtered, { format: "class" });
+    expect(dts).not.toContain("debugId");
+    expect(dts).not.toContain("legacyFlag");
+    expect(dts).not.toContain("INTERNAL_CONST");
+    expect(dts).not.toContain("debug-panel");
+    expect(dts).not.toContain("InternalCount");
+    expect(dts).not.toContain('"debug"');
+    expect(dts).toContain("label");
+    expect(dts).toContain("PublicLabel");
   });
 });
 

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -105,8 +105,20 @@ describe("component API JSON schema", () => {
 
     const entryExportProperties = objectProperty(objectProperty(defs, "entryExport"), "properties");
     expect(Object.keys(entryExportProperties)).toEqual(
-      expect.arrayContaining(["name", "kind", "type", "value", "description", "source", "isTypeOnly"]),
+      expect.arrayContaining([
+        "name",
+        "kind",
+        "type",
+        "value",
+        "description",
+        "deprecated",
+        "tags",
+        "source",
+        "isTypeOnly",
+      ]),
     );
+    expect(objectProperty(entryExportProperties, "deprecated")).toMatchObject({ $ref: "#/$defs/deprecated" });
+    expect(objectProperty(entryExportProperties, "tags")).toMatchObject({ items: { $ref: "#/$defs/jsdocTag" } });
     expect(objectProperty(entryExportProperties, "kind")).toMatchObject({
       enum: ["const", "let", "var", "function", "class", "type", "interface", "enum"],
     });

--- a/tests/fixtures-entry-exports/index.ts
+++ b/tests/fixtures-entry-exports/index.ts
@@ -5,5 +5,10 @@ export { MAX_RETRIES, VERSION } from "./constants";
 export type { Theme, ThemeConfig } from "./types";
 export { clamp, invertTheme } from "./utils";
 
-/** Default theme applied when none is configured. */
+/**
+ * Default theme applied when none is configured.
+ *
+ * @deprecated Use `invertTheme` with an explicit theme instead.
+ * @since 1.0.0
+ */
 export const DEFAULT_THEME = "light";

--- a/tests/fixtures/jsdoc-internal-ignore/input.svelte
+++ b/tests/fixtures/jsdoc-internal-ignore/input.svelte
@@ -1,0 +1,77 @@
+<script context="module">
+  /**
+   * Internal-only module export.
+   * @internal
+   */
+  export const INTERNAL_CONST = 1;
+
+  /** Public module export. */
+  export const PUBLIC_CONST = 2;
+</script>
+
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  /**
+   * The visible label.
+   */
+  export let label = "";
+
+  /**
+   * Internal-only prop, not part of the public API.
+   * @internal
+   */
+  export let debugId = "";
+
+  /**
+   * Ignored prop.
+   * @ignore
+   */
+  export let legacyFlag = false;
+
+  /**
+   * @internal
+   * @typedef {{ count: number }} InternalCount
+   */
+
+  /**
+   * @typedef {{ label: string }} PublicLabel
+   */
+
+  /**
+   * Fired when the value changes.
+   * @event {{ value: string }} change
+   */
+
+  /**
+   * Fired for internal diagnostics only.
+   * @event {{ reason: string }} debug
+   * @internal
+   */
+
+  /**
+   * Badge content rendered next to the label.
+   * @slot {{ count: number }} badge
+   */
+
+  /**
+   * Internal-only slot.
+   * @internal
+   * @slot {{}} debug-panel
+   */
+  function dispatchChange() {
+    dispatch("change", { value: label });
+    dispatch("debug", { reason: "test" });
+  }
+</script>
+
+<button on:click={dispatchChange}>
+  {label}
+  <slot
+    name="badge"
+    count={0}
+  />
+  <slot name="debug-panel" />
+</button>

--- a/tests/fixtures/jsdoc-internal-ignore/output-class.d.ts
+++ b/tests/fixtures/jsdoc-internal-ignore/output-class.d.ts
@@ -1,0 +1,61 @@
+import { SvelteComponentTyped } from "svelte";
+
+/**
+ * Internal-only module export.
+ */
+export declare const INTERNAL_CONST: number;
+
+/**
+ * Public module export.
+ */
+export declare const PUBLIC_CONST: number;
+
+export interface InternalCount {
+  count: number
+}
+
+export interface PublicLabel {
+  label: string
+}
+
+export type JsdocInternalIgnoreProps = {
+  /**
+   * The visible label.
+   * @default ""
+   */
+  label?: string;
+
+  /**
+   * Internal-only prop, not part of the public API.
+   * @default ""
+   */
+  debugId?: string;
+
+  /**
+   * Ignored prop.
+   * @default false
+   */
+  legacyFlag?: boolean;
+
+  /** Badge content rendered next to the label. */
+  badge?: (this: void, ...args: [{ count: number }]) => void;
+
+  /** Internal-only slot. */
+  "debug-panel"?: (this: void) => void;
+};
+
+export default class JsdocInternalIgnore extends SvelteComponentTyped<
+  JsdocInternalIgnoreProps,
+  {
+    /** Fired when the value changes. */
+    change: CustomEvent<{ value: string }>;
+    /** Fired for internal diagnostics only. */
+    debug: CustomEvent<{ reason: string }>;
+  },
+  {
+    /** Badge content rendered next to the label. */
+    badge: { count: number };
+    /** Internal-only slot. */
+    "debug-panel": Record<string, never>;
+  }
+> {}

--- a/tests/fixtures/jsdoc-internal-ignore/output-component.d.ts
+++ b/tests/fixtures/jsdoc-internal-ignore/output-component.d.ts
@@ -1,0 +1,60 @@
+import type { Component } from "svelte";
+
+/**
+ * Internal-only module export.
+ */
+export declare const INTERNAL_CONST: number;
+
+/**
+ * Public module export.
+ */
+export declare const PUBLIC_CONST: number;
+
+export interface InternalCount {
+  count: number
+}
+
+export interface PublicLabel {
+  label: string
+}
+
+export type JsdocInternalIgnoreProps = {
+  /**
+   * The visible label.
+   * @default ""
+   */
+  label?: string;
+
+  /**
+   * Internal-only prop, not part of the public API.
+   * @default ""
+   */
+  debugId?: string;
+
+  /**
+   * Ignored prop.
+   * @default false
+   */
+  legacyFlag?: boolean;
+
+  /** Badge content rendered next to the label. */
+  badge?: (this: void, ...args: [{ count: number }]) => void;
+
+  /** Internal-only slot. */
+  "debug-panel"?: (this: void) => void;
+
+  /** Fired when the value changes. */
+  onchange?: (event: CustomEvent<{ value: string }>) => void;
+
+  /** Fired for internal diagnostics only. */
+  ondebug?: (event: CustomEvent<{ reason: string }>) => void;
+};
+
+export type JsdocInternalIgnoreExports = Record<string, never>;
+
+declare const JsdocInternalIgnore: Component<
+  JsdocInternalIgnoreProps,
+  JsdocInternalIgnoreExports,
+  ""
+>;
+export default JsdocInternalIgnore;

--- a/tests/fixtures/jsdoc-internal-ignore/output.json
+++ b/tests/fixtures/jsdoc-internal-ignore/output.json
@@ -1,0 +1,247 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 78,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "label",
+      "kind": "let",
+      "description": "The visible label.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"\"",
+      "defaultValue": {
+        "raw": "\"\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 20,
+          "column": 2
+        },
+        "end": {
+          "line": 20,
+          "column": 24
+        }
+      }
+    },
+    {
+      "name": "debugId",
+      "kind": "let",
+      "description": "Internal-only prop, not part of the public API.",
+      "internal": true,
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"\"",
+      "defaultValue": {
+        "raw": "\"\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 26,
+          "column": 2
+        },
+        "end": {
+          "line": 26,
+          "column": 26
+        }
+      }
+    },
+    {
+      "name": "legacyFlag",
+      "kind": "let",
+      "description": "Ignored prop.",
+      "internal": true,
+      "type": "boolean",
+      "typeSource": "default",
+      "value": "false",
+      "defaultValue": {
+        "raw": "false",
+        "kind": "literal",
+        "value": false
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 32,
+          "column": 2
+        },
+        "end": {
+          "line": 32,
+          "column": 32
+        }
+      }
+    }
+  ],
+  "moduleExports": [
+    {
+      "name": "INTERNAL_CONST",
+      "kind": "const",
+      "description": "Internal-only module export.",
+      "internal": true,
+      "type": "number",
+      "typeSource": "default",
+      "value": "1",
+      "defaultValue": {
+        "raw": "1",
+        "kind": "literal",
+        "value": 1
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": true,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 34
+        }
+      }
+    },
+    {
+      "name": "PUBLIC_CONST",
+      "kind": "const",
+      "description": "Public module export.",
+      "type": "number",
+      "typeSource": "default",
+      "value": "2",
+      "defaultValue": {
+        "raw": "2",
+        "kind": "literal",
+        "value": 2
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": true,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 2
+        },
+        "end": {
+          "line": 9,
+          "column": 32
+        }
+      }
+    }
+  ],
+  "slots": [
+    {
+      "name": "badge",
+      "default": false,
+      "slot_props": "{ count: number }",
+      "description": "Badge content rendered next to the label.",
+      "source": {
+        "start": {
+          "line": 72,
+          "column": 2
+        },
+        "end": {
+          "line": 75,
+          "column": 4
+        }
+      }
+    },
+    {
+      "name": "debug-panel",
+      "default": false,
+      "slot_props": "Record<string, never>",
+      "description": "Internal-only slot.",
+      "internal": true,
+      "source": {
+        "start": {
+          "line": 76,
+          "column": 2
+        },
+        "end": {
+          "line": 76,
+          "column": 29
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "dispatched",
+      "name": "change",
+      "detail": "{ value: string }",
+      "description": "Fired when the value changes.",
+      "source": {
+        "start": {
+          "line": 65,
+          "column": 4
+        },
+        "end": {
+          "line": 65,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": "dispatched",
+      "name": "debug",
+      "detail": "{ reason: string }",
+      "description": "Fired for internal diagnostics only.",
+      "internal": true,
+      "source": {
+        "start": {
+          "line": 66,
+          "column": 4
+        },
+        "end": {
+          "line": 66,
+          "column": 41
+        }
+      }
+    }
+  ],
+  "typedefs": [
+    {
+      "type": "{ count: number }",
+      "name": "InternalCount",
+      "ts": "interface InternalCount { count: number }",
+      "internal": true
+    },
+    {
+      "type": "{ label: string }",
+      "name": "PublicLabel",
+      "ts": "interface PublicLabel { label: string }"
+    }
+  ],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/markdown-entry-exports.test.ts
+++ b/tests/markdown-entry-exports.test.ts
@@ -45,6 +45,24 @@ describe("renderComponentsToMarkdown (entry exports)", () => {
     expect(output).not.toContain("theme: Theme;\n");
   });
 
+  test("strikes through a deprecated export's name with its reason", () => {
+    const output = render(new Map(), [
+      {
+        name: "DEFAULT_THEME",
+        kind: "const",
+        value: '"light"',
+        deprecated: "Use `invertTheme` instead.",
+        isTypeOnly: false,
+      },
+      { name: "LEGACY_FLAG", kind: "const", value: "true", deprecated: true, isTypeOnly: false },
+    ]);
+
+    expect(output).toContain(
+      "| <s>DEFAULT_THEME</s><br />**Deprecated**: Use `invertTheme` instead. | <code>const</code> | <code>\"light\"</code> | -- |",
+    );
+    expect(output).toContain("| <s>LEGACY_FLAG</s><br />**Deprecated** | <code>const</code> | <code>true</code> | -- |");
+  });
+
   test("omits the Exports section when there are no entry exports", () => {
     expect(render(new Map(), [])).not.toContain("## Exports");
     expect(render(new Map())).not.toContain("## Exports");

--- a/tests/markdown-entry-exports.test.ts
+++ b/tests/markdown-entry-exports.test.ts
@@ -58,9 +58,11 @@ describe("renderComponentsToMarkdown (entry exports)", () => {
     ]);
 
     expect(output).toContain(
-      "| <s>DEFAULT_THEME</s><br />**Deprecated**: Use `invertTheme` instead. | <code>const</code> | <code>\"light\"</code> | -- |",
+      '| <s>DEFAULT_THEME</s><br />**Deprecated**: Use `invertTheme` instead. | <code>const</code> | <code>"light"</code> | -- |',
     );
-    expect(output).toContain("| <s>LEGACY_FLAG</s><br />**Deprecated** | <code>const</code> | <code>true</code> | -- |");
+    expect(output).toContain(
+      "| <s>LEGACY_FLAG</s><br />**Deprecated** | <code>const</code> | <code>true</code> | -- |",
+    );
   });
 
   test("omits the Exports section when there are no entry exports", () => {

--- a/tests/parse-entry-exports.test.ts
+++ b/tests/parse-entry-exports.test.ts
@@ -120,6 +120,19 @@ describe("parseEntryExports", () => {
     });
   });
 
+  test("captures @deprecated and pass-through tags on an entry export", async () => {
+    const exports = await parseEntryExports(entryFile);
+
+    expect(byName(exports, "DEFAULT_THEME")).toMatchObject({
+      deprecated: "Use `invertTheme` with an explicit theme instead.",
+      tags: [{ name: "since", body: "1.0.0" }],
+    });
+
+    // Exports without either tag stay undefined.
+    expect(byName(exports, "VERSION").deprecated).toBeUndefined();
+    expect(byName(exports, "VERSION").tags).toBeUndefined();
+  });
+
   test("sorts exports alphabetically and resolves source paths", async () => {
     const exports = await parseEntryExports(entryFile);
 


### PR DESCRIPTION
Also captures `@deprecated`/`@since`/`@example`/`@see` on entry-barrel
exports, adds `@ignore`/`@internal` to drop a member from every
output, and rewrites `{@link}` tags to real Markdown links.

## `@ignore` / `@internal`

Hides a prop, event, slot, typedef, module export, entry export, or
context from JSON, Markdown, `.d.ts`, and the CEM, while keeping it
on the raw parse (so `--check` still knows it existed):

```svelte
<script>
  /**
   * Implementation detail; not part of the public API.
   * @internal
   */
  export let debugId = "";
</script>
```

## `{@link}` in Markdown

```svelte
<script>
  /** See {@link https://example.com/width|width docs}. */
  export let width = 0;
</script>
```

renders as `See [width docs](https://example.com/width).` in the
Markdown table instead of the literal tag.
