### PR TITLE
feat(config): strict profiles ci and local

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ If a component [`@extendProps`](#extendprops) / [`@extends`](#extendprops) anoth
 
 ### Compile-checked `@example` blocks (`checkExamples`)
 
-`@example` blocks are just text. Rename a prop and the sample code can sit there broken for months. Set `checkExamples: true` to run plain TS/JS `@example` blocks through the TypeScript program. Broken examples show up as `example-compile-error` diagnostics.
+`@example` blocks are just text. Rename a prop and the sample code can sit there broken for months. Set `checkExamples: true` to check them: plain TS/JS bodies run through the TypeScript program, and `svelte`/`html` bodies run through sveld's own template parser. Broken examples show up as `example-compile-error` (TS/JS) or `example-syntax-error` (markup) diagnostics.
 
 ```ts
 await sveld({ json: true, checkExamples: true });
@@ -345,15 +345,21 @@ If `formatValue` is later renamed and the example is never updated, `checkExampl
     - Line 1: Cannot find name 'formatValue'.
 ```
 
-Plain TS/JS only. Examples fenced as `svelte` or `html`, or bare markup like `<Button />`, are skipped. Checking those needs `svelte2tsx` or similar, and sveld stays AST-only.
+A `svelte`/`html`-fenced example is syntax-checked, not type-checked: sveld parses the markup and discards the AST, so it catches malformed markup (a mismatched closing tag, an unterminated attribute) but not a prop that doesn't exist or a type error inside an expression. Those still need `svelte-check` in the consumer's own tests. Bare unfenced markup (`<Button />` with no code fence) is skipped either way.
 
-The check is narrow on purpose. It catches renamed or removed symbols and wrong argument counts. It is not full type checking and never pulls in types sveld cannot see.
+```
+@example blocks that failed to parse (1):
+  ./Component.svelte
+    - Line 1: sveld: invalid closing tag </span>.
+```
 
-Needs `typescript` 7+ and a `tsconfig.json`, same as `resolveTypes` (see [Requirements](#requirements)); missing either fails the run rather than silently skipping every example. Use `--strict` (or the `strict` option) to fail CI when an example breaks.
+The TS/JS check is narrow on purpose too. It catches renamed or removed symbols and wrong argument counts. Neither path is full type checking, and neither pulls in types sveld cannot see.
+
+The TS/JS path needs `typescript` 7+ and a `tsconfig.json`, same as `resolveTypes` (see [Requirements](#requirements)); missing either fails the run rather than silently skipping every example. The markup path needs neither: pass `checkExamples: "syntax"` to run only it, so a project with only `svelte`/`html` examples (or no `tsconfig.json`) never loads TypeScript. Use `--strict` (or the `strict` option) to fail CI when an example breaks.
 
 ### Type inference diagnostics
 
-`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, `$props()`/`{@render}` syntax sveld can't model, and (when `checkExamples` is enabled) `example-compile-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`. Each diagnostic carries an optional `source` range (the same `{ start: { line, column }, end: { line, column } }` shape as JSON output source ranges) whenever the parser holds a stable position for it.
+`sveld` collects unresolved-type diagnostics on every run: props that fall back to `any`, context values typed as `any`, `@event` tags with no dispatch or callback, `$props()`/`{@render}` syntax sveld can't model, and (when `checkExamples` is enabled) `example-compile-error`/`example-syntax-error`. They are always returned from the programmatic `sveld()` API in `SveldResult.diagnostics`. Each diagnostic carries an optional `source` range (the same `{ start: { line, column }, end: { line, column } }` shape as JSON output source ranges) whenever the parser holds a stable position for it.
 
 A prop with no type annotation, no `@type` JSDoc, and no initializer has nothing to infer a type or a default from: its JSON `type` stays absent (`"typeSource": "unknown"`), it triggers a `prop-unknown-type` diagnostic, and the emitted `.d.ts` types it as `any` with no `@default` line (rather than the literal type `undefined`).
 
@@ -380,12 +386,16 @@ Component syntax sveld skipped (1):
     - {@render tabs(getTabProps())} argument is not a plain object literal; the render call was not mapped to slot metadata. (./Tabs.svelte:6:4) [sveld/syntax-skipped]
 ```
 
-When `checkExamples` is also enabled, `@example` compile failures appear as a fifth group:
+When `checkExamples` is also enabled, `@example` failures appear as additional groups: TS/JS failures under `example-compile-error`, `svelte`/`html` failures under `example-syntax-error`.
 
 ```
 @example blocks that failed to compile (1):
   ./Component.svelte
     - Line 1: Cannot find name 'formatValue'. [sveld/example-compile-error]
+
+@example blocks that failed to parse (1):
+  ./Component.svelte
+    - Line 1: sveld: invalid closing tag </span>. [sveld/example-syntax-error]
 ```
 
 By default, nothing is printed. Opt in when you are working on types or want CI output:
@@ -418,7 +428,8 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 | `sveld/prop-unknown-type` | `warning` | Add a native TypeScript annotation, a `@type` JSDoc tag, or an initializer sveld can infer a type from. |
 | `sveld/context-any-type` | `warning` | Annotate the `setContext` value's declaration with `@type` or a native TypeScript type. |
 | `sveld/event-no-source` | `warning` | Dispatch the event (`createEventDispatcher`/`dispatch`), forward it (`on:name`), or add a matching `on<Name>` callback prop; otherwise remove the stale `@event` tag. |
-| `sveld/example-compile-error` | `error` | Fix the `@example` code block so it type-checks, or remove the broken example. |
+| `sveld/example-compile-error` | `error` | Fix the `@example` TS/JS code block so it type-checks, or remove the broken example. |
+| `sveld/example-syntax-error` | `error` | Fix the `@example` `svelte`/`html` markup so it parses, or remove the broken example. |
 | `sveld/syntax-skipped` | `error` | Rewrite the flagged syntax in a form sveld can model (see the diagnostic's `message` for what was skipped). |
 | `sveld/rest-props-unresolved` | `warning` | Spread `$$restProps` onto a plain element (or `svelte:element`) instead of a component, or add an `@restProps` tag to type it manually. |
 | `sveld/context-duplicate-key` | `warning` | Remove the duplicate `setContext` call, or give it a distinct key; only the first call's shape is used. |
@@ -436,7 +447,7 @@ Every diagnostic carries a stable, namespaced `code` (`"sveld/<kind>"`) alongsid
 
 #### Severity and `--strict=errors`
 
-Each diagnostic's `severity` is `"error"` (`example-compile-error`, `syntax-skipped`, `extend-props-target-missing`, `internal-typedef-referenced` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override`, `jsdoc-unknown-tag`, `typedef-duplicate`, `property-duplicate`, `generics-conflict`, `jsdoc-tag-dropped` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
+Each diagnostic's `severity` is `"error"` (`example-compile-error`, `example-syntax-error`, `syntax-skipped`, `extend-props-target-missing`, `internal-typedef-referenced` — sveld emitted broken or unmodeled output) or `"warning"` (`prop-unknown-type`, `context-any-type`, `event-no-source`, `rest-props-unresolved`, `context-duplicate-key`, `spread-unresolved`, `export-unresolved`, `extend-props-duplicate`, `extend-props-override`, `jsdoc-unknown-tag`, `typedef-duplicate`, `property-duplicate`, `generics-conflict`, `jsdoc-tag-dropped` — a type fell back to `any`). Plain `strict: true` / `--strict` fails on both, unchanged from before. Pass `strict: "errors"` (or `--strict=errors`) to fail CI only on `error`-severity diagnostics, letting `any`-fallback warnings through:
 
 ```sh
 npx sveld --json --strict=errors
@@ -692,8 +703,8 @@ npx sveld --json --strict=local
 The profile's keys are applied first, then any other key set alongside `strict` overrides it, so you can opt back out of one piece:
 
 ```ts
-// Everything --strict=ci implies, except checkExamples.
-await sveld({ json: true, strict: "ci", checkExamples: false });
+// Everything --strict=ci implies, except the TypeScript-checked half of checkExamples.
+await sveld({ json: true, strict: "ci", checkExamples: "syntax" });
 ```
 
 ### Node.js
@@ -917,7 +928,7 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
 - **`resolveTypes`** (boolean, optional, default: `false`): Load the TypeScript program to expand opaque imported whole-object `$props()` types into JSON. Also available as `--resolve-types` (`--resolveTypes` remains as a deprecated alias). See [Opt-in semantic resolution](#opt-in-semantic-resolution-resolvetypes).
 - **`cache`** (boolean | string, optional, default: `true`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. On by default, writing to `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path; pass `false` to disable. Also available as `--cache` / `--cache=<path>` / `--cache=false`. See [Persistent parse cache](#persistent-parse-cache-cache).
-- **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. Also available as `--check-examples` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
+- **`checkExamples`** (`boolean | "syntax"`, optional, default: `false`): `true` runs plain TS/JS `@example` blocks through the TypeScript program (`example-compile-error` diagnostics) and `svelte`/`html` blocks through sveld's own template parser (`example-syntax-error` diagnostics). `"syntax"` runs only the markup path, so `typescript` is never loaded. Also available as `--check-examples` / `--check-examples=syntax` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
 - **`strict`** (`boolean | "errors" | "ci" | "local"`, optional, default: `false`): Exit with code `4` when diagnostics exist. Implies `reportDiagnostics`. `"errors"` fails only on `severity: "error"` diagnostics, letting `warning` ones through. `"ci"` and `"local"` are strictness profiles that expand into other options before this object's own keys are applied. Also available as `--strict` / `--strict=errors` / `--strict=ci` / `--strict=local`. See [Type inference diagnostics](#type-inference-diagnostics) and [CI: strictness profiles](#ci-strictness-profiles---strictci---strictlocal).
 - **`diagnostics.ignore`** (`Array<{ code?: string; component?: string; name?: string }>`, optional): Marks matching diagnostics `ignored` — they're still reported and counted, but never fail `strict`. `component` is a glob; an omitted field on a matcher matches anything. No CLI flag; config-file or `sveld()` only. See [Ignoring diagnostics](#ignoring-diagnostics).

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ export default class Button extends SvelteComponentTyped<
   - [CLI](#cli)
   - [Exit codes](#exit-codes)
   - [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check)
+  - [CI: strictness profiles (`--strict=ci`/`--strict=local`)](#ci-strictness-profiles---strictci---strictlocal)
   - [Node.js](#nodejs)
   - [Browser](#browser)
   - [Config File](#config-file)
@@ -672,6 +673,29 @@ The CLI exits non-zero on any fatal error (an unreadable entry, a config file th
 
 Pass `--format=json` for a machine-readable report on `stdout` instead of the prose above, e.g. `sveld --check --format=json | jq '.bump'` or `sveld --check --format=json | jq '.changes[] | select(.bump == "major")'`.
 
+### CI: strictness profiles (`--strict=ci`/`--strict=local`)
+
+CI and local runs usually want a different bundle of `strict`, `reportDiagnostics`, `check`, and `checkExamples` flags, previously assembled by hand. `--strict=ci`/`strict: "ci"` and `--strict=local`/`strict: "local"` are shorthands for two common bundles. Bare `--strict`/`strict: true` (and `--strict=errors`) are unchanged.
+
+`--strict=ci` expands to `{ strict: true, reportDiagnostics: true, check: true, checkExamples: true }` — the full gate for a CI job:
+
+```sh
+npx sveld --json --strict=ci
+```
+
+`--strict=local` expands to `{ reportDiagnostics: true }` — diagnostics printed for a developer to see, without failing the command or requiring a committed `COMPONENT_API.json` snapshot:
+
+```sh
+npx sveld --json --strict=local
+```
+
+The profile's keys are applied first, then any other key set alongside `strict` overrides it, so you can opt back out of one piece:
+
+```ts
+// Everything --strict=ci implies, except checkExamples.
+await sveld({ json: true, strict: "ci", checkExamples: false });
+```
+
 ### Node.js
 
 You can also call `sveld` from Node.js. See [Requirements](#requirements) for supported Node versions and the ESM-only constraint.
@@ -895,7 +919,7 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`cache`** (boolean | string, optional, default: `true`): Write parsed component output to disk and skip re-parsing unchanged files on later runs. On by default, writing to `node_modules/.cache/sveld/parse-cache.json`; a string sets a custom path; pass `false` to disable. Also available as `--cache` / `--cache=<path>` / `--cache=false`. See [Persistent parse cache](#persistent-parse-cache-cache).
 - **`checkExamples`** (boolean, optional, default: `false`): Run plain TS/JS `@example` blocks through the TypeScript program. Broken ones get an `example-compile-error` diagnostic. Also available as `--check-examples` (`--checkExamples` remains as a deprecated alias). See [Compile-checked `@example` blocks](#compile-checked-example-blocks-checkexamples).
 - **`reportDiagnostics`** (boolean, optional, default: `false`): Print unresolved-type diagnostics to stderr (CLI) or `console.warn` (programmatic API). Also available as `--report-diagnostics`. See [Type inference diagnostics](#type-inference-diagnostics).
-- **`strict`** (`boolean | "errors"`, optional, default: `false`): Exit with code `4` when diagnostics exist. Implies `reportDiagnostics`. `"errors"` fails only on `severity: "error"` diagnostics, letting `warning` ones through. Also available as `--strict` / `--strict=errors`. See [Type inference diagnostics](#type-inference-diagnostics).
+- **`strict`** (`boolean | "errors" | "ci" | "local"`, optional, default: `false`): Exit with code `4` when diagnostics exist. Implies `reportDiagnostics`. `"errors"` fails only on `severity: "error"` diagnostics, letting `warning` ones through. `"ci"` and `"local"` are strictness profiles that expand into other options before this object's own keys are applied. Also available as `--strict` / `--strict=errors` / `--strict=ci` / `--strict=local`. See [Type inference diagnostics](#type-inference-diagnostics) and [CI: strictness profiles](#ci-strictness-profiles---strictci---strictlocal).
 - **`diagnostics.ignore`** (`Array<{ code?: string; component?: string; name?: string }>`, optional): Marks matching diagnostics `ignored` — they're still reported and counted, but never fail `strict`. `component` is a glob; an omitted field on a matcher matches anything. No CLI flag; config-file or `sveld()` only. See [Ignoring diagnostics](#ignoring-diagnostics).
 - **`check`** (boolean | string, optional, default: `false`): Diff the parsed component API against a committed snapshot and assign a semver bump to each change. `true` uses the `json` writer's `outFile` (or `COMPONENT_API.json`); a string sets a custom snapshot path. Also available as `--check` / `--check=<path>`. On the CLI this exits `3` on a breaking change; from `sveld()` it's returned on `SveldResult.check` for you to act on. See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check).
 - **`checkLevel`** (`"major" | "minor" | "patch"`, optional, default: `"major"`): Minimum bump `--check` fails the CLI run on. Also available as `--check-level`. See [CI: API-drift checks (`--check`)](#ci-api-drift-checks---check).

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -12,7 +12,7 @@ import {
   dedupeDiagnostics,
   type SveldDiagnostic,
 } from "./diagnostics";
-import { collectExampleSources } from "./example-check";
+import { collectExampleSources, type ExampleCheckSource } from "./example-check";
 import { hashSource, ParseCache, resolveCacheFilePath } from "./parse-cache";
 import { type EntryExports, parseEntryExports } from "./parse-entry-exports";
 import { type ParsedExports, parseExports } from "./parse-exports";
@@ -28,6 +28,7 @@ import {
 } from "./resolve-call-defaults";
 import { type ContextKeyResolution, resolveContextKeyCandidates } from "./resolve-context-keys";
 import type { TypeResolver } from "./resolve-types";
+import { parse as parseTemplate, TemplateParseNotImplementedError } from "./svelte-template-parse";
 
 export interface ComponentDocApi extends ParsedComponent {
   filePath: NormalizedPath;
@@ -105,12 +106,15 @@ export interface GenerateBundleOptions {
    */
   cache?: boolean | string;
   /**
-   * Run plain TS/JS `@example` blocks on props, module exports, slots, and
-   * events through the TypeScript program. Broken examples become
-   * `example-compile-error` diagnostics. Svelte/HTML markup is skipped.
-   * Off by default. Requires `typescript`.
+   * Check `@example` blocks on props, module exports, slots, and events.
+   * `true` runs plain TS/JS examples through the TypeScript program
+   * (`example-compile-error` diagnostics; requires `typescript`) and
+   * Svelte/HTML examples through sveld's own template parser
+   * (`example-syntax-error` diagnostics; no `typescript` needed). Pass
+   * `"syntax"` to run only the markup path, so `typescript` is never loaded
+   * even when TS/JS examples exist. Off by default.
    */
-  checkExamples?: boolean;
+  checkExamples?: boolean | "syntax";
   /**
    * Parse as usual (so cache reads and real errors still apply) but skip
    * persisting the parse cache to disk. Set by the CLI's `--dry-run`.
@@ -137,7 +141,7 @@ export function toGenerateBundleOptions(
     resolveTypes: opts?.resolveTypes === true,
     documentExports: opts?.documentExports === true,
     cache: opts?.cache,
-    checkExamples: opts?.checkExamples === true,
+    checkExamples: opts?.checkExamples === "syntax" ? "syntax" : opts?.checkExamples === true,
     dryRun: opts?.dryRun === true,
     diagnostics: opts?.diagnostics,
   };
@@ -727,15 +731,29 @@ export async function generateBundle(
   // checkExamples runs over all discovered components, not just barrel exports.
   const resolveTypesCandidates = options.resolveTypes ? collectResolveTypesCandidates(components) : [];
   const checkExamplesCandidates = options.checkExamples ? collectCheckExamplesCandidates(allComponentsForTypes) : [];
+  // `checkExamples: "syntax"` only runs the template-parser path, so plain
+  // TS/JS examples never reach the TypeScript program.
+  const checkExamplesCompileCandidates =
+    options.checkExamples === true ? candidatesForKind(checkExamplesCandidates, "compile") : [];
+  const checkExamplesSyntaxCandidates = options.checkExamples
+    ? candidatesForKind(checkExamplesCandidates, "syntax")
+    : [];
 
-  if (resolveTypesCandidates.length > 0 || checkExamplesCandidates.length > 0) {
+  if (checkExamplesSyntaxCandidates.length > 0) {
+    checkComponentExamplesSyntax(checkExamplesSyntaxCandidates);
+  }
+
+  if (resolveTypesCandidates.length > 0 || checkExamplesCompileCandidates.length > 0) {
     // Share one TypeResolver when both resolveTypes and checkExamples are enabled.
+    // Guarded on `checkExamplesCompileCandidates` (not `checkExamplesCandidates`)
+    // so `checkExamples: true`/`"syntax"` with only markup fences never loads
+    // TypeScript.
     const { TypeResolver } = await import("./resolve-types");
     const created = await TypeResolver.create(rootDir);
     if (!created.ok) {
       const features = [
         resolveTypesCandidates.length > 0 ? "resolveTypes" : null,
-        checkExamplesCandidates.length > 0 ? "checkExamples" : null,
+        checkExamplesCompileCandidates.length > 0 ? "checkExamples" : null,
       ]
         .filter((feature): feature is string => feature !== null)
         .join(" and ");
@@ -747,8 +765,8 @@ export async function generateBundle(
       if (resolveTypesCandidates.length > 0) {
         await resolveImportedPropTypes(resolveTypesCandidates, resolver, resolveComponentFilePath);
       }
-      if (checkExamplesCandidates.length > 0) {
-        await checkComponentExamples(checkExamplesCandidates, resolver, resolveComponentFilePath);
+      if (checkExamplesCompileCandidates.length > 0) {
+        await checkComponentExamples(checkExamplesCompileCandidates, resolver, resolveComponentFilePath);
       }
     } finally {
       await resolver?.dispose();
@@ -951,6 +969,54 @@ function collectCheckExamplesCandidates(components: ComponentDocs): CheckExample
   }
 
   return candidates;
+}
+
+/** Narrows each candidate's `sources` to one `ExampleCheckKind`, dropping candidates left with none. */
+function candidatesForKind(
+  candidates: CheckExamplesCandidate[],
+  kind: ExampleCheckSource["kind"],
+): CheckExamplesCandidate[] {
+  const filtered: CheckExamplesCandidate[] = [];
+
+  for (const { component, sources } of candidates) {
+    const matching = sources.filter((source) => source.kind === kind);
+    if (matching.length === 0) continue;
+    filtered.push({ component, sources: matching });
+  }
+
+  return filtered;
+}
+
+/**
+ * Syntax-checks `kind: "syntax"` `@example` blocks (Svelte/HTML markup) with
+ * sveld's own template parser: parse only, discard the AST. A parser error
+ * becomes an `example-syntax-error` diagnostic; a construct the parser
+ * doesn't model yet ({@link TemplateParseNotImplementedError}) is not the
+ * example's fault, so it's skipped rather than reported.
+ */
+function checkComponentExamplesSyntax(candidates: CheckExamplesCandidate[]): void {
+  for (const { component, sources } of candidates) {
+    const diagnostics = component.diagnostics ?? [];
+
+    for (const source of sources) {
+      try {
+        parseTemplate(source.code);
+      } catch (error) {
+        if (error instanceof TemplateParseNotImplementedError) continue;
+        diagnostics.push(
+          createDiagnostic({
+            component: component.filePath,
+            kind: "example-syntax-error",
+            name: source.name,
+            message: error instanceof Error ? error.message : String(error),
+            ...(source.source ? { source: source.source } : {}),
+          }),
+        );
+      }
+    }
+
+    component.diagnostics = diagnostics;
+  }
 }
 
 async function checkComponentExamples(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,7 @@ Options:
   --stdout[=json|ndjson] Print the document from exactly one of --json, --markdown, or --custom-elements to stdout and write nothing to disk (rejects --types and --check); --stdout=ndjson prints one JSON object per component per line and requires --json
   --cache[=<path>]      Persist parsed output and skip re-parsing unchanged files (on by default, default path: node_modules/.cache/sveld/parse-cache.json; pass --cache=false to disable)
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
-  --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
+  --check-examples[=syntax]  Check @example blocks: TS/JS against the TypeScript program, svelte/html markup against sveld's own parser (alias: --checkExamples, deprecated); --check-examples=syntax runs only the markup path and never loads TypeScript
   --report-diagnostics  Print unresolved-type diagnostics to stderr
   --strict[=errors|ci|local]  Exit with code 4 when diagnostics exist (implies --report-diagnostics); --strict=errors only fails on error-severity diagnostics; --strict=ci expands to {strict:true, reportDiagnostics:true, check:true, checkExamples:true}, --strict=local to {reportDiagnostics:true}
   --types-format=<format>  ".d.ts" output format: "class" (default) or "component" (Svelte 5 Component<...>)
@@ -233,7 +233,12 @@ function parseCliFlagValue(flag: string, value: string | boolean, arg: string, r
     case "resolve-types":
       return { kind: "option", option: { resolveTypes: value === true || value === "true" } };
     case "check-examples":
-      return { kind: "option", option: { checkExamples: value === true || value === "true" } };
+      // Bare `--check-examples` runs both the TypeScript and syntax paths;
+      // `--check-examples=syntax` runs only the markup path, so `typescript`
+      // is never loaded even when TS/JS examples exist.
+      if (value === true || value === "true") return { kind: "option", option: { checkExamples: true } };
+      if (value === "false") return { kind: "option", option: { checkExamples: false } };
+      return { kind: "option", option: { checkExamples: value as "syntax" } };
     case "fail-fast":
       return { kind: "option", option: { failFast: value === true || value === "true" } };
     case "dry-run":
@@ -421,6 +426,17 @@ export async function cli(process: NodeJS.Process) {
     options.checkLevel !== "patch"
   ) {
     console.error(`sveld: --check-level must be "major", "minor", or "patch"; got "${options.checkLevel}".`);
+    process.exitCode = EXIT_CODES.USAGE_ERROR;
+    return;
+  }
+
+  if (
+    options.checkExamples !== undefined &&
+    options.checkExamples !== true &&
+    options.checkExamples !== false &&
+    options.checkExamples !== "syntax"
+  ) {
+    console.error(`sveld: --check-examples must be "syntax" when given a value; got "${options.checkExamples}".`);
     process.exitCode = EXIT_CODES.USAGE_ERROR;
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ import {
   formatDiagnosticsGitHubSummary,
 } from "./github-annotations";
 import { closestMatch } from "./levenshtein";
-import { loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
+import { expandStrictProfile, loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
 import { setQuiet } from "./logger";
 import { normalizeSeparators } from "./path";
 import { generateBundle, toGenerateBundleOptions, writeOutput, writeStdout } from "./plugin";
@@ -74,7 +74,7 @@ Options:
   --resolve-types       Expand opaque imported $props() types into JSON (alias: --resolveTypes, deprecated)
   --check-examples      Compile-check @example blocks against the TypeScript program (alias: --checkExamples, deprecated)
   --report-diagnostics  Print unresolved-type diagnostics to stderr
-  --strict[=errors]     Exit with code 4 when diagnostics exist (implies --report-diagnostics); --strict=errors only fails on error-severity diagnostics
+  --strict[=errors|ci|local]  Exit with code 4 when diagnostics exist (implies --report-diagnostics); --strict=errors only fails on error-severity diagnostics; --strict=ci expands to {strict:true, reportDiagnostics:true, check:true, checkExamples:true}, --strict=local to {reportDiagnostics:true}
   --types-format=<format>  ".d.ts" output format: "class" (default) or "component" (Svelte 5 Component<...>)
   --check[=<path>]      Diff the parsed API against a committed snapshot; exit 3 on a breaking change (default path: COMPONENT_API.json)
   --check-level=<major|minor|patch>  Minimum bump --check fails the run on (default: major)
@@ -227,7 +227,7 @@ function parseCliFlagValue(flag: string, value: string | boolean, arg: string, r
       // error (`--strict=oops`); a bare `--strict` means `true`.
       if (value === true || value === "true") return { kind: "option", option: { strict: true } };
       if (value === "false") return { kind: "option", option: { strict: false } };
-      return { kind: "option", option: { strict: value as "errors" } };
+      return { kind: "option", option: { strict: value as "errors" | "ci" | "local" } };
     case "report-diagnostics":
       return { kind: "option", option: { reportDiagnostics: value === true || value === "true" } };
     case "resolve-types":
@@ -355,7 +355,7 @@ export async function cli(process: NodeJS.Process) {
 
   const cliOptions = parsed.options;
   const fileConfig = await loadConfig();
-  const options = mergeConfig<CliOptions>(fileConfig, cliOptions);
+  const options = expandStrictProfile(mergeConfig<CliOptions>(fileConfig, cliOptions));
   validateOptions(options);
 
   if (options.stdout) {
@@ -409,7 +409,7 @@ export async function cli(process: NodeJS.Process) {
     options.strict !== false &&
     options.strict !== "errors"
   ) {
-    console.error(`sveld: --strict must be "errors" when given a value; got "${options.strict}".`);
+    console.error(`sveld: --strict must be "errors", "ci", or "local" when given a value; got "${options.strict}".`);
     process.exitCode = EXIT_CODES.USAGE_ERROR;
     return;
   }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -7,7 +7,8 @@ import { matchesGlob } from "./glob-match";
  * - `prop-unknown-type`: prop `typeSource` is `"unknown"`.
  * - `context-any-type`: `setContext` value inferred as `any`.
  * - `event-no-source`: `@event` with no dispatch, forward, or callback prop.
- * - `example-compile-error`: an `@example` block failed to type-check (opt-in, `checkExamples`).
+ * - `example-compile-error`: a TS/JS `@example` block failed to type-check (opt-in, `checkExamples`).
+ * - `example-syntax-error`: a `svelte`/`html` `@example` block failed to parse (opt-in, `checkExamples`).
  * - `syntax-skipped`: `$props()`/`{@render}` syntax the parser can't model; omitted from output.
  * - `rest-props-unresolved`: every `{...$$restProps}` target was a component, so `$RestProps` couldn't be typed.
  * - `context-duplicate-key`: `setContext` called more than once with the same key; only the first call's shape is used.
@@ -28,6 +29,7 @@ export type SveldDiagnosticKind =
   | "context-any-type"
   | "event-no-source"
   | "example-compile-error"
+  | "example-syntax-error"
   | "syntax-skipped"
   | "rest-props-unresolved"
   | "context-duplicate-key"
@@ -57,6 +59,7 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
   "context-any-type": "sveld/context-any-type",
   "event-no-source": "sveld/event-no-source",
   "example-compile-error": "sveld/example-compile-error",
+  "example-syntax-error": "sveld/example-syntax-error",
   "syntax-skipped": "sveld/syntax-skipped",
   "rest-props-unresolved": "sveld/rest-props-unresolved",
   "context-duplicate-key": "sveld/context-duplicate-key",
@@ -74,15 +77,16 @@ export const DIAGNOSTIC_CODES: Record<SveldDiagnosticKind, string> = {
 };
 
 /**
- * `example-compile-error` and `syntax-skipped` are errors (sveld emitted
- * broken or unmodeled output); the rest are warnings (a type fell back to
- * `any`).
+ * `example-compile-error`, `example-syntax-error`, and `syntax-skipped` are
+ * errors (sveld emitted broken or unmodeled output); the rest are warnings
+ * (a type fell back to `any`).
  */
 export const DIAGNOSTIC_SEVERITIES: Record<SveldDiagnosticKind, SveldDiagnosticSeverity> = {
   "prop-unknown-type": "warning",
   "context-any-type": "warning",
   "event-no-source": "warning",
   "example-compile-error": "error",
+  "example-syntax-error": "error",
   "syntax-skipped": "error",
   "rest-props-unresolved": "warning",
   "context-duplicate-key": "warning",
@@ -207,6 +211,7 @@ const KIND_LABELS: Record<SveldDiagnosticKind, string> = {
   "context-any-type": "Context values typed as `any`",
   "event-no-source": "@event tags with no dispatch or callback",
   "example-compile-error": "@example blocks that failed to compile",
+  "example-syntax-error": "@example blocks that failed to parse",
   "syntax-skipped": "Component syntax sveld skipped",
   "rest-props-unresolved": "$$restProps spread only onto components",
   "context-duplicate-key": "Duplicate setContext keys",
@@ -228,6 +233,7 @@ const KIND_ORDER: SveldDiagnosticKind[] = [
   "context-any-type",
   "event-no-source",
   "example-compile-error",
+  "example-syntax-error",
   "syntax-skipped",
   "rest-props-unresolved",
   "context-duplicate-key",

--- a/src/example-check.ts
+++ b/src/example-check.ts
@@ -1,47 +1,63 @@
 import type { ComponentProp, ComponentSlot, ParsedComponent, SourceRange } from "./ComponentParser";
 
+/** `"compile"` runs through the TypeScript program; `"syntax"` runs through sveld's template parser only. */
+export type ExampleCheckKind = "compile" | "syntax";
+
 /**
- * One `@example` block worth type-checking, reduced to what `resolve-types.ts`
- * needs: a declaration for the documented symbol and the example body itself.
+ * One `@example` block worth checking, reduced to what `resolve-types.ts`
+ * (for `kind: "compile"`) or the template parser (for `kind: "syntax"`) needs.
  */
 export interface ExampleCheckSource {
   /** Stable id for diagnostics, e.g. `"prop:variant"` or `"prop:variant#1"` for a second example. */
   id: string;
   /** Human-readable name shown in diagnostics, e.g. `"variant"` or `"variant (example 2)"`. */
   name: string;
-  /** TypeScript type to bind the documented symbol to before running `code`. */
+  /** TypeScript type to bind the documented symbol to before running `code`. Unused for `kind: "syntax"`. */
   type: string;
   /** The `@example` body, stripped of any surrounding code fence. */
   code: string;
+  /** How `code` gets checked. */
+  kind: ExampleCheckKind;
   /** Source range of the documented symbol (prop/export/slot/event), when available. */
   source?: SourceRange;
 }
 
 const FENCE_REGEX = /^```([\w-]*)\r?\n([\s\S]*?)\r?\n?```$/;
 
-/** Languages sveld can type-check with `tsc`. Anything else (svelte, html, ...) is markup and skipped. */
-const CHECKABLE_FENCE_LANGS = new Set(["", "js", "jsx", "ts", "tsx", "javascript", "typescript"]);
+/** Languages sveld can type-check with `tsc`. */
+const COMPILE_FENCE_LANGS = new Set(["", "js", "jsx", "ts", "tsx", "javascript", "typescript"]);
+
+/** Languages sveld can syntax-check with its own template parser. */
+const SYNTAX_FENCE_LANGS = new Set(["svelte", "html"]);
+
+interface ExtractedExampleCode {
+  kind: ExampleCheckKind;
+  code: string;
+}
 
 /**
- * Extracts plain TS/JS code from an `@example` body, or `null` when the
- * example is Svelte/HTML markup (or another language sveld can't type-check
- * without `svelte2tsx` or similar).
+ * Extracts checkable code from an `@example` body: plain TS/JS (`kind:
+ * "compile"`), Svelte/HTML markup (`kind: "syntax"`), or `null` when the
+ * example is fenced as something else, or is bare unfenced markup sveld
+ * doesn't try to check.
  */
-function extractCheckableCode(body: string): string | null {
+function extractCheckableCode(body: string): ExtractedExampleCode | null {
   const trimmed = body.trim();
   if (trimmed === "") return null;
 
   const fenceMatch = trimmed.match(FENCE_REGEX);
   if (fenceMatch) {
     const lang = fenceMatch[1].toLowerCase();
-    if (!CHECKABLE_FENCE_LANGS.has(lang)) return null;
     const inner = fenceMatch[2].trim();
-    return inner === "" ? null : inner;
+    if (inner === "") return null;
+    if (COMPILE_FENCE_LANGS.has(lang)) return { kind: "compile", code: inner };
+    if (SYNTAX_FENCE_LANGS.has(lang)) return { kind: "syntax", code: inner };
+    return null;
   }
 
   // No fence: skip bare markup like `<Disclosure open />`.
   if (trimmed.startsWith("<")) return null;
-  return trimmed;
+  return { kind: "compile", code: trimmed };
 }
 
 /** The type sveld declares the documented symbol as before running its examples. */
@@ -62,14 +78,15 @@ function sourcesFromTags(
   const sources: ExampleCheckSource[] = [];
 
   examples.forEach((tag, index) => {
-    const code = extractCheckableCode(tag.body);
-    if (code === null) return;
+    const extracted = extractCheckableCode(tag.body);
+    if (extracted === null) return;
     const numbered = examples.length > 1;
     sources.push({
       id: numbered ? `${idPrefix}#${index}` : idPrefix,
       name: numbered ? `${name} (example ${index + 1})` : name,
       type,
-      code,
+      code: extracted.code,
+      kind: extracted.kind,
       ...(source ? { source } : {}),
     });
   });
@@ -82,10 +99,10 @@ function slotName(slot: ComponentSlot): string {
 }
 
 /**
- * Collects every `@example` block sveld can type-check for a parsed component:
- * plain TS/JS bodies on props, module exports, slots, and events. Svelte/HTML
- * markup examples (most slot/event examples, many prop examples) are skipped.
- * Checking those needs `svelte2tsx` or similar; sveld stays AST-only.
+ * Collects every `@example` block sveld can check for a parsed component:
+ * plain TS/JS bodies (`kind: "compile"`) on props, module exports, slots, and
+ * events, plus Svelte/HTML markup bodies (`kind: "syntax"`). Bare unfenced
+ * markup and other fenced languages are skipped.
  */
 export function collectExampleSources(component: ParsedComponent): ExampleCheckSource[] {
   const sources: ExampleCheckSource[] = [];

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -18,8 +18,15 @@ export interface SveldRuntimeOptions extends PluginSveldOptions {
    * `"errors"` to fail only on `severity: "error"` diagnostics
    * (`example-compile-error`, `syntax-skipped`), letting warnings
    * (`prop-unknown-type`, `context-any-type`, `event-no-source`) through.
+   *
+   * `"ci"` and `"local"` are strictness profiles, expanded by
+   * {@link expandStrictProfile} into a set of other options before this
+   * object's own explicit keys are applied (so they can still opt back out
+   * of one, e.g. `{ strict: "ci", checkExamples: false }`):
+   * - `"ci"`: `{ strict: true, reportDiagnostics: true, check: true, checkExamples: true }`.
+   * - `"local"`: `{ reportDiagnostics: true }` (does not itself enable `strict`).
    */
-  strict?: boolean | "errors";
+  strict?: boolean | "errors" | "ci" | "local";
   /**
    * Diff the parsed component API against a committed snapshot (default:
    * the `json` writer's `outFile`, or `COMPONENT_API.json`) and assign a
@@ -172,6 +179,30 @@ export function mergeConfig<T extends PluginSveldOptions = PluginSveldOptions>(
   }
 
   return merged as Partial<T>;
+}
+
+/** The options a `strict: "ci" | "local"` profile expands into. See `SveldRuntimeOptions.strict`. */
+const STRICT_PROFILES: Record<"ci" | "local", Partial<SveldRuntimeOptions>> = {
+  ci: { strict: true, reportDiagnostics: true, check: true, checkExamples: true },
+  local: { reportDiagnostics: true },
+};
+
+/** `options` with `strict` narrowed from a resolved `"ci"`/`"local"` profile to its plain runtime value. */
+type WithExpandedStrict<T> = Omit<T, "strict"> & { strict?: boolean | "errors" };
+
+/**
+ * Expands a `strict: "ci" | "local"` profile into its constituent options.
+ * The profile's own keys are applied first, then `options`' other explicit
+ * keys are layered on top, so `{ strict: "ci", checkExamples: false }` still
+ * opts back out of `checkExamples`. A plain `strict: true | "errors" | false
+ * | undefined` passes through unchanged.
+ */
+export function expandStrictProfile<T extends Partial<SveldRuntimeOptions>>(options: T): WithExpandedStrict<T> {
+  const { strict, ...rest } = options;
+
+  if (strict !== "ci" && strict !== "local") return options as WithExpandedStrict<T>;
+
+  return { ...STRICT_PROFILES[strict], ...rest } as WithExpandedStrict<T>;
 }
 
 /** Top-level keys accepted anywhere in `PluginSveldOptions` / `SveldRuntimeOptions`. */

--- a/src/sveld.ts
+++ b/src/sveld.ts
@@ -8,7 +8,7 @@ import {
   type SveldDiagnostic,
 } from "./diagnostics";
 import { getSvelteEntry } from "./get-svelte-entry";
-import { loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
+import { expandStrictProfile, loadConfig, mergeConfig, type SveldRuntimeOptions, validateOptions } from "./load-config";
 import { setQuiet } from "./logger";
 import { generateBundle, toGenerateBundleOptions, writeOutput } from "./plugin";
 
@@ -61,7 +61,7 @@ export async function sveld(opts?: SveldOptions): Promise<SveldResult> {
       'sveld: could not resolve a Svelte entry point. Set package.json#svelte, or pass the "entry" option.',
     );
   }
-  const merged = mergeConfig<SveldRuntimeOptions>(fileConfig, runtimeOpts, { entry: input });
+  const merged = expandStrictProfile(mergeConfig<SveldRuntimeOptions>(fileConfig, runtimeOpts, { entry: input }));
   validateOptions(merged);
   setQuiet(merged.quiet === true);
   const result = await generateBundle(input, merged.glob === true, toGenerateBundleOptions(merged));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -137,6 +137,14 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--strict=false"])).toEqual({ kind: "options", options: { strict: false } });
   });
 
+  test("--strict=ci sets strict to the ci profile", () => {
+    expect(parseCliOptions(["--strict=ci"])).toEqual({ kind: "options", options: { strict: "ci" } });
+  });
+
+  test("--strict=local sets strict to the local profile", () => {
+    expect(parseCliOptions(["--strict=local"])).toEqual({ kind: "options", options: { strict: "local" } });
+  });
+
   test("--stdout enables stdout", () => {
     expect(parseCliOptions(["--stdout"])).toEqual({ kind: "options", options: { stdout: true } });
   });
@@ -1408,6 +1416,54 @@ describe("cli() exit codes", () => {
 
     expect(process.exitCode).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--strict must be "errors"'));
+  });
+
+  test("--strict=ci expands to strict+reportDiagnostics+check+checkExamples: exitCode 4 and a diagnostics summary without --report-diagnostics", async () => {
+    writeFileSync(
+      join(dir, "src", "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Phantom } from "./Phantom.svelte";\n');
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json", "--strict=ci"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(4);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("unresolved type"));
+    // `check: true` from the profile ran (no snapshot committed yet, so it just notices and doesn't fail).
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("no snapshot found"));
+  });
+
+  test("--strict=local expands to reportDiagnostics only: prints diagnostics but keeps exitCode 0", async () => {
+    writeFileSync(
+      join(dir, "src", "Phantom.svelte"),
+      "<script>\n  /** @event {CustomEvent<null>} phantom */\n  export let label;\n</script>\n<button>{label}</button>\n",
+    );
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Phantom } from "./Phantom.svelte";\n');
+    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--types=false", "--json", "--strict=local"];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("unresolved type"));
+  });
+
+  test("--strict=ci --check-examples=false opts back out of the profile's checkExamples", async () => {
+    writeFileSync(join(dir, "src", "Button.svelte"), "<script></script>\n<button>Click</button>\n");
+    writeFileSync(join(dir, "src", "index.js"), 'export { default as Button } from "./Button.svelte";\n');
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--types=false",
+      "--json",
+      "--strict=ci",
+      "--check-examples=false",
+    ];
+
+    await cli(process);
+
+    expect(process.exitCode).toBe(0);
   });
 
   test("exits 3 (not 4) when a --check breaking change and --strict diagnostics both apply in one run", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -145,6 +145,13 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--strict=local"])).toEqual({ kind: "options", options: { strict: "local" } });
   });
 
+  test("--check-examples=syntax runs only the markup path", () => {
+    expect(parseCliOptions(["--check-examples=syntax"])).toEqual({
+      kind: "options",
+      options: { checkExamples: "syntax" },
+    });
+  });
+
   test("--stdout enables stdout", () => {
     expect(parseCliOptions(["--stdout"])).toEqual({ kind: "options", options: { stdout: true } });
   });

--- a/tests/example-check.test.ts
+++ b/tests/example-check.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { asNormalizedPath } from "../src/brands";
+import { generateBundle } from "../src/bundle";
 import ComponentParser from "../src/ComponentParser";
 import { collectExampleSources } from "../src/example-check";
 import { TypeResolver } from "../src/resolve-types";
@@ -7,6 +10,50 @@ import { TypeResolver } from "../src/resolve-types";
 const FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "example-check");
 const COMPONENT_PATH = path.join(FIXTURE_DIR, "input.svelte");
 const ARGUMENT_REGEX = /argument/i;
+
+/** A valid and a broken `svelte`-fenced `@example`, and nothing checkable by `tsc`. */
+const MARKUP_ONLY_COMPONENT = `<script>
+  /**
+   * @example
+   * \`\`\`svelte
+   * <Widget prop="ok" />
+   * \`\`\`
+   */
+  export let validExample = "a";
+
+  /**
+   * Mismatched closing tag: not valid Svelte markup.
+   * @example
+   * \`\`\`svelte
+   * <div></span>
+   * \`\`\`
+   */
+  export let brokenExample = "b";
+</script>
+`;
+
+/** A broken \`svelte\`-fenced example alongside a plain TS/JS one, on the same component. */
+const MIXED_EXAMPLE_COMPONENT = `<script>
+  /**
+   * Mismatched closing tag: not valid Svelte markup.
+   * @example
+   * \`\`\`svelte
+   * <div></span>
+   * \`\`\`
+   */
+  export let brokenExample = "b";
+
+  /**
+   * @example
+   * \`\`\`js
+   * formatValue("ok");
+   * \`\`\`
+   */
+  export function formatValue(value) {
+    return value;
+  }
+</script>
+`;
 
 async function parseFixture() {
   const source = await Bun.file(COMPONENT_PATH).text();
@@ -18,21 +65,34 @@ async function parseFixture() {
 }
 
 describe("collectExampleSources", () => {
-  test("collects plain TS/JS examples and skips markup examples", async () => {
+  test("tags plain TS/JS examples as 'compile' and svelte-fenced examples as 'syntax'", async () => {
     const parsed = await parseFixture();
     const sources = collectExampleSources(parsed);
     const byId = Object.fromEntries(sources.map((source) => [source.id, source]));
 
-    expect(Object.keys(byId).sort()).toEqual(["prop:formatValue", "prop:newFormatName", "prop:tooManyArgs"]);
-    expect(byId["prop:formatValue"]).toMatchObject({ name: "formatValue", type: "(value: any) => any" });
+    expect(Object.keys(byId).sort()).toEqual([
+      "prop:formatValue",
+      "prop:newFormatName",
+      "prop:tooManyArgs",
+      "prop:widgetSlot",
+    ]);
+    expect(byId["prop:formatValue"]).toMatchObject({
+      name: "formatValue",
+      type: "(value: any) => any",
+      kind: "compile",
+    });
     expect(byId["prop:formatValue"].code).toBe('formatValue("ok");');
+    expect(byId["prop:widgetSlot"]).toMatchObject({ kind: "syntax" });
+    expect(byId["prop:widgetSlot"].code).toBe("<Widget prop={doesNotExist} />");
   });
 });
 
 describe("opt-in @example compile checking", () => {
   test("flags a renamed symbol and a wrong-arity call, leaves a valid example untouched", async () => {
     const parsed = await parseFixture();
-    const sources = collectExampleSources(parsed);
+    // Only `kind: "compile"` sources reach the TypeScript program; bundle.ts
+    // filters the same way before calling `checkExamples`.
+    const sources = collectExampleSources(parsed).filter((source) => source.kind === "compile");
 
     const created = await TypeResolver.create(FIXTURE_DIR);
     expect(created.ok).toBe(true);
@@ -55,4 +115,52 @@ describe("opt-in @example compile checking", () => {
       await resolver.dispose();
     }
   }, 30_000);
+});
+
+describe("checkExamples: syntax-checking svelte/html fences", () => {
+  let dir: string;
+  let createSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sveld-example-syntax-"));
+    createSpy = jest.spyOn(TypeResolver, "create");
+  });
+
+  afterEach(() => {
+    createSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a broken svelte fence produces an example-syntax-error diagnostic; a valid one does not", async () => {
+    writeFileSync(path.join(dir, "index.js"), `export { default as Widget } from "./Widget.svelte";\n`);
+    writeFileSync(path.join(dir, "Widget.svelte"), MARKUP_ONLY_COMPONENT);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true, { checkExamples: true });
+    const syntaxDiagnostics = result.diagnostics.filter((d) => d.kind === "example-syntax-error");
+    const byName = Object.fromEntries(syntaxDiagnostics.map((d) => [d.name, d]));
+
+    expect(byName.validExample).toBeUndefined();
+    expect(byName.brokenExample?.message).toContain("invalid closing tag");
+  });
+
+  test("checkExamples: true with only markup fences never loads TypeScript (no tsconfig.json needed)", async () => {
+    writeFileSync(path.join(dir, "index.js"), `export { default as Widget } from "./Widget.svelte";\n`);
+    writeFileSync(path.join(dir, "Widget.svelte"), MARKUP_ONLY_COMPONENT);
+
+    await generateBundle(path.join(dir, "index.js"), true, { checkExamples: true });
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("checkExamples: 'syntax' skips the TS/JS example on a mixed component and never loads TypeScript", async () => {
+    writeFileSync(path.join(dir, "index.js"), `export { default as Widget } from "./Widget.svelte";\n`);
+    writeFileSync(path.join(dir, "Widget.svelte"), MIXED_EXAMPLE_COMPONENT);
+
+    const result = await generateBundle(path.join(dir, "index.js"), true, { checkExamples: "syntax" });
+    const syntaxDiagnostics = result.diagnostics.filter((d) => d.kind === "example-syntax-error");
+
+    expect(syntaxDiagnostics.map((d) => d.name)).toEqual(["brokenExample"]);
+    expect(result.diagnostics.some((d) => d.kind === "example-compile-error")).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
 });

--- a/tests/load-config.test.ts
+++ b/tests/load-config.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   defineConfig,
+  expandStrictProfile,
   loadConfig,
   loadConfigFrom,
   mergeConfig,
@@ -203,6 +204,49 @@ describe("mergeConfig", () => {
     const overriddenOnAppend = () => {};
     expect(mergeConfig(fileConfig, { markdownOptions: { onAppend: overriddenOnAppend } })).toEqual({
       markdownOptions: { onAppend: overriddenOnAppend },
+    });
+  });
+});
+
+describe("expandStrictProfile", () => {
+  test("expands strict: 'ci' to strict, reportDiagnostics, check, and checkExamples", () => {
+    expect(expandStrictProfile({ strict: "ci" })).toEqual({
+      strict: true,
+      reportDiagnostics: true,
+      check: true,
+      checkExamples: true,
+    });
+  });
+
+  test("expands strict: 'local' to reportDiagnostics only, without enabling strict", () => {
+    expect(expandStrictProfile({ strict: "local" })).toEqual({ reportDiagnostics: true });
+  });
+
+  test("lets an explicit key on the same object opt back out of the profile", () => {
+    expect(expandStrictProfile({ strict: "ci", checkExamples: false })).toEqual({
+      strict: true,
+      reportDiagnostics: true,
+      check: true,
+      checkExamples: false,
+    });
+  });
+
+  test("passes through plain strict values unchanged", () => {
+    expect(expandStrictProfile({ strict: true, json: true })).toEqual({ strict: true, json: true });
+    expect(expandStrictProfile({ strict: "errors" })).toEqual({ strict: "errors" });
+    expect(expandStrictProfile({ strict: false })).toEqual({ strict: false });
+    expect(expandStrictProfile({ json: true })).toEqual({ json: true });
+  });
+
+  test("composes with mergeConfig: a later source's strict profile expands after merging", () => {
+    const fileConfig: Partial<SveldRuntimeOptions> = { strict: "local", json: true };
+    const merged = mergeConfig<SveldRuntimeOptions>(fileConfig, { strict: "ci" });
+    expect(expandStrictProfile(merged)).toEqual({
+      strict: true,
+      reportDiagnostics: true,
+      check: true,
+      checkExamples: true,
+      json: true,
     });
   });
 });


### PR DESCRIPTION
Also teaches checkExamples to syntax-check svelte/html @example
fences with sveld's own template parser, and guards the TypeScript
resolver so it only loads when a compile-kind example actually
exists.

```sh
npx sveld --json --strict=ci
```

```ts
// Skip the TS/JS half, keep the markup syntax check.
await sveld({ json: true, strict: "ci", checkExamples: "syntax" });
```