### PR TITLE
feat(markdown): render module exports and accessor kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3768,6 +3768,8 @@ export default class Component extends SvelteComponentTyped<
 
 When only `@param` tags are present without `@returns`, the return type defaults to `any`. When only `@returns` is present without `@param`, the function signature is `() => returnType`.
 
+The Markdown writer marks the same exports (a `const`, or a real function declaration) with Kind `accessor` in the Props table, instead of their raw `const`/`function` kind, matching the `.d.ts` output above.
+
 ## Troubleshooting
 
 **A prop came out `any`.** Enable [`reportDiagnostics`](#type-inference-diagnostics) (or `strict` to fail CI) to see which props sveld couldn't infer, then tighten them with `@type` or a native TypeScript annotation.

--- a/README.md
+++ b/README.md
@@ -1325,6 +1325,8 @@ interface OutputWriter<TOptions = unknown> {
   (also exported from `sveld`) to get the sorted, `diagnostics`-stripped,
   schema-versioned document the built-in writers build from. It's memoized
   per `components` map, so calling it more than once in one run is free.
+- **`options`** always carries `dryRun` alongside whatever fields the writer
+  itself defines. See [The `dryRun` contract](#the-dryrun-contract) below.
 
 ### Registering a writer
 
@@ -1342,6 +1344,50 @@ registerWriter({
 `registerWriter` is a side effect — call it once, before the plugin or CLI
 runs, e.g. at the top of `vite.config.ts` or `sveld.config.ts`, or in a file
 either of those imports.
+
+Registering a `name` that's already taken — a built-in writer's name, or
+another `registerWriter` call — throws instead of silently overwriting it.
+Pass `{ replace: true }` as a second argument when overwriting is intentional
+(e.g. re-registering a writer module during development):
+
+```ts
+registerWriter(
+  {
+    name: "my-format",
+    write(components, options) {
+      // ...
+    },
+  },
+  { replace: true },
+);
+```
+
+### The `dryRun` contract
+
+Every writer — built-in or `additionalWriters` — receives `dryRun: true` in
+its `options` when the run is `sveld --dry-run` (or `{ dryRun: true }` from
+the programmatic API). A writer must check it and skip touching disk; sveld
+does not do this for you:
+
+```ts
+import { writeFileSync } from "node:fs";
+
+registerWriter({
+  name: "my-format",
+  write(components, options: { outFile: string; dryRun?: boolean }) {
+    if (options.dryRun) {
+      console.log(`would write "${options.outFile}"`);
+      return;
+    }
+    writeFileSync(options.outFile, "...");
+  },
+});
+```
+
+A writer that throws — synchronously or from a rejected promise — has its
+error re-thrown as `sveld: writer "<name>" failed: <message>`, with the
+original error attached as `cause`, so a broken third-party writer never
+fails silently or without saying which one.
 
 ### Running it via the plugin
 

--- a/README.md
+++ b/README.md
@@ -774,6 +774,23 @@ sveld({
 });
 ```
 
+#### `jsonOptions.source`
+
+Every prop, slot, event, typedef, and context in `COMPONENT_API.json` carries a `source` position range (plus `componentCommentSource` on the component itself) when the parser has a stable AST position for it. For a large component library this is a substantial share of the file — roughly a quarter of `COMPONENT_API.json` for a 150+ component library — and many consumers (docs sites, LLM context) never read it.
+
+Set `jsonOptions.source` to `false` to omit every `source`/`componentCommentSource` range and shrink the file:
+
+```js
+sveld({
+  json: true,
+  jsonOptions: {
+    source: false,
+  },
+});
+```
+
+`source: true` is the default; every other field is unaffected. `EntryExport.source` (the declaring module's relative path, from `documentExports`) is a different field with a string value and is never stripped.
+
 ### Browser
 
 `sveld/browser` is a Node-free subpath export for running `sveld` client-side — e.g. an in-browser Svelte playground or REPL that parses whatever `.svelte` source the user typed and renders docs for it live. It bundles with Vite, esbuild, webpack, or Rollup without a `node:fs`/`node:path` polyfill.
@@ -909,6 +926,7 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
 - **`jsonOptions`** (object, optional): Options for JSON output.
   - **`outFile`** (string, optional, default: `"COMPONENT_API.json"`): Path (relative to the project root) for the single combined JSON document. Ignored when `outDir` is set.
   - **`outDir`** (string, optional): Emit one JSON file per component (`<ComponentName>.api.json`) into this directory instead of a single combined file. See [`jsonOptions.outDir`](#jsonoptionsoutdir).
+  - **`source`** (boolean, optional, default: `true`): Set to `false` to omit every `source`/`componentCommentSource` position range from the output. See [`jsonOptions.source`](#jsonoptionssource).
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.
 - **`markdownOptions`** (object, optional): Options for Markdown output.
   - **`outFile`** (string, optional, default: `"COMPONENT_INDEX.md"`): Path (relative to the project root) for the generated Markdown file.

--- a/README.md
+++ b/README.md
@@ -929,8 +929,9 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
   - **`source`** (boolean, optional, default: `true`): Set to `false` to omit every `source`/`componentCommentSource` position range from the output. See [`jsonOptions.source`](#jsonoptionssource).
 - **`markdown`** (boolean, optional): Generate component documentation in Markdown format.
 - **`markdownOptions`** (object, optional): Options for Markdown output.
-  - **`outFile`** (string, optional, default: `"COMPONENT_INDEX.md"`): Path (relative to the project root) for the generated Markdown file.
-  - **`write`** (boolean, optional, default: `true`): Set to `false` to render the Markdown document without writing it to disk.
+  - **`outFile`** (string, optional, default: `"COMPONENT_INDEX.md"`): Path (relative to the project root) for the single combined Markdown document. Ignored when `outDir` is set.
+  - **`outDir`** (string, optional): Emit one `<ModuleName>.md` file per component into this directory, plus an index `README.md` linking to each, instead of a single combined file. See [`markdownOptions.outDir`](#markdownoptionsoutdir).
+  - **`write`** (boolean, optional, default: `true`): Set to `false` to skip writing to disk — the rendered combined document is still returned, or (with `outDir` set) no files are written at all.
   - **`onAppend`** (function, optional): Callback invoked every time a heading, quote, paragraph, divider, or raw block is appended to the document. Lets you inject extra content, e.g. a summary line under the title. See [`markdownOptions.onAppend`](#markdownoptionsonappend) below.
 - **`customElements`** (boolean, optional): Generate a [Custom Elements Manifest](#custom-elements-manifest) (`custom-elements.json`). Also available as the `--custom-elements` CLI flag.
 - **`customElementsOptions`** (object, optional): Options for Custom Elements Manifest output.
@@ -1015,6 +1016,24 @@ sveld({
 
 > 1 components exported from sveld-scratch@1.0.0.
 ```
+
+#### `markdownOptions.outDir`
+
+With `markdown: true`, `sveld` writes a single `COMPONENT_INDEX.md` at the project root, documenting every component.
+
+Use `markdownOptions.outDir` to split that into one `<ModuleName>.md` file per component, plus an index `README.md` that links to each one (and holds the Exports section when `documentExports` is on — per-component sections live entirely in their own file):
+
+```js
+sveld({
+  markdown: true,
+  markdownOptions: {
+    // e.g. "docs/Button.md", "docs/README.md"
+    outDir: "docs",
+  },
+});
+```
+
+`onAppend` still fires for both the index and every per-component file. `outFile` is ignored once `outDir` is set.
 
 ## Documenting Entry Exports
 

--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,8 @@ Nested barrels are followed too: `export { X } from "./dir"`, where `./dir/index
 
 JSON adds `exports` and `totalExports`. Markdown adds an "Exports" section. Each item has `name`, `kind`, type text, optional JSDoc `description`, `source`, and — same as props — optional `@deprecated` and pass-through `tags`. A deprecated export's name is struck through in the Markdown table, same as a deprecated prop. See [`@deprecated`](#deprecated).
 
+An overloaded function (repeated `export function f(...)` signatures, or an import re-exported through a barrel) always documents the implementation signature, i.e. the last declaration. An `enum` export's `type` is the literal union of its members' values (`"A" | "B"` for a string enum, `0 | 1` for a numeric one), falling back to the bare enum name when a member's value can't be determined (e.g. a computed initializer). When two different modules export the same name (most commonly via `export * from "./a"; export * from "./b"`), `sveld` keeps whichever was declared first and prints a warning; it does not silently pick one or emit both.
+
 ## JSON Output
 
 When `json: true` is enabled, `sveld` emits a `COMPONENT_API.json` file with schema and generator metadata plus the parsed

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -340,7 +340,8 @@
         "tags": {
           "type": "array",
           "items": { "$ref": "#/$defs/jsdocTag" }
-        }
+        },
+        "source": { "$ref": "#/$defs/sourceRange" }
       }
     },
     "context": {
@@ -358,7 +359,8 @@
         "hasUnresolvedSpread": {
           "type": "boolean",
           "description": "True when a {...spread} in the context's object literal couldn't be resolved; the generated type intersects with Record<string, any>."
-        }
+        },
+        "source": { "$ref": "#/$defs/sourceRange" }
       }
     },
     "contextProperty": {

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -198,6 +198,8 @@ export interface PendingContextKeyCandidate {
   importedName: string;
   properties: ComponentContextProp[];
   description?: string;
+  /** Source range of the `setContext(...)` call, when available. */
+  source?: SourceRange;
 }
 
 export interface LocalTypeDeclaration {
@@ -525,6 +527,8 @@ export interface TypeDef {
   tags?: JsDocPassthroughTag[];
   /** True from `@ignore`/`@internal` JSDoc; excluded from every output by `buildComponentApiDocument`. */
   internal?: boolean;
+  /** Source range of the `@typedef`/`@callback` tag, when available. */
+  source?: SourceRange;
 }
 
 export type ComponentGenerics = [name: string, type: string] | null;
@@ -638,6 +642,8 @@ export interface ComponentContext {
   hasUnresolvedSpread?: boolean;
   /** True from `@ignore`/`@internal` JSDoc on the `setContext` call; excluded from every output by `buildComponentApiDocument`. */
   internal?: boolean;
+  /** Source range of the `setContext(...)` call, when available. */
+  source?: SourceRange;
 }
 
 /**

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -911,6 +911,7 @@ function applyContextKeyResolutions(component: ComponentDocApi, resolutions: Con
         typeName: generateContextTypeName(key),
         description: candidate.description,
         properties: candidate.properties,
+        source: candidate.source,
       },
     ];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,10 @@ export { defineConfig, type SveldConfig, type SveldRuntimeOptions } from "./load
 export { default } from "./plugin";
 export { type SveldResult, sveld } from "./sveld";
 export { buildComponentApiDocument, type ComponentApiDocument } from "./writer/document-model";
-export { getWriter, listWriters, type OutputWriter, registerWriter } from "./writer/registry";
+export {
+  getWriter,
+  listWriters,
+  type OutputWriter,
+  type RegisterWriterOptions,
+  registerWriter,
+} from "./writer/registry";

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -242,7 +242,7 @@ const KNOWN_TOP_LEVEL_KEYS = [
 const KNOWN_NESTED_KEYS: Record<string, string[]> = {
   typesOptions: ["outDir", "preamble", "format", "exports", "dryRun", "cache", "resolvedPathByFilePath"],
   jsonOptions: ["input", "outFile", "outDir", "entryExports", "dryRun", "source"],
-  markdownOptions: ["write", "outFile", "entryExports", "onAppend", "dryRun"],
+  markdownOptions: ["write", "outFile", "outDir", "entryExports", "onAppend", "dryRun"],
   customElementsOptions: ["outFile", "dryRun"],
   llmsOptions: ["outDir", "linkBase", "title", "summary", "entryExports", "dryRun"],
   diagnostics: ["ignore"],

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -241,7 +241,7 @@ const KNOWN_TOP_LEVEL_KEYS = [
 /** Known keys inside each `*Options` object, keyed by the top-level option name. `additionalWriters` is userland-defined and not validated here. */
 const KNOWN_NESTED_KEYS: Record<string, string[]> = {
   typesOptions: ["outDir", "preamble", "format", "exports", "dryRun", "cache", "resolvedPathByFilePath"],
-  jsonOptions: ["input", "outFile", "outDir", "entryExports", "dryRun"],
+  jsonOptions: ["input", "outFile", "outDir", "entryExports", "dryRun", "source"],
   markdownOptions: ["write", "outFile", "entryExports", "onAppend", "dryRun"],
   customElementsOptions: ["outFile", "dryRun"],
   llmsOptions: ["outDir", "linkBase", "title", "summary", "entryExports", "dryRun"],

--- a/src/parse-entry-exports.ts
+++ b/src/parse-entry-exports.ts
@@ -259,6 +259,60 @@ function collectAstReturnArguments(body: AstNode, out: Array<AstNode | null>): v
   }
 }
 
+/** A `TSEnumMember`'s literal initializer value, or `undefined` for anything not a plain string/number literal. */
+function enumMemberLiteralValue(member: AstNode): string | number | undefined {
+  const initializer = asNode(member.initializer);
+  if (!initializer) return undefined;
+
+  if (initializer.type === "Literal") {
+    const value = (initializer as unknown as { value: unknown }).value;
+    return typeof value === "string" || typeof value === "number" ? value : undefined;
+  }
+
+  // Negative numeric literals parse as `UnaryExpression` (`-1`), not `Literal`.
+  if (initializer.type === "UnaryExpression") {
+    const argument = asNode((initializer as unknown as { argument?: unknown }).argument);
+    const operator = (initializer as unknown as { operator?: string }).operator;
+    if (operator === "-" && argument?.type === "Literal") {
+      const value = (argument as unknown as { value: unknown }).value;
+      if (typeof value === "number") return -value;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Builds a literal union type for a `TSEnumDeclaration` (`"A" | "B"` for a
+ * string enum, `0 | 1` for a numeric one), matching what the enum's members
+ * actually widen to. Falls back to `undefined` (letting the caller keep the
+ * bare enum name) when a member's value can't be determined - e.g. a
+ * computed initializer like `1 << 2`.
+ */
+function enumMemberUnionType(declaration: AstNode): string | undefined {
+  const members = asNodeArray(declaration.members);
+  if (members.length === 0) return undefined;
+
+  const literals: string[] = [];
+  let nextNumeric = 0;
+  for (const member of members) {
+    const initializer = asNode(member.initializer);
+    if (!initializer) {
+      literals.push(String(nextNumeric));
+      nextNumeric += 1;
+      continue;
+    }
+
+    const value = enumMemberLiteralValue(member);
+    if (value === undefined) return undefined;
+
+    literals.push(typeof value === "string" ? JSON.stringify(value) : String(value));
+    nextNumeric = typeof value === "number" ? value + 1 : nextNumeric;
+  }
+
+  return literals.join(" | ");
+}
+
 function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocStart: number): InternalExport[] {
   const declFile = source.filePath;
   const description = leadingJsDoc(source.text, jsdocStart);
@@ -389,7 +443,17 @@ function describeDeclaration(source: ModuleSource, declaration: AstNode, jsdocSt
     const name = identifierName(asNode(declaration.id));
     if (!name) return [];
     return [
-      { name, kind: "enum", type: name, description, deprecated, tags, ...internalField, declFile, isTypeOnly: false },
+      {
+        name,
+        kind: "enum",
+        type: enumMemberUnionType(declaration) ?? name,
+        description,
+        deprecated,
+        tags,
+        ...internalField,
+        declFile,
+        isTypeOnly: false,
+      },
     ];
   }
 
@@ -485,7 +549,10 @@ export function collectModuleExports(filePath: string, ctx: ResolveContext): Int
     const target = resolveModuleFile(imported.specifier, source.dir);
     if (!target) return null;
 
-    return collectModuleExports(target, ctx).find((entry) => entry.name === imported.importedName) ?? null;
+    // `findLast`, not `find`: overloaded declarations (`export function f(...): A;` /
+    // `export function f(...): B;` / `export function f(...) { ... }`) all describe
+    // to the same name, in source order, with the implementation last.
+    return collectModuleExports(target, ctx).findLast((entry) => entry.name === imported.importedName) ?? null;
   };
 
   for (const node of body) {
@@ -528,7 +595,8 @@ export function collectModuleExports(filePath: string, ctx: ResolveContext): Int
       if (moduleSpecifier) {
         const target = resolveModuleFile(moduleSpecifier, source.dir);
         if (target) {
-          resolved = collectModuleExports(target, ctx).find((entry) => entry.name === localName) ?? null;
+          // `findLast`: see the comment on the equivalent lookup in `resolveLocal`.
+          resolved = collectModuleExports(target, ctx).findLast((entry) => entry.name === localName) ?? null;
         }
       } else {
         resolved = resolveLocal(localName);
@@ -575,13 +643,29 @@ export async function parseEntryExports(entryFile: string): Promise<EntryExports
   const resolved = resolve(entryFile);
   const entryDir = dirname(resolved);
   const collected = collectModuleExports(resolved, { cache: new Map(), computing: new Set() });
+  const relativeSource = (declFile: string) => normalizeSeparators(`./${relative(entryDir, declFile)}`);
 
   const byName = new Map<string, EntryExport>();
+  // Tracks which file each name currently resolves to, to tell an overloaded
+  // declaration (repeated entries from the *same* file - the implementation
+  // signature should win) apart from a genuine `export *` collision between
+  // two different files (the first one seen should win, with a warning).
+  const declFileByName = new Map<string, string>();
   for (const entry of collected) {
+    const existingDeclFile = declFileByName.get(entry.name);
+    if (existingDeclFile !== undefined && existingDeclFile !== entry.declFile) {
+      console.warn(
+        `Warning: "${entry.name}" is exported from both "${relativeSource(existingDeclFile)}" and "${relativeSource(
+          entry.declFile,
+        )}"; keeping the first and dropping the rest.`,
+      );
+      continue;
+    }
+    declFileByName.set(entry.name, entry.declFile);
+
     // Drop internal returnType/literalValue; public EntryExport does not expose them.
     const { declFile, returnType: _returnType, literalValue: _literalValue, ...rest } = entry;
-    const source = normalizeSeparators(`./${relative(entryDir, declFile)}`);
-    byName.set(entry.name, { ...rest, source });
+    byName.set(entry.name, { ...rest, source: relativeSource(declFile) });
   }
 
   return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));

