### PR TITLE
feat(diagnostics): flag public types referencing an @internal typedef

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,10 +431,11 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/property-duplicate` | `warning` | Remove the duplicate `@property`; only the later one is kept. |
 | `sveld/generics-conflict` | `warning` | Rename one of the `@generics`/`@template` declarations to a distinct generic name. |
 | `sveld/jsdoc-tag-dropped` | `warning` | Move the tag next to a `@slot`/`@snippet`/`@event`/`@typedef`/`@callback` tag in the same comment block so it has something to attach to. |
+| `sveld/internal-typedef-referenced` | `error` | Remove `@internal`/`@ignore` from the referenced typedef, or stop referencing it from public type text (inline the shape, or make the referencing item `@internal` too). |
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped`, `extend-props-target-missing` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override`, `jsdoc-unknown-tag`, `typedef-duplicate`, `property-duplicate`, `generics-conflict`, `jsdoc-tag-dropped` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped`, `extend-props-target-missing`, `internal-typedef-referenced` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override`, `jsdoc-unknown-tag`, `typedef-duplicate`, `property-duplicate`, `generics-conflict`, `jsdoc-tag-dropped` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -2146,6 +2146,73 @@ export default class ComponentParser {
       );
     }
 
+    /**
+     * A public prop/typedef/event/slot/module-export/context-property whose type
+     * text still names a now-excluded `@internal` typedef leaves a dangling
+     * reference in the generated `.d.ts`. Cheap early-out: most components
+     * declare no `@internal` typedefs at all.
+     */
+    const internalTypedefNames = typedefsArray
+      .filter((typedef) => typedef.internal)
+      .map((typedef) => typedef.name.split("<")[0]);
+
+    if (internalTypedefNames.length > 0) {
+      const internalTypedefMatchers = internalTypedefNames.map((name) => ({
+        name,
+        regex: new RegExp(`\\b${name}\\b`),
+      }));
+
+      const scanForInternalReference = (
+        referencingName: string,
+        typeText: string | undefined,
+        source?: SourceRange,
+      ) => {
+        if (!typeText) return;
+        for (const { name: internalName, regex } of internalTypedefMatchers) {
+          if (!regex.test(typeText)) continue;
+          recordDiagnostic(
+            this.ctx,
+            "internal-typedef-referenced",
+            referencingName,
+            `"${referencingName}" references "${internalName}", which is @internal and excluded from output; the generated .d.ts will contain a dangling reference to it.`,
+            source,
+          );
+        }
+      };
+
+      for (const prop of processedProps) {
+        if (prop.internal) continue;
+        scanForInternalReference(prop.name, prop.type, prop.source);
+      }
+
+      for (const moduleExport of moduleExportsArray) {
+        if (moduleExport.internal) continue;
+        scanForInternalReference(moduleExport.name, moduleExport.type, moduleExport.source);
+      }
+
+      for (const typedef of typedefsArray) {
+        if (typedef.internal) continue;
+        scanForInternalReference(typedef.name, typedef.ts);
+      }
+
+      for (const event of eventsArray) {
+        if (event.internal || event.type !== "dispatched") continue;
+        scanForInternalReference(event.name, event.detail, event.source);
+      }
+
+      for (const slot of processedSlots) {
+        if (slot.internal) continue;
+        scanForInternalReference(slot.name ?? "default", slot.slot_props, slot.source);
+      }
+
+      for (const context of contextsArray) {
+        if (context.internal) continue;
+        for (const property of context.properties) {
+          scanForInternalReference(property.name, property.type);
+        }
+      }
+    }
+
     const parsedComponent: ParsedComponent = {
       source: sourceRangeFromOffsets(this.ctx, 0, this.ctx.source?.length),
       syntaxMode: this.ctx.syntaxMode,

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -21,6 +21,7 @@ import { matchesGlob } from "./glob-match";
  * - `property-duplicate`: a second `@property` reused a name on the same `@event`/`@typedef`; the later declaration overwrites the earlier one.
  * - `generics-conflict`: a second `@generics`/`@template` reused a generic name.
  * - `jsdoc-tag-dropped`: a passthrough JSDoc tag (e.g. `@see`) couldn't attach to a following or preceding structural tag.
+ * - `internal-typedef-referenced`: a public prop/typedef/event/slot/module-export/context type references an `@internal` typedef by name, which is excluded from output; the generated `.d.ts` will contain a dangling reference.
  */
 export type SveldDiagnosticKind =
   | "prop-unknown-type"
@@ -39,7 +40,8 @@ export type SveldDiagnosticKind =
   | "typedef-duplicate"
   | "property-duplicate"
   | "generics-conflict"
-  | "jsdoc-tag-dropped";
+  | "jsdoc-tag-dropped"
+  | "internal-typedef-referenced";
 
 /** `"error"` fails `--strict=errors`; `"warning"` only fails plain `--strict`. */
 export type SveldDiagnosticSeverity = "error" | "warning";
@@ -68,6 +70,7 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "property-duplicate": "sveld/property-duplicate",
   "generics-conflict": "sveld/generics-conflict",
   "jsdoc-tag-dropped": "sveld/jsdoc-tag-dropped",
+  "internal-typedef-referenced": "sveld/internal-typedef-referenced",
 };
 
 /**
@@ -93,6 +96,7 @@ export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticS
   "property-duplicate": "warning",
   "generics-conflict": "warning",
   "jsdoc-tag-dropped": "warning",
+  "internal-typedef-referenced": "error",
 };
 
 /**
@@ -216,6 +220,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "property-duplicate": "Duplicate @property names",
   "generics-conflict": "Duplicate @generics/@template names",
   "jsdoc-tag-dropped": "Passthrough JSDoc tags that couldn't attach",
+  "internal-typedef-referenced": "Public types referencing an @internal typedef",
 };
 
 const KIND_ORDER: SveldDiagnosticKind[] = [
@@ -236,6 +241,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "property-duplicate",
   "generics-conflict",
   "jsdoc-tag-dropped",
+  "internal-typedef-referenced",
 ];
 
 /**

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -545,6 +545,81 @@ describe("ComponentParser diagnostics", () => {
 
     expect(diagnostics?.some((d) => d.kind === "jsdoc-unknown-tag")).toBe(false);
   });
+
+  test("flags a public prop whose @type references an @internal typedef by name", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @internal
+         * @typedef {{ count: number }} InternalCount
+         */
+
+        /** @type {InternalCount} */
+        export let value;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const referencedDiagnostic = diagnostics?.find((d) => d.kind === "internal-typedef-referenced");
+
+    expect(referencedDiagnostic).toMatchObject({ kind: "internal-typedef-referenced", name: "value" });
+  });
+
+  test("flags a public typedef whose declaration references an @internal typedef by name", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @internal
+         * @typedef {{ count: number }} InternalCount
+         */
+
+        /**
+         * @typedef {{ items: InternalCount[] }} PublicList
+         */
+
+        /** @type {PublicList} */
+        export let list;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+    const referencedDiagnostic = diagnostics?.find((d) => d.kind === "internal-typedef-referenced");
+
+    expect(referencedDiagnostic).toMatchObject({ kind: "internal-typedef-referenced", name: "PublicList" });
+  });
+
+  test("does not flag an @internal typedef that nothing else references", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        /**
+         * @internal
+         * @typedef {{ count: number }} InternalCount
+         */
+        export let value = 1;
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "internal-typedef-referenced")).toBe(false);
+  });
+
+  test("does not flag or throw for components with no @internal typedefs at all", () => {
+    const parser = new ComponentParser();
+    const source = `
+      <script>
+        export let a = 1;
+        export let b = "hello";
+      </script>
+    `;
+
+    const { diagnostics } = parser.parseSvelteComponent(source, parseContext);
+
+    expect(diagnostics?.some((d) => d.kind === "internal-typedef-referenced")).toBe(false);
+  });
 });
 
 describe("diagnostics helpers", () => {

--- a/tests/fixtures/internal-typedef-referenced/input.svelte
+++ b/tests/fixtures/internal-typedef-referenced/input.svelte
@@ -1,0 +1,15 @@
+<script>
+  /**
+   * @internal
+   * @typedef {{ count: number }} InternalCount
+   */
+
+  /**
+   * @typedef {{ items: InternalCount[] }} PublicList
+   */
+
+  /** @type {PublicList} */
+  export let list;
+</script>
+
+<div />

--- a/tests/fixtures/internal-typedef-referenced/output-class.d.ts
+++ b/tests/fixtures/internal-typedef-referenced/output-class.d.ts
@@ -1,0 +1,19 @@
+import { SvelteComponentTyped } from "svelte";
+
+export interface InternalCount {
+  count: number
+}
+
+export interface PublicList {
+  items: InternalCount[]
+}
+
+export type InternalTypedefReferencedProps = {
+  list: PublicList;
+};
+
+export default class InternalTypedefReferenced extends SvelteComponentTyped<
+  InternalTypedefReferencedProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/internal-typedef-referenced/output-component.d.ts
+++ b/tests/fixtures/internal-typedef-referenced/output-component.d.ts
@@ -1,0 +1,22 @@
+import type { Component } from "svelte";
+
+export interface InternalCount {
+  count: number
+}
+
+export interface PublicList {
+  items: InternalCount[]
+}
+
+export type InternalTypedefReferencedProps = {
+  list: PublicList;
+};
+
+export type InternalTypedefReferencedExports = Record<string, never>;
+
+declare const InternalTypedefReferenced: Component<
+  InternalTypedefReferencedProps,
+  InternalTypedefReferencedExports,
+  ""
+>;
+export default InternalTypedefReferenced;

--- a/tests/fixtures/internal-typedef-referenced/output.json
+++ b/tests/fixtures/internal-typedef-referenced/output.json
@@ -1,0 +1,65 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "js",
+  "props": [
+    {
+      "name": "list",
+      "kind": "let",
+      "type": "PublicList",
+      "typeSource": "jsdoc",
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": true,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 2
+        },
+        "end": {
+          "line": 12,
+          "column": 18
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [
+    {
+      "type": "{ count: number }",
+      "name": "InternalCount",
+      "ts": "interface InternalCount { count: number }",
+      "internal": true
+    },
+    {
+      "type": "{ items: InternalCount[] }",
+      "name": "PublicList",
+      "ts": "interface PublicList { items: InternalCount[] }"
+    }
+  ],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": [
+    {
+      "component": "internal-typedef-referenced/input.svelte",
+      "kind": "internal-typedef-referenced",
+      "name": "PublicList",
+      "message": "\"PublicList\" references \"InternalCount\", which is @internal and excluded from output; the generated .d.ts will contain a dangling reference to it.",
+      "code": "sveld/internal-typedef-referenced",
+      "severity": "error"
+    }
+  ]
+}


### PR DESCRIPTION
@ignore/@internal excludes a typedef from every output, but nothing
checked whether a still-public prop, typedef, event, slot,
module-export, or context still referenced it by name in its type
text. The generated .d.ts silently ended up with a dangling
reference to a type that no longer exists anywhere in the file.

This adds a new `internal-typedef-referenced` diagnostic (severity:
error) that scans every non-internal type-bearing field for a
word-boundary match against each `@internal` typedef's name, once
per parse.

```svelte
<script>
  /**
   * @internal
   * @typedef {{ count: number }} InternalCount
   */

  /** @typedef {{ items: InternalCount[] }} PublicList */

  /** @type {PublicList} */
  export let list;
</script>
```

`PublicList` now gets flagged since its declaration still references
the excluded `InternalCount`.