### PR TITLE
feat(context): support @internal on per-property context values

### DIFF
--- a/README.md
+++ b/README.md
@@ -2762,7 +2762,23 @@ For a context (`setContext(key, value)`), tag the JSDoc on the *value* variable,
 </script>
 ```
 
-An inline object literal passed directly to `setContext` (no intermediate variable) has no JSDoc position of its own, so `@internal` isn't supported there.
+A whole inline object literal passed directly to `setContext` (no intermediate variable) has no JSDoc position of its own, so `@internal` isn't supported there. An individual property *inside* one can be marked `@internal`, though, as long as its value is an identifier carrying its own JSDoc:
+
+```svelte
+<script>
+  /**
+   * @type {string}
+   * @internal
+   */
+  let debugToken = "";
+
+  let publicUser = { name: "" };
+
+  setContext("session", { user: publicUser, debug: debugToken });
+</script>
+```
+
+Only the `debug` property is excluded from `session`'s generated shape; `user` and the context itself are unaffected.
 
 Because an internal member never appears in output, adding `@internal` to a previously-public prop, event, slot, or typedef is a breaking change for `--check` purposes (it disappears from the generated `.d.ts` just like an outright removal). Removing an already-`@internal` member, by contrast, is not breaking — it was never part of the committed public snapshot to begin with.
 

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -581,6 +581,8 @@ export interface ComponentContextProp {
   description?: string;
   /** True when optional. */
   optional: boolean;
+  /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
+  internal?: boolean;
 }
 
 /** Context from `setContext(key, value)`. */

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -84,6 +84,7 @@ function parseContextObjectProperties(
 
     let propType = "any";
     let propDescription: string | undefined;
+    let propInternal: boolean | undefined;
 
     if (isIdentifier(prop.value)) {
       const varName = prop.value.name;
@@ -91,6 +92,7 @@ function parseContextObjectProperties(
       if (varInfo) {
         propType = varInfo.type;
         propDescription = varInfo.description;
+        propInternal = varInfo.internal;
       } else {
         recordDiagnostic(
           ctx,
@@ -126,6 +128,7 @@ function parseContextObjectProperties(
       type: propType,
       description: propDescription,
       optional: false,
+      ...(propInternal ? { internal: true } : {}),
     });
   }
 

--- a/src/writer/document-model.ts
+++ b/src/writer/document-model.ts
@@ -61,7 +61,14 @@ function excludeInternalMembers(component: ComponentDocApi): ComponentDocApi {
     slots: excludeInternal(component.slots),
     events: excludeInternal(component.events),
     typedefs: excludeInternal(component.typedefs),
-    ...(component.contexts ? { contexts: excludeInternal(component.contexts) } : {}),
+    ...(component.contexts
+      ? {
+          contexts: excludeInternal(component.contexts).map((context) => ({
+            ...context,
+            properties: excludeInternal(context.properties),
+          })),
+        }
+      : {}),
   };
 }
 

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -296,6 +296,48 @@ describe("component API JSON schema", () => {
     expect(dts).toContain("label");
     expect(dts).toContain("PublicLabel");
   });
+
+  test("@internal on an identifier-valued context property excludes only that property", () => {
+    const source = `
+<script>
+  import { setContext } from "svelte";
+
+  /**
+   * Public user info.
+   * @type {{ name: string }}
+   */
+  let publicUser = { name: "" };
+
+  /**
+   * Internal-only debug token.
+   * @type {string}
+   * @internal
+   */
+  let debugToken = "";
+
+  setContext("session", { user: publicUser, debug: debugToken });
+</script>
+`;
+    const filePath = path.join(root, "tests", "fixtures", "jsdoc-internal-ignore", "context-property.svelte");
+    const parser = new ComponentParser();
+    const parsed = parser.parseSvelteComponent(source, { filePath, moduleName: "ContextPropertyInternal" });
+    const component = { ...parsed, moduleName: "ContextPropertyInternal", filePath: asNormalizedPath(filePath) };
+
+    // The raw ParsedComponent keeps both properties, with only `debug` flagged `internal: true`.
+    const sessionContext = findObjectByProperty(component.contexts ?? [], "key", "session");
+    const rawProperties = arrayProperty(sessionContext, "properties");
+    expect(findObjectByProperty(rawProperties, "name", "user")).not.toMatchObject({ internal: true });
+    expect(findObjectByProperty(rawProperties, "name", "debug")).toMatchObject({ internal: true });
+
+    const components: ComponentDocs = new Map([["ContextPropertyInternal", component]]);
+    const document = buildComponentApiDocument(components);
+    const filtered = document.components[0];
+
+    const filteredContext = findObjectByProperty(filtered.contexts ?? [], "key", "session");
+    const filteredProperties = arrayProperty(filteredContext, "properties");
+    expect(filteredProperties.map((p) => (p as JsonObject).name)).toContain("user");
+    expect(filteredProperties.map((p) => (p as JsonObject).name)).not.toContain("debug");
+  });
 });
 
 // Representative directory-name prefixes chosen to cover every syntax mode


### PR DESCRIPTION
Extends @ignore/@internal to individual identifier-valued properties
inside an inline setContext(key, { a, b }) object literal, not just
a whole context value. Filters those properties out of every built
document alongside every other internal member.

```svelte
<script>
  /**
   * @type {string}
   * @internal
   */
  let debugToken = "";

  let publicUser = { name: "" };

  setContext("session", { user: publicUser, debug: debugToken });
</script>
```

Only `debug` is excluded from the generated `session` shape; `user`
and the context itself are untouched.