--- a/src/parser/contexts.ts
+++ b/src/parser/contexts.ts
@@ -319,6 +319,8 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
   const valueArg = callExpr.arguments[1];
   if (!valueArg) return;
 
+  const callSource = sourceRangeFromNode(ctx, node);
+
   if (resolution.kind === "pending") {
     /** Properties come from the local value. The key is resolved later. */
     const contextInfo = parseContextValue(ctx, parser, valueArg, "");
@@ -328,6 +330,7 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
         importedName: resolution.importedName,
         properties: contextInfo.properties,
         description: contextInfo.description,
+        source: callSource,
       });
     }
     return;
@@ -343,10 +346,10 @@ export function parseSetContextCall(ctx: ParserContext, parser: ComponentParser,
       "context-duplicate-key",
       contextKey,
       `setContext("${contextKey}", ...) was called more than once; only the first call's shape is used.`,
-      sourceRangeFromNode(ctx, node),
+      callSource,
     );
     return;
   }
 
-  ctx.contexts.set(contextKey, contextInfo);
+  ctx.contexts.set(contextKey, { ...contextInfo, source: callSource });
 }

--- a/src/parser/jsdoc.ts
+++ b/src/parser/jsdoc.ts
@@ -692,6 +692,7 @@ export function parseCustomTypes(
           ts: typedefTs,
           tags: currentTypedefTags.length > 0 ? currentTypedefTags : undefined,
           ...(currentTypedefInternal ? { internal: true as const } : {}),
+          source: currentTypedefSource,
         });
 
         typedefProperties.length = 0;
