### PR TITLE
feat(cem): custom element prop config, accessor methods, and css docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1178,14 +1178,61 @@ sveld({
 
 Each exported component becomes one `javascript-module` with a class declaration:
 
-- **Members** — every prop becomes a `ClassField` (`name`, `type.text`, `default`, `description`, `deprecated`).
-- **Attributes** — derived conservatively from props: only props with a bare primitive type (`string`, `number`, or `boolean`) become attributes, using the same default name Svelte's custom-element runtime uses (`prop.toLowerCase()`, unless the tool's own `attribute` override applies). Props whose lowercased name collides with another prop are dropped from `attributes` on both sides, since which one wins at runtime is ambiguous. Complex types (arrays, objects, unions, custom types) never become attributes.
+- **Members** — every `export let`/`const` prop becomes a `ClassField` (`name`, `type.text`, `default`, `description`, `deprecated`; `readonly: true` for an `export const`). An accessor prop (`export function`) becomes a `ClassMethod` (`name`, `static: false`, `parameters`, `return.type.text`) instead — see [Accessor methods](#accessor-methods) below.
+- **Attributes** — every prop becomes an attribute (Svelte's custom-element runtime observes one for every prop by default), excluding `export function` accessors. The attribute name is `prop.toLowerCase()` by default, or the `customElement.props.<name>.attribute` config when set — see [Object-form `customElement` config](#object-form-customelement-config) below. Props that collide on the same attribute name keep the first (in declaration order); the rest are skipped with a console warning, since which one wins at runtime is ambiguous.
 - **Events** — dispatched events (`createEventDispatcher()`, and `$host().dispatchEvent(...)` from inside a custom element) become `{ name, type: { text: "CustomEvent<...>" } }`. Forwarded (`on:click`) events are left out, since they aren't dispatched by the component's own class.
 - **Slots** — named and default slots, with descriptions. The default slot's `name` is `""`, matching the CEM convention.
+- **`cssParts`/`cssProperties`** — from `@csspart`/`@cssprop` JSDoc tags — see [CSS parts and custom properties](#css-parts-and-custom-properties) below.
 
 When a component sets `<svelte:options customElement="x-foo" />` (or the object form, `<svelte:options customElement={{ tag: "x-foo" }} />`), its declaration gets `tagName: "x-foo"` and `customElement: true`, and the module's `exports` include a `custom-element-definition` export alongside the plain `js` export.
 
 Components without `customElement` still emit a plain class declaration (no `tagName`/`customElement`) — useful for documenting the class shape even before it's compiled as a custom element, but the manifest is most useful for `customElement`-compiled builds, where downstream tooling can resolve `tagName`, `attributes`, and `events` for actual custom-element usage.
+
+### Object-form `customElement` config
+
+The object form of `<svelte:options customElement={{ ... }} />` is read in full, not just `tag`:
+
+```svelte
+<svelte:options
+  customElement={{
+    tag: "x-widget",
+    shadow: "none",
+    props: {
+      variant: { attribute: "data-variant" },
+      active: { reflect: true },
+      tags: { type: "Array" }
+    },
+    extend: (customElementConstructor) => customElementConstructor
+  }}
+/>
+```
+
+| Config | Effect on the manifest |
+| --- | --- |
+| `props.<name>.attribute` | Overrides that prop's attribute name (default: `name.toLowerCase()`). `attribute: false` omits the prop's attribute entirely. |
+| `props.<name>.reflect` | Adds `reflects: true` to that prop's attribute. |
+| `props.<name>.type` | `"Array"`/`"Object"` appends a note to the attribute's description that the value is JSON-serialized (matching Svelte's runtime `JSON.stringify`/`JSON.parse` for those types); the attribute's `type.text` is still the prop's own TS type, not this config value. |
+| `shadow`, `extend` | Parsed and available on the raw `ParsedComponent.customElement` (Node API), but don't affect the manifest. |
+
+This full config (`tag`, `shadow`, `props`, `extend`) is also on `ParsedComponent.customElement` in the JSON output (`COMPONENT_API.json`), alongside the existing `customElementTag` shorthand.
+
+### Accessor methods
+
+An `export function` prop (a Svelte accessor, e.g. `export function focus() { ... }`) becomes a `ClassMethod`, not a `ClassField`, and is excluded from `attributes` (accessors aren't part of Svelte's props definition). `parameters`/`return` come from `@param`/`@returns` JSDoc when present, otherwise from splitting the function's TypeScript signature text (e.g. `(id: string) => boolean`).
+
+### CSS parts and custom properties
+
+Document shadow-DOM styling hooks with `@csspart`/`@cssprop` (alias `@cssproperty`) tags in the component's own JSDoc comment (the same comment block `@slot` tags go in):
+
+```js
+/**
+ * @csspart header - Styles the header region.
+ * @cssprop {Color} [--card-background=white] - Background color of the card.
+ * @cssprop --card-border-color - Border color of the card.
+ */
+```
+
+`@cssprop`'s `{type}` and `[--name=default]` are both optional, following the [Custom Elements Manifest analyzer](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/#css-custom-properties) grammar. These populate `cssParts`/`cssProperties` on the class declaration, and `ParsedComponent.cssParts`/`cssProperties` in the JSON output; the Markdown writer renders them as two extra tables when present.
 
 ### Consuming the manifest
 

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -137,7 +137,61 @@
         "customElementTag": {
           "type": "string",
           "description": "Custom-element tag name from `<svelte:options customElement=\"x-foo\" />` (or the object form's `tag`), when present."
+        },
+        "customElement": { "$ref": "#/$defs/customElement" },
+        "cssParts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/cssPart" }
+        },
+        "cssProperties": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/cssProperty" }
         }
