### PR TITLE
fix(llms): render passthrough tags for props and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ With that in place:
 
 ## llms.txt Output
 
-Set `llms: true` to emit an [`llms.txt`](https://llmstxt.org) / `llms-full.txt` pair: `llms.txt` is an index of every exported component (one link plus a one-line summary each), and `llms-full.txt` is the flattened full reference (every component's Props, Bindings, Events, Slots/Snippets, Typedefs, and Module exports, as terse Markdown tables).
+Set `llms: true` to emit an [`llms.txt`](https://llmstxt.org) / `llms-full.txt` pair: `llms.txt` is an index of every exported component (one link plus a one-line summary each), and `llms-full.txt` is the flattened full reference (every component's Props, Bindings, Events, Slots/Snippets, Typedefs, and Module exports, as terse Markdown tables). Props and Events Description columns include `@since`/`@example` tags, same as `COMPONENT_INDEX.md`.
 
 ```diff
 sveld({

--- a/src/writer/writer-llms.ts
+++ b/src/writer/writer-llms.ts
@@ -12,7 +12,6 @@ import {
   formatDescriptionWithTags,
   formatEventDetail,
   formatNameWithDeprecation,
-  formatPropDescription,
   formatPropType,
   formatPropValue,
   formatSlotFallback,
@@ -65,7 +64,7 @@ function renderPropsTableSection(document: MarkdownWriterBaseImpl, heading: stri
       "raw",
       `| ${formatNameWithDeprecation(prop.name, prop.deprecated)} | ${formatPropType(prop.type)} | ${formatPropValue(
         prop.value,
-      )} | ${prop.isRequired ? "Yes" : "No"} | ${formatPropDescription(prop.description)} |\n`,
+      )} | ${prop.isRequired ? "Yes" : "No"} | ${formatDescriptionWithTags(prop.description, prop.tags)} |\n`,
     );
   }
   document.append("raw", "\n");
@@ -81,7 +80,7 @@ function renderEventsSection(document: MarkdownWriterBaseImpl, events: Serialize
       "raw",
       `| ${formatNameWithDeprecation(event.name, event.deprecated)} | ${event.type} | ${
         event.type === "dispatched" ? formatEventDetail(event.detail) : MD_TYPE_UNDEFINED
-      } | ${formatPropDescription(event.description)} |\n`,
+      } | ${formatDescriptionWithTags(event.description, event.tags)} |\n`,
     );
   }
   document.append("raw", "\n");

--- a/tests/WriterLlms.test.ts
+++ b/tests/WriterLlms.test.ts
@@ -183,6 +183,29 @@ describe("renderLlmsDocuments", () => {
     expect(llmsFullTxt).toContain("DEFAULT_OPTION");
   });
 
+  test("props and events tables render pass-through tags like slots do", () => {
+    const example = mockComponentDocApi("Example", "Example.svelte", {
+      syntaxMode: "legacy",
+      props: [
+        mockProp("size", {
+          description: "Current value.",
+          tags: [{ name: "since", body: "1.2.0" }],
+        }),
+      ],
+      events: [
+        mockEvent("change", {
+          description: "Fires on change.",
+          tags: [{ name: "example", body: "on:change={handleChange}" }],
+        }),
+      ],
+    });
+
+    const { llmsFullTxt } = renderLlmsDocuments(new Map([["Example", example]]), { title: "my-library" });
+
+    expect(llmsFullTxt).toContain("Current value.<br />@since 1.2.0");
+    expect(llmsFullTxt).toContain("Fires on change.<br />@example on:change={handleChange}");
+  });
+
   test("omits empty sections entirely", () => {
     const { llmsFullTxt } = renderLlmsDocuments(new Map([["Select", select]]), { title: "my-library" });
 


### PR DESCRIPTION
llms-full.txt's Props/Bindings/Module-exports and Events tables only
read description, so a prop or event's @since/@example tags never
made it into the Description column. Same gap PR #461 closed for
COMPONENT_INDEX.md, left over here since the llms.txt writer has its
own render functions.