@@ -724,6 +725,7 @@ export function parseCustomTypes(
           ts: callbackTs,
           tags: currentCallbackTags.length > 0 ? currentCallbackTags : undefined,
           ...(currentCallbackInternal ? { internal: true as const } : {}),
+          source: currentCallbackSource,
         });
 
         callbackParams.length = 0;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,7 +13,7 @@ import { WATCH_RELEVANT_EXT_REGEX } from "./path";
 import { createSveldBundle, type SveldBundle } from "./watch";
 // Side-effect import: registers the built-in "json"/"markdown"/"types"/"custom-elements" writers.
 import "./writer/built-in-writers";
-import { getWriter } from "./writer/registry";
+import { getWriter, type OutputWriter } from "./writer/registry";
 import { renderCustomElementsManifest, type WriteCustomElementsOptions } from "./writer/writer-custom-elements";
 import { renderJsonDocument, renderJsonLines, type WriteJsonOptions } from "./writer/writer-json";
 import type { WriteLlmsOptions } from "./writer/writer-llms";
@@ -343,10 +343,34 @@ export async function writeOutput(
       return undefined;
     }
     const components = writer.componentSet === "all" ? result.allComponentsForTypes : result.components;
-    return writer.write(components, writerOptions);
+    // Same `dryRun` contract as every built-in writer above: report the
+    // resolved path instead of writing, from `sveld --dry-run`.
+    const options = { ...(writerOptions as Record<string, unknown>), dryRun };
+    return runCustomWriter(name, writer, components, options);
   });
 
   await Promise.all(additionalWrites);
+}
+
+/**
+ * Runs a userland writer registered via `additionalWriters`, attributing any
+ * failure to its registered `name`. Wrapping the call in an `async` function
+ * (rather than calling `writer.write` directly in the `.map()` above) turns a
+ * *synchronous* throw into a rejected promise instead of one that escapes
+ * `.map()` itself, so the other writers in the batch still run to completion.
+ */
+async function runCustomWriter(
+  name: string,
+  writer: OutputWriter<unknown>,
+  components: ComponentDocs,
+  options: unknown,
+): Promise<unknown> {
+  try {
+    return await writer.write(components, options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`sveld: writer "${name}" failed: ${message}`, { cause: error });
+  }
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -367,7 +367,7 @@ export async function writeStdout(
       ...opts?.jsonOptions,
       inputDir,
       entryExports: result.entryExports,
-    } satisfies Pick<WriteJsonOptions, "inputDir" | "entryExports">;
+    } satisfies Pick<WriteJsonOptions, "inputDir" | "entryExports" | "source">;
 
     const rendered =
       opts.stdout === "ndjson"

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -1,3 +1,4 @@
+import type { ComponentProp } from "../ComponentParser";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocApi, ComponentDocs } from "../plugin";
 import { buildComponentApiDocument } from "./document-model";
@@ -70,6 +71,30 @@ function renderExports(document: MarkdownDocument, entryExports: EntryExports) {
   document.append("divider");
 }
 