+      }
+    },
+    "customElement": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Full `<svelte:options customElement=... />` config (shorthand or object form), when present.",
+      "properties": {
+        "tag": { "type": "string" },
+        "shadow": { "enum": ["open", "none"] },
+        "props": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/customElementPropConfig" }
+        },
+        "extend": { "const": true }
+      }
+    },
+    "customElementPropConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attribute": {
+          "oneOf": [{ "type": "string" }, { "const": false }]
+        },
+        "reflect": { "type": "boolean" },
+        "type": { "enum": ["String", "Boolean", "Number", "Array", "Object"] }
+      }
+    },
+    "cssPart": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "cssProperty": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Includes the leading `--`." },
+        "type": { "type": "string" },
+        "default": { "type": "string" },
+        "description": { "type": "string" }
       }
     },
     "prop": {

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -568,6 +568,45 @@ export interface Extends {
   import: string;
 }
 
+/** `customElement.props.<name>.type` in `<svelte:options customElement={{ ... }} />`. */
+export type CustomElementPropType = "String" | "Boolean" | "Number" | "Array" | "Object";
+
+/** `customElement.props.<name>` config in `<svelte:options customElement={{ ... }} />`. */
+export interface CustomElementPropConfig {
+  /** Explicit attribute name. Svelte itself always observes every prop as an attribute; sveld's own output omits the attribute entirely when this is `false`. */
+  attribute?: string | false;
+  reflect?: boolean;
+  type?: CustomElementPropType;
+}
+
+/**
+ * Parsed `<svelte:options customElement="tag" />` (shorthand, `tag` only) or
+ * `<svelte:options customElement={{ tag, shadow, props, extend }} />` (object
+ * form). `extend`'s callback expression isn't serializable, so only its
+ * presence is recorded.
+ */
+export interface CustomElementOptions {
+  tag?: string;
+  shadow?: "open" | "none";
+  props?: Record<string, CustomElementPropConfig>;
+  extend?: true;
+}
+
+/** From a component-level `@csspart` JSDoc tag. */
+export interface ComponentCssPart {
+  name: string;
+  description?: string;
+}
+
+/** From a component-level `@cssprop`/`@cssproperty` JSDoc tag. */
+export interface ComponentCssProperty {
+  /** Includes the leading `--`. */
+  name: string;
+  type?: string;
+  default?: string;
+  description?: string;
+}
+
 export interface ComponentPropBindings {
   elements: string[];
 }
@@ -640,6 +679,12 @@ export interface ParsedComponent {
   componentCommentSource?: SourceRange;
   contexts?: ComponentContext[];
   customElementTag?: string;
+  /** Full `<svelte:options customElement=... />` config (shorthand or object form), when present. */
+  customElement?: CustomElementOptions;
+  /** From component-level `@csspart` JSDoc tags. */
+  cssParts?: ComponentCssPart[];
+  /** From component-level `@cssprop`/`@cssproperty` JSDoc tags. */
+  cssProperties?: ComponentCssProperty[];
   /**
    * Type guesses from this parse (unknown props, `any` contexts, orphan `@event` tags).
    */
@@ -2231,6 +2276,9 @@ export default class ComponentParser {
       componentCommentSource: this.ctx.componentCommentSource,
       contexts: contextsArray,
       customElementTag: this.ctx.customElementTag,
+      customElement: this.ctx.customElement,
+      ...(this.ctx.cssParts.length > 0 ? { cssParts: this.ctx.cssParts.slice() } : {}),
+      ...(this.ctx.cssProperties.length > 0 ? { cssProperties: this.ctx.cssProperties.slice() } : {}),
       diagnostics: this.ctx.diagnosticRecords.slice(),
     };
 

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -1,12 +1,15 @@
 import type { FunctionDeclaration, VariableDeclaration } from "estree";
 import type {
   ComponentContext,
+  ComponentCssPart,
+  ComponentCssProperty,
   ComponentElement,
   ComponentEvent,
   ComponentGenerics,
   ComponentInlineElement,
   ComponentProp,
   ComponentPropBindings,
+  CustomElementOptions,
   Extends,
   InternalComponentSlot,
   LexicalScope,
@@ -43,6 +46,7 @@ export interface ParserContext {
   rest_props?: RestProps;
   extends?: Extends;
   customElementTag?: string;
+  customElement?: CustomElementOptions;
   componentComment?: string;
   componentCommentSource?: SourceRange;
   generics: ComponentGenerics;
@@ -92,6 +96,11 @@ export interface ParserContext {
   readonly slots: Map<string | null, InternalComponentSlot>;
   readonly snippetPropLocals: Set<string>;
 
+  /** From component-level `@csspart` JSDoc tags. */
+  readonly cssParts: ComponentCssPart[];
+  /** From component-level `@cssprop`/`@cssproperty` JSDoc tags. */
+  readonly cssProperties: ComponentCssProperty[];
+
   /** `@template` tags from a `@slot`/`@snippet` block (no `@extends`), held until finalization. */
   deferredSlotBlockGenerics: Array<{ name: string; constraint: string }>;
 
@@ -132,6 +141,7 @@ export function createParserContext(): ParserContext {
     rest_props: undefined,
     extends: undefined,
     customElementTag: undefined,
+    customElement: undefined,
     componentComment: undefined,
     componentCommentSource: undefined,
     generics: null,
@@ -161,6 +171,8 @@ export function createParserContext(): ParserContext {
     activeScopes: [],
     slots: new Map(),
     snippetPropLocals: new Set(),
+    cssParts: [],
+    cssProperties: [],
     deferredSlotBlockGenerics: [],
     events: new Map(),
     eventDescriptions: new Map(),

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -186,6 +186,9 @@ export function getCommentTags(parsed: JSDocComment[]) {
     "deprecated",
     "ignore",
     "internal",
+    "csspart",
+    "cssprop",
+    "cssproperty",
   ]);
 
   let typeTag: (typeof tags)[number] | undefined;
@@ -828,6 +831,25 @@ export function parseCustomTypes(
               if (slot) slot.tags = [...(slot.tags ?? []), trailingTag];
             };
           }
+          break;
+        }
+        case "csspart": {
+          const partDescription = cleanDescription(getInlineTagDescription(tagSource));
+          ctx.cssParts.push({
+            name,
+            ...(partDescription ? { description: partDescription } : {}),
+          });
+          break;
+        }
+        case "cssprop":
+        case "cssproperty": {
+          const propertyDescription = cleanDescription(getInlineTagDescription(tagSource));
+          ctx.cssProperties.push({
+            name,
+            ...(type ? { type } : {}),
+            ...(defaultValue === undefined ? {} : { default: defaultValue }),
+            ...(propertyDescription ? { description: propertyDescription } : {}),
+          });
           break;
         }
         case "event": {

--- a/src/parser/runes-props.ts
+++ b/src/parser/runes-props.ts
@@ -2,6 +2,8 @@ import type { AssignmentPattern, Identifier, Property, VariableDeclaration, Vari
 import { getTypeCastAnnotation, isCallExpressionNamed, unwrapTypeCastExpression } from "../ast-guards";
 import type ComponentParser from "../ComponentParser";
 import type {
+  CustomElementPropConfig,
+  CustomElementPropType,
   ModernRunesTypeMember,
   ModernRunesTypeNode,
   ModernScriptNode,
@@ -228,8 +230,33 @@ type ModernParsedRoot = {
     };
   };
   module?: ModernScriptNode;
-  options?: { customElement?: { tag?: string }; runes?: boolean } | null;
+  options?: {
+    customElement?: {
+      tag?: string;
+      shadow?: "open" | "none" | unknown;
+      props?: Record<string, ModernCustomElementPropConfig>;
+      extend?: unknown;
+    };
+    runes?: boolean;
+  } | null;
 };
+
+type ModernCustomElementPropConfig = { attribute?: string; reflect?: boolean; type?: CustomElementPropType };
+
+/** JSON-safe copy of the raw `customElement.props` config read off `modernParsedRoot.options`. */
+function buildCustomElementPropConfigs(
+  props: Record<string, ModernCustomElementPropConfig>,
+): Record<string, CustomElementPropConfig> {
+  const result: Record<string, CustomElementPropConfig> = {};
+  for (const [name, config] of Object.entries(props)) {
+    result[name] = {
+      ...(config.attribute === undefined ? {} : { attribute: config.attribute }),
+      ...(config.reflect === undefined ? {} : { reflect: config.reflect }),
+      ...(config.type === undefined ? {} : { type: config.type }),
+    };
+  }
+  return result;
+}
 
 /**
  * Reads type imports, local types, explicit `export let` annotations, and
@@ -251,7 +278,16 @@ export function buildRunesPropTypeMetadata(parser: ComponentParser, ctx: ParserC
   const modernParsed = modernParsedRoot as ModernParsedRoot;
 
   ctx.scriptLanguage = parser.resolveScriptLanguage(modernParsed);
-  ctx.customElementTag = modernParsed.options?.customElement?.tag;
+  const customElement = modernParsed.options?.customElement;
+  ctx.customElementTag = customElement?.tag;
+  ctx.customElement = customElement
+    ? {
+        ...(customElement.tag === undefined ? {} : { tag: customElement.tag }),
+        ...(customElement.shadow === "open" || customElement.shadow === "none" ? { shadow: customElement.shadow } : {}),
+        ...(customElement.props ? { props: buildCustomElementPropConfigs(customElement.props) } : {}),
+        ...(customElement.extend === undefined ? {} : { extend: true as const }),
+      }
+    : undefined;
   ctx.runesOptionOverride = modernParsed.options?.runes;
   ctx.scriptGenericsAttribute = parser.resolveScriptGenericsAttribute(modernParsed);
   const body = modernParsed.instance?.content?.body ?? [];

--- a/src/template-parse/read-options.ts
+++ b/src/template-parse/read-options.ts
@@ -1,10 +1,15 @@
 import type { AST } from "svelte/compiler";
 
 /**
- * From svelte's `read/options.js`, but only `runes` and `customElement.tag`.
- * Those are the two `<svelte:options>` fields `src/parser/runes-props.ts` reads.
- * Doesn't validate reserved tag names or malformed objects. The shim test
- * drops any field this doesn't populate.
+ * From svelte's `read/options.js`, but only `runes` and `customElement`
+ * (both the `tag` shorthand and the object form's `tag`/`shadow`/`props`/
+ * `extend`). Those are the `<svelte:options>` fields `src/parser/runes-props.ts`
+ * reads. Doesn't validate reserved tag names or malformed objects - a
+ * malformed property is skipped rather than erroring. The shim test drops
+ * any field this doesn't populate, and structurally compares whatever it
+ * does against svelte's own `read_options`, so shapes here must match
+ * `AST.SvelteOptions['customElement']` exactly (e.g. `extend` stays the raw
+ * expression node, not a boolean).
  */
 export function readOptions(node: { start: number; end: number; attributes: AST.Attribute[] }): AST.SvelteOptions {
   const options: AST.SvelteOptions = {
@@ -22,8 +27,8 @@ export function readOptions(node: { start: number; end: number; attributes: AST.
     }
 
     if (attribute.name === "customElement") {
-      const tag = getCustomElementTag(attribute);
-      if (tag !== undefined) options.customElement = { tag };
+      const customElement = getCustomElement(attribute);
+      if (customElement !== undefined) options.customElement = customElement;
     }
   }
 
@@ -42,7 +47,59 @@ function getStaticValue(attribute: AST.Attribute): unknown {
   return chunk.expression.value;
 }
 
-function getCustomElementTag(attribute: AST.Attribute): string | undefined {
+type CustomElement = NonNullable<AST.SvelteOptions["customElement"]>;
+type CustomElementPropConfig = NonNullable<CustomElement["props"]>[string];
+
+const CUSTOM_ELEMENT_PROP_TYPES = new Set(["String", "Boolean", "Number", "Array", "Object"]);
+
+/** Non-computed `Identifier`-keyed properties of an `ObjectExpression`, as `[name, value]` pairs. */
+function namedProperties(objectExpression: { properties: unknown[] }): Array<[string, unknown]> {
+  const pairs: Array<[string, unknown]> = [];
+  for (const property of objectExpression.properties) {
+    if (
+      !property ||
+      typeof property !== "object" ||
+      (property as { type?: string }).type !== "Property" ||
+      (property as { computed?: boolean }).computed ||
+      (property as { key?: { type?: string } }).key?.type !== "Identifier"
+    ) {
+      continue;
+    }
+    const { key, value } = property as { key: { name: string }; value: unknown };
+    pairs.push([key.name, value]);
+  }
+  return pairs;
+}
+
+/** `customElement.props.<name>` config: `{ attribute?, reflect?, type? }`. Invalid entries are skipped. */
+function getCustomElementPropConfig(value: unknown): CustomElementPropConfig {
+  const config: CustomElementPropConfig = {};
+  if (!value || typeof value !== "object" || (value as { type?: string }).type !== "ObjectExpression") return config;
+
+  for (const [name, propValue] of namedProperties(value as { properties: unknown[] })) {
+    if (!propValue || typeof propValue !== "object" || (propValue as { type?: string }).type !== "Literal") continue;
+    const literalValue = (propValue as { value: unknown }).value;
+
+    if (name === "attribute" && typeof literalValue === "string") {
+      config.attribute = literalValue;
+    } else if (name === "reflect" && typeof literalValue === "boolean") {
+      config.reflect = literalValue;
+    } else if (name === "type" && typeof literalValue === "string" && CUSTOM_ELEMENT_PROP_TYPES.has(literalValue)) {
+      config.type = literalValue as "String" | "Boolean" | "Number" | "Array" | "Object";
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Parses `customElement="my-el"` (shorthand) or `customElement={{ tag, shadow,
+ * props, extend }}` (object form) into svelte's own `AST.SvelteOptions['customElement']`
+ * shape. `shadow`'s `ObjectExpression` form and `extend` are kept as the raw
+ * expression node (unused by sveld beyond presence checks downstream), matching
+ * what svelte's real parser produces, for shim-test parity.
+ */
+function getCustomElement(attribute: AST.Attribute): AST.SvelteOptions["customElement"] {
   const { value } = attribute;
   if (value === true) return undefined;
 
@@ -52,24 +109,50 @@ function getCustomElementTag(attribute: AST.Attribute): string | undefined {
   // `customElement="my-el"` shorthand.
   if (chunk.type === "Text") {
     const tag = getStaticValue(attribute);
-    return typeof tag === "string" ? tag : undefined;
+    return typeof tag === "string" ? { tag } : undefined;
   }
 
-  // `customElement={{ tag: 'my-el', ... }}`. Only `tag` is extracted.
-  if (chunk.expression.type === "ObjectExpression") {
-    for (const property of chunk.expression.properties) {
-      if (
-        property.type === "Property" &&
-        !property.computed &&
-        property.key.type === "Identifier" &&
-        property.key.name === "tag" &&
-        property.value.type === "Literal" &&
-        typeof property.value.value === "string"
-      ) {
-        return property.value.value;
-      }
+  const expression = chunk.expression;
+  if (expression.type === "Literal" && expression.value === null) return undefined;
+  if (expression.type !== "ObjectExpression") return undefined;
+
+  const properties = namedProperties(expression);
+  const customElement: CustomElement = {};
+
+  const tagValue = properties.find(([name]) => name === "tag")?.[1];
+  if (
+    tagValue &&
+    typeof tagValue === "object" &&
+    (tagValue as { type?: string }).type === "Literal" &&
+    typeof (tagValue as { value: unknown }).value === "string"
+  ) {
+    customElement.tag = (tagValue as { value: string }).value;
+  }
+
+  const propsValue = properties.find(([name]) => name === "props")?.[1];
+  if (propsValue && typeof propsValue === "object" && (propsValue as { type?: string }).type === "ObjectExpression") {
+    customElement.props = {};
+    for (const [name, config] of namedProperties(propsValue as { properties: unknown[] })) {
+      customElement.props[name] = getCustomElementPropConfig(config);
     }
   }
 
-  return undefined;
+  const shadowValue = properties.find(([name]) => name === "shadow")?.[1];
+  if (shadowValue && typeof shadowValue === "object") {
+    const shadowNode = shadowValue as { type?: string; value?: unknown };
+    if (shadowNode.type === "Literal" && (shadowNode.value === "open" || shadowNode.value === "none")) {
+      customElement.shadow = shadowNode.value;
+    } else if (shadowNode.type === "ObjectExpression") {
+      // biome-ignore lint/suspicious/noExplicitAny: mirrors svelte's own `AST.SvelteOptions['customElement']['shadow']`, which types this branch as a raw `ObjectExpression`.
+      customElement.shadow = shadowValue as any;
+    }
+  }
+
+  const extendValue = properties.find(([name]) => name === "extend")?.[1];
+  if (extendValue !== undefined) {
+    // biome-ignore lint/suspicious/noExplicitAny: mirrors svelte's own `AST.SvelteOptions['customElement']['extend']`, a raw `ArrowFunctionExpression | Identifier` node.
+    customElement.extend = extendValue as any;
+  }
+
+  return customElement;
 }

--- a/src/writer/markdown-format-utils.ts
+++ b/src/writer/markdown-format-utils.ts
@@ -12,6 +12,9 @@ export const SLOT_TABLE_HEADER =
   "| Slot name | Default | Props | Fallback | Description |\n| :- | :- | :- | :- | :- |\n";
 export const EVENT_TABLE_HEADER = "| Event name | Type | Detail | Description |\n| :- | :- | :- | :- |\n";
 export const EXPORT_TABLE_HEADER = "| Name | Kind | Type | Description |\n| :- | :- | :- | :- |\n";
+export const CSS_PART_TABLE_HEADER = "| Part name | Description |\n| :- | :- |\n";
+export const CSS_PROPERTY_TABLE_HEADER =
+  "| Property name | Type | Default value | Description |\n| :- | :- | :- | :- |\n";
 
 const PIPE_REGEX = /\|/g;
 const LT_REGEX = /</g;

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -3,6 +3,8 @@ import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import { buildComponentApiDocument } from "./document-model";
 import type { AppendType } from "./MarkdownWriterBase";
 import {
+  CSS_PART_TABLE_HEADER,
+  CSS_PROPERTY_TABLE_HEADER,
   EVENT_TABLE_HEADER,
   EXPORT_TABLE_HEADER,
   formatDescriptionWithTags,
@@ -149,4 +151,27 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
       );
     }
   });
+
+  if (component.cssParts && component.cssParts.length > 0) {
+    document.append("h3", "CSS Parts");
+    document.append("raw", CSS_PART_TABLE_HEADER);
+    for (const cssPart of component.cssParts) {
+      document.append("raw", `| ${cssPart.name} | ${formatPropDescription(cssPart.description)} |\n`);
+    }
+    document.append("raw", "\n");
+  }
+
+  if (component.cssProperties && component.cssProperties.length > 0) {
+    document.append("h3", "CSS Custom Properties");
+    document.append("raw", CSS_PROPERTY_TABLE_HEADER);
+    for (const cssProperty of component.cssProperties) {
+      document.append(
+        "raw",
+        `| ${cssProperty.name} | ${formatPropType(cssProperty.type)} | ${formatPropValue(cssProperty.default)} | ${formatPropDescription(
+          cssProperty.description,
+        )} |\n`,
+      );
+    }
+    document.append("raw", "\n");
+  }
 }

--- a/src/writer/writer-custom-elements-core.ts
+++ b/src/writer/writer-custom-elements-core.ts
@@ -1,4 +1,5 @@
 import type { DeprecatedValue } from "../ComponentParser";
+import { splitTopLevelCommas } from "../parser/generics";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import { buildComponentApiDocument } from "./document-model";
 
@@ -22,11 +23,52 @@ export interface CemClassField {
   default?: string;
   description?: string;
   deprecated?: DeprecatedValue;
+  /** Present, and `true`, for an `export const` prop. */
+  readonly?: true;
+}
+
+export interface CemParameter {
+  name: string;
+  type?: CemType;
+  optional?: true;
+  rest?: true;
+}
+
+/** An `export function` prop (a Svelte accessor), mapped to a method instead of a field. */
+export interface CemClassMethod {
+  kind: "method";
+  name: string;
+  static: boolean;
+  parameters?: CemParameter[];
+  return?: { type: CemType };
+  description?: string;
+  deprecated?: DeprecatedValue;
 }
 
 export interface CemAttribute {
   name: string;
   fieldName: string;
+  type?: CemType;
+  default?: string;
+  description?: string;
+  /** Present, and `true`, when the prop's `customElement` config sets `reflect: true`. */
+  reflects?: true;
+}
+
+export interface CemCssPart {
+  name: string;
+  description?: string;
+}
+
+/**
+ * The published schema names this field `syntax` (a strict CSS
+ * `@property`-style syntax string, e.g. `"<color>"`). sveld's `@cssprop
+ * {type}` is free-form prose (e.g. `"Color"`), so it's emitted as `type.text`
+ * instead, matching every other typed field in this manifest.
+ */
+export interface CemCssCustomProperty {
+  /** Includes the leading `--`. */
+  name: string;
   type?: CemType;
   default?: string;
   description?: string;
@@ -49,10 +91,14 @@ export interface CemClassDeclaration {
   kind: "class";
   name: string;
   description?: string;
-  members: CemClassField[];
+  members: Array<CemClassField | CemClassMethod>;
   attributes: CemAttribute[];
   events: CemEvent[];
   slots: CemSlot[];
+  /** From component-level `@csspart` JSDoc tags. */
+  cssParts?: CemCssPart[];
+  /** From component-level `@cssprop`/`@cssproperty` JSDoc tags. */
+  cssProperties?: CemCssCustomProperty[];
   /** Only present when the source component sets `<svelte:options customElement="..." />`. */
   tagName?: string;
   /** Only present when the source component sets `<svelte:options customElement="..." />`. */
@@ -85,60 +131,178 @@ export interface CustomElementsManifest {
   modules: CemModule[];
 }
 
-/**
- * Attribute-compatible prop types: primitives only. Anything else (arrays,
- * objects, unions, custom types) is skipped, since sveld doesn't attempt to
- * infer how a complex type reflects to a DOM attribute string.
- */
-const PRIMITIVE_ATTRIBUTE_TYPES = new Set(["string", "number", "boolean"]);
+type ComponentPropApi = ComponentDocApi["props"][number];
 
-function buildMembers(props: ComponentDocApi["props"]): CemClassField[] {
-  return props.map((prop) => ({
-    kind: "field",
-    name: prop.name,
-    ...(prop.type ? { type: { text: prop.type } } : {}),
-    ...(prop.value === undefined ? {} : { default: prop.value }),
-    ...(prop.description ? { description: prop.description } : {}),
-    ...(prop.deprecated === undefined ? {} : { deprecated: prop.deprecated }),
-  }));
+/**
+ * Splits an accessor's TS signature text (e.g. `"(input: string) => number"`,
+ * produced by {@link buildFunctionDeclarationSignature} when there's no
+ * `@param`/`@returns` JSDoc to prefer instead) into CEM parameters/return.
+ * Textual split, not a real type parse: params are whatever's between the
+ * signature's leading balanced `(...)`, split on top-level commas.
+ */
+const ARROW_PREFIX_REGEX = /^=>\s*/;
+
+function parseAccessorSignatureText(signature: string): { parameters: CemParameter[]; returnTypeText: string } {
+  const trimmed = signature.trim();
+  if (!trimmed.startsWith("(")) return { parameters: [], returnTypeText: trimmed || "any" };
+
+  let depth = 0;
+  let closeIndex = -1;
+  for (let i = 0; i < trimmed.length; i++) {
+    if (trimmed[i] === "(") depth++;
+    else if (trimmed[i] === ")") {
+      depth--;
+      if (depth === 0) {
+        closeIndex = i;
+        break;
+      }
+    }
+  }
+  if (closeIndex === -1) return { parameters: [], returnTypeText: "any" };
+
+  const paramsText = trimmed.slice(1, closeIndex).trim();
+  const returnText = trimmed
+    .slice(closeIndex + 1)
+    .trim()
+    .replace(ARROW_PREFIX_REGEX, "");
+
+  const parameters =
+    paramsText === ""
+      ? []
+      : splitTopLevelCommas(paramsText).map((paramText): CemParameter => {
+          const text = paramText.trim();
+          const isRest = text.startsWith("...");
+          const rest = isRest ? text.slice(3) : text;
+          const colonIndex = rest.indexOf(":");
+          const namePart = (colonIndex === -1 ? rest : rest.slice(0, colonIndex)).trim();
+          const typeText = colonIndex === -1 ? undefined : rest.slice(colonIndex + 1).trim();
+          const optional = namePart.endsWith("?");
+
+          return {
+            name: optional ? namePart.slice(0, -1) : namePart,
+            ...(typeText ? { type: { text: typeText } } : {}),
+            ...(optional ? { optional: true } : {}),
+            ...(isRest ? { rest: true } : {}),
+          };
+        });
+
+  return { parameters, returnTypeText: returnText || "any" };
 }
 
 /**
- * Derives attributes from props whose name is already attribute-compatible
- * (Svelte's custom-element runtime lowercases the prop name by default,
- * `key.toLowerCase()`) and whose type is a bare primitive. Props that would
- * collide on the same lowercased attribute name are dropped on both sides,
- * since which prop wins at runtime is ambiguous.
+ * Parameters/return for an `export function` accessor prop. JSDoc
+ * `@param`/`@returns` win when present (already structured on the prop);
+ * otherwise falls back to splitting the prop's TS signature text.
  */
-function buildAttributes(props: ComponentDocApi["props"]): CemAttribute[] {
-  const byAttributeName = new Map<string, ComponentDocApi["props"]>();
-
-  for (const prop of props) {
-    if (!prop.type || !PRIMITIVE_ATTRIBUTE_TYPES.has(prop.type.trim())) continue;
-
-    const attributeName = prop.name.toLowerCase();
-    const existing = byAttributeName.get(attributeName);
-    if (existing) {
-      existing.push(prop);
-    } else {
-      byAttributeName.set(attributeName, [prop]);
-    }
+function accessorParametersAndReturn(prop: ComponentPropApi): { parameters: CemParameter[]; returnTypeText: string } {
+  if (prop.params !== undefined || prop.returnType !== undefined) {
+    const parameters = (prop.params ?? []).map(
+      (param): CemParameter => ({
+        name: param.name,
+        ...(param.type ? { type: { text: param.type } } : {}),
+        ...(param.optional ? { optional: true } : {}),
+      }),
+    );
+    return { parameters, returnTypeText: prop.returnType ?? "any" };
   }
 
+  return prop.type ? parseAccessorSignatureText(prop.type) : { parameters: [], returnTypeText: "any" };
+}
+
+function buildMembers(props: ComponentDocApi["props"]): Array<CemClassField | CemClassMethod> {
+  return props.map((prop): CemClassField | CemClassMethod => {
+    if (prop.isFunctionDeclaration) {
+      const { parameters, returnTypeText } = accessorParametersAndReturn(prop);
+      return {
+        kind: "method",
+        name: prop.name,
+        static: false,
+        ...(parameters.length > 0 ? { parameters } : {}),
+        return: { type: { text: returnTypeText } },
+        ...(prop.description ? { description: prop.description } : {}),
+        ...(prop.deprecated === undefined ? {} : { deprecated: prop.deprecated }),
+      };
+    }
+
+    return {
+      kind: "field",
+      name: prop.name,
+      ...(prop.type ? { type: { text: prop.type } } : {}),
+      ...(prop.value === undefined ? {} : { default: prop.value }),
+      ...(prop.description ? { description: prop.description } : {}),
+      ...(prop.deprecated === undefined ? {} : { deprecated: prop.deprecated }),
+      ...(prop.kind === "const" ? { readonly: true } : {}),
+    };
+  });
+}
+
+/**
+ * Derives attributes from every prop (Svelte's custom-element runtime
+ * observes an attribute for every prop by default, converting to/from JSON
+ * for `Array`/`Object`-typed props), excluding `export function` accessors
+ * (those aren't part of Svelte's props definition; see {@link buildMembers}).
+ * The attribute name is the `customElement.props.<name>.attribute` config
+ * when present, the lowercased prop name otherwise; `attribute: false` in
+ * that config omits the prop's attribute entirely. Props that collide on the
+ * same attribute name keep the first (in declaration order); the rest are
+ * skipped with a console warning, since which prop wins at runtime is
+ * ambiguous.
+ */
+function buildAttributes(component: ComponentDocApi): CemAttribute[] {
+  const propConfigs = component.customElement?.props;
+  const claimedBy = new Map<string, string>();
   const attributes: CemAttribute[] = [];
-  for (const [attributeName, candidates] of byAttributeName) {
-    if (candidates.length !== 1) continue;
-    const prop = candidates[0];
+
+  for (const prop of component.props) {
+    if (prop.isFunctionDeclaration) continue;
+
+    const config = propConfigs?.[prop.name];
+    if (config?.attribute === false) continue;
+
+    const attributeName = config?.attribute || prop.name.toLowerCase();
+    const claimedByFieldName = claimedBy.get(attributeName);
+    if (claimedByFieldName !== undefined) {
+      console.warn(
+        `sveld: props "${claimedByFieldName}" and "${prop.name}" of component "${component.moduleName}" both map to the custom-element attribute "${attributeName}"; only "${claimedByFieldName}" is included.`,
+      );
+      continue;
+    }
+    claimedBy.set(attributeName, prop.name);
+
+    const isJsonSerialized = config?.type === "Array" || config?.type === "Object";
+    const description = isJsonSerialized
+      ? [prop.description, "Serialized to/from JSON for the attribute."].filter(Boolean).join(" ")
+      : prop.description;
+
     attributes.push({
       name: attributeName,
       fieldName: prop.name,
-      type: { text: prop.type as string },
+      ...(prop.type ? { type: { text: prop.type } } : {}),
       ...(prop.value === undefined ? {} : { default: prop.value }),
-      ...(prop.description ? { description: prop.description } : {}),
+      ...(description ? { description } : {}),
+      ...(config?.reflect ? { reflects: true } : {}),
     });
   }
 
   return attributes;
+}
+
+function buildCssParts(cssParts: ComponentDocApi["cssParts"]): CemCssPart[] | undefined {
+  if (!cssParts || cssParts.length === 0) return undefined;
+  return cssParts.map((cssPart) => ({
+    name: cssPart.name,
+    ...(cssPart.description ? { description: cssPart.description } : {}),
+  }));
+}
+
+function buildCssProperties(cssProperties: ComponentDocApi["cssProperties"]): CemCssCustomProperty[] | undefined {
+  if (!cssProperties || cssProperties.length === 0) return undefined;
+  return cssProperties.map((cssProperty) => ({
+    name: cssProperty.name,
+    ...(cssProperty.type ? { type: { text: cssProperty.type } } : {}),
+    ...(cssProperty.default === undefined ? {} : { default: cssProperty.default }),
+    ...(cssProperty.description ? { description: cssProperty.description } : {}),
+  }));
 }
 
 function buildEvents(events: ComponentDocApi["events"]): CemEvent[] {
@@ -161,14 +325,19 @@ function buildSlots(slots: ComponentDocApi["slots"]): CemSlot[] {
 }
 
 function buildDeclaration(component: ComponentDocApi): CemClassDeclaration {
+  const cssParts = buildCssParts(component.cssParts);
+  const cssProperties = buildCssProperties(component.cssProperties);
+
   const declaration: CemClassDeclaration = {
     kind: "class",
     name: component.moduleName,
     ...(component.componentComment ? { description: component.componentComment } : {}),
     members: buildMembers(component.props),
-    attributes: buildAttributes(component.props),
+    attributes: buildAttributes(component),
     events: buildEvents(component.events),
     slots: buildSlots(component.slots),
+    ...(cssParts ? { cssParts } : {}),
+    ...(cssProperties ? { cssProperties } : {}),
   };
 
   if (component.customElementTag) {

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -552,4 +552,64 @@ describe("WriterMarkdown", () => {
     expect(positions.every((position) => position !== -1)).toBe(true);
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
+
+  test("renders CSS Parts and CSS Custom Properties tables only when present", () => {
+    const withCss = writeMarkdownCore(
+      new Map([
+        [
+          "Card",
+          {
+            filePath: asNormalizedPath("Card.svelte"),
+            moduleName: "Card",
+            syntaxMode: "legacy",
+            props: [],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+            cssParts: [{ name: "header", description: "Styles the header region." }],
+            cssProperties: [
+              { name: "--card-background", type: "Color", default: "white", description: "Card background." },
+              { name: "--card-border-color", description: "Card border color." },
+            ],
+          },
+        ],
+      ]),
+    );
+
+    expect(withCss).toContain("### CSS Parts");
+    expect(withCss).toContain("| Part name | Description |");
+    expect(withCss).toContain("| header | Styles the header region. |");
+    expect(withCss).toContain("### CSS Custom Properties");
+    expect(withCss).toContain("| Property name | Type | Default value | Description |");
+    expect(withCss).toContain("| --card-background | <code>Color</code> | <code>white</code> | Card background. |");
+    expect(withCss).toContain("| --card-border-color | -- | -- | Card border color. |");
+
+    const withoutCss = writeMarkdownCore(
+      new Map([
+        [
+          "Plain",
+          {
+            filePath: asNormalizedPath("Plain.svelte"),
+            moduleName: "Plain",
+            syntaxMode: "legacy",
+            props: [],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(withoutCss).not.toContain("CSS Parts");
+    expect(withoutCss).not.toContain("CSS Custom Properties");
+  });
 });

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -92,8 +92,43 @@ describe("component API JSON schema", () => {
         "componentCommentSource",
         "contexts",
         "customElementTag",
+        "customElement",
+        "cssParts",
+        "cssProperties",
       ]),
     );
+  });
+
+  test("documents the object-form customElement config and CSS parts/properties", () => {
+    const schema = readJson("schema/component-api.schema.json");
+    const defs = objectProperty(schema, "$defs");
+
+    const customElementProperties = objectProperty(objectProperty(defs, "customElement"), "properties");
+    expect(Object.keys(customElementProperties)).toEqual(expect.arrayContaining(["tag", "shadow", "props", "extend"]));
+
+    const propConfigProperties = objectProperty(objectProperty(defs, "customElementPropConfig"), "properties");
+    expect(Object.keys(propConfigProperties)).toEqual(expect.arrayContaining(["attribute", "reflect", "type"]));
+
+    expect(stringArrayProperty(objectProperty(defs, "cssPart"), "required")).toEqual(["name"]);
+    expect(stringArrayProperty(objectProperty(defs, "cssProperty"), "required")).toEqual(["name"]);
+
+    const parser = new ComponentParser();
+    const filePath = path.join(root, "tests", "fixtures", "cem-custom-element-object-config", "input.svelte");
+    const source = readFileSync(filePath, "utf-8");
+    const parsed = parser.parseSvelteComponent(source, { filePath, moduleName: "CemCustomElementObjectConfig" });
+    const components: ComponentDocs = new Map([
+      [
+        "CemCustomElementObjectConfig",
+        { ...parsed, moduleName: "CemCustomElementObjectConfig", filePath: asNormalizedPath(filePath) },
+      ],
+    ]);
+
+    const ajv = new Ajv2020({ strict: true, allErrors: true });
+    const validate = ajv.compile(schema);
+    const document = buildComponentApiDocument(components);
+    const valid = validate(document);
+    if (!valid) throw new Error(`Schema validation failed:\n${ajv.errorsText(validate.errors, { separator: "\n" })}`);
+    expect(valid).toBe(true);
   });
 
   test("documents the optional entry exports collection", () => {

--- a/tests/custom-elements-schema.test.ts
+++ b/tests/custom-elements-schema.test.ts
@@ -7,10 +7,11 @@ import { asNormalizedPath, buildCustomElementsManifest, type ComponentDocs, Comp
 
 const root = process.cwd();
 
-// Same representative prefixes as tests/component-api-schema.test.ts: every
-// syntax mode plus the typedef/context/slot metadata shapes, without paying
-// for all ~90 fixtures on every run.
-const FIXTURE_PREFIXES = ["runes-", "legacy-", "typedef-", "context-", "slot-"];
+// Same representative prefixes as tests/component-api-schema.test.ts (every
+// syntax mode plus the typedef/context/slot metadata shapes), plus every
+// `cem-*` fixture exercising Custom Elements Manifest fidelity - without
+// paying for all ~90 fixtures on every run.
+const FIXTURE_PREFIXES = ["runes-", "legacy-", "typedef-", "context-", "slot-", "cem-"];
 
 async function buildRepresentativeFixtureComponents(): Promise<ComponentDocs> {
   const fixturesRoot = path.join(root, "tests", "fixtures");

--- a/tests/fixtures/cem-accessor-methods/input.svelte
+++ b/tests/fixtures/cem-accessor-methods/input.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  export const version = "1.0.0";
+
+  /**
+   * @param {string} label - The new label text
+   * @returns {string} The previous label text
+   */
+  export function setLabel(label: string): string {
+    return label;
+  }
+
+  export function getCount(): number {
+    return 0;
+  }
+</script>
+
+<div>{version}</div>

--- a/tests/fixtures/cem-accessor-methods/output-class.d.ts
+++ b/tests/fixtures/cem-accessor-methods/output-class.d.ts
@@ -1,0 +1,15 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type CemAccessorMethodsProps = Record<string, never>;
+
+export default class CemAccessorMethods extends SvelteComponentTyped<
+  CemAccessorMethodsProps,
+  Record<string, any>,
+  Record<string, never>
+> {
+  version: string;
+
+  setLabel: (label: string) => string;
+
+  getCount: () => number;
+}

--- a/tests/fixtures/cem-accessor-methods/output-component.d.ts
+++ b/tests/fixtures/cem-accessor-methods/output-component.d.ts
@@ -1,0 +1,18 @@
+import type { Component } from "svelte";
+
+export type CemAccessorMethodsProps = Record<string, never>;
+
+export type CemAccessorMethodsExports = {
+  version: string;
+
+  setLabel: (label: string) => string;
+
+  getCount: () => number;
+};
+
+declare const CemAccessorMethods: Component<
+  CemAccessorMethodsProps,
+  CemAccessorMethodsExports,
+  ""
+>;
+export default CemAccessorMethods;

--- a/tests/fixtures/cem-accessor-methods/output.json
+++ b/tests/fixtures/cem-accessor-methods/output.json
@@ -1,0 +1,101 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 18,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "version",
+      "kind": "const",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"1.0.0\"",
+      "defaultValue": {
+        "raw": "\"1.0.0\"",
+        "kind": "literal",
+        "value": "1.0.0"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": true,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 33
+        }
+      }
+    },
+    {
+      "name": "setLabel",
+      "kind": "function",
+      "type": "(label: string) => string",
+      "typeSource": "typescript",
+      "params": [
+        {
+          "name": "label",
+          "type": "string",
+          "description": "The new label text",
+          "optional": false
+        }
+      ],
+      "returnType": "string",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 3
+        }
+      }
+    },
+    {
+      "name": "getCount",
+      "kind": "function",
+      "type": "() => number",
+      "typeSource": "typescript",
+      "isFunction": true,
+      "isFunctionDeclaration": true,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 2
+        },
+        "end": {
+          "line": 14,
+          "column": 3
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "diagnostics": []
+}

--- a/tests/fixtures/cem-attribute-collision/input.svelte
+++ b/tests/fixtures/cem-attribute-collision/input.svelte
@@ -1,0 +1,9 @@
+<script>
+  /** Lowercase value. */
+  export let value = "";
+
+  /** Capitalized value collides with `value` on the attribute name. */
+  export let Value = "";
+</script>
+
+<div>{value}{Value}</div>

--- a/tests/fixtures/cem-attribute-collision/output-class.d.ts
+++ b/tests/fixtures/cem-attribute-collision/output-class.d.ts
@@ -1,0 +1,21 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type CemAttributeCollisionProps = {
+  /**
+   * Lowercase value.
+   * @default ""
+   */
+  value?: string;
+
+  /**
+   * Capitalized value collides with `value` on the attribute name.
+   * @default ""
+   */
+  Value?: string;
+};
+
+export default class CemAttributeCollision extends SvelteComponentTyped<
+  CemAttributeCollisionProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/cem-attribute-collision/output-component.d.ts
+++ b/tests/fixtures/cem-attribute-collision/output-component.d.ts
@@ -1,0 +1,24 @@
+import type { Component } from "svelte";
+
+export type CemAttributeCollisionProps = {
+  /**
+   * Lowercase value.
+   * @default ""
+   */
+  value?: string;
+
+  /**
+   * Capitalized value collides with `value` on the attribute name.
+   * @default ""
+   */
+  Value?: string;
+};
+
+export type CemAttributeCollisionExports = Record<string, never>;
+
+declare const CemAttributeCollision: Component<
+  CemAttributeCollisionProps,
+  CemAttributeCollisionExports,
+  ""
+>;
+export default CemAttributeCollision;

--- a/tests/fixtures/cem-attribute-collision/output.json
+++ b/tests/fixtures/cem-attribute-collision/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 11,
+      "line": 10,
       "column": 0
     }
   },
@@ -13,9 +13,9 @@
   "scriptLanguage": "js",
   "props": [
     {
-      "name": "label",
+      "name": "value",
       "kind": "let",
-      "description": "The badge label.",
+      "description": "Lowercase value.",
       "type": "string",
       "typeSource": "default",
       "value": "\"\"",
@@ -31,41 +31,49 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 5,
+          "line": 3,
           "column": 2
         },
         "end": {
-          "line": 5,
+          "line": 3,
+          "column": 24
+        }
+      }
+    },
+    {
+      "name": "Value",
+      "kind": "let",
+      "description": "Capitalized value collides with `value` on the attribute name.",
+      "type": "string",
+      "typeSource": "default",
+      "value": "\"\"",
+      "defaultValue": {
+        "raw": "\"\"",
+        "kind": "literal",
+        "value": ""
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
           "column": 24
         }
       }
     }
   ],
   "moduleExports": [],
-  "slots": [
-    {
-      "name": null,
-      "default": true,
-      "slot_props": "Record<string, never>",
-      "source": {
-        "start": {
-          "line": 10,
-          "column": 0
-        },
-        "end": {
-          "line": 10,
-          "column": 8
-        }
-      }
-    }
-  ],
+  "slots": [],
   "events": [],
   "typedefs": [],
   "generics": null,
   "contexts": [],
-  "customElementTag": "x-badge",
-  "customElement": {
-    "tag": "x-badge"
-  },
   "diagnostics": []
 }

--- a/tests/fixtures/cem-css-parts-and-props/input.svelte
+++ b/tests/fixtures/cem-css-parts-and-props/input.svelte
@@ -1,0 +1,17 @@
+<script>
+  /** The card's title. */
+  export let title = "";
+
+  /**
+   * @csspart header - Styles the header region.
+   * @csspart body - Styles the body region.
+   * @cssprop {Color} [--card-background=white] - Background color of the card.
+   * @cssprop --card-border-color - Border color of the card.
+   * @cssproperty {Length} [--card-padding=1rem] - Padding inside the card.
+   */
+</script>
+
+<div>
+  <div part="header">{title}</div>
+  <div part="body"><slot /></div>
+</div>

--- a/tests/fixtures/cem-css-parts-and-props/output-class.d.ts
+++ b/tests/fixtures/cem-css-parts-and-props/output-class.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type CemCssPartsAndPropsProps = {
+  /**
+   * The card's title.
+   * @default ""
+   */
+  title?: string;
+
+  children?: (this: void) => void;
+};
+
+export default class CemCssPartsAndProps extends SvelteComponentTyped<
+  CemCssPartsAndPropsProps,
+  Record<string, any>,
+  { default: Record<string, never> }
+> {}

--- a/tests/fixtures/cem-css-parts-and-props/output-component.d.ts
+++ b/tests/fixtures/cem-css-parts-and-props/output-component.d.ts
@@ -1,0 +1,20 @@
+import type { Component } from "svelte";
+
+export type CemCssPartsAndPropsProps = {
+  /**
+   * The card's title.
+   * @default ""
+   */
+  title?: string;
+
+  children?: (this: void) => void;
+};
+
+export type CemCssPartsAndPropsExports = Record<string, never>;
+
+declare const CemCssPartsAndProps: Component<
+  CemCssPartsAndPropsProps,
+  CemCssPartsAndPropsExports,
+  ""
+>;
+export default CemCssPartsAndProps;

--- a/tests/fixtures/cem-css-parts-and-props/output.json
+++ b/tests/fixtures/cem-css-parts-and-props/output.json
@@ -5,7 +5,7 @@
       "column": 0
     },
     "end": {
-      "line": 11,
+      "line": 18,
       "column": 0
     }
   },
@@ -13,9 +13,9 @@
   "scriptLanguage": "js",
   "props": [
     {
-      "name": "label",
+      "name": "title",
       "kind": "let",
-      "description": "The badge label.",
+      "description": "The card's title.",
       "type": "string",
       "typeSource": "default",
       "value": "\"\"",
@@ -31,11 +31,11 @@
       "reactive": false,
       "source": {
         "start": {
-          "line": 5,
+          "line": 3,
           "column": 2
         },
         "end": {
-          "line": 5,
+          "line": 3,
           "column": 24
         }
       }
@@ -49,12 +49,12 @@
       "slot_props": "Record<string, never>",
       "source": {
         "start": {
-          "line": 10,
-          "column": 0
+          "line": 16,
+          "column": 19
         },
         "end": {
-          "line": 10,
-          "column": 8
+          "line": 16,
+          "column": 27
         }
       }
     }
@@ -63,9 +63,33 @@
   "typedefs": [],
   "generics": null,
   "contexts": [],
-  "customElementTag": "x-badge",
-  "customElement": {
-    "tag": "x-badge"
-  },
+  "cssParts": [
+    {
+      "name": "header",
+      "description": "Styles the header region."
+    },
+    {
+      "name": "body",
+      "description": "Styles the body region."
+    }
+  ],
+  "cssProperties": [
+    {
+      "name": "--card-background",
+      "type": "Color",
+      "default": "white",
+      "description": "Background color of the card."
+    },
+    {
+      "name": "--card-border-color",
+      "description": "Border color of the card."
+    },
+    {
+      "name": "--card-padding",
+      "type": "Length",
+      "default": "1rem",
+      "description": "Padding inside the card."
+    }
+  ],
   "diagnostics": []
 }

--- a/tests/fixtures/cem-custom-element-object-config/input.svelte
+++ b/tests/fixtures/cem-custom-element-object-config/input.svelte
@@ -1,0 +1,20 @@
+<svelte:options
+  customElement={{
+    tag: "x-config-widget",
+    shadow: "none",
+    props: {
+      variant: { attribute: "data-variant" },
+      active: { reflect: true },
+      tags: { type: "Array" }
+    },
+    extend: (ceClass) => ceClass
+  }}
+/>
+
+<script lang="ts">
+  export let variant: string = "default";
+  export let active: boolean = false;
+  export let tags: string[] = [];
+</script>
+
+<div data-variant={variant}>{variant}</div>

--- a/tests/fixtures/cem-custom-element-object-config/output-class.d.ts
+++ b/tests/fixtures/cem-custom-element-object-config/output-class.d.ts
@@ -1,0 +1,24 @@
+import { SvelteComponentTyped } from "svelte";
+
+export type CemCustomElementObjectConfigProps = {
+  /**
+   * @default "default"
+   */
+  variant?: string;
+
+  /**
+   * @default false
+   */
+  active?: boolean;
+
+  /**
+   * @default []
+   */
+  tags?: string[];
+};
+
+export default class CemCustomElementObjectConfig extends SvelteComponentTyped<
+  CemCustomElementObjectConfigProps,
+  Record<string, any>,
+  Record<string, never>
+> {}

--- a/tests/fixtures/cem-custom-element-object-config/output-component.d.ts
+++ b/tests/fixtures/cem-custom-element-object-config/output-component.d.ts
@@ -1,0 +1,27 @@
+import type { Component } from "svelte";
+
+export type CemCustomElementObjectConfigProps = {
+  /**
+   * @default "default"
+   */
+  variant?: string;
+
+  /**
+   * @default false
+   */
+  active?: boolean;
+
+  /**
+   * @default []
+   */
+  tags?: string[];
+};
+
+export type CemCustomElementObjectConfigExports = Record<string, never>;
+
+declare const CemCustomElementObjectConfig: Component<
+  CemCustomElementObjectConfigProps,
+  CemCustomElementObjectConfigExports,
+  ""
+>;
+export default CemCustomElementObjectConfig;

--- a/tests/fixtures/cem-custom-element-object-config/output.json
+++ b/tests/fixtures/cem-custom-element-object-config/output.json
@@ -1,0 +1,121 @@
+{
+  "source": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 21,
+      "column": 0
+    }
+  },
+  "syntaxMode": "legacy",
+  "scriptLanguage": "ts",
+  "props": [
+    {
+      "name": "variant",
+      "kind": "let",
+      "type": "string",
+      "typeSource": "typescript",
+      "value": "\"default\"",
+      "defaultValue": {
+        "raw": "\"default\"",
+        "kind": "literal",
+        "value": "default"
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 2
+        },
+        "end": {
+          "line": 15,
+          "column": 41
+        }
+      }
+    },
+    {
+      "name": "active",
+      "kind": "let",
+      "type": "boolean",
+      "typeSource": "typescript",
+      "value": "false",
+      "defaultValue": {
+        "raw": "false",
+        "kind": "literal",
+        "value": false
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 37
+        }
+      }
+    },
+    {
+      "name": "tags",
+      "kind": "let",
+      "type": "string[]",
+      "typeSource": "typescript",
+      "value": "[]",
+      "defaultValue": {
+        "raw": "[]",
+        "kind": "array",
+        "value": []
+      },
+      "isFunction": false,
+      "isFunctionDeclaration": false,
+      "isRequired": false,
+      "constant": false,
+      "reactive": false,
+      "source": {
+        "start": {
+          "line": 17,
+          "column": 2
+        },
+        "end": {
+          "line": 17,
+          "column": 33
+        }
+      }
+    }
+  ],
+  "moduleExports": [],
+  "slots": [],
+  "events": [],
+  "typedefs": [],
+  "generics": null,
+  "contexts": [],
+  "customElementTag": "x-config-widget",
+  "customElement": {
+    "tag": "x-config-widget",
+    "shadow": "none",
+    "props": {
+      "variant": {
+        "attribute": "data-variant"
+      },
+      "active": {
+        "reflect": true
+      },
+      "tags": {
+        "type": "Array"
+      }
+    },
+    "extend": true
+  },
+  "diagnostics": []
+}

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.json
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.json
@@ -35,5 +35,8 @@
   "generics": null,
   "contexts": [],
   "customElementTag": "my-el",
+  "customElement": {
+    "tag": "my-el"
+  },
   "diagnostics": []
 }

--- a/tests/fixtures/runes-host-custom-element/output.json
+++ b/tests/fixtures/runes-host-custom-element/output.json
@@ -85,6 +85,9 @@
   "generics": null,
   "contexts": [],
   "customElementTag": "my-widget",
+  "customElement": {
+    "tag": "my-widget"
+  },
   "diagnostics": [
     {
       "component": "runes-host-custom-element/input.svelte",

--- a/tests/writer-custom-elements.test.ts
+++ b/tests/writer-custom-elements.test.ts
@@ -219,10 +219,12 @@ describe("writeCustomElements", () => {
         { kind: "field", name: "data", type: { text: "Record<string, unknown>" } },
       ]);
 
-      // Only bare primitive-typed props become attributes; "data" is skipped.
+      // Every prop becomes an attribute, including non-primitive types like "data";
+      // Svelte's custom-element runtime observes an attribute for every prop.
       expect(declaration.attributes).toEqual([
         { name: "label", fieldName: "label", type: { text: "string" }, default: '"hi"', description: "The label." },
         { name: "count", fieldName: "count", type: { text: "number" } },
+        { name: "data", fieldName: "data", type: { text: "Record<string, unknown>" } },
       ]);
 
       expect(declaration.events).toEqual([
@@ -235,7 +237,8 @@ describe("writeCustomElements", () => {
     }
   });
 
-  test("drops attributes that collide on the same lowercased name", async () => {
+  test("keeps the first prop on an attribute-name collision and warns", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const components: ComponentDocs = new Map([
       [
         "Clash",
@@ -247,8 +250,196 @@ describe("writeCustomElements", () => {
     const { module, cleanup } = await runWriter(components);
 
     try {
-      expect(module.declarations[0].attributes).toEqual([]);
+      expect(module.declarations[0].attributes).toEqual([
+        { name: "value", fieldName: "value", type: { text: "string" } },
+      ]);
       expect(module.declarations[0].members).toHaveLength(2);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"value" and "Value"'));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("uses the customElement.props config for the attribute name, reflect, and JSON-typed props", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Themed",
+        mockComponentDocApi("Themed", "Themed.svelte", {
+          props: [
+            mockProp("variant", { type: "string" }),
+            mockProp("active", { type: "boolean" }),
+            mockProp("tags", { type: "string[]", description: "The tags." }),
+            mockProp("hidden", { type: "boolean" }),
+          ],
+          customElement: {
+            props: {
+              variant: { attribute: "data-variant" },
+              active: { reflect: true },
+              tags: { type: "Array" },
+              hidden: { attribute: false },
+            },
+          },
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].attributes).toEqual([
+        { name: "data-variant", fieldName: "variant", type: { text: "string" } },
+        { name: "active", fieldName: "active", type: { text: "boolean" }, reflects: true },
+        {
+          name: "tags",
+          fieldName: "tags",
+          type: { text: "string[]" },
+          description: "The tags. Serialized to/from JSON for the attribute.",
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("excludes export function accessors from attributes", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Accessor",
+        mockComponentDocApi("Accessor", "Accessor.svelte", {
+          props: [mockProp("getValue", { isFunctionDeclaration: true, isFunction: true })],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].attributes).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("maps an export function accessor to a method, preferring JSDoc params/returns", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Notifier",
+        mockComponentDocApi("Notifier", "Notifier.svelte", {
+          props: [
+            mockProp("add", {
+              isFunctionDeclaration: true,
+              isFunction: true,
+              params: [{ name: "id", type: "string", description: "The id.", optional: false }],
+              returnType: "boolean",
+              description: "Adds a notification.",
+            }),
+          ],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].members).toEqual([
+        {
+          kind: "method",
+          name: "add",
+          static: false,
+          parameters: [{ name: "id", type: { text: "string" } }],
+          return: { type: { text: "boolean" } },
+          description: "Adds a notification.",
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("falls back to splitting the TS signature text when there's no JSDoc params/returns", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Calculator",
+        mockComponentDocApi("Calculator", "Calculator.svelte", {
+          props: [
+            mockProp("add", {
+              isFunctionDeclaration: true,
+              isFunction: true,
+              type: "(a: number, b?: number, ...rest: number[]) => number",
+            }),
+          ],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].members).toEqual([
+        {
+          kind: "method",
+          name: "add",
+          static: false,
+          parameters: [
+            { name: "a", type: { text: "number" } },
+            { name: "b", type: { text: "number" }, optional: true },
+            { name: "rest", type: { text: "number[]" }, rest: true },
+          ],
+          return: { type: { text: "number" } },
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("marks an export const prop's field readonly", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Constant",
+        mockComponentDocApi("Constant", "Constant.svelte", {
+          props: [mockProp("version", { kind: "const", constant: true, type: "string", value: '"1.0.0"' })],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].members).toEqual([
+        { kind: "field", name: "version", type: { text: "string" }, default: '"1.0.0"', readonly: true },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("populates cssParts and cssProperties on the declaration when present", async () => {
+    const components: ComponentDocs = new Map([
+      [
+        "Card",
+        mockComponentDocApi("Card", "Card.svelte", {
+          cssParts: [{ name: "header", description: "The header region." }],
+          cssProperties: [
+            { name: "--card-background", type: "Color", default: "white", description: "Card background." },
+          ],
+        }),
+      ],
+    ]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].cssParts).toEqual([{ name: "header", description: "The header region." }]);
+      expect(module.declarations[0].cssProperties).toEqual([
+        { name: "--card-background", type: { text: "Color" }, default: "white", description: "Card background." },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("omits cssParts and cssProperties when absent", async () => {
+    const components: ComponentDocs = new Map([["Plain", mockComponentDocApi("Plain", "Plain.svelte")]]);
+    const { module, cleanup } = await runWriter(components);
+
+    try {
+      expect(module.declarations[0].cssParts).toBeUndefined();
+      expect(module.declarations[0].cssProperties).toBeUndefined();
     } finally {
       cleanup();
     }


### PR DESCRIPTION
Reads the full object-form customElement config (shadow, per-prop
attribute/reflect/type, extend) instead of just tag, includes every
prop as a manifest attribute instead of only primitives, maps
accessor exports to methods, and adds @csspart/@cssprop tags.

```svelte
<svelte:options
  customElement={{
    tag: "x-widget",
    props: {
      variant: { attribute: "data-variant" },
      active: { reflect: true }
    }
  }}
/>
```