### PR TITLE
feat(writer): migration readiness report

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ export default class Button extends SvelteComponentTyped<
 - [Custom Elements Manifest](#custom-elements-manifest)
   - [Consuming the manifest](#consuming-the-manifest)
 - [llms.txt Output](#llmstxt-output)
+- [Migration Report](#migration-report)
 - [Custom Writers](#custom-writers)
   - [The `OutputWriter` contract](#the-outputwriter-contract)
   - [Registering a writer](#registering-a-writer)
@@ -923,6 +924,9 @@ The `svelte` condition lets bundlers that understand it (Vite, Rollup, webpack v
   - **`linkBase`** (string, optional, default: `""`): Prefixed to each component's link in `llms.txt`.
   - **`title`** (string, optional, default: the `"name"` field from `package.json`): The `# <title>` heading both files start with.
   - **`summary`** (string, optional, default: the `"description"` field from `package.json`): The `> <summary>` blockquote under the title.
+- **`migrationReport`** (boolean, optional): Generate a [Svelte 5 migration readiness report](#migration-report) (`MIGRATION_REPORT.json` / `MIGRATION_REPORT.md`). Also available as the `--migration-report` CLI flag.
+- **`migrationReportOptions`** (object, optional): Options for migration report output.
+  - **`outDir`** (string, optional): Directory (relative to the project root) both files are written into. Defaults to the project root.
 - **`config`** (boolean | string, optional, default: `false`): Load `sveld.config.{js,mjs,ts}` and merge it with these options; these options win when a key is set in both. `true` resolves the config from the Vite project root (or `process.cwd()` outside Vite); a string is an explicit path to the config file. See [Config File](#config-file).
 - **`watch`** (boolean, optional, default: `false`): Regenerate output incrementally when relevant source changes during `vite dev` / `vite build --watch`. A reparse is triggered by: editing a component; editing the entry barrel itself, which adds/removes the corresponding component; or editing a non-`.svelte` file a component depends on via [`@extendProps`](#extendprops) / `@extends` or a typedef `import("./x")` reference. Only the affected components are re-parsed, rather than rebuilding every component. Overlapping regenerations are queued, never run concurrently. Without this option, the plugin only runs during `vite build`.
 - **`failFast`** (boolean, optional, default: `false`): Abort the entire run when a single component fails to parse. By default, parse failures are collected as diagnostics (and reported to `stderr`) so the remaining components still emit their output. Also available as the `--fail-fast` CLI flag.
@@ -1268,6 +1272,35 @@ sveld({
   - **`summary`** (string, optional, default: the `"description"` field from `package.json`): The `> <summary>` blockquote under the title. Omitted when neither is set.
 
 Each component's one-line summary in `llms.txt` is the first sentence of its [`@component` comment](#component-comments), falling back to `"Component"`. Set `documentExports: true` to also list entry-barrel exports (consts, functions, types) in `llms.txt` under an `## Exports` heading.
+
+## Migration Report
+
+Set `migrationReport: true` to emit `MIGRATION_REPORT.json` / `MIGRATION_REPORT.md`: a per-component Svelte 5 migration readiness heuristic, covering every discovered component (like `.d.ts` output, not just the exported public API surface).
+
+```diff
+sveld({
++  migrationReport: true,
+})
+```
+
+- **`migrationReport`** (boolean, optional): Generate `MIGRATION_REPORT.json` and `MIGRATION_REPORT.md`. Also available as the `--migration-report` CLI flag.
+- **`migrationReportOptions`** (object, optional):
+  - **`outDir`** (string, optional): Directory (relative to the project root) both files are written into. Defaults to the project root.
+
+Each component is scored `syntaxMode: "runes"` -> `100` (already migrated); `syntaxMode: "legacy"` -> `100` minus a weighted count of legacy patterns, capped at `0`:
+
+| Pattern | Field | Weight |
+| :- | :- | :- |
+| Legacy `export let` prop | `exportLet` | 2 |
+| Bare `on:event` forwarding | `onDirectives` | 4 |
+| `<slot>` declaration | `slots` | 5 |
+| `createEventDispatcher()` event | `createEventDispatcher` | 6 |
+| `$$restProps` usage | `restPropsLegacy` | 10 |
+| Top-level `$:` reactive statement | `reactiveStatements` | 3 |
+
+The Markdown report leads with a rollup line (component totals by `syntaxMode`, mean score), then one table of every component sorted by score ascending. The JSON report additionally lists the ten lowest-scoring components under `summary.lowestScoring`.
+
+The score is a **directional heuristic, not an authoritative migration cost estimate** - the same honesty as the [`reactive`](#reactive) field. It counts legacy patterns; it doesn't weigh how hard each one is to migrate in your specific component, so two components with the same score can take very different amounts of effort to convert. Use it to prioritize which components to look at first, not as a work estimate.
 
 ## Custom Writers
 

--- a/schema/component-api.schema.json
+++ b/schema/component-api.schema.json
@@ -114,6 +114,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/typedef" }
         },
+        "reactiveStatementCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of top-level `$:` reactive-statement labels in the instance script. Always 0 in runes mode."
+        },
         "generics": {
           "oneOf": [
             { "type": "null" },

--- a/schema/migration-report.schema.json
+++ b/schema/migration-report.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://carbon-design-system.github.io/sveld/migration-report.schema.json",
+  "title": "sveld Migration Report",
+  "description": "Per-component Svelte 5 migration readiness heuristic, written by the `migration-report` writer (`--migration-report`).",
+  "type": "object",
+  "required": ["schemaVersion", "generator", "components", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "generator": {
+      "type": "object",
+      "required": ["name", "version", "svelteVersion"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "svelteVersion": { "type": "string" }
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/component" }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["totalComponents", "byMode", "meanScore", "lowestScoring"],
+      "additionalProperties": false,
+      "properties": {
+        "totalComponents": { "type": "integer", "minimum": 0 },
+        "byMode": {
+          "type": "object",
+          "required": ["legacy", "runes"],
+          "additionalProperties": false,
+          "properties": {
+            "legacy": { "type": "integer", "minimum": 0 },
+            "runes": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "meanScore": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "lowestScoring": {
+          "type": "array",
+          "maxItems": 10,
+          "items": { "$ref": "#/$defs/lowestScoringEntry" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "required": ["moduleName", "filePath", "syntaxMode", "counts", "score"],
+      "additionalProperties": false,
+      "properties": {
+        "moduleName": { "type": "string" },
+        "filePath": { "type": "string" },
+        "syntaxMode": { "enum": ["legacy", "runes"] },
+        "counts": { "$ref": "#/$defs/counts" },
+        "score": { "type": "integer", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "required": [
+        "exportLet",
+        "onDirectives",
+        "slots",
+        "createEventDispatcher",
+        "restPropsLegacy",
+        "reactiveStatements"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exportLet": { "type": "integer", "minimum": 0 },
+        "onDirectives": { "type": "integer", "minimum": 0 },
+        "slots": { "type": "integer", "minimum": 0 },
+        "createEventDispatcher": { "type": "integer", "minimum": 0 },
+        "restPropsLegacy": { "type": "integer", "minimum": 0 },
+        "reactiveStatements": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "lowestScoringEntry": {
+      "type": "object",
+      "required": ["moduleName", "filePath", "score"],
+      "additionalProperties": false,
+      "properties": {
+        "moduleName": { "type": "string" },
+        "filePath": { "type": "string" },
+        "score": { "type": "integer", "minimum": 0, "maximum": 100 }
+      }
+    }
+  }
+}

--- a/src/ComponentParser.ts
+++ b/src/ComponentParser.ts
@@ -40,7 +40,7 @@ import { parseCustomTypes, processNodeJSDoc } from "./parser/jsdoc";
 import { resolvePropTypeAndDocs } from "./parser/prop-shared";
 import { addProp, processInitializer } from "./parser/props";
 import { maybeSetRestProps } from "./parser/rest-props";
-import { detectSyntaxMode } from "./parser/runes-detection";
+import { countReactiveStatements, detectSyntaxMode } from "./parser/runes-detection";
 import {
   buildRunesPropTypeMetadata,
   normalizeRunesCallbackProps,
@@ -671,6 +671,8 @@ export interface ParsedComponent {
   /** Serialized events for JSON/API output. */
   events: SerializedComponentEvent[];
   typedefs: TypeDef[];
+  /** Count of top-level `$:` reactive-statement labels in the instance script. Always 0 in runes mode. */
+  reactiveStatementCount: number;
   generics: null | ComponentGenerics;
   rest_props: RestProps;
   extends?: Extends;
@@ -2269,6 +2271,7 @@ export default class ComponentParser {
       slots: processedSlots,
       events: eventsArray,
       typedefs: typedefsArray,
+      reactiveStatementCount: countReactiveStatements(this.ctx.parsed?.instance),
       generics: this.ctx.generics,
       rest_props: this.ctx.rest_props,
       extends: this.ctx.extends,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,7 @@ Options:
   --markdown            Generate component documentation in Markdown format
   --custom-elements     Generate a Custom Elements Manifest (custom-elements.json)
   --llms                Generate an llms.txt / llms-full.txt pair (https://llmstxt.org)
+  --migration-report    Generate a Svelte 5 migration readiness report (MIGRATION_REPORT.json / MIGRATION_REPORT.md)
   --fail-fast           Abort the run when a single component fails to parse
   --dry-run             Resolve, parse, and print "would write" lines for each output file instead of writing anything (including the parse cache)
   --quiet               Suppress progress logs (errors, the diagnostics summary, and the --check report are unaffected)
@@ -116,6 +117,7 @@ const KNOWN_FLAGS = [
   "stdout",
   "custom-elements",
   "llms",
+  "migration-report",
   "strict",
   "report-diagnostics",
   "resolve-types",
@@ -142,6 +144,7 @@ const BOOLEAN_FLAGS = new Set([
   "quiet",
   "custom-elements",
   "llms",
+  "migration-report",
   "strict",
   "report-diagnostics",
   "resolve-types",
@@ -222,6 +225,8 @@ function parseCliFlagValue(flag: string, value: string | boolean, arg: string, r
       return { kind: "option", option: { customElements: value === true || value === "true" } };
     case "llms":
       return { kind: "option", option: { llms: value === true || value === "true" } };
+    case "migration-report":
+      return { kind: "option", option: { migrationReport: value === true || value === "true" } };
     case "strict":
       // The value is validated in `cli()` once it can be reported as a usage
       // error (`--strict=oops`); a bare `--strict` means `true`.

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -221,6 +221,8 @@ const KNOWN_TOP_LEVEL_KEYS = [
   "customElementsOptions",
   "llms",
   "llmsOptions",
+  "migrationReport",
+  "migrationReportOptions",
   "additionalWriters",
   "failFast",
   "watch",
@@ -245,6 +247,7 @@ const KNOWN_NESTED_KEYS: Record<string, string[]> = {
   markdownOptions: ["write", "outFile", "entryExports", "onAppend", "dryRun"],
   customElementsOptions: ["outFile", "dryRun"],
   llmsOptions: ["outDir", "linkBase", "title", "summary", "entryExports", "dryRun"],
+  migrationReportOptions: ["outDir", "dryRun"],
   diagnostics: ["ignore"],
 };
 

--- a/src/parser/runes-detection.ts
+++ b/src/parser/runes-detection.ts
@@ -222,7 +222,7 @@ function scanForRuneReference(root: unknown, baseScope: ScopeStack): boolean {
 }
 
 /** `<script>` / `<script module>` wrap their `Program` in `.content`. Same shape check as `scopes.ts`. */
-function getScriptProgramBody(script: unknown): unknown[] | undefined {
+export function getScriptProgramBody(script: unknown): unknown[] | undefined {
   if (!script || typeof script !== "object") return undefined;
 
   if ("content" in script) {
@@ -237,6 +237,29 @@ function getScriptProgramBody(script: unknown): unknown[] | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Counts top-level `$:` reactive-statement labels in an instance script. Only checks the
+ * script's direct statement list (Svelte never recognizes a `$:` label anywhere else), so
+ * this is a single non-recursive pass rather than a full AST walk.
+ */
+export function countReactiveStatements(instance: unknown): number {
+  const body = getScriptProgramBody(instance);
+  if (!body) return 0;
+
+  let count = 0;
+  for (const statement of body) {
+    if (
+      statement &&
+      typeof statement === "object" &&
+      (statement as { type?: string }).type === "LabeledStatement" &&
+      (statement as { label?: { name?: string } }).label?.name === "$"
+    ) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,7 @@ import { renderCustomElementsManifest, type WriteCustomElementsOptions } from ".
 import { renderJsonDocument, renderJsonLines, type WriteJsonOptions } from "./writer/writer-json";
 import type { WriteLlmsOptions } from "./writer/writer-llms";
 import { renderMarkdownDocument, type WriteMarkdownOptions } from "./writer/writer-markdown";
+import type { WriteMigrationReportOptions } from "./writer/writer-migration-report";
 import type { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 
 export type { ComponentDocApi, ComponentDocs, GenerateBundleResult } from "./bundle";
@@ -55,6 +56,13 @@ export interface PluginSveldOptions
   /** Generate a first-party `llms.txt` / `llms-full.txt` pair (per https://llmstxt.org). */
   llms?: boolean;
   llmsOptions?: Partial<WriteLlmsOptions>;
+  /**
+   * Generate a Svelte 5 migration readiness report (`MIGRATION_REPORT.json` /
+   * `MIGRATION_REPORT.md`): a per-component 0-100 heuristic score plus a
+   * library-wide rollup. See the README's "Migration report" section.
+   */
+  migrationReport?: boolean;
+  migrationReportOptions?: Partial<WriteMigrationReportOptions>;
   /**
    * Run additional, userland-registered writers (via `registerWriter` from
    * "sveld") beyond the built-in `json`/`markdown`/`types` outputs. Keyed by
@@ -225,7 +233,7 @@ export default function pluginSveld(opts?: PluginSveldOptions): SveldPlugin {
 
 /** Looks up a built-in writer by name; throws if `built-in-writers` never registered it. */
 function runBuiltInWriter(
-  name: "types" | "json" | "markdown" | "custom-elements" | "llms",
+  name: "types" | "json" | "markdown" | "custom-elements" | "llms" | "migration-report",
   components: ComponentDocs,
   options: unknown,
 ) {
@@ -334,6 +342,18 @@ export async function writeOutput(
       entryExports: result.entryExports,
       dryRun,
     } satisfies WriteLlmsOptions);
+  }
+
+  if (opts?.migrationReport) {
+    /**
+     * Use allComponentsForTypes, matching the .d.ts writer's convention: a
+     * migration readiness report is only useful if it covers every
+     * discovered component, not just the exported public API surface.
+     */
+    await runBuiltInWriter("migration-report", result.allComponentsForTypes, {
+      ...opts?.migrationReportOptions,
+      dryRun,
+    } satisfies WriteMigrationReportOptions);
   }
 
   const additionalWrites = Object.entries(opts?.additionalWriters ?? {}).map(([name, writerOptions]) => {

--- a/src/writer/built-in-writers.ts
+++ b/src/writer/built-in-writers.ts
@@ -3,6 +3,7 @@ import writeCustomElements from "./writer-custom-elements";
 import writeJson from "./writer-json";
 import writeLlms from "./writer-llms";
 import writeMarkdown from "./writer-markdown";
+import writeMigrationReport from "./writer-migration-report";
 import writeTsDefinitions from "./writer-ts-definitions";
 
 registerWriter({ name: "json", componentSet: "exported", write: writeJson });
@@ -10,3 +11,4 @@ registerWriter({ name: "markdown", componentSet: "exported", write: writeMarkdow
 registerWriter({ name: "types", componentSet: "all", write: writeTsDefinitions });
 registerWriter({ name: "custom-elements", componentSet: "exported", write: writeCustomElements });
 registerWriter({ name: "llms", componentSet: "exported", write: writeLlms });
+registerWriter({ name: "migration-report", componentSet: "all", write: writeMigrationReport });

--- a/src/writer/writer-migration-report.ts
+++ b/src/writer/writer-migration-report.ts
@@ -1,0 +1,214 @@
+import path from "node:path";
+import { info } from "../logger";
+import { normalizeSeparators } from "../path";
+import type { ComponentDocApi, ComponentDocs } from "../plugin";
+import { buildComponentApiDocument } from "./document-model";
+import Writer from "./Writer";
+
+export interface WriteMigrationReportOptions {
+  outDir?: string;
+  /** @internal Report the resolved paths instead of writing. Always set by the caller from `sveld --dry-run`. */
+  dryRun?: boolean;
+}
+
+export interface MigrationReportCounts {
+  /** Legacy `export let` props (0 for runes components). */
+  exportLet: number;
+  /** Bare `on:event` forwarded-event directives. */
+  onDirectives: number;
+  /** `<slot>` (legacy) or `{@render}` snippet (runes) declarations. */
+  slots: number;
+  /** `createEventDispatcher()`-style dispatched events. */
+  createEventDispatcher: number;
+  /** `$$restProps` usage (0 for runes components; runes rest-destructuring isn't migration debt). */
+  restPropsLegacy: number;
+  /** Top-level `$:` reactive-statement labels. */
+  reactiveStatements: number;
+}
+
+export interface MigrationReportComponentEntry {
+  moduleName: string;
+  filePath: string;
+  syntaxMode: "legacy" | "runes";
+  counts: MigrationReportCounts;
+  /** 0-100 readiness heuristic; see `WEIGHTS` and the README's "Migration report" section for the caveat. */
+  score: number;
+}
+
+export interface MigrationReportSummary {
+  totalComponents: number;
+  byMode: { legacy: number; runes: number };
+  /** Mean `score` across every component, rounded to the nearest integer. */
+  meanScore: number;
+  /** The ten lowest-scoring components, ascending. */
+  lowestScoring: Array<Pick<MigrationReportComponentEntry, "moduleName" | "filePath" | "score">>;
+}
+
+export interface MigrationReportDocument {
+  schemaVersion: 1;
+  generator: { name: string; version: string; svelteVersion: string };
+  components: MigrationReportComponentEntry[];
+  summary: MigrationReportSummary;
+}
+
+/**
+ * Points subtracted from 100 per occurrence of each count, for a legacy
+ * component's readiness score. A runes component always scores 100,
+ * regardless of these counts, since it has already migrated. Documented in
+ * the README so the weighting isn't a black box.
+ */
+export const MIGRATION_REPORT_SCORE_WEIGHTS: Record<keyof MigrationReportCounts, number> = {
+  exportLet: 2,
+  onDirectives: 4,
+  slots: 5,
+  createEventDispatcher: 6,
+  restPropsLegacy: 10,
+  reactiveStatements: 3,
+};
+
+const LOWEST_SCORING_LIMIT = 10;
+
+function computeCounts(component: ComponentDocApi): MigrationReportCounts {
+  const isLegacy = component.syntaxMode === "legacy";
+
+  return {
+    exportLet: isLegacy ? component.props.filter((prop) => prop.kind === "let").length : 0,
+    onDirectives: component.events.filter((event) => event.type === "forwarded").length,
+    slots: component.slots.length,
+    createEventDispatcher: component.events.filter((event) => event.type === "dispatched").length,
+    restPropsLegacy: isLegacy && component.rest_props !== undefined ? 1 : 0,
+    reactiveStatements: component.reactiveStatementCount,
+  };
+}
+
+/**
+ * 100 for a runes component (already migrated); otherwise 100 minus each
+ * count weighted by {@link MIGRATION_REPORT_SCORE_WEIGHTS}, capped at 0. A
+ * directional heuristic, not an authoritative migration cost estimate - see
+ * the README's "Migration report" section.
+ */
+function computeScore(syntaxMode: "legacy" | "runes", counts: MigrationReportCounts): number {
+  if (syntaxMode === "runes") return 100;
+
+  let deduction = 0;
+  for (const key of Object.keys(MIGRATION_REPORT_SCORE_WEIGHTS) as Array<keyof MigrationReportCounts>) {
+    deduction += counts[key] * MIGRATION_REPORT_SCORE_WEIGHTS[key];
+  }
+
+  return Math.max(0, 100 - deduction);
+}
+
+function buildSummary(entries: MigrationReportComponentEntry[]): MigrationReportSummary {
+  const byMode = { legacy: 0, runes: 0 };
+  let scoreTotal = 0;
+  for (const entry of entries) {
+    byMode[entry.syntaxMode] += 1;
+    scoreTotal += entry.score;
+  }
+
+  return {
+    totalComponents: entries.length,
+    byMode,
+    meanScore: entries.length === 0 ? 0 : Math.round(scoreTotal / entries.length),
+    lowestScoring: entries
+      .slice(0, LOWEST_SCORING_LIMIT)
+      .map(({ moduleName, filePath, score }) => ({ moduleName, filePath, score })),
+  };
+}
+
+/**
+ * Renders the migration readiness document (sorted by `score` ascending, so
+ * the least-migrated components lead) without touching disk. Used by both
+ * `writeMigrationReport` and tests.
+ */
+export function renderMigrationReportDocument(components: ComponentDocs): MigrationReportDocument {
+  const document = buildComponentApiDocument(components);
+
+  const entries = document.components
+    .map((component): MigrationReportComponentEntry => {
+      const counts = computeCounts(component);
+      return {
+        moduleName: component.moduleName,
+        filePath: component.filePath,
+        syntaxMode: component.syntaxMode,
+        counts,
+        score: computeScore(component.syntaxMode, counts),
+      };
+    })
+    .sort((a, b) => a.score - b.score);
+
+  return {
+    schemaVersion: 1,
+    generator: document.generator,
+    components: entries,
+    summary: buildSummary(entries),
+  };
+}
+
+const COUNT_COLUMNS: Array<{ key: keyof MigrationReportCounts; header: string }> = [
+  { key: "exportLet", header: "Export let" },
+  { key: "onDirectives", header: "on: forwarded" },
+  { key: "slots", header: "Slots/Snippets" },
+  { key: "createEventDispatcher", header: "dispatchEvent" },
+  { key: "restPropsLegacy", header: "$$restProps" },
+  { key: "reactiveStatements", header: "$: statements" },
+];
+
+/** Renders the Markdown report for a document already built by {@link renderMigrationReportDocument}. */
+export function renderMigrationReportMarkdown(report: MigrationReportDocument): string {
+  const lines: string[] = [];
+
+  lines.push("# Migration Readiness Report", "");
+  lines.push(
+    `${report.summary.totalComponents} component${report.summary.totalComponents === 1 ? "" : "s"} - ` +
+      `${report.summary.byMode.runes} runes, ${report.summary.byMode.legacy} legacy - ` +
+      `mean readiness score **${report.summary.meanScore}**.`,
+    "",
+  );
+
+  const headerCells = ["Component", "Mode", "Score", ...COUNT_COLUMNS.map((column) => column.header)];
+  lines.push(`| ${headerCells.join(" | ")} |`);
+  lines.push(`| ${headerCells.map(() => ":-").join(" | ")} |`);
+
+  for (const entry of report.components) {
+    const cells = [
+      entry.moduleName,
+      entry.syntaxMode,
+      String(entry.score),
+      ...COUNT_COLUMNS.map((column) => String(entry.counts[column.key])),
+    ];
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Writes `MIGRATION_REPORT.json` and `MIGRATION_REPORT.md`: a per-component
+ * Svelte 5 migration readiness heuristic (`syntaxMode`, legacy-pattern
+ * counts, and a 0-100 score), plus a library-wide rollup. See the README's
+ * "Migration report" section for the score's weights and its caveat.
+ *
+ * @example
+ * ```ts
+ * await writeMigrationReport(components, { outDir: "." });
+ * ```
+ */
+export default async function writeMigrationReport(components: ComponentDocs, options: WriteMigrationReportOptions) {
+  const report = renderMigrationReportDocument(components);
+  const writer = new Writer({ dryRun: options.dryRun });
+
+  const jsonRelPath = normalizeSeparators(path.join(options.outDir ?? "", "MIGRATION_REPORT.json"));
+  const mdRelPath = normalizeSeparators(path.join(options.outDir ?? "", "MIGRATION_REPORT.md"));
+
+  const [jsonWritten, mdWritten] = await Promise.all([
+    writer.write(path.join(process.cwd(), jsonRelPath), `${JSON.stringify(report, null, 2)}\n`),
+    writer.write(path.join(process.cwd(), mdRelPath), renderMigrationReportMarkdown(report)),
+  ]);
+
+  if (!options.dryRun) {
+    info(`${jsonWritten ? "created" : "unchanged"} "${jsonRelPath}".`);
+    info(`${mdWritten ? "created" : "unchanged"} "${mdRelPath}".`);
+  }
+}

--- a/tests/WriterMigrationReport.test.ts
+++ b/tests/WriterMigrationReport.test.ts
@@ -1,0 +1,270 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Ajv2020 from "ajv/dist/2020";
+import type { ComponentProp, SerializedComponentEvent } from "../src/ComponentParser";
+import { setQuiet } from "../src/logger";
+import { normalizeSeparators } from "../src/path";
+import type { ComponentDocs } from "../src/plugin";
+import writeMigrationReport, {
+  MIGRATION_REPORT_SCORE_WEIGHTS,
+  renderMigrationReportDocument,
+  renderMigrationReportMarkdown,
+} from "../src/writer/writer-migration-report";
+import { mockComponentDocApi } from "./test-brands";
+
+function mockProp(name: string, overrides?: Partial<ComponentProp>): ComponentProp {
+  return {
+    name,
+    kind: "let",
+    constant: false,
+    isFunction: false,
+    isFunctionDeclaration: false,
+    isRequired: true,
+    reactive: false,
+    ...overrides,
+  };
+}
+
+function mockForwardedEvent(name: string): SerializedComponentEvent {
+  return { type: "forwarded", name } as SerializedComponentEvent;
+}
+
+function mockDispatchedEvent(name: string): SerializedComponentEvent {
+  return { type: "dispatched", name } as SerializedComponentEvent;
+}
+
+const LEADING_TABLE_PIPE_REGEX = /^\|\s*/;
+
+// Pure-legacy fixture: every legacy migration-debt pattern present at least once.
+const legacyButton = mockComponentDocApi("Button", "Button.svelte", {
+  syntaxMode: "legacy",
+  props: [mockProp("label"), mockProp("size", { kind: "let" })],
+  events: [mockForwardedEvent("click"), mockDispatchedEvent("close")],
+  slots: [{ default: true }],
+  rest_props: { type: "Element", name: "div" },
+  reactiveStatementCount: 2,
+});
+
+const legacyModal = mockComponentDocApi("Modal", "Modal.svelte", {
+  syntaxMode: "legacy",
+  props: [mockProp("open")],
+  events: [],
+  slots: [{ default: true }, { default: false, name: "footer" }],
+});
+
+const pureLegacyComponents: ComponentDocs = new Map([
+  ["Button", legacyButton],
+  ["Modal", legacyModal],
+]);
+
+// Pure-runes fixture: same shapes as the legacy components (forwarded events,
+// slots/snippets), but already migrated, so every count-driving pattern that
+// still appears must not affect the score.
+const runesButton = mockComponentDocApi("RunesButton", "RunesButton.svelte", {
+  syntaxMode: "runes",
+  props: [mockProp("label")],
+  events: [mockForwardedEvent("click"), mockDispatchedEvent("close")],
+  slots: [{ default: true }],
+  reactiveStatementCount: 2,
+});
+
+const runesModal = mockComponentDocApi("RunesModal", "RunesModal.svelte", {
+  syntaxMode: "runes",
+  props: [],
+  slots: [{ default: false, name: "footer" }],
+});
+
+const pureRunesComponents: ComponentDocs = new Map([
+  ["RunesButton", runesButton],
+  ["RunesModal", runesModal],
+]);
+
+// Mixed-library fixture: enough components (with distinct scores) to exercise
+// the rollup's byMode totals, mean score, and the lowest-ten cap.
+function mockLegacyWithExportLetCount(name: string, exportLetCount: number) {
+  return mockComponentDocApi(name, `${name}.svelte`, {
+    syntaxMode: "legacy",
+    props: Array.from({ length: exportLetCount }, (_, index) => mockProp(`prop${index}`)),
+  });
+}
+
+const mixedComponents: ComponentDocs = new Map([
+  ...Array.from(
+    { length: 11 },
+    (_, index) => [`Legacy${index}`, mockLegacyWithExportLetCount(`Legacy${index}`, index + 1)] as const,
+  ),
+  ["RunesOnly", mockComponentDocApi("RunesOnly", "RunesOnly.svelte", { syntaxMode: "runes" })] as const,
+]);
+
+describe("renderMigrationReportDocument", () => {
+  test("counts legacy migration-debt patterns and derives a weighted score", () => {
+    const report = renderMigrationReportDocument(pureLegacyComponents);
+    const button = report.components.find((c) => c.moduleName === "Button");
+
+    expect(button?.counts).toEqual({
+      exportLet: 2,
+      onDirectives: 1,
+      slots: 1,
+      createEventDispatcher: 1,
+      restPropsLegacy: 1,
+      reactiveStatements: 2,
+    });
+
+    const expectedScore =
+      100 -
+      (2 * MIGRATION_REPORT_SCORE_WEIGHTS.exportLet +
+        1 * MIGRATION_REPORT_SCORE_WEIGHTS.onDirectives +
+        1 * MIGRATION_REPORT_SCORE_WEIGHTS.slots +
+        1 * MIGRATION_REPORT_SCORE_WEIGHTS.createEventDispatcher +
+        1 * MIGRATION_REPORT_SCORE_WEIGHTS.restPropsLegacy +
+        2 * MIGRATION_REPORT_SCORE_WEIGHTS.reactiveStatements);
+    expect(button?.score).toBe(expectedScore);
+  });
+
+  test("caps a heavily-flagged legacy component's score at 0", () => {
+    const overloaded = mockComponentDocApi("Overloaded", "Overloaded.svelte", {
+      syntaxMode: "legacy",
+      props: Array.from({ length: 50 }, (_, index) => mockProp(`prop${index}`)),
+    });
+
+    const report = renderMigrationReportDocument(new Map([["Overloaded", overloaded]]));
+    expect(report.components[0]?.score).toBe(0);
+  });
+
+  test("a runes component always scores 100, regardless of remaining forwarded events/slots", () => {
+    const report = renderMigrationReportDocument(pureRunesComponents);
+
+    for (const component of report.components) {
+      expect(component.syntaxMode).toBe("runes");
+      expect(component.score).toBe(100);
+    }
+
+    // The counts are still reported (informational), just not scored against.
+    const runesButtonEntry = report.components.find((c) => c.moduleName === "RunesButton");
+    expect(runesButtonEntry?.counts.onDirectives).toBe(1);
+    expect(runesButtonEntry?.counts.createEventDispatcher).toBe(1);
+    // Legacy-only counters are always 0 in runes mode.
+    expect(runesButtonEntry?.counts.exportLet).toBe(0);
+    expect(runesButtonEntry?.counts.restPropsLegacy).toBe(0);
+  });
+
+  test("components are sorted by score ascending", () => {
+    const report = renderMigrationReportDocument(mixedComponents);
+    const scores = report.components.map((c) => c.score);
+    expect(scores).toEqual([...scores].sort((a, b) => a - b));
+  });
+
+  test("summary rolls up totals by mode, mean score, and the ten lowest-scoring components", () => {
+    const report = renderMigrationReportDocument(mixedComponents);
+
+    expect(report.summary.totalComponents).toBe(12);
+    expect(report.summary.byMode).toEqual({ legacy: 11, runes: 1 });
+
+    const expectedMean = Math.round(
+      report.components.reduce((total, c) => total + c.score, 0) / report.components.length,
+    );
+    expect(report.summary.meanScore).toBe(expectedMean);
+
+    expect(report.summary.lowestScoring).toHaveLength(10);
+    expect(report.summary.lowestScoring).toEqual(
+      report.components.slice(0, 10).map(({ moduleName, filePath, score }) => ({ moduleName, filePath, score })),
+    );
+  });
+
+  test("JSON document matches schema/migration-report.schema.json", () => {
+    const ajv = new Ajv2020({ strict: true, allErrors: true });
+    const schema = JSON.parse(readFileSync(join(process.cwd(), "schema", "migration-report.schema.json"), "utf-8"));
+    const validate = ajv.compile(schema);
+
+    for (const components of [pureLegacyComponents, pureRunesComponents, mixedComponents]) {
+      const report = renderMigrationReportDocument(components);
+      const valid = validate(report);
+      if (!valid) {
+        throw new Error(`Schema validation failed:\n${ajv.errorsText(validate.errors, { separator: "\n" })}`);
+      }
+      expect(valid).toBe(true);
+    }
+  });
+});
+
+describe("renderMigrationReportMarkdown", () => {
+  test("leads with the rollup line, then one table sorted by score ascending", () => {
+    const report = renderMigrationReportDocument(pureLegacyComponents);
+    const markdown = renderMigrationReportMarkdown(report);
+
+    expect(markdown).toStartWith("# Migration Readiness Report\n\n");
+    expect(markdown).toContain("2 components - 0 runes, 2 legacy - mean readiness score");
+
+    const moduleNameOrder = report.components.map((c) => c.moduleName);
+    const tableStart = markdown.indexOf("| Component |");
+    const rows = markdown
+      .slice(tableStart)
+      .split("\n")
+      .filter((line) => line.startsWith("| ") && !line.startsWith("| Component") && !line.startsWith("| :-"));
+    expect(rows.map((row) => row.split(" | ")[0]?.replace(LEADING_TABLE_PIPE_REGEX, ""))).toEqual(moduleNameOrder);
+  });
+});
+
+describe("writeMigrationReport", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setQuiet(false);
+    jest.restoreAllMocks();
+  });
+
+  test("writes MIGRATION_REPORT.json and MIGRATION_REPORT.md to outDir", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "sveld-migration-report-"));
+    const previousCwd = process.cwd();
+    process.chdir(tempDir);
+
+    try {
+      await writeMigrationReport(pureLegacyComponents, { outDir: "docs" });
+
+      const report = renderMigrationReportDocument(pureLegacyComponents);
+      expect(JSON.parse(readFileSync(join(tempDir, "docs", "MIGRATION_REPORT.json"), "utf-8"))).toEqual(report);
+      expect(readFileSync(join(tempDir, "docs", "MIGRATION_REPORT.md"), "utf-8")).toBe(
+        renderMigrationReportMarkdown(report),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "docs/MIGRATION_REPORT.json".'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "docs/MIGRATION_REPORT.md".'));
+
+      errorSpy.mockClear();
+      await writeMigrationReport(pureLegacyComponents, { outDir: "docs" });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('unchanged "docs/MIGRATION_REPORT.json".'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('unchanged "docs/MIGRATION_REPORT.md".'));
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run reports the resolved paths and writes nothing to disk", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "sveld-migration-report-dry-run-"));
+    const previousCwd = process.cwd();
+    process.chdir(tempDir);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await writeMigrationReport(pureLegacyComponents, { dryRun: true });
+
+      const cwd = process.cwd();
+      expect(existsSync(join(tempDir, "MIGRATION_REPORT.json"))).toBe(false);
+      expect(existsSync(join(tempDir, "MIGRATION_REPORT.md"))).toBe(false);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`would write "${normalizeSeparators(join(cwd, "MIGRATION_REPORT.json"))}"`),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`would write "${normalizeSeparators(join(cwd, "MIGRATION_REPORT.md"))}"`),
+      );
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -111,6 +111,20 @@ describe("parseCliOptions", () => {
     expect(parseCliOptions(["--llms=false"])).toEqual({ kind: "options", options: { llms: false } });
   });
 
+  test("--migration-report enables migrationReport", () => {
+    expect(parseCliOptions(["--migration-report"])).toEqual({
+      kind: "options",
+      options: { migrationReport: true },
+    });
+  });
+
+  test("--migration-report=false disables migrationReport", () => {
+    expect(parseCliOptions(["--migration-report=false"])).toEqual({
+      kind: "options",
+      options: { migrationReport: false },
+    });
+  });
+
   test("--report-diagnostics enables reportDiagnostics", () => {
     expect(parseCliOptions(["--report-diagnostics"])).toEqual({
       kind: "options",
@@ -515,6 +529,7 @@ describe("cli() --dry-run", () => {
       "--markdown",
       "--custom-elements",
       "--llms",
+      "--migration-report",
       "--dry-run",
     ];
 
@@ -526,6 +541,8 @@ describe("cli() --dry-run", () => {
     expect(existsSync(join(dir, "custom-elements.json"))).toBe(false);
     expect(existsSync(join(dir, "llms.txt"))).toBe(false);
     expect(existsSync(join(dir, "llms-full.txt"))).toBe(false);
+    expect(existsSync(join(dir, "MIGRATION_REPORT.json"))).toBe(false);
+    expect(existsSync(join(dir, "MIGRATION_REPORT.md"))).toBe(false);
     expect(existsSync(join(dir, "src", "node_modules", ".cache"))).toBe(false);
   });
 
@@ -538,6 +555,7 @@ describe("cli() --dry-run", () => {
       "--markdown",
       "--custom-elements",
       "--llms",
+      "--migration-report",
       "--dry-run",
     ];
 
@@ -552,10 +570,21 @@ describe("cli() --dry-run", () => {
     expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "custom-elements.json"))}"`);
     expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "llms.txt"))}"`);
     expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "llms-full.txt"))}"`);
+    expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "MIGRATION_REPORT.json"))}"`);
+    expect(printed).toContain(`would write "${normalizeSeparators(join(cwd, "MIGRATION_REPORT.md"))}"`);
 
     // Now run for real and confirm the exact same paths land on disk.
     logSpy.mockClear();
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--llms"];
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--json",
+      "--markdown",
+      "--custom-elements",
+      "--llms",
+      "--migration-report",
+    ];
     await cli(process);
 
     expect(existsSync(join(dir, "types", "Button.svelte.d.ts"))).toBe(true);
@@ -565,6 +594,8 @@ describe("cli() --dry-run", () => {
     expect(existsSync(join(dir, "custom-elements.json"))).toBe(true);
     expect(existsSync(join(dir, "llms.txt"))).toBe(true);
     expect(existsSync(join(dir, "llms-full.txt"))).toBe(true);
+    expect(existsSync(join(dir, "MIGRATION_REPORT.json"))).toBe(true);
+    expect(existsSync(join(dir, "MIGRATION_REPORT.md"))).toBe(true);
   });
 
   test("prints per-component .api.json paths when jsonOptions.outDir is set", async () => {
@@ -658,7 +689,16 @@ describe("cli() --quiet", () => {
   });
 
   test("a plain run prints writer progress lines to stderr", async () => {
-    process.argv = ["bun", "cli.js", "--entry=src/index.js", "--json", "--markdown", "--custom-elements", "--llms"];
+    process.argv = [
+      "bun",
+      "cli.js",
+      "--entry=src/index.js",
+      "--json",
+      "--markdown",
+      "--custom-elements",
+      "--llms",
+      "--migration-report",
+    ];
 
     await cli(process);
 
@@ -668,6 +708,8 @@ describe("cli() --quiet", () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "custom-elements.json".'));
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "llms.txt".'));
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "llms-full.txt".'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "MIGRATION_REPORT.json".'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('created "MIGRATION_REPORT.md".'));
   });
 
   test("--quiet suppresses writer progress lines but still writes output files", async () => {

--- a/tests/fixtures/accessor-param-returns/output.json
+++ b/tests/fixtures/accessor-param-returns/output.json
@@ -235,6 +235,7 @@
       "ts": "type NotificationData = {\n  /** Optional id for deduplication */\n  id?: string;\n  kind?: \"error\" | \"info\" | \"success\";\n  title?: string;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/anchor-props/output.json
+++ b/tests/fixtures/anchor-props/output.json
@@ -31,6 +31,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/arrow-function-with-jsdoc/output.json
+++ b/tests/fixtures/arrow-function-with-jsdoc/output.json
@@ -93,6 +93,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/async-function-props/output.json
+++ b/tests/fixtures/async-function-props/output.json
@@ -95,6 +95,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/binary-expression-numeric/output.json
+++ b/tests/fixtures/binary-expression-numeric/output.json
@@ -199,6 +199,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/bind-this-multiple/output.json
+++ b/tests/fixtures/bind-this-multiple/output.json
@@ -102,6 +102,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/bind-this/output.json
+++ b/tests/fixtures/bind-this/output.json
@@ -54,6 +54,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/bindable-direction-legacy/output.json
+++ b/tests/fixtures/bindable-direction-legacy/output.json
@@ -101,6 +101,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/bindable-direction-runes/output.json
+++ b/tests/fixtures/bindable-direction-runes/output.json
@@ -102,6 +102,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/call-expression-default-hoisted-function/output.json
+++ b/tests/fixtures/call-expression-default-hoisted-function/output.json
@@ -43,6 +43,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/call-expression-defaults/output.json
+++ b/tests/fixtures/call-expression-defaults/output.json
@@ -121,6 +121,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/callback-typedef/output.json
+++ b/tests/fixtures/callback-typedef/output.json
@@ -81,6 +81,7 @@
       "ts": "type SortFn = (a: any, b: any, direction: SortDirection) => number;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/callback/output.json
+++ b/tests/fixtures/callback/output.json
@@ -115,6 +115,7 @@
       "ts": "type OnClose = () => void;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/component-comment-multi/output.json
+++ b/tests/fixtures/component-comment-multi/output.json
@@ -31,6 +31,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "componentComment": "\n@example\n<div>\n  Component comment\n</div>",
   "componentCommentSource": {

--- a/tests/fixtures/component-comment-single/output.json
+++ b/tests/fixtures/component-comment-single/output.json
@@ -31,6 +31,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "componentComment": " Component comment",
   "componentCommentSource": {

--- a/tests/fixtures/constructor-expression-defaults/output.json
+++ b/tests/fixtures/constructor-expression-defaults/output.json
@@ -329,6 +329,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/context-colon/output.json
+++ b/tests/fixtures/context-colon/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-const-key/output.json
+++ b/tests/fixtures/context-const-key/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-empty/output.json
+++ b/tests/fixtures/context-empty/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-generics-dollar-name/output.json
+++ b/tests/fixtures/context-generics-dollar-name/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Value$Type",
     "Value$Type extends string"

--- a/tests/fixtures/context-imported-type/output.json
+++ b/tests/fixtures/context-imported-type/output.json
@@ -38,6 +38,7 @@
       "ts": "type ModalAPI = {\n  open: () => void;\n  close: () => void;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-inline-functions/output.json
+++ b/tests/fixtures/context-inline-functions/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-issue-103/output.json
+++ b/tests/fixtures/context-issue-103/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-mixed-separators/output.json
+++ b/tests/fixtures/context-mixed-separators/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-module/output.json
+++ b/tests/fixtures/context-module/output.json
@@ -231,6 +231,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/context-simple/output.json
+++ b/tests/fixtures/context-simple/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-space/output.json
+++ b/tests/fixtures/context-space/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-symbol-for/output.json
+++ b/tests/fixtures/context-symbol-for/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-symbol/output.json
+++ b/tests/fixtures/context-symbol/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-template-tag-multiple/output.json
+++ b/tests/fixtures/context-template-tag-multiple/output.json
@@ -85,6 +85,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Value, Icon",
     "Value extends string = string, Icon = any"

--- a/tests/fixtures/context-template-tag/output.json
+++ b/tests/fixtures/context-template-tag/output.json
@@ -72,6 +72,7 @@
       "ts": "type DataTableRowId = any;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/context-ts-annotation/output.json
+++ b/tests/fixtures/context-ts-annotation/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-typedef/output.json
+++ b/tests/fixtures/context-typedef/output.json
@@ -38,6 +38,7 @@
       "ts": "type TabData = {\n  id: string;\n  label: string;\n  disabled?: boolean;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [
     {

--- a/tests/fixtures/context-unresolvable-key/output.json
+++ b/tests/fixtures/context-unresolvable-key/output.json
@@ -60,6 +60,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/custom-element-options-tag/output.json
+++ b/tests/fixtures/custom-element-options-tag/output.json
@@ -61,6 +61,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "customElementTag": "x-badge",

--- a/tests/fixtures/default-slot-with-props/output.json
+++ b/tests/fixtures/default-slot-with-props/output.json
@@ -61,6 +61,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/deprecated-tags/output.json
+++ b/tests/fixtures/deprecated-tags/output.json
@@ -133,6 +133,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.json
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name-host-dispatch/output.json
@@ -32,6 +32,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "customElementTag": "my-el",

--- a/tests/fixtures/dispatched-and-forwarded-same-event-name/output.json
+++ b/tests/fixtures/dispatched-and-forwarded-same-event-name/output.json
@@ -32,6 +32,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-dynamic/output.json
+++ b/tests/fixtures/dispatched-events-dynamic/output.json
@@ -32,6 +32,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/dispatched-events-jsdoc-properties/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-properties/output.json
@@ -88,6 +88,7 @@
       "ts": "type ChangeDetail = {\n  /** The full new set of items. */\n  items: string[];\n  /** Items added since the last change. */\n  added: string[];\n  /** Items removed since the last change. */\n  removed?: string[];\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-jsdoc-union-type/output.json
+++ b/tests/fixtures/dispatched-events-jsdoc-union-type/output.json
@@ -33,6 +33,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-object-detail/output.json
+++ b/tests/fixtures/dispatched-events-object-detail/output.json
@@ -69,6 +69,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-string-literal-detail/output.json
+++ b/tests/fixtures/dispatched-events-string-literal-detail/output.json
@@ -32,6 +32,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output.json
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-jsdoc/output.json
@@ -47,6 +47,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-typed-dispatcher-ts/output.json
+++ b/tests/fixtures/dispatched-events-typed-dispatcher-ts/output.json
@@ -47,6 +47,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events-typed/output.json
+++ b/tests/fixtures/dispatched-events-typed/output.json
@@ -64,6 +64,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/dispatched-events/output.json
+++ b/tests/fixtures/dispatched-events/output.json
@@ -93,6 +93,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/element-tag-map-new/output.json
+++ b/tests/fixtures/element-tag-map-new/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/element-tag-map-table-cells/output.json
+++ b/tests/fixtures/element-tag-map-table-cells/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/element-tag-map-text-elements/output.json
+++ b/tests/fixtures/element-tag-map-text-elements/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/empty-collection-defaults/output.json
+++ b/tests/fixtures/empty-collection-defaults/output.json
@@ -155,6 +155,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/empty-export/output.json
+++ b/tests/fixtures/empty-export/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/event-explicit-null/output.json
+++ b/tests/fixtures/event-explicit-null/output.json
@@ -62,6 +62,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/event-jsdoc-since/output.json
+++ b/tests/fixtures/event-jsdoc-since/output.json
@@ -71,6 +71,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/events-stable-order/output.json
+++ b/tests/fixtures/events-stable-order/output.json
@@ -77,6 +77,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/example-check/output.json
+++ b/tests/fixtures/example-check/output.json
@@ -162,6 +162,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/explicit-default-no-duplicate/output.json
+++ b/tests/fixtures/explicit-default-no-duplicate/output.json
@@ -274,6 +274,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/extend-props/output.json
+++ b/tests/fixtures/extend-props/output.json
@@ -60,6 +60,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/forwarded-custom-event-null/output.json
+++ b/tests/fixtures/forwarded-custom-event-null/output.json
@@ -51,6 +51,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-custom-events/output.json
+++ b/tests/fixtures/forwarded-custom-events/output.json
@@ -49,6 +49,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
+++ b/tests/fixtures/forwarded-events-native-with-jsdoc/output.json
@@ -84,6 +84,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-events-typed/output.json
+++ b/tests/fixtures/forwarded-events-typed/output.json
@@ -66,6 +66,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-events/output.json
+++ b/tests/fixtures/forwarded-events/output.json
@@ -92,6 +92,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-from-component-to-native/output.json
+++ b/tests/fixtures/forwarded-from-component-to-native/output.json
@@ -107,6 +107,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-native-with-detail/output.json
+++ b/tests/fixtures/forwarded-native-with-detail/output.json
@@ -34,6 +34,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/forwarded-standard-event-custom-detail/output.json
+++ b/tests/fixtures/forwarded-standard-event-custom-detail/output.json
@@ -91,6 +91,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/function-declaration/output.json
+++ b/tests/fixtures/function-declaration/output.json
@@ -112,6 +112,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/fuzz-generics-arrow-type-comma/output.json
+++ b/tests/fixtures/fuzz-generics-arrow-type-comma/output.json
@@ -75,6 +75,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Handler, Row",
     "Handler extends (value: string) => void = () => {}, Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/generics-bare-name/output.json
+++ b/tests/fixtures/generics-bare-name/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Item",
     "Item"

--- a/tests/fixtures/generics-multiple/output.json
+++ b/tests/fixtures/generics-multiple/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> { key: DataTableKey<Row>; value: Header; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row,Header",
     "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"

--- a/tests/fixtures/generics-with-rest-props/output.json
+++ b/tests/fixtures/generics-with-rest-props/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/generics/output.json
+++ b/tests/fixtures/generics/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/html-in-template-string/output.json
+++ b/tests/fixtures/html-in-template-string/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/infer-basic/output.json
+++ b/tests/fixtures/infer-basic/output.json
@@ -210,6 +210,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/infer-with-types/output.json
+++ b/tests/fixtures/infer-with-types/output.json
@@ -185,6 +185,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/input-events/output.json
+++ b/tests/fixtures/input-events/output.json
@@ -61,6 +61,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/instance-reexport/output.json
+++ b/tests/fixtures/instance-reexport/output.json
@@ -73,6 +73,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/internal-typedef-referenced/output.json
+++ b/tests/fixtures/internal-typedef-referenced/output.json
@@ -50,6 +50,7 @@
       "ts": "interface PublicList { items: InternalCount[] }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/jsdoc-internal-ignore/output.json
+++ b/tests/fixtures/jsdoc-internal-ignore/output.json
@@ -241,6 +241,7 @@
       "ts": "interface PublicLabel { label: string }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/jsdoc-type-params/output.json
+++ b/tests/fixtures/jsdoc-type-params/output.json
@@ -65,6 +65,7 @@
       "ts": "type TreeNodeId = string;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/legacy-bind-component-value/output.json
+++ b/tests/fixtures/legacy-bind-component-value/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/legacy-export-typed/output.json
+++ b/tests/fixtures/legacy-export-typed/output.json
@@ -65,6 +65,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/legacy-multi-declarator/output.json
+++ b/tests/fixtures/legacy-multi-declarator/output.json
@@ -94,6 +94,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/legacy-pass-through-nonreactive/output.json
+++ b/tests/fixtures/legacy-pass-through-nonreactive/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/legacy-untyped-no-default/output.json
+++ b/tests/fixtures/legacy-untyped-no-default/output.json
@@ -85,6 +85,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/mixed-event-types/output.json
+++ b/tests/fixtures/mixed-event-types/output.json
@@ -81,6 +81,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/mixed-events/output.json
+++ b/tests/fixtures/mixed-events/output.json
@@ -47,6 +47,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/module-reexport-mixed/output.json
+++ b/tests/fixtures/module-reexport-mixed/output.json
@@ -143,6 +143,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/module-reexport/output.json
+++ b/tests/fixtures/module-reexport/output.json
@@ -88,6 +88,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/multiple-typedef-same-property/output.json
+++ b/tests/fixtures/multiple-typedef-same-property/output.json
@@ -88,6 +88,7 @@
       "ts": "type ThemeConfig = {\n  /** Theme identifier */\n  id: string;\n  /** Theme display name */\n  name: string;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/no-props/output.json
+++ b/tests/fixtures/no-props/output.json
@@ -15,6 +15,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/non-literal-defaults/output.json
+++ b/tests/fixtures/non-literal-defaults/output.json
@@ -348,6 +348,7 @@
       "ts": "type Position = \"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\";"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/prop-comment-complex/output.json
+++ b/tests/fixtures/prop-comment-complex/output.json
@@ -100,6 +100,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/prop-comments/output.json
+++ b/tests/fixtures/prop-comments/output.json
@@ -129,6 +129,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/prop-default-identifier-jsdoc/output.json
@@ -310,6 +310,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/prop-jsdoc-since-example/output.json
+++ b/tests/fixtures/prop-jsdoc-since-example/output.json
@@ -89,6 +89,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/prop-metadata-consolidated/output.json
+++ b/tests/fixtures/prop-metadata-consolidated/output.json
@@ -305,6 +305,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/reactive-direct-mutation-still-true/output.json
+++ b/tests/fixtures/reactive-direct-mutation-still-true/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/reactive-shadowed-callback-param/output.json
+++ b/tests/fixtures/reactive-shadowed-callback-param/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/reactive-shadowed-each-binding/output.json
+++ b/tests/fixtures/reactive-shadowed-each-binding/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/reactive-shadowed-local-reassignment/output.json
+++ b/tests/fixtures/reactive-shadowed-local-reassignment/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/renamed-props/output.json
+++ b/tests/fixtures/renamed-props/output.json
@@ -46,6 +46,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/required/output.json
+++ b/tests/fixtures/required/output.json
@@ -130,6 +130,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/resolve-default-chained/output.json
+++ b/tests/fixtures/resolve-default-chained/output.json
@@ -99,6 +99,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/rest-props-description-multiline/output.json
+++ b/tests/fixtures/rest-props-description-multiline/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/rest-props-description/output.json
+++ b/tests/fixtures/rest-props-description/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/rest-props-multiple/output.json
+++ b/tests/fixtures/rest-props-multiple/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/rest-props-simple/output.json
+++ b/tests/fixtures/rest-props-simple/output.json
@@ -15,6 +15,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/runes-attachment-array/output.json
+++ b/tests/fixtures/runes-attachment-array/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-attachment-factory/output.json
+++ b/tests/fixtures/runes-attachment-factory/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-attachment-generic/output.json
+++ b/tests/fixtures/runes-attachment-generic/output.json
@@ -39,6 +39,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Element",
     "Element extends HTMLElement = HTMLDivElement"

--- a/tests/fixtures/runes-attachment-prop/output.json
+++ b/tests/fixtures/runes-attachment-prop/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-bindable-no-default/output.json
+++ b/tests/fixtures/runes-bindable-no-default/output.json
@@ -86,6 +86,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-callback-annotated/output.json
+++ b/tests/fixtures/runes-callback-annotated/output.json
@@ -83,6 +83,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-callback-prop-ts-type-no-default/output.json
+++ b/tests/fixtures/runes-callback-prop-ts-type-no-default/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-derived-prop-default-resolved/output.json
+++ b/tests/fixtures/runes-derived-prop-default-resolved/output.json
@@ -69,6 +69,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-derived-prop-default/output.json
+++ b/tests/fixtures/runes-derived-prop-default/output.json
@@ -43,6 +43,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-dispatched-events/output.json
+++ b/tests/fixtures/runes-dispatched-events/output.json
@@ -57,6 +57,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-generic-interface-type-args/output.json
+++ b/tests/fixtures/runes-generic-interface-type-args/output.json
@@ -59,6 +59,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-generics/output.json
+++ b/tests/fixtures/runes-generics/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/runes-host-custom-element/output.json
+++ b/tests/fixtures/runes-host-custom-element/output.json
@@ -82,6 +82,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "customElementTag": "my-widget",

--- a/tests/fixtures/runes-internal-noleak/output.json
+++ b/tests/fixtures/runes-internal-noleak/output.json
@@ -57,6 +57,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-non-identifier-prop-names/output.json
+++ b/tests/fixtures/runes-non-identifier-prop-names/output.json
@@ -111,6 +111,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
+++ b/tests/fixtures/runes-prop-default-identifier-jsdoc/output.json
@@ -279,6 +279,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-prop-jsdoc-since-example/output.json
+++ b/tests/fixtures/runes-prop-jsdoc-since-example/output.json
@@ -71,6 +71,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-prop-metadata-consolidated/output.json
+++ b/tests/fixtures/runes-prop-metadata-consolidated/output.json
@@ -225,6 +225,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-props-as-cast-destructured/output.json
+++ b/tests/fixtures/runes-props-as-cast-destructured/output.json
@@ -59,6 +59,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-props-as-cast/output.json
+++ b/tests/fixtures/runes-props-as-cast/output.json
@@ -59,6 +59,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-props-basic/output.json
+++ b/tests/fixtures/runes-props-basic/output.json
@@ -64,6 +64,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-props-html-intersection/output.json
+++ b/tests/fixtures/runes-props-html-intersection/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/runes-props-id-default/output.json
+++ b/tests/fixtures/runes-props-id-default/output.json
@@ -37,6 +37,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-props-interface/output.json
+++ b/tests/fixtures/runes-props-interface/output.json
@@ -59,6 +59,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-props-intersection/output.json
+++ b/tests/fixtures/runes-props-intersection/output.json
@@ -59,6 +59,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-props-renamed/output.json
+++ b/tests/fixtures/runes-props-renamed/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-render-skipped-argument/output.json
+++ b/tests/fixtures/runes-render-skipped-argument/output.json
@@ -37,6 +37,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-rest-props/output.json
+++ b/tests/fixtures/runes-rest-props/output.json
@@ -37,6 +37,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/runes-script-generics-attribute-const/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-const/output.json
@@ -54,6 +54,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "T",
     "const T extends readonly string[]"

--- a/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-jsdoc-conflict/output.json
@@ -75,6 +75,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/runes-script-generics-attribute-multiple/output.json
+++ b/tests/fixtures/runes-script-generics-attribute-multiple/output.json
@@ -96,6 +96,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row, K",
     "Row extends DataTableRow = DataTableRow, K extends keyof Map<string, Row> = never"

--- a/tests/fixtures/runes-script-generics-attribute/output.json
+++ b/tests/fixtures/runes-script-generics-attribute/output.json
@@ -75,6 +75,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/runes-snippet-description-hyphens/output.json
+++ b/tests/fixtures/runes-snippet-description-hyphens/output.json
@@ -74,6 +74,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-snippet-generic-tuple/output.json
+++ b/tests/fixtures/runes-snippet-generic-tuple/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row"

--- a/tests/fixtures/runes-snippet-positional/output.json
+++ b/tests/fixtures/runes-snippet-positional/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-snippets-annotated/output.json
+++ b/tests/fixtures/runes-snippets-annotated/output.json
@@ -91,6 +91,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-snippets-default/output.json
+++ b/tests/fixtures/runes-snippets-default/output.json
@@ -53,6 +53,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-snippets-named/output.json
+++ b/tests/fixtures/runes-snippets-named/output.json
@@ -53,6 +53,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/runes-typed-props/output.json
+++ b/tests/fixtures/runes-typed-props/output.json
@@ -105,6 +105,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-uncontrolled-state-prop/output.json
+++ b/tests/fixtures/runes-uncontrolled-state-prop/output.json
@@ -45,6 +45,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-whole-props-generic-resolve-types/output.json
+++ b/tests/fixtures/runes-whole-props-generic-resolve-types/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "T",
     "T extends Identifiable"

--- a/tests/fixtures/runes-whole-props-imported/output.json
+++ b/tests/fixtures/runes-whole-props-imported/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-whole-props-typed/output.json
+++ b/tests/fixtures/runes-whole-props-typed/output.json
@@ -75,6 +75,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/runes-whole-props-union-resolve-types/output.json
+++ b/tests/fixtures/runes-whole-props-union-resolve-types/output.json
@@ -16,6 +16,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-description-hyphens-inline/output.json
+++ b/tests/fixtures/slot-description-hyphens-inline/output.json
@@ -33,6 +33,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-description-with-dash/output.json
+++ b/tests/fixtures/slot-description-with-dash/output.json
@@ -33,6 +33,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-event-template-prop-reference/output.json
+++ b/tests/fixtures/slot-event-template-prop-reference/output.json
@@ -76,6 +76,7 @@
     }
   ],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Icon",
     "Icon = any"

--- a/tests/fixtures/slot-extends-template/output.json
+++ b/tests/fixtures/slot-extends-template/output.json
@@ -60,6 +60,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Icon",
     "Icon = any"

--- a/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.json
+++ b/tests/fixtures/slot-jsdoc-enum-not-passthrough/output.json
@@ -33,6 +33,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-inheritdoc-before-slot/output.json
@@ -39,6 +39,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/slot-jsdoc-multiple-tags/output.json
+++ b/tests/fixtures/slot-jsdoc-multiple-tags/output.json
@@ -40,6 +40,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.json
+++ b/tests/fixtures/slot-jsdoc-orphan-type-before-slot/output.json
@@ -33,6 +33,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-jsdoc-since/output.json
+++ b/tests/fixtures/slot-jsdoc-since/output.json
@@ -39,6 +39,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
+++ b/tests/fixtures/slot-jsdoc-tags-named-pair/output.json
@@ -56,6 +56,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-jsdoc-template-not-passthrough/output.json
+++ b/tests/fixtures/slot-jsdoc-template-not-passthrough/output.json
@@ -33,6 +33,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.json
+++ b/tests/fixtures/slot-jsdoc-two-slots-one-block-order/output.json
@@ -54,6 +54,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-plain-text-attribute-prop/output.json
+++ b/tests/fixtures/slot-plain-text-attribute-prop/output.json
@@ -32,6 +32,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-prop-dotted-access/output.json
+++ b/tests/fixtures/slot-prop-dotted-access/output.json
@@ -63,6 +63,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-props-union-types/output.json
+++ b/tests/fixtures/slot-props-union-types/output.json
@@ -76,6 +76,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slot-template-prop-reference/output.json
+++ b/tests/fixtures/slot-template-prop-reference/output.json
@@ -61,6 +61,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": [
     "Icon",
     "Icon = any"

--- a/tests/fixtures/slots-named/output.json
+++ b/tests/fixtures/slots-named/output.json
@@ -109,6 +109,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slots-spread-typed/output.json
+++ b/tests/fixtures/slots-spread-typed/output.json
@@ -48,6 +48,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/slots-spread/output.json
+++ b/tests/fixtures/slots-spread/output.json
@@ -48,6 +48,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/style-block-jsdoc-comment-ignored/output.json
+++ b/tests/fixtures/style-block-jsdoc-comment-ignored/output.json
@@ -52,6 +52,7 @@
       "ts": "type RealTypedef = {\n  name: string;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/svelte-element-dynamic/output.json
+++ b/tests/fixtures/svelte-element-dynamic/output.json
@@ -44,6 +44,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/svelte-element-hardcoded-button/output.json
+++ b/tests/fixtures/svelte-element-hardcoded-button/output.json
@@ -15,6 +15,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/svelte-element-hardcoded-div/output.json
+++ b/tests/fixtures/svelte-element-hardcoded-div/output.json
@@ -15,6 +15,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/svg-props/output.json
+++ b/tests/fixtures/svg-props/output.json
@@ -15,6 +15,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/template-expression-shapes-ts/output.json
+++ b/tests/fixtures/template-expression-shapes-ts/output.json
@@ -97,6 +97,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/template-expression-shapes/output.json
+++ b/tests/fixtures/template-expression-shapes/output.json
@@ -150,6 +150,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "rest_props": {
     "type": "Element",

--- a/tests/fixtures/template-literal-default/output.json
+++ b/tests/fixtures/template-literal-default/output.json
@@ -126,6 +126,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/template-tag-multiple/output.json
+++ b/tests/fixtures/template-tag-multiple/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow, Header = DataTableRow> { key: DataTableKey<Row>; value: Header; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row, Header",
     "Row extends DataTableRow = DataTableRow, Header extends DataTableRow = DataTableRow"

--- a/tests/fixtures/template-tag-with-rest-props/output.json
+++ b/tests/fixtures/template-tag-with-rest-props/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/template-tag/output.json
+++ b/tests/fixtures/template-tag/output.json
@@ -103,6 +103,7 @@
       "ts": "interface DataTableHeader<Row = DataTableRow> { key: DataTableKey<Row>; value: string; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": [
     "Row",
     "Row extends DataTableRow = DataTableRow"

--- a/tests/fixtures/theme-component/output.json
+++ b/tests/fixtures/theme-component/output.json
@@ -207,6 +207,7 @@
       "ts": "type CarbonTheme = \"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\";"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/ts-accessor-signature/output.json
+++ b/tests/fixtures/ts-accessor-signature/output.json
@@ -96,6 +96,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/ts-legacy-imported-prop-type/output.json
+++ b/tests/fixtures/ts-legacy-imported-prop-type/output.json
@@ -60,6 +60,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/ts-local-enum-prop/output.json
+++ b/tests/fixtures/ts-local-enum-prop/output.json
@@ -59,6 +59,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/ts-runes-per-prop-imported-type/output.json
+++ b/tests/fixtures/ts-runes-per-prop-imported-type/output.json
@@ -38,6 +38,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/ts-value-import-as-type/output.json
+++ b/tests/fixtures/ts-value-import-as-type/output.json
@@ -54,6 +54,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typed-props/output.json
+++ b/tests/fixtures/typed-props/output.json
@@ -120,6 +120,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/typed-slots/output.json
+++ b/tests/fixtures/typed-slots/output.json
@@ -76,6 +76,7 @@
   ],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-branded-types/output.json
+++ b/tests/fixtures/typedef-branded-types/output.json
@@ -74,6 +74,7 @@
       "ts": "type Cents = number & { readonly __brand: \"Cents\" };"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-description/output.json
+++ b/tests/fixtures/typedef-description/output.json
@@ -73,6 +73,7 @@
       "ts": "type StackScaleOrString = StackScale | string;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-discriminated-union-intersection/output.json
+++ b/tests/fixtures/typedef-discriminated-union-intersection/output.json
@@ -70,6 +70,7 @@
       "ts": "type Entity = User | Post;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-discriminated-union/output.json
+++ b/tests/fixtures/typedef-discriminated-union/output.json
@@ -85,6 +85,7 @@
       "ts": "type Status = { ok: true; data: number } | { ok: false; reason: string } | \"pending\";"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-duplicate-name/output.json
+++ b/tests/fixtures/typedef-duplicate-name/output.json
@@ -44,6 +44,7 @@
       "ts": "type Config = {\n  /** Count */\n  count: number;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/typedef-duplicate-property/output.json
+++ b/tests/fixtures/typedef-duplicate-property/output.json
@@ -44,6 +44,7 @@
       "ts": "type Config = {\n  /** Second declaration wins */\n  id: number;\n};"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/typedef-event-shared-block/output.json
+++ b/tests/fixtures/typedef-event-shared-block/output.json
@@ -232,6 +232,7 @@
       "ts": "type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;"
     }
   ],
+  "reactiveStatementCount": 1,
   "generics": null,
   "contexts": [],
   "diagnostics": [

--- a/tests/fixtures/typedef-import-type/output.json
+++ b/tests/fixtures/typedef-import-type/output.json
@@ -134,6 +134,7 @@
       "ts": "interface TableContext { rows: import(\"svelte/store\").Writable<string[]>; selected: import(\"svelte/store\").Readable<number> }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-jsdoc-properties/output.json
+++ b/tests/fixtures/typedef-jsdoc-properties/output.json
@@ -130,6 +130,7 @@
       "ts": "interface SimpleType { id: number; label: string; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-type-predicate/output.json
+++ b/tests/fixtures/typedef-type-predicate/output.json
@@ -73,6 +73,7 @@
       "ts": "type UserGuard = (value: unknown) => value is User;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-unknown-type/output.json
+++ b/tests/fixtures/typedef-unknown-type/output.json
@@ -61,6 +61,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef-utility-types/output.json
+++ b/tests/fixtures/typedef-utility-types/output.json
@@ -118,6 +118,7 @@
       "ts": "type Factory = () => Options;"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedef/output.json
+++ b/tests/fixtures/typedef/output.json
@@ -94,6 +94,7 @@
       "ts": "interface MyTypedef { [key: string]: boolean; }"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/typedefs/output.json
+++ b/tests/fixtures/typedefs/output.json
@@ -100,6 +100,7 @@
       "ts": "type MyTypedefArray = MyTypedef[];"
     }
   ],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/fixtures/unary-expression-defaults/output.json
+++ b/tests/fixtures/unary-expression-defaults/output.json
@@ -154,6 +154,7 @@
   "slots": [],
   "events": [],
   "typedefs": [],
+  "reactiveStatementCount": 0,
   "generics": null,
   "contexts": [],
   "diagnostics": []

--- a/tests/test-brands.ts
+++ b/tests/test-brands.ts
@@ -32,6 +32,7 @@ export function mockComponentDocApi(
     slots: [],
     events: [],
     typedefs: [],
+    reactiveStatementCount: 0,
     generics: null,
     rest_props: undefined,
     contexts: [],


### PR DESCRIPTION
Adds a `migration-report` writer that scores every discovered
component's Svelte 5 migration readiness (legacy `export let`,
`on:` forwarding, `<slot>`, `createEventDispatcher`, `$$restProps`,
`$:` statements), plus a library-wide rollup.

```diff
sveld({
+  migrationReport: true,
})
```

```json
{
  "moduleName": "Modal",
  "syntaxMode": "legacy",
  "counts": { "exportLet": 1, "slots": 2, "onDirectives": 0, ... },
  "score": 90
}
```

Runes components always score 100. Nothing tracked `$:` usage
before, so `ParsedComponent` gained a `reactiveStatementCount`
field to feed the score.