+/**
+ * `<script context="module">` exports whose `kind` puts them on the
+ * compiled component's static side as a getter (`const`) or method
+ * (a real function declaration), rather than a plain assignable field.
+ * Mirrors the `.d.ts` writer's `genAccessors` filter.
+ */
+function isAccessorProp(prop: ComponentProp): boolean {
+  return prop.kind === "const" || prop.isFunctionDeclaration;
+}
+
+function renderModuleExports(document: MarkdownDocument, moduleExports: ComponentProp[]) {
+  document.append("h3", "Module exports");
+  document.append("raw", EXPORT_TABLE_HEADER);
+  for (const moduleExport of moduleExports) {
+    document.append(
+      "raw",
+      `| ${formatNameWithDeprecation(moduleExport.name, moduleExport.deprecated)} | ${`<code>${moduleExport.kind}</code>`} | ${formatPropType(
+        moduleExport.type,
+      )} | ${formatDescriptionWithTags(moduleExport.description, moduleExport.tags)} |\n`,
+    );
+  }
+  document.append("raw", "\n");
+}
+
 function renderSectionIfNotEmpty<TItem>(
   document: MarkdownDocument,
   items: TItem[],
@@ -114,9 +139,10 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
       .sort((a, b) => rank(a.prop) - rank(b.prop) || a.index - b.index)
       .map(({ prop }) => prop);
     for (const prop of sortedProps) {
+      const kind = isAccessorProp(prop) ? "accessor" : prop.kind;
       document.append(
         "raw",
-        `| ${formatNameWithDeprecation(prop.name, prop.deprecated)} | ${prop.isRequired ? "Yes" : "No"} | ${`<code>${prop.kind}</code>`} | ${
+        `| ${formatNameWithDeprecation(prop.name, prop.deprecated)} | ${prop.isRequired ? "Yes" : "No"} | ${`<code>${kind}</code>`} | ${
           prop.reactive ? "Yes" : "No"
         } | ${prop.binding ?? "--"} | ${formatPropType(prop.type)} | ${formatPropValue(prop.value)} | ${formatDescriptionWithTags(
           prop.description,
@@ -125,6 +151,10 @@ function renderComponent(document: MarkdownDocument, component: ComponentDocApi)
       );
     }
   });
+
+  if (component.moduleExports.length > 0) {
+    renderModuleExports(document, component.moduleExports);
+  }
 
   document.append("h3", "Slots");
   renderSectionIfNotEmpty(document, component.slots, () => {

--- a/src/writer/markdown-render-utils.ts
+++ b/src/writer/markdown-render-utils.ts
@@ -49,6 +49,31 @@ export function renderComponentsToMarkdown(
   }
 }
 
+/**
+ * Renders the index page for `markdownOptions.outDir` mode: a title, a link
+ * list to each component's own file, and the Exports section (when
+ * `documentExports` is on) - the same content the combined single-file mode
+ * puts before its table of contents, minus the per-component sections
+ * themselves, which live in their own files.
+ */
+export function renderComponentIndexToMarkdown(
+  document: MarkdownDocument,
+  components: ComponentDocApi[],
+  entryExports?: EntryExports,
+) {
+  document.append("h1", "Component Index");
+  document.append("h2", "Components");
+  for (const component of components) {
+    document.append("raw", `- [${component.moduleName}](./${component.moduleName}.md)\n`);
+  }
+  document.append("raw", "\n");
+  document.append("divider");
+
+  if (entryExports && entryExports.length > 0) {
+    renderExports(document, entryExports);
+  }
+}
+
 function renderExports(document: MarkdownDocument, entryExports: EntryExports) {
   document.append("h2", "Exports");
   document.append("raw", EXPORT_TABLE_HEADER);
@@ -108,6 +133,11 @@ function renderSectionIfNotEmpty<TItem>(
   } else {
     document.append("p", emptyMessage ?? "None.");
   }
+}
+
+/** Renders one component's section, for both the combined document and `markdownOptions.outDir`'s per-component files. */
+export function renderComponentToMarkdown(document: MarkdownDocument, component: ComponentDocApi) {
+  renderComponent(document, component);
 }
 
 function renderComponent(document: MarkdownDocument, component: ComponentDocApi) {

--- a/src/writer/registry.ts
+++ b/src/writer/registry.ts
@@ -27,12 +27,41 @@ export interface OutputWriter<TOptions = unknown> {
   name: string;
   /** Which component set this writer expects — see {@link WriterComponentSet}. @default "exported" */
   componentSet?: WriterComponentSet;
+  /**
+   * `options` always carries `dryRun: true` under `sveld --dry-run` (or
+   * `{ dryRun: true }` from the programmatic API), alongside whatever
+   * `TOptions` fields the writer defines. `write` must check it and skip
+   * touching disk; sveld does not do this for you. A thrown error (sync or
+   * async) is re-thrown by the caller as `sveld: writer "<name>" failed: ...`
+   * with the original error as `cause`.
+   */
   write(components: ComponentDocs, options: TOptions): Promise<unknown> | unknown;
+}
+
+export interface RegisterWriterOptions {
+  /** Overwrite an existing writer registered under the same `name` instead of throwing. @default false */
+  replace?: boolean;
 }
 
 const writers = new Map<string, OutputWriter<unknown>>();
 
-export function registerWriter<TOptions = unknown>(writer: OutputWriter<TOptions>): void {
+/**
+ * Registers a writer under `writer.name`. Throws if that name is already
+ * taken - a silent overwrite would otherwise let a userland writer clobber
+ * a built-in one (`json`/`markdown`/`types`/`custom-elements`/`llms`), or
+ * two third-party writers with the same name shadow each other depending on
+ * import order. Pass `{ replace: true }` to overwrite intentionally, e.g.
+ * when hot-reloading a writer module during development.
+ */
+export function registerWriter<TOptions = unknown>(
+  writer: OutputWriter<TOptions>,
+  options?: RegisterWriterOptions,
+): void {
+  if (!options?.replace && writers.has(writer.name)) {
+    throw new Error(
+      `sveld: a writer named "${writer.name}" is already registered. Pass { replace: true } to overwrite it.`,
+    );
+  }
   writers.set(writer.name, writer as OutputWriter<unknown>);
 }
 

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -20,8 +20,43 @@ export interface WriteJsonOptions {
    * via `jsonOptions` has no effect.
    */
   entryExports?: EntryExports;
+  /**
+   * Include `source`/`componentCommentSource` position ranges in the
+   * output. These are the bulk of a large component library's
+   * `COMPONENT_API.json` (roughly a quarter of the file for a 150+
+   * component library); set to `false` to omit them and shrink the file
+   * when consumers don't need exact source positions.
+   * @default true
+   */
+  source?: boolean;
   /** @internal Report resolved paths instead of writing. Always set by the caller from `sveld --dry-run`. */
   dryRun?: boolean;
+}
+
+/** Narrows a `source`/`componentCommentSource` value to an actual `SourceRange`, as opposed to `EntryExport.source` (a module path string). */
+function isSourceRange(value: unknown): value is { start: unknown; end: unknown } {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && "start" in value && "end" in value;
+}
+
+/**
+ * Recursively strips `source`/`componentCommentSource` position ranges from
+ * a component (or any nested value), for `jsonOptions.source: false`.
+ * `EntryExport.source` (a declaring-module path string, not a range) is
+ * left untouched since it fails the `isSourceRange` check.
+ */
+function stripSourceRanges<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripSourceRanges(item)) as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if ((key === "source" || key === "componentCommentSource") && isSourceRange(item)) continue;
+      result[key] = stripSourceRanges(item);
+    }
+    return result as T;
+  }
+  return value;
 }
 
 /**
@@ -64,7 +99,8 @@ function jsonFileName(component: ComponentDocApi, hasCollision: boolean, warnedM
 
 async function writeJsonComponents(components: ComponentDocs, options: WriteJsonOptions) {
   const document = buildComponentApiDocument(components);
-  const output = withNormalizedFilePaths(document.components, options.inputDir);
+  let output = withNormalizedFilePaths(document.components, options.inputDir);
+  if (options.source === false) output = stripSourceRanges(output);
 
   const moduleNameCounts = new Map<string, number>();
   for (const component of output) {
@@ -91,13 +127,14 @@ async function writeJsonComponents(components: ComponentDocs, options: WriteJson
  */
 export function renderJsonDocument(
   components: ComponentDocs,
-  options: Pick<WriteJsonOptions, "inputDir" | "entryExports">,
+  options: Pick<WriteJsonOptions, "inputDir" | "entryExports" | "source">,
 ): string {
   const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
-  const output: ComponentApiDocument = {
+  let output: ComponentApiDocument = {
     ...document,
     components: withNormalizedFilePaths(document.components, options.inputDir),
   };
+  if (options.source === false) output = stripSourceRanges(output);
 
   return formatJsonOutput(output);
 }
@@ -109,10 +146,11 @@ export function renderJsonDocument(
  */
 export function renderJsonLines(
   components: ComponentDocs,
-  options: Pick<WriteJsonOptions, "inputDir" | "entryExports">,
+  options: Pick<WriteJsonOptions, "inputDir" | "entryExports" | "source">,
 ): string {
   const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
-  const output = withNormalizedFilePaths(document.components, options.inputDir);
+  let output = withNormalizedFilePaths(document.components, options.inputDir);
+  if (options.source === false) output = stripSourceRanges(output);
 
   return `${output.map((c) => JSON.stringify(c)).join("\n")}\n`;
 }

--- a/src/writer/writer-markdown.ts
+++ b/src/writer/writer-markdown.ts
@@ -1,14 +1,26 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { info } from "../logger";
 import type { EntryExports } from "../parse-entry-exports";
 import type { ComponentDocs } from "../plugin";
-import { renderComponentsToMarkdown } from "./markdown-render-utils";
+import { buildComponentApiDocument } from "./document-model";
+import {
+  renderComponentIndexToMarkdown,
+  renderComponentsToMarkdown,
+  renderComponentToMarkdown,
+} from "./markdown-render-utils";
 import Writer from "./Writer";
 import WriterMarkdown, { type AppendType } from "./WriterMarkdown";
 
 export interface WriteMarkdownOptions {
   write?: boolean;
   outFile: string;
+  /**
+   * Emit one `<ModuleName>.md` file per component into this directory,
+   * plus an index `README.md` linking to each, instead of the single
+   * combined `outFile`. See `jsonOptions.outDir` for the equivalent JSON
+   * option.
+   */
+  outDir?: string;
   /**
    * @internal Entry-barrel exports when `documentExports` is on. Always
    * computed from the parsed bundle and injected by the caller; setting it
@@ -20,6 +32,43 @@ export interface WriteMarkdownOptions {
   dryRun?: boolean;
 }
 
+function newDocument(options: Pick<WriteMarkdownOptions, "onAppend">, components: ComponentDocs): WriterMarkdown {
+  return new WriterMarkdown({
+    onAppend: (type, document) => {
+      options.onAppend?.call(null, type, document, components);
+    },
+  });
+}
+
+/**
+ * Writes one `<ModuleName>.md` file per component into `outDir`, plus an
+ * index `README.md` linking to each. Mirrors `writer-json.ts`'s `outDir`
+ * mode; unlike JSON, `moduleName` collisions aren't handled here since the
+ * built-in Markdown writer only ever receives the "exported" component set,
+ * where `moduleName` is unique by construction.
+ */
+async function writeMarkdownComponents(components: ComponentDocs, options: WriteMarkdownOptions) {
+  const outDir = options.outDir as string;
+  const document = buildComponentApiDocument(components, { entryExports: options.entryExports });
+  const writer = new Writer({ dryRun: options.dryRun });
+
+  const indexDocument = newDocument(options, components);
+  renderComponentIndexToMarkdown(indexDocument, document.components, options.entryExports);
+  const indexFile = resolve(join(outDir, "README.md"));
+  const wroteIndex = await writer.write(indexFile, indexDocument.end());
+  if (!options.dryRun) info(`${wroteIndex ? "created" : "unchanged"} "${indexFile}".`);
+
+  await Promise.all(
+    document.components.map(async (component) => {
+      const componentDocument = newDocument(options, components);
+      renderComponentToMarkdown(componentDocument, component);
+      const outFile = resolve(join(outDir, `${component.moduleName}.md`));
+      const wasWritten = await writer.write(outFile, componentDocument.end());
+      if (!options.dryRun) info(`${wasWritten ? "created" : "unchanged"} "${outFile}".`);
+    }),
+  );
+}
+
 /**
  * Renders the Markdown document without touching disk. Used by both
  * `writeMarkdown` and the CLI's `--stdout` mode so the two channels can't
@@ -29,11 +78,7 @@ export function renderMarkdownDocument(
   components: ComponentDocs,
   options: Pick<WriteMarkdownOptions, "entryExports" | "onAppend">,
 ): string {
-  const document = new WriterMarkdown({
-    onAppend: (type, document) => {
-      options.onAppend?.call(null, type, document, components);
-    },
-  });
+  const document = newDocument(options, components);
 
   renderComponentsToMarkdown(document, components, options.entryExports);
 
@@ -53,6 +98,11 @@ export function renderMarkdownDocument(
  * ```
  */
 export default async function writeMarkdown(components: ComponentDocs, options: WriteMarkdownOptions) {
+  if (options.outDir) {
+    if (options.write !== false) await writeMarkdownComponents(components, options);
+    return undefined;
+  }
+
   const write = options?.write !== false;
   const rendered = renderMarkdownDocument(components, options);
 

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -612,4 +612,134 @@ describe("WriterMarkdown", () => {
     expect(withoutCss).not.toContain("CSS Parts");
     expect(withoutCss).not.toContain("CSS Custom Properties");
   });
+
+  test('renders a Module exports table for `<script context="module">` exports', () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [],
+            moduleExports: [
+              {
+                name: "VERSION",
+                kind: "const",
+                constant: true,
+                type: "string",
+                description: "Package version.",
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "reset",
+                kind: "function",
+                constant: false,
+                isFunction: true,
+                isFunctionDeclaration: true,
+                isRequired: false,
+                reactive: false,
+                description: "Resets shared state.",
+              },
+            ],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toContain("### Module exports");
+    expect(output).toContain("| Name | Kind | Type | Description |");
+    expect(output).toContain("| VERSION | <code>const</code> | <code>string</code> | Package version. |");
+    expect(output).toContain("| reset | <code>function</code> | -- | Resets shared state. |");
+  });
+
+  test("omits the Module exports table when there are no module exports", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "legacy",
+            props: [],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).not.toContain("Module exports");
+  });
+
+  test("marks const and function-declaration props as accessor kind in the props table", () => {
+    const output = writeMarkdownCore(
+      new Map([
+        [
+          "Example",
+          {
+            filePath: asNormalizedPath("Example.svelte"),
+            moduleName: "Example",
+            syntaxMode: "runes",
+            props: [
+              {
+                name: "count",
+                kind: "const",
+                constant: true,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "focus",
+                kind: "function",
+                constant: false,
+                isFunction: true,
+                isFunctionDeclaration: true,
+                isRequired: false,
+                reactive: false,
+              },
+              {
+                name: "label",
+                kind: "let",
+                constant: false,
+                isFunction: false,
+                isFunctionDeclaration: false,
+                isRequired: false,
+                reactive: false,
+              },
+            ],
+            moduleExports: [],
+            slots: [],
+            events: [],
+            typedefs: [],
+            generics: null,
+            rest_props: undefined,
+            contexts: [],
+          },
+        ],
+      ]),
+    );
+
+    expect(output).toContain("| count | No | <code>accessor</code> |");
+    expect(output).toContain("| focus | No | <code>accessor</code> |");
+    expect(output).toContain("| label | No | <code>let</code> |");
+  });
 });

--- a/tests/WriterMarkdown.test.ts
+++ b/tests/WriterMarkdown.test.ts
@@ -1,7 +1,13 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
 import { asNormalizedPath } from "../src/brands";
+import type { ComponentDocs } from "../src/plugin";
 import type { AppendType } from "../src/writer/WriterMarkdown";
 import WriterMarkdown from "../src/writer/WriterMarkdown";
+import writeMarkdown from "../src/writer/writer-markdown";
 import { writeMarkdownCore } from "../src/writer/writer-markdown-core";
+import { mockComponentDocApi } from "./test-brands";
 
 describe("WriterMarkdown", () => {
   test("basic functionality", () => {
@@ -741,5 +747,70 @@ describe("WriterMarkdown", () => {
     expect(output).toContain("| count | No | <code>accessor</code> |");
     expect(output).toContain("| focus | No | <code>accessor</code> |");
     expect(output).toContain("| label | No | <code>let</code> |");
+  });
+
+  describe("markdownOptions.outDir", () => {
+    test("writes one file per component plus an index README.md with links", async () => {
+      const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-outdir-"));
+      const components: ComponentDocs = new Map([
+        ["Alert", mockComponentDocApi("Alert", "Alert.svelte")],
+        ["Button", mockComponentDocApi("Button", "Button.svelte")],
+      ]);
+
+      try {
+        await writeMarkdown(components, { outFile: "unused.md", outDir: tempDir });
+
+        expect(existsSync(path.join(tempDir, "README.md"))).toBe(true);
+        expect(existsSync(path.join(tempDir, "Alert.md"))).toBe(true);
+        expect(existsSync(path.join(tempDir, "Button.md"))).toBe(true);
+
+        const index = readFileSync(path.join(tempDir, "README.md"), "utf-8");
+        expect(index).toContain("# Component Index");
+        expect(index).toContain("- [Alert](./Alert.md)");
+        expect(index).toContain("- [Button](./Button.md)");
+        // Per-component sections live in their own files, not the index.
+        expect(index).not.toContain("### Props");
+
+        const alert = readFileSync(path.join(tempDir, "Alert.md"), "utf-8");
+        expect(alert).toContain("## `Alert`");
+        expect(alert).toContain("### Props");
+        expect(alert).not.toContain("`Button`");
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("index README.md includes the Exports section when documentExports is on", async () => {
+      const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-outdir-exports-"));
+      const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+      try {
+        await writeMarkdown(components, {
+          outFile: "unused.md",
+          outDir: tempDir,
+          entryExports: [{ name: "VERSION", kind: "const", type: "string", isTypeOnly: false, value: '"1.0.0"' }],
+        });
+
+        const index = readFileSync(path.join(tempDir, "README.md"), "utf-8");
+        expect(index).toContain("## Exports");
+        expect(index).toContain("VERSION");
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("outFile is ignored and no combined file is written when outDir is set", async () => {
+      const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-md-outdir-ignores-outfile-"));
+      const components: ComponentDocs = new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]);
+
+      try {
+        await writeMarkdown(components, { outFile: path.join(tempDir, "COMPONENT_INDEX.md"), outDir: tempDir });
+
+        expect(existsSync(path.join(tempDir, "COMPONENT_INDEX.md"))).toBe(false);
+        expect(existsSync(path.join(tempDir, "README.md"))).toBe(true);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/tests/component-api-schema.test.ts
+++ b/tests/component-api-schema.test.ts
@@ -10,6 +10,7 @@ import {
   writeTsDefinition,
 } from "../src/browser";
 import { parseEntryExports } from "../src/parse-entry-exports";
+import { renderJsonDocument } from "../src/writer/writer-json";
 
 type JsonObject = Record<string, unknown>;
 
@@ -168,6 +169,16 @@ describe("component API JSON schema", () => {
       "kind",
       "isTypeOnly",
     ]);
+  });
+
+  test("typedefs and contexts carry a source range like other component metadata", () => {
+    const schema = readJson("schema/component-api.schema.json");
+    const defs = objectProperty(schema, "$defs");
+
+    for (const def of ["typedef", "context"]) {
+      const properties = objectProperty(objectProperty(defs, def), "properties");
+      expect(objectProperty(properties, "source")).toMatchObject({ $ref: "#/$defs/sourceRange" });
+    }
   });
 
   test("covers recent prop metadata fields", () => {
@@ -432,6 +443,19 @@ describe("component API JSON schema validates real emitted output", () => {
   test("validates the committed svelte5-vite e2e COMPONENT_API.json", () => {
     const api = readJson("tests/e2e/svelte5-vite/COMPONENT_API.json");
     expectValid(api);
+  });
+
+  test("validates the document with jsonOptions.source: false, and strips every source range", async () => {
+    const components = await buildRepresentativeFixtureComponents();
+
+    const rendered = renderJsonDocument(components, { inputDir: root, source: false });
+    const document = JSON.parse(rendered) as JsonObject;
+    expectValid(document);
+
+    for (const component of arrayProperty(document, "components")) {
+      expect(JSON.stringify(component)).not.toContain('"source"');
+      expect(JSON.stringify(component)).not.toContain('"componentCommentSource"');
+    }
   });
 
   const carbonApiPath = "tests/e2e/carbon/COMPONENT_API.json";

--- a/tests/fixtures-entry-exports/index.ts
+++ b/tests/fixtures-entry-exports/index.ts
@@ -2,6 +2,8 @@
 export { default as Button } from "./Button.svelte";
 
 export { MAX_RETRIES, VERSION } from "./constants";
+export { format } from "./overloads";
+export { Priority, Status } from "./status";
 export type { Theme, ThemeConfig } from "./types";
 export { clamp, invertTheme } from "./utils";
 

--- a/tests/fixtures-entry-exports/overloads.ts
+++ b/tests/fixtures-entry-exports/overloads.ts
@@ -1,0 +1,5 @@
+export function format(value: string): string;
+export function format(value: number): string;
+export function format(value: string | number): string {
+  return String(value);
+}

--- a/tests/fixtures-entry-exports/status.ts
+++ b/tests/fixtures-entry-exports/status.ts
@@ -1,0 +1,11 @@
+/** Lifecycle status. */
+export enum Status {
+  Active = "active",
+  Inactive = "inactive",
+}
+
+export enum Priority {
+  Low,
+  Medium,
+  High,
+}

--- a/tests/fixtures/accessor-param-returns/output.json
+++ b/tests/fixtures/accessor-param-returns/output.json
@@ -232,7 +232,17 @@
     {
       "type": "{\n  /** Optional id for deduplication */\n  id?: string;\n  kind?: \"error\" | \"info\" | \"success\";\n  title?: string;\n}",
       "name": "NotificationData",
-      "ts": "type NotificationData = {\n  /** Optional id for deduplication */\n  id?: string;\n  kind?: \"error\" | \"info\" | \"success\";\n  title?: string;\n};"
+      "ts": "type NotificationData = {\n  /** Optional id for deduplication */\n  id?: string;\n  kind?: \"error\" | \"info\" | \"success\";\n  title?: string;\n};",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 39
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/callback-typedef/output.json
+++ b/tests/fixtures/callback-typedef/output.json
@@ -73,12 +73,32 @@
     {
       "type": "\"asc\" | \"desc\"",
       "name": "SortDirection",
-      "ts": "type SortDirection = \"asc\" | \"desc\";"
+      "ts": "type SortDirection = \"asc\" | \"desc\";",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 44
+        }
+      }
     },
     {
       "type": "(a: any, b: any, direction: SortDirection) => number",
       "name": "SortFn",
-      "ts": "type SortFn = (a: any, b: any, direction: SortDirection) => number;"
+      "ts": "type SortFn = (a: any, b: any, direction: SortDirection) => number;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 21
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/callback/output.json
+++ b/tests/fixtures/callback/output.json
@@ -101,18 +101,48 @@
       "type": "(value: string, index: number) => void",
       "name": "OnChange",
       "description": "Callback fired when the value changes.",
-      "ts": "type OnChange = (value: string, index: number) => void;"
+      "ts": "type OnChange = (value: string, index: number) => void;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 23
+        }
+      }
     },
     {
       "type": "(a: any, b: any) => number",
       "name": "Comparator",
-      "ts": "type Comparator = (a: any, b: any) => number;"
+      "ts": "type Comparator = (a: any, b: any) => number;",
+      "source": {
+        "start": {
+          "line": 11,
+          "column": 5
+        },
+        "end": {
+          "line": 11,
+          "column": 25
+        }
+      }
     },
     {
       "type": "() => void",
       "name": "OnClose",
       "description": "No-arg callback.",
-      "ts": "type OnClose = () => void;"
+      "ts": "type OnClose = () => void;",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 5
+        },
+        "end": {
+          "line": 19,
+          "column": 22
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/context-colon/output.json
+++ b/tests/fixtures/context-colon/output.json
@@ -34,7 +34,17 @@
           "description": "Close the modal",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 45
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-const-key/output.json
+++ b/tests/fixtures/context-const-key/output.json
@@ -50,7 +50,17 @@
           "description": "Close the modal",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 2
+        },
+        "end": {
+          "line": 18,
+          "column": 42
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-empty/output.json
+++ b/tests/fixtures/context-empty/output.json
@@ -21,7 +21,17 @@
     {
       "key": "BreadcrumbItem",
       "typeName": "BreadcrumbItemContext",
-      "properties": []
+      "properties": [],
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-generics-dollar-name/output.json
+++ b/tests/fixtures/context-generics-dollar-name/output.json
@@ -47,7 +47,17 @@
           "description": "",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 31
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-imported-type/output.json
+++ b/tests/fixtures/context-imported-type/output.json
@@ -35,7 +35,17 @@
     {
       "type": "{\n  open: () => void;\n  close: () => void;\n}",
       "name": "ModalAPI",
-      "ts": "type ModalAPI = {\n  open: () => void;\n  close: () => void;\n};"
+      "ts": "type ModalAPI = {\n  open: () => void;\n  close: () => void;\n};",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 31
+        }
+      }
     }
   ],
   "generics": null,
@@ -50,7 +60,17 @@
           "description": "Modal API object",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 23,
+          "column": 2
+        },
+        "end": {
+          "line": 23,
+          "column": 31
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-inline-functions/output.json
+++ b/tests/fixtures/context-inline-functions/output.json
@@ -48,7 +48,17 @@
           "type": "() => any",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 12,
+          "column": 4
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-issue-103/output.json
+++ b/tests/fixtures/context-issue-103/output.json
@@ -44,7 +44,17 @@
           "description": "Log a message to the console",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 2
+        },
+        "end": {
+          "line": 12,
+          "column": 30
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-mixed-separators/output.json
+++ b/tests/fixtures/context-mixed-separators/output.json
@@ -34,7 +34,17 @@
           "description": "Reset the state",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 53
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-simple/output.json
+++ b/tests/fixtures/context-simple/output.json
@@ -50,7 +50,17 @@
           "description": "Close the modal",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 16,
+          "column": 2
+        },
+        "end": {
+          "line": 16,
+          "column": 45
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-space/output.json
+++ b/tests/fixtures/context-space/output.json
@@ -28,7 +28,17 @@
           "description": "Toggle visibility",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 38
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-symbol-for/output.json
+++ b/tests/fixtures/context-symbol-for/output.json
@@ -44,7 +44,17 @@
           "description": "Push a notification message.",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 52
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-symbol/output.json
+++ b/tests/fixtures/context-symbol/output.json
@@ -50,7 +50,17 @@
           "description": "Register a tab and return its index.",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 2
+        },
+        "end": {
+          "line": 18,
+          "column": 45
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-template-tag-multiple/output.json
+++ b/tests/fixtures/context-template-tag-multiple/output.json
@@ -105,7 +105,17 @@
           "type": "Icon",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 2
+        },
+        "end": {
+          "line": 19,
+          "column": 53
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-template-tag/output.json
+++ b/tests/fixtures/context-template-tag/output.json
@@ -64,12 +64,32 @@
     {
       "type": "{ id: any; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: any; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: any; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 5
+        },
+        "end": {
+          "line": 6,
+          "column": 61
+        }
+      }
     },
     {
       "type": "any",
       "name": "DataTableRowId",
-      "ts": "type DataTableRowId = any;"
+      "ts": "type DataTableRowId = any;",
+      "source": {
+        "start": {
+          "line": 7,
+          "column": 5
+        },
+        "end": {
+          "line": 7,
+          "column": 34
+        }
+      }
     }
   ],
   "generics": [
@@ -105,7 +125,17 @@
           "description": "Filter rows by search value",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 39,
+          "column": 2
+        },
+        "end": {
+          "line": 44,
+          "column": 4
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-ts-annotation/output.json
+++ b/tests/fixtures/context-ts-annotation/output.json
@@ -43,7 +43,17 @@
           "type": "{ theme: string }",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 24
+        }
+      }
     },
     {
       "key": "legacy",
@@ -55,7 +65,17 @@
           "description": "",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 2
+        },
+        "end": {
+          "line": 9,
+          "column": 32
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/context-typedef/output.json
+++ b/tests/fixtures/context-typedef/output.json
@@ -35,7 +35,17 @@
     {
       "type": "{\n  id: string;\n  label: string;\n  disabled?: boolean;\n}",
       "name": "TabData",
-      "ts": "type TabData = {\n  id: string;\n  label: string;\n  disabled?: boolean;\n};"
+      "ts": "type TabData = {\n  id: string;\n  label: string;\n  disabled?: boolean;\n};",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 30
+        }
+      }
     }
   ],
   "generics": null,
@@ -56,7 +66,17 @@
           "description": "Remove a tab by ID",
           "optional": false
         }
-      ]
+      ],
+      "source": {
+        "start": {
+          "line": 27,
+          "column": 2
+        },
+        "end": {
+          "line": 27,
+          "column": 43
+        }
+      }
     }
   ],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.json
@@ -85,7 +85,17 @@
       "type": "{\n  /** The full new set of items. */\n  items: string[];\n  /** Items added since the last change. */\n  added: string[];\n  /** Items removed since the last change. */\n  removed?: string[];\n}",
       "name": "ChangeDetail",
       "description": "The event detail described once as a named typedef, then reused via `@event`.",
-      "ts": "type ChangeDetail = {\n  /** The full new set of items. */\n  items: string[];\n  /** Items added since the last change. */\n  added: string[];\n  /** Items removed since the last change. */\n  removed?: string[];\n};"
+      "ts": "type ChangeDetail = {\n  /** The full new set of items. */\n  items: string[];\n  /** Items added since the last change. */\n  added: string[];\n  /** Items removed since the last change. */\n  removed?: string[];\n};",
+      "source": {
+        "start": {
+          "line": 24,
+          "column": 5
+        },
+        "end": {
+          "line": 24,
+          "column": 35
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/generics-multiple/output.json
+++ b/tests/fixtures/generics-multiple/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: Header; }",
       "name": "DataTableHeader<Row = DataTableRow, Header = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> { key: DataTableKey<Row>; value: Header; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> { key: DataTableKey<Row>; value: Header; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 112
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/generics-with-rest-props/output.json
+++ b/tests/fixtures/generics-with-rest-props/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: string; }",
       "name": "DataTableHeader<Row = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 92
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/generics/output.json
+++ b/tests/fixtures/generics/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: string; }",
       "name": "DataTableHeader<Row = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 92
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/internal-typedef-referenced/output.json
+++ b/tests/fixtures/internal-typedef-referenced/output.json
@@ -42,12 +42,32 @@
       "type": "{ count: number }",
       "name": "InternalCount",
       "ts": "interface InternalCount { count: number }",
-      "internal": true
+      "internal": true,
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 47
+        }
+      }
     },
     {
       "type": "{ items: InternalCount[] }",
       "name": "PublicList",
-      "ts": "interface PublicList { items: InternalCount[] }"
+      "ts": "interface PublicList { items: InternalCount[] }",
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 5
+        },
+        "end": {
+          "line": 8,
+          "column": 53
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/jsdoc-internal-ignore/output.json
+++ b/tests/fixtures/jsdoc-internal-ignore/output.json
@@ -233,12 +233,32 @@
       "type": "{ count: number }",
       "name": "InternalCount",
       "ts": "interface InternalCount { count: number }",
-      "internal": true
+      "internal": true,
+      "source": {
+        "start": {
+          "line": 36,
+          "column": 5
+        },
+        "end": {
+          "line": 36,
+          "column": 47
+        }
+      }
     },
     {
       "type": "{ label: string }",
       "name": "PublicLabel",
-      "ts": "interface PublicLabel { label: string }"
+      "ts": "interface PublicLabel { label: string }",
+      "source": {
+        "start": {
+          "line": 40,
+          "column": 5
+        },
+        "end": {
+          "line": 40,
+          "column": 45
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/jsdoc-type-params/output.json
+++ b/tests/fixtures/jsdoc-type-params/output.json
@@ -62,7 +62,17 @@
     {
       "type": "string",
       "name": "TreeNodeId",
-      "ts": "type TreeNodeId = string;"
+      "ts": "type TreeNodeId = string;",
+      "source": {
+        "start": {
+          "line": 2,
+          "column": 6
+        },
+        "end": {
+          "line": 2,
+          "column": 37
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/multiple-typedef-same-property/output.json
+++ b/tests/fixtures/multiple-typedef-same-property/output.json
@@ -80,12 +80,32 @@
     {
       "type": "{\n  /** User identifier */\n  id: string;\n  /** User display name */\n  name: string;\n}",
       "name": "UserConfig",
-      "ts": "type UserConfig = {\n  /** User identifier */\n  id: string;\n  /** User display name */\n  name: string;\n};"
+      "ts": "type UserConfig = {\n  /** User identifier */\n  id: string;\n  /** User display name */\n  name: string;\n};",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 33
+        }
+      }
     },
     {
       "type": "{\n  /** Theme identifier */\n  id: string;\n  /** Theme display name */\n  name: string;\n}",
       "name": "ThemeConfig",
-      "ts": "type ThemeConfig = {\n  /** Theme identifier */\n  id: string;\n  /** Theme display name */\n  name: string;\n};"
+      "ts": "type ThemeConfig = {\n  /** Theme identifier */\n  id: string;\n  /** Theme display name */\n  name: string;\n};",
+      "source": {
+        "start": {
+          "line": 9,
+          "column": 5
+        },
+        "end": {
+          "line": 9,
+          "column": 34
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/non-literal-defaults/output.json
+++ b/tests/fixtures/non-literal-defaults/output.json
@@ -345,7 +345,17 @@
     {
       "type": "\"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\"",
       "name": "Position",
-      "ts": "type Position = \"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\";"
+      "ts": "type Position = \"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\";",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 82
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/runes-generics/output.json
+++ b/tests/fixtures/runes-generics/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: string; }",
       "name": "DataTableHeader<Row = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 92
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/style-block-jsdoc-comment-ignored/output.json
+++ b/tests/fixtures/style-block-jsdoc-comment-ignored/output.json
@@ -49,7 +49,17 @@
     {
       "type": "{\n  name: string;\n}",
       "name": "RealTypedef",
-      "ts": "type RealTypedef = {\n  name: string;\n};"
+      "ts": "type RealTypedef = {\n  name: string;\n};",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 34
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/template-tag-multiple/output.json
+++ b/tests/fixtures/template-tag-multiple/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: Header; }",
       "name": "DataTableHeader<Row = DataTableRow, Header = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> { key: DataTableKey<Row>; value: Header; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> { key: DataTableKey<Row>; value: Header; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 112
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/template-tag-with-rest-props/output.json
+++ b/tests/fixtures/template-tag-with-rest-props/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: string; }",
       "name": "DataTableHeader<Row = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 92
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/template-tag/output.json
+++ b/tests/fixtures/template-tag/output.json
@@ -90,17 +90,47 @@
     {
       "type": "{ id: string | number; [key: string]: any; }",
       "name": "DataTableRow",
-      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }"
+      "ts": "interface DataTableRow { id: string | number; [key: string]: any; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 73
+        }
+      }
     },
     {
       "type": "Exclude<keyof Row, \"id\">",
       "name": "DataTableKey<Row>",
-      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;"
+      "ts": "type DataTableKey<Row> = Exclude<keyof Row, \"id\">;",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "{ key: DataTableKey<Row>; value: string; }",
       "name": "DataTableHeader<Row = DataTableRow>",
-      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
+      "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 92
+        }
+      }
     }
   ],
   "generics": [

--- a/tests/fixtures/theme-component/output.json
+++ b/tests/fixtures/theme-component/output.json
@@ -204,7 +204,17 @@
     {
       "type": "\"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\"",
       "name": "CarbonTheme",
-      "ts": "type CarbonTheme = \"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\";"
+      "ts": "type CarbonTheme = \"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\";",
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 5
+        },
+        "end": {
+          "line": 18,
+          "column": 68
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-branded-types/output.json
+++ b/tests/fixtures/typedef-branded-types/output.json
@@ -65,13 +65,33 @@
       "type": "string & { readonly __brand: \"UserId\" }",
       "name": "UserId",
       "description": "A branded string. At runtime it is a plain `string`, but the brand makes it\na distinct domain type that other strings cannot be assigned to.",
-      "ts": "type UserId = string & { readonly __brand: \"UserId\" };"
+      "ts": "type UserId = string & { readonly __brand: \"UserId\" };",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 5
+        },
+        "end": {
+          "line": 6,
+          "column": 62
+        }
+      }
     },
     {
       "type": "number & { readonly __brand: \"Cents\" }",
       "name": "Cents",
       "description": "A branded number representing a monetary amount in cents.",
-      "ts": "type Cents = number & { readonly __brand: \"Cents\" };"
+      "ts": "type Cents = number & { readonly __brand: \"Cents\" };",
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 5
+        },
+        "end": {
+          "line": 12,
+          "column": 60
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-description/output.json
+++ b/tests/fixtures/typedef-description/output.json
@@ -65,12 +65,32 @@
       "type": "0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13",
       "name": "StackScale",
       "description": "The stack scale maps to the following `@carbon/layout` values:\n- 0  --> 0 (no gap)\n- 1  --> 0.125rem\n- 2  --> 0.25rem\n- 3  --> 0.5rem\n- 4  --> 0.75rem\n- 5  --> 1rem\n- 6  --> 1.5rem\n- 7  --> 2rem\n- 8  --> 2.5rem\n- 9  --> 3rem\n- 10 --> 4rem\n- 11 --> 5rem\n- 12 --> 6rem\n- 13 --> 10rem",
-      "ts": "type StackScale = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;"
+      "ts": "type StackScale = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;",
+      "source": {
+        "start": {
+          "line": 18,
+          "column": 5
+        },
+        "end": {
+          "line": 18,
+          "column": 84
+        }
+      }
     },
     {
       "type": "StackScale | string",
       "name": "StackScaleOrString",
-      "ts": "type StackScaleOrString = StackScale | string;"
+      "ts": "type StackScaleOrString = StackScale | string;",
+      "source": {
+        "start": {
+          "line": 19,
+          "column": 5
+        },
+        "end": {
+          "line": 19,
+          "column": 54
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-discriminated-union-intersection/output.json
+++ b/tests/fixtures/typedef-discriminated-union-intersection/output.json
@@ -52,22 +52,62 @@
     {
       "type": "{ id: string; createdAt: number }",
       "name": "Base",
-      "ts": "interface Base { id: string; createdAt: number }"
+      "ts": "interface Base { id: string; createdAt: number }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 54
+        }
+      }
     },
     {
       "type": "Base & { kind: \"user\"; name: string }",
       "name": "User",
-      "ts": "type User = Base & { kind: \"user\"; name: string };"
+      "ts": "type User = Base & { kind: \"user\"; name: string };",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 58
+        }
+      }
     },
     {
       "type": "Base & { kind: \"post\"; title: string; body: string }",
       "name": "Post",
-      "ts": "type Post = Base & { kind: \"post\"; title: string; body: string };"
+      "ts": "type Post = Base & { kind: \"post\"; title: string; body: string };",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 73
+        }
+      }
     },
     {
       "type": "User | Post",
       "name": "Entity",
-      "ts": "type Entity = User | Post;"
+      "ts": "type Entity = User | Post;",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 5
+        },
+        "end": {
+          "line": 6,
+          "column": 34
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-discriminated-union/output.json
+++ b/tests/fixtures/typedef-discriminated-union/output.json
@@ -77,12 +77,32 @@
     {
       "type": "{ kind: \"success\"; value: string } | { kind: \"error\"; error: Error }",
       "name": "Result",
-      "ts": "type Result = { kind: \"success\"; value: string } | { kind: \"error\"; error: Error };"
+      "ts": "type Result = { kind: \"success\"; value: string } | { kind: \"error\"; error: Error };",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 91
+        }
+      }
     },
     {
       "type": "{ ok: true; data: number } | { ok: false; reason: string } | \"pending\"",
       "name": "Status",
-      "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \"pending\";"
+      "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \"pending\";",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 93
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-duplicate-name/output.json
+++ b/tests/fixtures/typedef-duplicate-name/output.json
@@ -41,7 +41,17 @@
     {
       "type": "{\n  /** Count */\n  count: number;\n}",
       "name": "Config",
-      "ts": "type Config = {\n  /** Count */\n  count: number;\n};"
+      "ts": "type Config = {\n  /** Count */\n  count: number;\n};",
+      "source": {
+        "start": {
+          "line": 8,
+          "column": 5
+        },
+        "end": {
+          "line": 8,
+          "column": 29
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-duplicate-property/output.json
+++ b/tests/fixtures/typedef-duplicate-property/output.json
@@ -41,7 +41,17 @@
     {
       "type": "{\n  /** Second declaration wins */\n  id: number;\n}",
       "name": "Config",
-      "ts": "type Config = {\n  /** Second declaration wins */\n  id: number;\n};"
+      "ts": "type Config = {\n  /** Second declaration wins */\n  id: number;\n};",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 29
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-event-shared-block/output.json
+++ b/tests/fixtures/typedef-event-shared-block/output.json
@@ -224,12 +224,32 @@
       "type": "\"sm\" | \"md\" | \"lg\" | \"xlg\" | \"max\"",
       "name": "BreakpointSize",
       "description": "Breakpoint size names",
-      "ts": "type BreakpointSize = \"sm\" | \"md\" | \"lg\" | \"xlg\" | \"max\";"
+      "ts": "type BreakpointSize = \"sm\" | \"md\" | \"lg\" | \"xlg\" | \"max\";",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 65
+        }
+      }
     },
     {
       "type": "320 | 672 | 1056 | 1312 | 1584",
       "name": "BreakpointValue",
-      "ts": "type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;"
+      "ts": "type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 62
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-import-type/output.json
+++ b/tests/fixtures/typedef-import-type/output.json
@@ -131,7 +131,17 @@
       "type": "{ rows: import(\"svelte/store\").Writable<string[]>; selected: import(\"svelte/store\").Readable<number> }",
       "name": "TableContext",
       "description": "The value stored under a Svelte context key, typed with imported store\ntypes. `import(...)` works inside a `@typedef` too.",
-      "ts": "interface TableContext { rows: import(\"svelte/store\").Writable<string[]>; selected: import(\"svelte/store\").Readable<number> }"
+      "ts": "interface TableContext { rows: import(\"svelte/store\").Writable<string[]>; selected: import(\"svelte/store\").Readable<number> }",
+      "source": {
+        "start": {
+          "line": 34,
+          "column": 5
+        },
+        "end": {
+          "line": 34,
+          "column": 131
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-jsdoc-properties/output.json
+++ b/tests/fixtures/typedef-jsdoc-properties/output.json
@@ -115,19 +115,49 @@
       "type": "{\n  /** The user's full name. */\n  name: string;\n  /** The user's email address. */\n  email: string;\n  /** The user's age in years. */\n  age: number;\n  /** Optional nickname. */\n  nickname?: string;\n  /** Optional phone with default. @default 555-0000 */\n  phone?: string;\n}",
       "name": "User",
       "description": "Represents a user in the system.",
-      "ts": "type User = {\n  /** The user's full name. */\n  name: string;\n  /** The user's email address. */\n  email: string;\n  /** The user's age in years. */\n  age: number;\n  /** Optional nickname. */\n  nickname?: string;\n  /** Optional phone with default. @default 555-0000 */\n  phone?: string;\n};"
+      "ts": "type User = {\n  /** The user's full name. */\n  name: string;\n  /** The user's email address. */\n  email: string;\n  /** The user's age in years. */\n  age: number;\n  /** Optional nickname. */\n  nickname?: string;\n  /** Optional phone with default. @default 555-0000 */\n  phone?: string;\n};",
+      "source": {
+        "start": {
+          "line": 5,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 27
+        }
+      }
     },
     {
       "type": "{\n  /** Whether the component is enabled. */\n  enabled: boolean;\n  /** The component theme. */\n  theme: string;\n  /** Optional timeout in milliseconds. @default 5000 */\n  timeout?: number;\n}",
       "name": "ComponentConfig",
       "description": "Configuration options for the component.",
-      "ts": "type ComponentConfig = {\n  /** Whether the component is enabled. */\n  enabled: boolean;\n  /** The component theme. */\n  theme: string;\n  /** Optional timeout in milliseconds. @default 5000 */\n  timeout?: number;\n};"
+      "ts": "type ComponentConfig = {\n  /** Whether the component is enabled. */\n  enabled: boolean;\n  /** The component theme. */\n  theme: string;\n  /** Optional timeout in milliseconds. @default 5000 */\n  timeout?: number;\n};",
+      "source": {
+        "start": {
+          "line": 15,
+          "column": 5
+        },
+        "end": {
+          "line": 15,
+          "column": 38
+        }
+      }
     },
     {
       "type": "{ id: number; label: string; }",
       "name": "SimpleType",
       "description": "Simple typedef without properties (backwards compatibility test).",
-      "ts": "interface SimpleType { id: number; label: string; }"
+      "ts": "interface SimpleType { id: number; label: string; }",
+      "source": {
+        "start": {
+          "line": 23,
+          "column": 5
+        },
+        "end": {
+          "line": 23,
+          "column": 57
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-type-predicate/output.json
+++ b/tests/fixtures/typedef-type-predicate/output.json
@@ -64,13 +64,33 @@
     {
       "type": "{ id: string; name: string }",
       "name": "User",
-      "ts": "interface User { id: string; name: string }"
+      "ts": "interface User { id: string; name: string }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 49
+        }
+      }
     },
     {
       "type": "(value: unknown) => value is User",
       "name": "UserGuard",
       "description": "A type guard expressed as a `@callback`.",
-      "ts": "type UserGuard = (value: unknown) => value is User;"
+      "ts": "type UserGuard = (value: unknown) => value is User;",
+      "source": {
+        "start": {
+          "line": 17,
+          "column": 5
+        },
+        "end": {
+          "line": 17,
+          "column": 59
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef-utility-types/output.json
+++ b/tests/fixtures/typedef-utility-types/output.json
@@ -109,13 +109,33 @@
       "type": "{ id: string; size: \"sm\" | \"md\" | \"lg\"; disabled: boolean }",
       "name": "Options",
       "description": "The full set of options. Other prop types are derived from this one\ninstead of redeclaring its fields.",
-      "ts": "interface Options { id: string; size: \"sm\" | \"md\" | \"lg\"; disabled: boolean }"
+      "ts": "interface Options { id: string; size: \"sm\" | \"md\" | \"lg\"; disabled: boolean }",
+      "source": {
+        "start": {
+          "line": 6,
+          "column": 5
+        },
+        "end": {
+          "line": 6,
+          "column": 83
+        }
+      }
     },
     {
       "type": "() => Options",
       "name": "Factory",
       "description": "A factory that produces an `Options` value.",
-      "ts": "type Factory = () => Options;"
+      "ts": "type Factory = () => Options;",
+      "source": {
+        "start": {
+          "line": 12,
+          "column": 5
+        },
+        "end": {
+          "line": 12,
+          "column": 37
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedef/output.json
+++ b/tests/fixtures/typedef/output.json
@@ -91,7 +91,17 @@
     {
       "type": "{ [key: string]: boolean; }",
       "name": "MyTypedef",
-      "ts": "interface MyTypedef { [key: string]: boolean; }"
+      "ts": "interface MyTypedef { [key: string]: boolean; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 53
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/fixtures/typedefs/output.json
+++ b/tests/fixtures/typedefs/output.json
@@ -92,12 +92,32 @@
     {
       "type": "{ [key: string]: boolean; }",
       "name": "MyTypedef",
-      "ts": "interface MyTypedef { [key: string]: boolean; }"
+      "ts": "interface MyTypedef { [key: string]: boolean; }",
+      "source": {
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 3,
+          "column": 53
+        }
+      }
     },
     {
       "type": "MyTypedef[]",
       "name": "MyTypedefArray",
-      "ts": "type MyTypedefArray = MyTypedef[];"
+      "ts": "type MyTypedefArray = MyTypedef[];",
+      "source": {
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 42
+        }
+      }
     }
   ],
   "generics": null,

--- a/tests/parse-entry-exports.test.ts
+++ b/tests/parse-entry-exports.test.ts
@@ -145,6 +145,61 @@ describe("parseEntryExports", () => {
     expect(byName(exports, "DEFAULT_THEME").source).toBe("./index.ts");
   });
 
+  test("keeps the implementation signature for an overloaded function re-exported through a barrel", async () => {
+    const exports = await parseEntryExports(entryFile);
+
+    expect(byName(exports, "format")).toMatchObject({
+      name: "format",
+      kind: "function",
+      type: "(value: string | number) => string",
+    });
+  });
+
+  test("records an enum's members as a literal union type", async () => {
+    const exports = await parseEntryExports(entryFile);
+
+    expect(byName(exports, "Status")).toMatchObject({
+      name: "Status",
+      kind: "enum",
+      type: '"active" | "inactive"',
+    });
+    expect(byName(exports, "Priority")).toMatchObject({
+      name: "Priority",
+      kind: "enum",
+      type: "0 | 1 | 2",
+    });
+  });
+
+  test("`export *` collisions keep the first declaration and warn", async () => {
+    // Not written under tests/fixtures-entry-exports because `export * from`
+    // trips the repo's own `noReExportAll` lint rule.
+    const dir = mkdtempSync(path.join(tmpdir(), "sveld-entry-exports-export-star-collision-"));
+    try {
+      writeFileSync(path.join(dir, "collide-a.ts"), 'export const SHARED = "a";\n');
+      writeFileSync(path.join(dir, "collide-b.ts"), 'export const SHARED = "b";\n');
+      writeFileSync(
+        path.join(dir, "index.ts"),
+        ['export * from "./collide-a";', 'export * from "./collide-b";', ""].join("\n"),
+      );
+
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const exports = await parseEntryExports(path.join(dir, "index.ts"));
+
+      expect(byName(exports, "SHARED")).toMatchObject({
+        name: "SHARED",
+        kind: "const",
+        value: '"a"',
+        source: "./collide-a.ts",
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("SHARED"));
+
+      warn.mockRestore();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("warns and skips a re-exported module the underlying parser can't handle, instead of throwing", async () => {
     // Not written under tests/fixtures-entry-exports because the redeclaration
     // below (valid to acorn-typescript, rejected by tsc/biome) would otherwise

--- a/tests/writer-registry.test.ts
+++ b/tests/writer-registry.test.ts
@@ -12,6 +12,8 @@ interface PlainTextWriterOptions {
   outFile: string;
 }
 
+const DUPLICATE_WRITER_ERROR_REGEX = /test-registry-duplicate-writer.*already registered/;
+
 describe("built-in writers", () => {
   test("registers json, markdown, types, custom-elements, and llms", () => {
     const names = listWriters().map((writer) => writer.name);
@@ -31,6 +33,38 @@ describe("custom writer registration (public API)", () => {
 
     expect(getWriter("test-registry-discovery-writer")).toBe(writer);
     expect(listWriters()).toContainEqual(writer);
+  });
+
+  test("registerWriter throws on a duplicate name, without replacing the original", () => {
+    const original: OutputWriter<PlainTextWriterOptions> = {
+      name: "test-registry-duplicate-writer",
+      write: () => {},
+    };
+    const duplicate: OutputWriter<PlainTextWriterOptions> = {
+      name: "test-registry-duplicate-writer",
+      write: () => {},
+    };
+
+    registerWriter(original);
+
+    expect(() => registerWriter(duplicate)).toThrow(DUPLICATE_WRITER_ERROR_REGEX);
+    expect(getWriter("test-registry-duplicate-writer")).toBe(original);
+  });
+
+  test("registerWriter overwrites a duplicate name when replace: true is passed", () => {
+    const original: OutputWriter<PlainTextWriterOptions> = {
+      name: "test-registry-replace-writer",
+      write: () => {},
+    };
+    const replacement: OutputWriter<PlainTextWriterOptions> = {
+      name: "test-registry-replace-writer",
+      write: () => {},
+    };
+
+    registerWriter(original);
+    registerWriter(replacement, { replace: true });
+
+    expect(getWriter("test-registry-replace-writer")).toBe(replacement);
   });
 
   test("a trivial custom writer registered via the public API produces its output file", async () => {
@@ -71,5 +105,111 @@ describe("custom writer registration (public API)", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  function makeResult(): GenerateBundleResult {
+    return {
+      exports: {},
+      entryExports: [],
+      components: new Map([["Button", mockComponentDocApi("Button", "Button.svelte")]]),
+      allComponentsForTypes: new Map(),
+      errors: [],
+      diagnostics: [],
+    };
+  }
+
+  test("attributes a synchronous throw in a custom writer to its registered name", async () => {
+    registerWriter({
+      name: "test-sync-throwing-writer",
+      write: () => {
+        throw new Error("boom");
+      },
+    });
+
+    await expect(
+      writeOutput(
+        makeResult(),
+        { types: false, additionalWriters: { "test-sync-throwing-writer": {} } },
+        "/mock/src/index.js",
+      ),
+    ).rejects.toThrow('sveld: writer "test-sync-throwing-writer" failed: boom');
+  });
+
+  test("attributes an async rejection in a custom writer to its registered name, with the original error as cause", async () => {
+    const original = new Error("async boom");
+    registerWriter({
+      name: "test-async-throwing-writer",
+      write: async () => {
+        throw original;
+      },
+    });
+
+    const promise = writeOutput(
+      makeResult(),
+      { types: false, additionalWriters: { "test-async-throwing-writer": {} } },
+      "/mock/src/index.js",
+    );
+
+    await expect(promise).rejects.toThrow('sveld: writer "test-async-throwing-writer" failed: async boom');
+    await promise.catch((error: Error) => {
+      expect(error.cause).toBe(original);
+    });
+  });
+
+  test("a throwing custom writer doesn't stop sibling writers in the same run", async () => {
+    const tempDir = await mkdtemp(path.join(process.cwd(), ".tmp-sveld-custom-writer-sibling-"));
+    const outFile = path.join(tempDir, "sibling.txt");
+
+    try {
+      registerWriter({
+        name: "test-sibling-throwing-writer",
+        write: () => {
+          throw new Error("boom");
+        },
+      });
+      registerWriter<PlainTextWriterOptions>({
+        name: "test-sibling-ok-writer",
+        write: (_components, options) => {
+          writeFileSync(options.outFile, "ok");
+        },
+      });
+
+      await expect(
+        writeOutput(
+          makeResult(),
+          {
+            types: false,
+            additionalWriters: {
+              "test-sibling-throwing-writer": {},
+              "test-sibling-ok-writer": { outFile },
+            },
+          },
+          "/mock/src/index.js",
+        ),
+      ).rejects.toThrow();
+
+      expect(existsSync(outFile)).toBe(true);
+      expect(readFileSync(outFile, "utf-8")).toBe("ok");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("passes dryRun through to a custom writer's options", async () => {
+    let received: boolean | undefined;
+    registerWriter<{ dryRun?: boolean }>({
+      name: "test-dry-run-writer",
+      write: (_components, options) => {
+        received = options.dryRun;
+      },
+    });
+
+    await writeOutput(
+      makeResult(),
+      { types: false, dryRun: true, additionalWriters: { "test-dry-run-writer": {} } },
+      "/mock/src/index.js",
+    );
+
+    expect(received).toBe(true);
   });
 });


### PR DESCRIPTION
Five small, independent writer/parser fixes bundled together: JSON
output can drop source position ranges to shrink large files, entry
barrel exports handle function overloads, enums, and `export *`
collisions correctly, custom writer failures are now attributed to
the writer that threw, and Markdown can split into one file per
component.

```js
sveld({
  markdown: true,
  markdownOptions: {
    // writes docs/Button.md, docs/Alert.md, ... plus docs/README.md
    outDir: "docs",
  },
});
```